### PR TITLE
config: add google to predefined trust proxy CIDRs

### DIFF
--- a/cmd/parapet-ingress-controller/config.go
+++ b/cmd/parapet-ingress-controller/config.go
@@ -55,4 +55,12 @@ var predefinedCIDRs = map[string][]string{
 		"2a06:98c0::/29",
 		"2c0f:f248::/32",
 	},
+	"google": {
+		// Google Front End / Google Cloud Load Balancer source ranges
+		// https://cloud.google.com/load-balancing/docs/https#source_ip_addresses_for_client_traffic
+		"35.191.0.0/16",
+		"130.211.0.0/22",
+		"2600:2d00:1:1::/64",
+		"2600:2d00:1:b029::/64",
+	},
 }


### PR DESCRIPTION
## Summary

- Adds a `google` entry to `predefinedCIDRs` in [cmd/parapet-ingress-controller/config.go](cmd/parapet-ingress-controller/config.go), covering Google Front End / Google Cloud Load Balancer source IP ranges.
- Users can now opt in by setting `TRUST_PROXY=google` (or combine, e.g. `TRUST_PROXY=cloudflare,google`).

## CIDRs included

IPv4 (per [Google Cloud LB docs](https://cloud.google.com/load-balancing/docs/https#source_ip_addresses_for_client_traffic)):
- `35.191.0.0/16`
- `130.211.0.0/22`

IPv6:
- `2600:2d00:1:1::/64` — Global external Application Load Balancer traffic
- `2600:2d00:1:b029::/64` — IPv6 health check probes

The existing `parapet.TrustCIDRs` already handles IPv6 (the `cloudflare` entry uses it).

## Test plan

- [x] `go build ./cmd/parapet-ingress-controller/` succeeds
- [ ] Manually verify `TRUST_PROXY=google` parses to the expected CIDR list at startup
- [ ] Confirm X-Forwarded-* headers are trusted when traffic comes via a GCP HTTPS load balancer

🤖 Generated with [Claude Code](https://claude.com/claude-code)