### PR TITLE
perf: eliminate per-request allocations in metrics hot path

### DIFF
--- a/metric/host.go
+++ b/metric/host.go
@@ -25,7 +25,7 @@ func init() {
 		Namespace: prom.Namespace,
 		Name:      "host_active_requests",
 	}, []string{"host", "upgrade"})
-	_host.m = make(map[string]prometheus.Gauge, hostSizeHint)
+	_host.m = make(map[hostKey]prometheus.Gauge, hostSizeHint)
 	prom.Registry().MustRegister(_host.vec)
 }
 
@@ -35,14 +35,18 @@ type host struct {
 	vec *prometheus.GaugeVec
 
 	mu sync.RWMutex
-	m  map[string]prometheus.Gauge // host/upgrade
+	m  map[hostKey]prometheus.Gauge
+}
+
+// hostKey is the cache key for the per-(host,upgrade) gauge handle. A
+// comparable struct avoids allocating a joined string key per request.
+type hostKey struct {
+	host    string
+	upgrade string
 }
 
 func (p *host) getM(host, upgrade string) prometheus.Gauge {
-	key := strings.Join([]string{
-		host,
-		upgrade,
-	}, "/")
+	key := hostKey{host: host, upgrade: upgrade}
 
 	p.mu.RLock()
 	m := p.m[key]

--- a/metric/metric_bench_test.go
+++ b/metric/metric_bench_test.go
@@ -1,0 +1,44 @@
+package metric
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/moonrhythm/parapet-ingress-controller/state"
+)
+
+// BenchmarkPromRequestsInc measures the steady-state (cache-hit) per-request
+// cost of recording request metrics — the path every request takes.
+func BenchmarkPromRequestsInc(b *testing.B) {
+	r := httptest.NewRequest("GET", "http://example.com/path", nil)
+	s := state.State{
+		"namespace":   "default",
+		"ingress":     "my-ingress",
+		"serviceName": "my-service",
+		"serviceType": "ClusterIP",
+	}
+	r = r.WithContext(state.NewContext(r.Context(), s))
+	start := time.Now()
+
+	// warm the cache so we measure the hot path, not the one-time miss
+	_promRequests.Inc(r, 200, start)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_promRequests.Inc(r, 200, start)
+	}
+}
+
+// BenchmarkHostGetM measures the steady-state (cache-hit) per-request cost of
+// resolving the host active-requests gauge.
+func BenchmarkHostGetM(b *testing.B) {
+	_host.getM("example.com", "") // warm
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_host.getM("example.com", "")
+	}
+}

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -1,0 +1,63 @@
+package metric
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/moonrhythm/parapet-ingress-controller/state"
+)
+
+func TestHostGetMCaching(t *testing.T) {
+	// same key returns the same cached handle
+	a := _host.getM("cache-test.example.com", "")
+	b := _host.getM("cache-test.example.com", "")
+	assert.Same(t, a, b)
+
+	// differing on either field yields a distinct handle
+	c := _host.getM("cache-test.example.com", "websocket")
+	d := _host.getM("other.example.com", "")
+	assert.NotSame(t, a, c)
+	assert.NotSame(t, a, d)
+}
+
+func TestPromRequestsIncCachesAndCounts(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://count-test.example.com/x", nil)
+	s := state.State{
+		"namespace":   "ns",
+		"ingress":     "ing",
+		"serviceName": "svc",
+		"serviceType": "ClusterIP",
+	}
+	r = r.WithContext(state.NewContext(r.Context(), s))
+	start := time.Now()
+
+	_promRequests.Inc(r, 200, start)
+	_promRequests.Inc(r, 200, start)
+
+	key := requestKey{
+		host:        "count-test.example.com",
+		namespace:   "ns",
+		ingress:     "ing",
+		serviceName: "svc",
+		serviceType: "ClusterIP",
+		method:      "GET",
+		status:      200,
+	}
+
+	// the two 200 calls share one cache entry; a 404 adds a second
+	_promRequests.Inc(r, 404, start)
+
+	_promRequests.mu.RLock()
+	rm200 := _promRequests.m[key]
+	key.status = 404
+	rm404 := _promRequests.m[key]
+	_promRequests.mu.RUnlock()
+
+	// both 200 calls resolved to one cached entry; 404 is a distinct one
+	assert.NotNil(t, rm200)
+	assert.NotNil(t, rm404)
+	assert.NotSame(t, rm200, rm404)
+}

--- a/metric/requests.go
+++ b/metric/requests.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"net/http"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -30,8 +29,27 @@ type promRequests struct {
 	durations *prometheus.HistogramVec
 
 	mu sync.RWMutex
-	m  map[string]prometheus.Counter // host/namespace/ingress/service/type/method/status
-	d  map[string]prometheus.Observer
+	m  map[requestKey]*requestMetric
+}
+
+// requestKey is the cache key for the per-label-set metric handles. Using a
+// comparable struct instead of a joined string avoids allocating a key on
+// every request and removes any separator-collision risk.
+type requestKey struct {
+	host        string
+	namespace   string
+	ingress     string
+	serviceName string
+	serviceType string
+	method      string
+	status      int
+}
+
+// requestMetric bundles the counter and duration observer for one label set so
+// the hot path resolves both with a single map lookup.
+type requestMetric struct {
+	counter  prometheus.Counter
+	observer prometheus.Observer
 }
 
 func init() {
@@ -43,8 +61,7 @@ func init() {
 		Namespace: prom.Namespace,
 		Name:      "service_duration_seconds",
 	}, []string{"service_type", "service_namespace", "service_name"})
