### PR TITLE
fix: RedirectRules drops valid rules when one entry is invalid

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -94,7 +94,7 @@ func RedirectRules(ctx Context) {
 		yaml.Unmarshal([]byte(a), &obj)
 		for srcHost, targetURL := range obj {
 			if srcHost == "" || targetURL == "" || strings.HasPrefix(srcHost, "/") {
-				return
+				continue
 			}
 			if !strings.HasSuffix(srcHost, "/") {
 				srcHost += "/"

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -178,6 +178,37 @@ api.example.com: 308,https://www.example.com/api`
 	})
 }
 
+func TestRedirectRulesSkipsInvalidEntries(t *testing.T) {
+	t.Parallel()
+
+	// A mix of valid rules with one invalid (empty target) entry. The invalid
+	// entry must be skipped without dropping the valid rules — regardless of
+	// Go's randomized map iteration order.
+	config := `
+a.example.com: https://target-a.example.com
+b.example.com: https://target-b.example.com
+c.example.com: https://target-c.example.com
+d.example.com: https://target-d.example.com
+bad.example.com: ""`
+	ctx := Context{
+		Middlewares: &parapet.Middlewares{},
+		Ingress: &networking.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"parapet.moonrhythm.io/redirect": config,
+				},
+			},
+		},
+		Routes: map[string]http.Handler{},
+	}
+	RedirectRules(ctx)
+
+	for _, h := range []string{"a.example.com/", "b.example.com/", "c.example.com/", "d.example.com/"} {
+		assert.Contains(t, ctx.Routes, h, "valid rule must be registered even when another entry is invalid")
+	}
+	assert.NotContains(t, ctx.Routes, "bad.example.com/")
+}
+
 func TestBodyLimit(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## The bug

`RedirectRules` (`plugin/plugin.go`) used `return` inside its range loop to skip an invalid redirect entry (empty host/target, or a path-like key):

```go
for srcHost, targetURL := range obj {
    if srcHost == "" || targetURL == "" || strings.HasPrefix(srcHost, "/") {
        return   // ← exits the whole function
    }
    ...
}
```

Because `return` exits the entire function, **a single malformed entry abandoned every redirect rule that hadn't been processed yet**. Go randomizes map iteration order, so *which* rules survived was non-deterministic from one reload to the next — a redirect could silently stop working after an unrelated config change.

## The fix

`return` → `continue`, so only the invalid entry is skipped.

## Test

Adds `TestRedirectRulesSkipsInvalidEntries`: registers four valid rules alongside one invalid (empty-target) entry and asserts all four valid rules are present and the invalid one is absent. It passes deterministically on the fix and reliably fails on the old `return` (verified: fails ~4/5 of runs on the buggy code, never fails on the fix across repeated runs).

## Test plan

- [x] `go test ./...` green
- [x] New regression test passes on fix (`-count=5`), fails on buggy version

🤖 Generated with [Claude Code](https://claude.com/claude-code)