### PR TITLE
test: guard state isolation across pooled requests

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -29,11 +29,17 @@ func putState(s State) {
 	pool.Put(s)
 }
 
-// Get gets state from context
+// Get returns the State stored in ctx by Middleware.
+//
+// If ctx carries no State — i.e. Get is called outside the Middleware chain —
+// it returns an empty throwaway State so callers can read and write without a
+// nil check. That fallback map is not pooled and never reaches the access log,
+// so writes to it are silently dropped; in normal operation every request
+// passes through Middleware and this path is not taken.
 func Get(ctx context.Context) State {
 	s, _ := ctx.Value(ctxKey{}).(State)
 	if s == nil {
-		s = make(State) // this line is not used, since we inject middleware
+		s = make(State, sizeHint)
 	}
 	return s
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -68,3 +68,29 @@ func TestMiddleware(t *testing.T) {
 	h.ServeHTTP(w, r)
 	assert.True(t, called)
 }
+
+// Middleware recycles State maps through a sync.Pool; if a map isn't cleared
+// before reuse, one request's state (service name, auth context, ...) leaks
+// into the next request's logs. This drives two sequential requests through the
+// middleware on the same goroutine — so the pool returns the recycled map — and
+// asserts the second request sees a clean slate.
+func TestMiddlewareDoesNotLeakStateBetweenRequests(t *testing.T) {
+	var m parapet.Middlewares
+	m.Use(Middleware())
+
+	first := true
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s := Get(r.Context())
+		if first {
+			s["leak"] = "from-first-request"
+			first = false
+			return
+		}
+		_, ok := s["leak"]
+		assert.False(t, ok, "state must not carry over from a prior request via the pool")
+	}))
+
+	for i := 0; i < 2; i++ {
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	}
+}


### PR DESCRIPTION
From a review of the `state` package. It's **correct** — `Middleware` recycles `State` maps through a `sync.Pool` and `clear`s each on return, and all production `state.Get` call sites (`controller.go`, `plugin/plugin.go`, `metric/requests.go`) run *inside* `Middleware`, so the not-in-context fallback is never on the hot path. Two small hardening changes.

## 1. Regression test for cross-request isolation

`Middleware` hands out pooled `State` maps and relies on `clear(s)` in `putState` to wipe them before reuse. If that clear ever regressed, **one request's state — service name, ingress, auth context — would leak into the next request's access log** via the recycled map. That's a correctness/security property with no test.

`TestMiddlewareDoesNotLeakStateBetweenRequests` drives two sequential requests through the middleware on the same goroutine (so `sync.Pool` returns the recycled map) and asserts the second request sees a clean slate. **Verified it fails if `clear()` is removed** and passes reliably (×5) on the correct code; it never false-fails (if the pool happens to hand back a fresh map, the assertion still holds).

## 2. Clarify `Get`'s contract

The old `// this line is not used, since we inject middleware` comment was misleading — the fallback *is* reachable (tests, or any call outside `Middleware`). Reworded the doc to explain it's a nil-check convenience whose writes are neither pooled nor logged, and sized the fallback map with `sizeHint` to match the pool.

## Test plan

- [x] `go test ./...` green, `go test -race ./state/` clean
- [x] `go vet` / `gofmt` clean
- [x] new test confirmed to fail when `clear()` is removed from `putState`

🤖 Generated with [Claude Code](https://claude.com/claude-code)