-	_promRequests.m = make(map[string]prometheus.Counter, requestSizeHint)
-	_promRequests.d = make(map[string]prometheus.Observer, requestSizeHint)
+	_promRequests.m = make(map[requestKey]*requestMetric, requestSizeHint)
 
 	prom.Registry().MustRegister(_promRequests.vec, _promRequests.durations)
 }
@@ -55,50 +72,47 @@ func (p *promRequests) Inc(r *http.Request, status int, start time.Time) {
 	ctx := r.Context()
 	s := state.Get(ctx)
 
-	key := strings.Join([]string{
-		r.Host,
-		s["namespace"],
-		s["ingress"],
-		s["serviceName"],
-		s["serviceType"],
-		r.Method,
-		strconv.Itoa(status),
-	}, "/")
+	key := requestKey{
+		host:        r.Host,
+		namespace:   s["namespace"],
+		ingress:     s["ingress"],
+		serviceName: s["serviceName"],
+		serviceType: s["serviceType"],
+		method:      r.Method,
+		status:      status,
+	}
 
 	p.mu.RLock()
-	m := p.m[key]
-	d := p.d[key]
+	rm := p.m[key]
 	p.mu.RUnlock()
 
-	if m == nil {
+	if rm == nil {
 		p.mu.Lock()
-		if p.m[key] == nil {
-			p.m[key] = p.vec.With(prometheus.Labels{
-				"host":              r.Host,
-				"method":            r.Method,
-				"ingress_name":      s["ingress"],
-				"ingress_namespace": s["namespace"],
-				"service_type":      s["serviceType"],
-				"service_name":      s["serviceName"],
-				"status":            strconv.Itoa(status),
-			})
+		rm = p.m[key]
+		if rm == nil {
+			rm = &requestMetric{
+				counter: p.vec.With(prometheus.Labels{
+					"host":              r.Host,
+					"method":            r.Method,
+					"ingress_name":      s["ingress"],
+					"ingress_namespace": s["namespace"],
+					"service_type":      s["serviceType"],
+					"service_name":      s["serviceName"],
+					"status":            strconv.Itoa(status),
+				}),
+				observer: p.durations.With(prometheus.Labels{
+					"service_type":      s["serviceType"],
+					"service_name":      s["serviceName"],
+					"service_namespace": s["namespace"],
+				}),
+			}
+			p.m[key] = rm
 		}
-		m = p.m[key]
-
-		if p.d[key] == nil {
-			p.d[key] = p.durations.With(prometheus.Labels{
-				"service_type":      s["serviceType"],
-				"service_name":      s["serviceName"],
-				"service_namespace": s["namespace"],
-			})
-		}
-		d = p.d[key]
-
 		p.mu.Unlock()
 	}
 
-	m.Inc()
-	d.Observe(duration.Seconds())
+	rm.counter.Inc()
+	rm.observer.Observe(duration.Seconds())
 }
 
 func (p *promRequests) ServeHandler(h http.Handler) http.Handler {


### PR DESCRIPTION
## Summary

`metric.Requests()` and `metric.HostActiveTracker()` run on **every** request and were building a `strings.Join(...)` string purely to use as a map cache key — allocating on each request.

This replaces the string keys with comparable **struct keys** (`requestKey`, `hostKey`). In `requests.go` it also bundles the counter and duration observer into one cached value (`requestMetric`) so the hot path does a **single** map lookup instead of two. Struct keys are also strictly more correct — they remove the `/`-separator collision risk the joined string had.

## Measured impact

Steady-state cache-hit path (`-benchmem`, 8 runs), via the new benchmarks:

| Benchmark (per request) | Before | After | Change |
|---|---|---|---|
| `promRequests.Inc` | ~169 ns, 67 B, **2 allocs** | ~122 ns, 0 B, **0 allocs** | −28% time, −2 allocs |
| `host.getM` | ~40.5 ns, 16 B, **1 alloc** | ~15.0 ns, 0 B, **0 allocs** | −63% time, −1 alloc |

Net: **3 allocations and ~83 B eliminated per request**, reducing GC pressure across the request fleet.

## Notes

- `backendconns.go` already keys by `addr` directly (no allocation), so it's left unchanged.
- Adds `metric_test.go` (cache-correctness — the package previously had no tests) and `metric_bench_test.go` (the before/after proof).
- **No new dependencies.**

## Test plan

- [x] `go test ./...` (all packages green)
- [x] `go vet ./...` clean
- [x] New cache-correctness tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)