### PR TITLE
feat: support multiple comma-separated values for HOST_COUNTRY_HEADER

### DIFF
--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -275,18 +275,33 @@ func hostRateLimit() parapet.Middleware {
 func hostCountryRateLimit() parapet.Middleware {
 	concurrentCapacity := config.Int("HOST_COUNTRY_CONCURRENT_CAPACITY") // concurrent requests
 	concurrentSize := config.Int("HOST_COUNTRY_CONCURRENT_SIZE")         // queue size
-	countryHeader := strings.TrimSpace(config.String("HOST_COUNTRY_HEADER"))
+	countryHeaderRaw := strings.TrimSpace(config.String("HOST_COUNTRY_HEADER"))
 
 	if concurrentCapacity <= 0 {
 		return nil
 	}
-	if countryHeader == "" {
+	if countryHeaderRaw == "" {
 		return nil
 	}
-	countryHeader = http.CanonicalHeaderKey(countryHeader)
+
+	var countryHeaders []string
+	for _, h := range strings.Split(countryHeaderRaw, ",") {
+		if h = strings.TrimSpace(h); h != "" {
+			countryHeaders = append(countryHeaders, http.CanonicalHeaderKey(h))
+		}
+	}
+	if len(countryHeaders) == 0 {
+		return nil
+	}
 
 	keyFromRequest := func(r *http.Request) string {
-		country := header.Get(r.Header, countryHeader)
+		country := ""
+		for _, h := range countryHeaders {
+			if v := header.Get(r.Header, h); v != "" {
+				country = v
+				break
+			}
+		}
 		if country == "" {
 			country = "XX"
 		}


### PR DESCRIPTION
## Summary

- `HOST_COUNTRY_HEADER` now accepts a comma-separated list of header names (e.g. `CF-IPCountry,X-Country-Code`)
- Headers are evaluated left-to-right; the first non-empty value is used as the country key
- Falls back to `XX` if none of the headers are present (existing behavior unchanged for single-header configs)

## Why

Some deployments have multiple proxies or CDN layers that set different country headers. This change allows the rate limiter to work across environments without requiring separate configs.

## Reviewer notes

- Canonical header key normalization is applied to each entry after splitting
- Blank entries after trimming are silently skipped, so trailing commas are safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)