### PR TITLE
refactor: harden route load balancer and quiet bad-addr logging

### DIFF
--- a/route/badaddr.go
+++ b/route/badaddr.go
@@ -18,8 +18,21 @@ func (t *badAddrTable) MarkBad(addr string) {
 	if host == "" {
 		host = addr
 	}
-	slog.Warn("badAddrTable: mark bad", "host", host)
+	// Log only on the transition into a bad state. A sustained outage re-marks
+	// the same host on every failed dial; logging each one would flood the log
+	// exactly when it's busiest. A host that recovered (its entry expired) and
+	// fails again logs once more, so distinct outage episodes are still visible.
+	if t.mark(host) {
+		slog.Warn("badAddrTable: mark bad", "host", host)
+	}
+}
+
+// mark records host as bad and reports whether it transitioned from a not-bad
+// state (absent or expired) — used to log once per outage episode.
+func (t *badAddrTable) mark(host string) (transitioned bool) {
+	transitioned = !t.IsBad(host)
 	t.addrs.Store(host, time.Now())
+	return
 }
 
 func (t *badAddrTable) IsBad(host string) bool {

--- a/route/badaddr_test.go
+++ b/route/badaddr_test.go
@@ -2,6 +2,7 @@ package route
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -21,4 +22,44 @@ func TestBadAddrTable(t *testing.T) {
 	assert.True(t, badAddr.IsBad("192.168.0.11"))
 
 	assert.False(t, badAddr.IsBad("192.168.0.1"))
+}
+
+func TestBadAddrExpiry(t *testing.T) {
+	t.Parallel()
+
+	badAddr := badAddrTable{}
+	// an entry older than badDuration is no longer bad (backdated to avoid waiting)
+	badAddr.addrs.Store("192.168.0.20", time.Now().Add(-2*badDuration))
+	assert.False(t, badAddr.IsBad("192.168.0.20"))
+
+	// a fresh entry is bad
+	badAddr.addrs.Store("192.168.0.21", time.Now())
+	assert.True(t, badAddr.IsBad("192.168.0.21"))
+}
+
+func TestBadAddrClearRemovesOnlyExpired(t *testing.T) {
+	t.Parallel()
+
+	badAddr := badAddrTable{}
+	badAddr.addrs.Store("expired", time.Now().Add(-2*badDuration))
+	badAddr.addrs.Store("fresh", time.Now())
+
+	badAddr.Clear()
+
+	_, expiredPresent := badAddr.addrs.Load("expired")
+	_, freshPresent := badAddr.addrs.Load("fresh")
+	assert.False(t, expiredPresent, "expired entry should be removed")
+	assert.True(t, freshPresent, "fresh entry should be kept")
+}
+
+func TestBadAddrMarkTransition(t *testing.T) {
+	t.Parallel()
+
+	badAddr := badAddrTable{}
+	assert.True(t, badAddr.mark("10.0.0.1"), "first mark is a transition")
+	assert.False(t, badAddr.mark("10.0.0.1"), "already-bad host is not a transition")
+
+	// once the entry expires, marking again is a fresh transition
+	badAddr.addrs.Store("10.0.0.1", time.Now().Add(-2*badDuration))
+	assert.True(t, badAddr.mark("10.0.0.1"), "re-mark after expiry is a transition")
 }

--- a/route/rrlb.go
+++ b/route/rrlb.go
@@ -19,7 +19,9 @@ func (lb *RRLB) Get(badAddr *badAddrTable) (ip string) {
 		return lb.IPs[0]
 	}
 
-	p := int(atomic.AddUint32(&lb.current, 1)) % l
+	// take the modulo in uint32 space: int(uint32) can be negative on 32-bit
+	// platforms once current exceeds MaxInt32, which would yield a negative index.
+	p := int(atomic.AddUint32(&lb.current, 1) % uint32(l))
 	for k := 0; k < l; k++ { // try gets not bad address
 		i := (p + k) % l
 		ip = lb.IPs[i]

--- a/route/table_test.go
+++ b/route/table_test.go
@@ -1,8 +1,6 @@
 package route
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,34 +62,4 @@ func TestTable(t *testing.T) {
 		res = tb.Lookup("about.service.svc.cluster.local:8000")
 		assert.Equal(t, "192.168.3.2:9003", res)
 	})
-}
-
-func BenchmarkSprintf(b *testing.B) {
-	host := "192.168.100.10"
-	port := "8080"
-	var r string
-	for i := 0; i < b.N; i++ {
-		r = fmt.Sprintf("%s:%s", host, port)
-	}
-	_ = r
-}
-
-func BenchmarkStringConcat(b *testing.B) {
-	host := "192.168.100.10"
-	port := "8080"
-	var r string
-	for i := 0; i < b.N; i++ {
-		r = host + ":" + port
-	}
-	_ = r
-}
-
-func BenchmarkStringsJoin(b *testing.B) {
-	host := "192.168.100.10"
-	port := "8080"
-	var r string
-	for i := 0; i < b.N; i++ {
-		r = strings.Join([]string{host, port}, ":")
-	}
-	_ = r
 }


### PR DESCRIPTION
Findings from a review of the `route` module, bundled into one PR.

## 1. `RRLB.Get` — modulo in uint32 space (latent correctness) · `rrlb.go`

```go
-	p := int(atomic.AddUint32(&lb.current, 1)) % l
+	p := int(atomic.AddUint32(&lb.current, 1) % uint32(l))
```

`int(uint32)` can be **negative on 32-bit platforms** once the counter passes `MaxInt32`, producing a negative slice index → panic in the lookup loop. No effect on the amd64 build target (64-bit `int` is always non-negative here), but now correct on any platform. Behavior on amd64 is byte-for-byte identical.

## 2. `badAddrTable.MarkBad` — log only on transition into bad (log-spam fix) · `badaddr.go`

Previously every failed dial logged a `Warn`. During a sustained backend outage at high RPS that floods the log exactly when it's busiest. Now it logs only when a host **transitions** into a bad state; a host that recovered (its entry expired) and fails again logs once more, so distinct outage episodes stay visible. Store/expiry semantics are unchanged. The transition decision is extracted into a small testable `mark()` helper.

## 3. Drop dead micro-benchmarks · `table_test.go`

`BenchmarkSprintf`/`StringConcat`/`StringsJoin` exercised no route code — they were a one-off experiment that justified `Lookup`'s string concat. Removed (also drops the only `fmt`/`strings` test imports).

## 4. Cover the bad-address expiry path · `badaddr_test.go`

Previously untested. Added:
- `IsBad` returns false after `badDuration`
- `Clear` removes only expired entries, keeps fresh ones
- the new `mark()` transition logic (first mark transitions, immediate re-mark doesn't, re-mark after expiry transitions again)

All use backdated timestamps, so no test waits on the wall clock.

## Test plan

- [x] `go test ./...` green
- [x] `go test -race ./route/` clean
- [x] `go vet` / `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)