### PR TITLE
feat: add LoadAllCerts opt-in for full TLS-secret cert pool

### DIFF
--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -42,6 +42,7 @@ func main() {
 	disableLog := config.Bool("DISABLE_LOG")
 	waitBeforeShutdown := config.DurationDefault("WAIT_BEFORE_SHUTDOWN", 30*time.Second)
 	httpServerMaxHeaderBytes := config.IntDefault("HTTP_SERVER_MAX_HEADER_BYTES", 1<<14) // 16K
+	loadAllCerts := config.Bool("LOAD_ALL_CERTS")
 
 	hostname, _ := os.Hostname()
 
@@ -59,6 +60,7 @@ func main() {
 		"watch_namespace", watchNamespace,
 		"profiler", enableProfiler,
 		"http_server_max_header_bytes", httpServerMaxHeaderBytes,
+		"load_all_certs", loadAllCerts,
 	)
 
 	if enableProfiler {
@@ -87,6 +89,7 @@ func main() {
 	proxy.ConfigTransport(configTransport)
 
 	ctrl := controller.New(watchNamespace, proxy)
+	ctrl.LoadAllCerts = loadAllCerts
 	ctrl.Use(plugin.InjectStateIngress)
 	ctrl.Use(plugin.AllowRemote)
 	ctrl.Use(plugin.RedirectHTTPS)

--- a/controller.go
+++ b/controller.go
@@ -44,6 +44,14 @@ type Controller struct {
 	// namespace to watch, or empty to watch all
 	watchNamespace string
 
+	// LoadAllCerts, when true, builds the cert table from every TLS-typed
+	// secret in the watch namespace instead of only those referenced by an
+	// Ingress's spec.tls.secretName. The cert table already does SNI lookup
+	// with wildcard climbing, so enabling this lets a wildcard cert serve any
+	// matching subdomain without the user (or operator) having to wire the
+	// matching secret into each ingress. Off by default to preserve behavior.
+	LoadAllCerts bool
+
 	// holds current k8s state
 	watchedIngresses sync.Map
 	watchedServices  sync.Map
@@ -440,6 +448,30 @@ func (ctrl *Controller) reloadSecretDebounced() {
 		}
 	}()
 
+	var certs []*tls.Certificate
+
+	if ctrl.LoadAllCerts {
+		// Load every TLS-typed secret in the watch namespace. The cert table
+		// indexes by SAN and does SNI lookup with wildcard climbing, so this
+		// is enough for a wildcard cert in tls-example-com to serve SNI for
+		// foo.example.com without any ingress wiring.
+		ctrl.watchedSecrets.Range(func(_, value any) bool {
+			s := value.(*v1.Secret)
+			if s.Type != v1.SecretTypeTLS {
+				return true
+			}
+			crt, err := tls.X509KeyPair(s.Data["tls.crt"], s.Data["tls.key"])
+			if err != nil {
+				slog.Error("can not load x509 certificate", "namespace", s.Namespace, "name", s.Name, "error", err)
+				return true
+			}
+			certs = append(certs, &crt)
+			return true
+		})
+		ctrl.certTable.Set(certs)
+		return
+	}
+
 	secretToBuild := make(map[string]struct{}, secretSizeHint)
 
 	ctrl.watchedIngresses.Range(func(_, value any) bool {
@@ -452,7 +484,6 @@ func (ctrl *Controller) reloadSecretDebounced() {
 	})
 
 	// build certs
-	var certs []*tls.Certificate
 	for key := range secretToBuild {
 		v, ok := ctrl.watchedSecrets.Load(key)
 		if !ok {


### PR DESCRIPTION
## Summary

Add an opt-in mode that builds the SNI cert table from every `kubernetes.io/tls` secret in the watched namespace, instead of only those referenced by an `Ingress.spec.tls.secretName`.

**Off by default — old behavior is unchanged.** Enable with `LOAD_ALL_CERTS=true` on the controller binary.

## Why

`cert.Table` already:
- Indexes by SAN (cert/table.go:63-80), so a wildcard cert with SANs `[example.com, *.example.com]` covers both apex and subdomain hits.
- Does SNI lookup with exact → wildcard climb (cert/table.go:23-51).

The only thing constraining it today is the loader in `reloadSecretDebounced`, which selects secrets by walking each Ingress's `spec.tls.secretName`. That couples cert availability to ingress wiring — and breaks when an Ingress for `foo.example.com` references `tls-foo-example-com` while the actual wildcard cert lives in `tls-example-com`.

`LoadAllCerts=true` decouples the two: any TLS-typed secret in the namespace is eligible to serve SNI, and the existing wildcard-aware lookup picks the right cert per connection. Useful when you manage cert lifecycle independently of ingress objects (e.g. one Certificate per domain owned by an external control plane).

## What changed

- `controller.go`: new `LoadAllCerts bool` exported field on `Controller`.
- `controller.go` `reloadSecretDebounced`: when `LoadAllCerts` is true, iterate `watchedSecrets`, filter by `Type == v1.SecretTypeTLS`, parse each, set the table. Otherwise the original ingress-driven path runs unchanged.
- `cmd/parapet-ingress-controller/main.go`: read `LOAD_ALL_CERTS` env var, set on `ctrl.LoadAllCerts`, log it in the startup banner.

No changes to `cert.Table` (already wildcard-aware), no changes to the HTTPS listener (already uses `GetCertificate`), no changes to ingress watch / route logic.

## Behavior matrix

| `LOAD_ALL_CERTS` | Secrets loaded | Notes |
|---|---|---|
| unset / false | only those referenced by Ingress `spec.tls.secretName` | current behavior |
| true | every `kubernetes.io/tls` secret in the watch namespace | new opt-in |

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [ ] Default behavior (env unset) unchanged — verify by deploying without setting the var: cert table is built from ingress refs only, secrets without an ingress ref are not loaded.
- [ ] With `LOAD_ALL_CERTS=true`: deploy a wildcard cert in a Secret named `tls-example-com` (no Ingress referencing it). Confirm SNI hits for `foo.example.com` succeed.
- [ ] Reload behavior: deleting or rotating any tls Secret triggers a debounced reload — cert table updates without restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)