### PR TITLE
build: update Dockerfile base images to debian trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-bookworm
+FROM golang:1.26.3-trixie
 
 ARG VERSION
 ARG GOAMD64
@@ -20,7 +20,7 @@ RUN go build \
 		-tags=cbrotli \
 		./cmd/parapet-ingress-controller
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && \
 	apt-get -y install libbrotli1 ca-certificates && \


### PR DESCRIPTION
## Summary

- Updates builder stage from `golang:1.26.3-bookworm` to `golang:1.26.3-trixie`
- Updates runtime stage from `debian:bookworm-slim` to `debian:trixie-slim`

## Why

Keeps the base images on Debian trixie (testing/next stable), consistent with the Go version already referenced in CLAUDE.md documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)