### PR TITLE
perf: trim allocations in cert SNI lookup

### DIFF
--- a/cert/table.go
+++ b/cert/table.go
@@ -37,11 +37,11 @@ func (t *Table) Get(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) 
 		}
 	}
 
-	// wildcard name
-	if len(name) > 0 {
-		labels := strings.Split(name, ".")
-		labels[0] = "*"
-		wildcardName := strings.Join(labels, ".")
+	// wildcard name: replace the leftmost label with "*", e.g.
+	// www.example.com -> *.example.com. TLS wildcards match exactly one label,
+	// so only the first label is replaced.
+	if i := strings.IndexByte(name, '.'); i >= 0 {
+		wildcardName := "*" + name[i:]
 		if cert, ok := certs[wildcardName]; ok {
 			return findSupportCert(cert, clientHello), nil
 		}
@@ -70,6 +70,9 @@ func buildNameToCertificate(certs []*tls.Certificate) map[string][]*tls.Certific
 			if err != nil {
 				continue
 			}
+			// cache the parsed leaf so SupportsCertificate (called per TLS
+			// handshake in findSupportCert) doesn't re-parse the DER each time
+			cert.Leaf = x509Cert
 		}
 		// use only SAN, CN already deprecated
 		for _, san := range x509Cert.DNSNames {

--- a/cert/table_test.go
+++ b/cert/table_test.go
@@ -1,11 +1,18 @@
 package cert
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTable(t *testing.T) {
@@ -77,4 +84,84 @@ func TestTable(t *testing.T) {
 			assert.Equal(t, certs[1], cert)
 		}
 	})
+}
+
+func TestTableRealCertificate(t *testing.T) {
+	t.Parallel()
+
+	// a real cert with Leaf left nil, so Set must parse Certificate[0]
+	der := genCertDER(t, "secure.example.com", "*.wild.example.com")
+	cert := &tls.Certificate{Certificate: [][]byte{der}}
+
+	table := Table{}
+	table.Set([]*tls.Certificate{cert})
+
+	// Set caches the parsed leaf so SupportsCertificate doesn't re-parse per handshake
+	assert.NotNil(t, cert.Leaf)
+
+	hello := func(name string) *tls.ClientHelloInfo {
+		return &tls.ClientHelloInfo{ServerName: name, SupportedVersions: []uint16{tls.VersionTLS13}}
+	}
+
+	t.Run("exact SAN", func(t *testing.T) {
+		got, err := table.Get(hello("secure.example.com"))
+		assert.NoError(t, err)
+		assert.Same(t, cert, got)
+	})
+
+	t.Run("wildcard SAN", func(t *testing.T) {
+		got, err := table.Get(hello("foo.wild.example.com"))
+		assert.NoError(t, err)
+		assert.Same(t, cert, got)
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		got, err := table.Get(hello("other.example.com"))
+		assert.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("single-label name does not panic", func(t *testing.T) {
+		got, err := table.Get(hello("localhost"))
+		assert.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}
+
+func genCertDER(t testing.TB, dnsNames ...string) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: dnsNames[0]},
+		DNSNames:     dnsNames,
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	return der
+}
+
+func BenchmarkGetWildcard(b *testing.B) {
+	// mirror a production cert: Leaf is pre-populated (as tls.X509KeyPair does),
+	// so this measures the wildcard-name lookup, not x509 re-parsing.
+	der := genCertDER(b, "*.bench.example.com")
+	leaf, err := x509.ParseCertificate(der)
+	require.NoError(b, err)
+	table := Table{}
+	table.Set([]*tls.Certificate{{Certificate: [][]byte{der}, Leaf: leaf}})
+	hello := &tls.ClientHelloInfo{
+		ServerName:        "host.bench.example.com",
+		SupportedVersions: []uint16{tls.VersionTLS13},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = table.Get(hello)
+	}
 }


### PR DESCRIPTION
From a performance-focused review of the `cert` package. The table is otherwise **correct** — RFC-style single-label wildcard matching, race-safe (immutable map swapped under lock, read-only after), and empty/no-match SNI falls back to the TLS config's default cert. Two changes reduce work on the TLS-handshake path.

## 1. Wildcard name: `IndexByte` + concat instead of `Split`+`Join` · `table.go`

```go
-	if len(name) > 0 {
-		labels := strings.Split(name, ".")
-		labels[0] = "*"
-		wildcardName := strings.Join(labels, ".")
-		if cert, ok := certs[wildcardName]; ok { ... }
-	}
+	if i := strings.IndexByte(name, '.'); i >= 0 {
+		wildcardName := "*" + name[i:]
+		if cert, ok := certs[wildcardName]; ok { ... }
+	}
```

The wildcard branch is the **common path** for wildcard-cert / `LoadAllCerts` deployments (every subdomain misses the exact lookup). Behaviour is identical — including leading/trailing-dot edge cases — except a single-label name (no `.`) now skips the always-missing `"*"` lookup instead of constructing it.

`BenchmarkGetWildcard` (with `Leaf` pre-set, mirroring production `X509KeyPair` certs):

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before (Split+Join) | ~488 | 400 | 8 |
| after (IndexByte) | ~399 | 312 | 6 |

≈18% faster, 2 fewer allocs per wildcard lookup.

## 2. Cache the parsed leaf · `table.go`

When `buildNameToCertificate` has to parse `Certificate[0]` (because `Leaf` was nil), store it back onto `cert.Leaf`, so `SupportsCertificate` — called per handshake in `findSupportCert` — doesn't re-parse the DER every time.

**Honest scope:** this is *defensive only*. `tls.X509KeyPair` already populates `Leaf` on Go 1.23+ (verified on the Go 1.26 toolchain here), so the controller's production certs never hit the parse branch and see no change. The value is robustness — the table no longer depends on the caller having pre-populated `Leaf` (for a `Leaf`-nil cert, it eliminates a full x509 parse per handshake).

## Tests

- `TestTableRealCertificate` — a real certificate with `Leaf` left nil: asserts `Set` caches the leaf, and that exact-SAN, wildcard-SAN, no-match, and single-label lookups all behave correctly.
- `BenchmarkGetWildcard` (above).

## Test plan

- [x] `go test ./...` green, `go test -race ./cert/` clean
- [x] `go vet` / `gofmt` clean
- [x] before/after benchmark captured with a production-like (Leaf-set) cert

🤖 Generated with [Claude Code](https://claude.com/claude-code)