### PR TITLE
ci(rust): fix compat image build (x86-64 baseline, not invalid x86-64-v1)

### DIFF
--- a/.github/workflows/rust-build.yaml
+++ b/.github/workflows/rust-build.yaml
@@ -46,13 +46,14 @@ jobs:
           tags: |
             us-docker.pkg.dev/moonrhythm-containers/gcr.io/parapet-ingress-controller:rust-${{ github.sha }}
             asia-southeast3-docker.pkg.dev/moonrhythm-core/public/parapet-ingress-controller:rust-${{ github.sha }}
-      # compatibility image: x86-64-v1
+      # compatibility image: x86-64 baseline (Go's GOAMD64=v1 equivalent;
+      # LLVM has no "x86-64-v1" — the baseline microarch level is just "x86-64")
       - uses: docker/build-push-action@v6
         with:
           context: rust
           provenance: false
           build-args: |
-            TARGET_CPU=x86-64-v1
+            TARGET_CPU=x86-64
           push: true
           cache-from: type=gha,scope=rust-v1
           cache-to: type=gha,mode=max,scope=rust-v1

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -42,7 +42,8 @@ WORKDIR /src
 COPY . .
 
 # Optional CPU baseline, mirroring the Go image's GOAMD64 v3/v1 split. CI passes
-# e.g. `--build-arg TARGET_CPU=x86-64-v3` (or `x86-64-v1` for the compat image).
+# e.g. `--build-arg TARGET_CPU=x86-64-v3` (or `x86-64` — the baseline level, Go's
+# GOAMD64=v1 equivalent — for the compat image; LLVM has no "x86-64-v1").
 # Left empty by default for a portable, generic-baseline build.
 ARG TARGET_CPU=
 ENV CARGO_TERM_COLOR=never


### PR DESCRIPTION
## Problem

The **Rust Build** workflow failed on the merge of #42 to `master` ([run 26407811709](https://github.com/moonrhythm/parapet-ingress-controller/actions/runs/26407811709)). The compatibility-image step aborted during `cargo build --release`:

```
rustc-LLVM ERROR: 64-bit code requested on a subtarget that doesn't support it!
error: could not compile `unicode-ident` (lib)
  ... -C target-cpu=x86-64-v1
```

## Root cause

`rust-build.yaml` passed `--build-arg TARGET_CPU=x86-64-v1`, which the Dockerfile turns into `RUSTFLAGS="-C target-cpu=x86-64-v1"`. **LLVM has no `x86-64-v1` CPU** — the x86-64 microarchitecture levels are `x86-64` (baseline), `x86-64-v2`, `x86-64-v3`, `x86-64-v4`. The name was carried over verbatim from Go's `GOAMD64=v1`; the LLVM/rustc equivalent of that baseline is just `x86-64`.

The default (v3) image was unaffected — `x86-64-v3` is valid.

## Fix

- `TARGET_CPU=x86-64-v1` → `TARGET_CPU=x86-64` in the compat-image build step.
- Updated the explanatory comments in `rust-build.yaml` and `rust/Dockerfile`.

The `-amd64v1` image **tag** is unchanged — it's only a label for the compat variant.

## Verifying

`rust-build.yaml` runs on push to `master` (and `workflow_dispatch`), not on PRs, so it won't run here. Validated locally that `x86-64` is a real target-cpu and `x86-64-v1` is not:

```
$ rustc --print target-cpus --target x86_64-unknown-linux-gnu | grep x86-64
    x86-64    - This is the default target CPU ...
    x86-64-v2
    x86-64-v3
    x86-64-v4
```

After merge, the master Rust Build should go green; `workflow_dispatch` can be used to confirm first if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)