### PR TITLE
refactor(rust): idiomatic cleanups — Option returns, typed upstream scheme, serde access log

### DIFF
--- a/rust/controller/src/k8s/fs.rs
+++ b/rust/controller/src/k8s/fs.rs
@@ -156,7 +156,7 @@ subsets:
                     e.kind,
                     RouteKind::Service {
                         target: "web.default.svc.cluster.local:80".into(),
-                        protocol: String::new(),
+                        scheme: crate::reconcile::UpstreamScheme::Http,
                     }
                 );
             }
@@ -167,8 +167,9 @@ subsets:
         assert_eq!(
             shared
                 .route_table
-                .lookup("web.default.svc.cluster.local:80"),
-            "10.0.0.1:8080"
+                .lookup("web.default.svc.cluster.local:80")
+                .as_deref(),
+            Some("10.0.0.1:8080")
         );
     }
 

--- a/rust/controller/src/proxy/mod.rs
+++ b/rust/controller/src/proxy/mod.rs
@@ -27,13 +27,11 @@ use pingora::protocols::ALPN;
 use pingora::proxy::{ProxyHttp, Session};
 use pingora::upstreams::peer::HttpPeer;
 use pingora::{Error, ErrorSource, ErrorType, Result};
-use serde_json::{Map, Value};
+use serde::Serialize;
 
 use self::limit::{Guard, HostConcurrency};
-use crate::config::{
-    single_joining_slash, BasicAuth, ForwardAuth, Hsts, RouteConfig, UpstreamProtocol,
-};
-use crate::reconcile::{RouteKind, RouteMeta};
+use crate::config::{single_joining_slash, BasicAuth, ForwardAuth, Hsts, RouteConfig};
+use crate::reconcile::{RouteKind, RouteMeta, UpstreamScheme};
 use crate::router::Match;
 use crate::shared::Shared;
 
@@ -121,7 +119,7 @@ impl Proxy {
 pub struct Ctx {
     // routing / upstream
     target: Option<String>,
-    protocol: String,
+    scheme: UpstreamScheme,
     config: Option<Arc<RouteConfig>>,
     tries: usize,
     last_addr: Option<String>,
@@ -263,9 +261,9 @@ impl ProxyHttp for Proxy {
                     RouteKind::Redirect { status, target } => {
                         Decision::Redirect(*status, target.clone())
                     }
-                    RouteKind::Service { target, protocol } => {
+                    RouteKind::Service { target, scheme } => {
                         ctx.target = Some(target.clone());
-                        ctx.protocol = protocol.clone();
+                        ctx.scheme = *scheme;
                         ctx.config = Some(entry.config.clone());
                         ctx.meta = entry.meta.clone();
                         ctx.pattern = entry.pattern.clone();
@@ -294,13 +292,12 @@ impl ProxyHttp for Proxy {
             .as_deref()
             .ok_or_else(|| Error::explain(ErrorType::HTTPStatus(404), "no route"))?;
 
-        let addr = self.shared.route_table.lookup(target);
-        if addr.is_empty() {
+        let Some(addr) = self.shared.route_table.lookup(target) else {
             return Err(Error::explain(
                 ErrorType::HTTPStatus(503),
                 "service unavailable",
             ));
-        }
+        };
         ctx.last_addr = Some(addr.clone());
 
         // backend in-flight gauge: move it to the new addr on a retry; `logging`
@@ -313,20 +310,20 @@ impl ProxyHttp for Proxy {
             ctx.backend_conn_addr = Some(addr.clone());
         }
 
-        let peer = match effective_protocol(ctx) {
-            EffProto::H2c => {
+        let peer = match ctx.scheme {
+            UpstreamScheme::H2c => {
                 let mut p = HttpPeer::new(addr.as_str(), false, String::new());
                 p.options.alpn = ALPN::H2;
                 p
             }
-            EffProto::Https => {
+            UpstreamScheme::Https => {
                 let mut p = HttpPeer::new(addr.as_str(), true, String::new());
                 p.options.alpn = ALPN::H2H1;
                 p.options.verify_cert = false;
                 p.options.verify_hostname = false;
                 p
             }
-            EffProto::Http => {
+            UpstreamScheme::Http => {
                 let mut p = HttpPeer::new(addr.as_str(), false, String::new());
                 p.options.alpn = ALPN::H1;
                 p
@@ -484,8 +481,8 @@ impl ProxyHttp for Proxy {
         if let Some(e) = e {
             if should_log_proxy_error(e) {
                 eprintln!(
-                    "[proxy-error] host={} target={:?} proto={} tries={} err={}",
-                    ctx.host, ctx.last_addr, ctx.protocol, ctx.tries, e
+                    "[proxy-error] host={} target={:?} proto={:?} tries={} err={}",
+                    ctx.host, ctx.last_addr, ctx.scheme, ctx.tries, e
                 );
             }
         }
@@ -516,33 +513,30 @@ impl ProxyHttp for Proxy {
 
         if self.log_enabled {
             let body_sent = session.body_bytes_sent() as i64;
-            let mut m = Map::new();
-            put_str(&mut m, "timestamp", &ctx.timestamp);
-            put_str(&mut m, "host", &ctx.host);
-            put_str(&mut m, "requestMethod", &ctx.method);
-            put_str(&mut m, "requestUrl", &ctx.request_url);
-            if ctx.request_body_size > 0 {
-                m.insert("requestBodySize".into(), ctx.request_body_size.into());
+            let log = AccessLog {
+                duration: duration.as_nanos() as i64,
+                duration_human: format!("{duration:?}"),
+                forwarded_for: &ctx.forwarded_for,
+                host: &ctx.host,
+                ingress: &ctx.meta.ingress_name,
+                namespace: &ctx.meta.ingress_namespace,
+                real_ip: &ctx.real_ip,
+                referer: &ctx.referer,
+                remote_ip: &ctx.remote_ip,
+                request_body_size: (ctx.request_body_size > 0).then_some(ctx.request_body_size),
+                request_method: &ctx.method,
+                request_url: &ctx.request_url,
+                response_body_size: (body_sent > 0).then_some(body_sent),
+                service_name: &ctx.meta.service_name,
+                service_target: ctx.last_addr.as_deref(),
+                service_type: &ctx.meta.service_type,
+                status,
+                timestamp: &ctx.timestamp,
+                user_agent: &ctx.user_agent,
+            };
+            if let Ok(line) = serde_json::to_string(&log) {
+                println!("{line}");
             }
-            put_str(&mut m, "referer", &ctx.referer);
-            put_str(&mut m, "userAgent", &ctx.user_agent);
-            put_str(&mut m, "remoteIp", &ctx.remote_ip);
-            put_str(&mut m, "realIp", &ctx.real_ip);
-            put_str(&mut m, "forwardedFor", &ctx.forwarded_for);
-            m.insert("duration".into(), (duration.as_nanos() as i64).into());
-            m.insert("durationHuman".into(), Value::from(format!("{duration:?}")));
-            m.insert("status".into(), status.into());
-            if body_sent > 0 {
-                m.insert("responseBodySize".into(), body_sent.into());
-            }
-            put_str(&mut m, "namespace", &ctx.meta.ingress_namespace);
-            put_str(&mut m, "ingress", &ctx.meta.ingress_name);
-            put_str(&mut m, "serviceName", &ctx.meta.service_name);
-            put_str(&mut m, "serviceType", &ctx.meta.service_type);
-            if let Some(t) = &ctx.last_addr {
-                put_str(&mut m, "serviceTarget", t);
-            }
-            println!("{}", Value::Object(m));
         }
     }
 }
@@ -701,24 +695,6 @@ impl Ctx {
     }
 }
 
-enum EffProto {
-    Http,
-    Https,
-    H2c,
-}
-
-fn effective_protocol(ctx: &Ctx) -> EffProto {
-    match ctx.protocol.as_str() {
-        "h2c" => EffProto::H2c,
-        "https" => EffProto::Https,
-        "" => match ctx.config.as_ref().map(|c| &c.upstream_protocol) {
-            Some(UpstreamProtocol::Https) => EffProto::Https,
-            _ => EffProto::Http,
-        },
-        _ => EffProto::Http,
-    }
-}
-
 /// Whether a proxy error is worth logging as `[proxy-error]`. Downstream-source
 /// errors are client-caused — most commonly a client disconnecting before the
 /// response body completes (a notification/SSE/long-poll client closing its
@@ -845,10 +821,48 @@ fn ct_eq(a: &[u8], b: &[u8]) -> bool {
     diff == 0
 }
 
-fn put_str(m: &mut Map<String, Value>, key: &str, value: &str) {
-    if !value.is_empty() {
-        m.insert(key.to_string(), Value::from(value));
-    }
+/// One JSON access-log line, serialized once per request. Fields are declared
+/// in the alphabetical key order the previous `serde_json::Map` (a `BTreeMap`)
+/// emitted, so the log output stays byte-identical. Empty strings and unset
+/// sizes/targets are omitted, matching the Go controller's access log.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AccessLog<'a> {
+    duration: i64,
+    duration_human: String,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    forwarded_for: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    host: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    ingress: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    namespace: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    real_ip: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    referer: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    remote_ip: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request_body_size: Option<i64>,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    request_method: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    request_url: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    response_body_size: Option<i64>,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    service_name: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    service_target: Option<&'a str>,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    service_type: &'a str,
+    status: u16,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    timestamp: &'a str,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    user_agent: &'a str,
 }
 
 enum ForwardAuthOutcome {
@@ -1047,28 +1061,6 @@ mod tests {
     }
 
     #[test]
-    fn effective_protocol_resolution() {
-        let mut ctx = Ctx {
-            protocol: "h2c".to_string(),
-            ..Default::default()
-        };
-        assert!(matches!(effective_protocol(&ctx), EffProto::H2c));
-        ctx.protocol = "https".to_string();
-        assert!(matches!(effective_protocol(&ctx), EffProto::Https));
-        ctx.protocol = "http".to_string();
-        assert!(matches!(effective_protocol(&ctx), EffProto::Http));
-        // empty annotation falls back to the route's upstream-protocol
-        ctx.protocol = String::new();
-        ctx.config = Some(Arc::new(RouteConfig {
-            upstream_protocol: UpstreamProtocol::Https,
-            ..Default::default()
-        }));
-        assert!(matches!(effective_protocol(&ctx), EffProto::Https));
-        ctx.config = Some(Arc::new(RouteConfig::default())); // default Http
-        assert!(matches!(effective_protocol(&ctx), EffProto::Http));
-    }
-
-    #[test]
     fn proxy_error_logging_skips_client_disconnects() {
         // Downstream (client-caused) errors — e.g. a client closing mid-response
         // — must NOT be logged as [proxy-error]; upstream/internal must be.
@@ -1087,5 +1079,64 @@ mod tests {
         assert!(ct_eq(b"", b""));
         assert!(!ct_eq(b"abc", b"abd"));
         assert!(!ct_eq(b"abc", b"ab")); // different lengths
+    }
+
+    #[test]
+    fn access_log_serializes_in_order_with_all_fields() {
+        let log = AccessLog {
+            duration: 1500,
+            duration_human: "1.5µs".to_string(),
+            forwarded_for: "1.2.3.4",
+            host: "example.com",
+            ingress: "ing",
+            namespace: "default",
+            real_ip: "1.2.3.4",
+            referer: "https://ref/",
+            remote_ip: "5.6.7.8",
+            request_body_size: Some(10),
+            request_method: "GET",
+            request_url: "https://example.com/",
+            response_body_size: Some(20),
+            service_name: "web",
+            service_target: Some("10.0.0.1:8080"),
+            service_type: "ClusterIP",
+            status: 200,
+            timestamp: "2026-05-25T00:00:00Z",
+            user_agent: "curl",
+        };
+        assert_eq!(
+            serde_json::to_string(&log).unwrap(),
+            r#"{"duration":1500,"durationHuman":"1.5µs","forwardedFor":"1.2.3.4","host":"example.com","ingress":"ing","namespace":"default","realIp":"1.2.3.4","referer":"https://ref/","remoteIp":"5.6.7.8","requestBodySize":10,"requestMethod":"GET","requestUrl":"https://example.com/","responseBodySize":20,"serviceName":"web","serviceTarget":"10.0.0.1:8080","serviceType":"ClusterIP","status":200,"timestamp":"2026-05-25T00:00:00Z","userAgent":"curl"}"#
+        );
+    }
+
+    #[test]
+    fn access_log_omits_empty_and_unset_fields() {
+        // empty strings, unset sizes and target are dropped; duration/status stay
+        let log = AccessLog {
+            duration: 42,
+            duration_human: "42ns".to_string(),
+            forwarded_for: "",
+            host: "",
+            ingress: "",
+            namespace: "",
+            real_ip: "",
+            referer: "",
+            remote_ip: "",
+            request_body_size: None,
+            request_method: "",
+            request_url: "",
+            response_body_size: None,
+            service_name: "",
+            service_target: None,
+            service_type: "",
+            status: 404,
+            timestamp: "",
+            user_agent: "",
+        };
+        assert_eq!(
+            serde_json::to_string(&log).unwrap(),
+            r#"{"duration":42,"durationHuman":"42ns","status":404}"#
+        );
     }
 }

--- a/rust/controller/src/reconcile.rs
+++ b/rust/controller/src/reconcile.rs
@@ -12,7 +12,7 @@ use k8s_openapi::api::networking::v1::{Ingress, IngressServiceBackend};
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 
 use crate::cert::LoadedCert;
-use crate::config::RouteConfig;
+use crate::config::{RouteConfig, UpstreamProtocol};
 use crate::route::Rrlb;
 use crate::router::Router;
 
@@ -39,10 +39,42 @@ pub struct RouteEntry {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum RouteKind {
-    /// Proxy to a service: `target` is the service DNS `host:port`.
-    Service { target: String, protocol: String },
+    /// Proxy to a service: `target` is the service DNS `host:port`, `scheme` is
+    /// the resolved upstream protocol (see [`UpstreamScheme`]).
+    Service {
+        target: String,
+        scheme: UpstreamScheme,
+    },
     /// Host-level redirect from a `redirect` annotation rule.
     Redirect { status: u16, target: String },
+}
+
+/// The wire protocol the proxy uses to reach an upstream, resolved once at
+/// reconcile time from the service port's `appProtocol` and the route's
+/// `upstream-protocol` annotation (see [`resolve_scheme`]). Replaces the Go
+/// controller's request-time string matching.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UpstreamScheme {
+    #[default]
+    Http,
+    Https,
+    H2c,
+}
+
+/// Resolve the effective upstream scheme. The service port's `appProtocol`
+/// (`app_protocol`) wins when it names a known scheme; an unset `appProtocol`
+/// falls back to the `upstream-protocol` annotation; anything else is plain
+/// HTTP. Mirrors the Go controller's resolution order exactly.
+pub fn resolve_scheme(app_protocol: &str, annotation: &UpstreamProtocol) -> UpstreamScheme {
+    match app_protocol {
+        "h2c" => UpstreamScheme::H2c,
+        "https" => UpstreamScheme::Https,
+        "" => match annotation {
+            UpstreamProtocol::Https => UpstreamScheme::Https,
+            UpstreamProtocol::Http => UpstreamScheme::Http,
+        },
+        _ => UpstreamScheme::Http,
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Default, Clone)]
@@ -53,18 +85,19 @@ pub struct RouteMeta {
     pub service_type: String,
 }
 
-fn ingress_class(ing: &Ingress) -> String {
-    if let Some(spec) = &ing.spec {
-        if let Some(c) = &spec.ingress_class_name {
-            return c.clone();
-        }
+fn ingress_class(ing: &Ingress) -> &str {
+    if let Some(c) = ing
+        .spec
+        .as_ref()
+        .and_then(|s| s.ingress_class_name.as_deref())
+    {
+        return c;
     }
-    if let Some(a) = &ing.metadata.annotations {
-        if let Some(c) = a.get("kubernetes.io/ingress.class") {
-            return c.clone();
-        }
-    }
-    String::new()
+    ing.metadata
+        .annotations
+        .as_ref()
+        .and_then(|a| a.get("kubernetes.io/ingress.class"))
+        .map_or("", String::as_str)
 }
 
 /// Resolve the backend's port to `(appProtocol, portNumber)`.
@@ -110,7 +143,7 @@ fn register(
     path: &str,
     path_type: &str,
     target: &str,
-    protocol: &str,
+    scheme: UpstreamScheme,
     config: &Arc<RouteConfig>,
     meta: &RouteMeta,
 ) {
@@ -121,7 +154,7 @@ fn register(
                 pattern,
                 kind: RouteKind::Service {
                     target: target.to_string(),
-                    protocol: protocol.to_string(),
+                    scheme,
                 },
                 config: config.clone(),
                 meta: meta.clone(),
@@ -214,6 +247,7 @@ pub fn build_router(
                 }
 
                 let target = build_host_port(ns, &backend.name, port_number);
+                let scheme = resolve_scheme(&protocol, &cfg.upstream_protocol);
                 let meta = RouteMeta {
                     ingress_namespace: ns.to_string(),
                     ingress_name: ing.metadata.name.clone().unwrap_or_default(),
@@ -230,7 +264,7 @@ pub fn build_router(
                     &path,
                     &p.path_type,
                     &target,
-                    &protocol,
+                    scheme,
                     &cfg,
                     &meta,
                 );
@@ -342,6 +376,20 @@ mod tests {
     use std::collections::BTreeMap;
 
     const CLASS: &str = "parapet";
+
+    #[test]
+    fn resolve_scheme_matches_go_order() {
+        use UpstreamProtocol::{Http, Https};
+        // appProtocol names a known scheme -> wins regardless of annotation
+        assert_eq!(resolve_scheme("h2c", &Http), UpstreamScheme::H2c);
+        assert_eq!(resolve_scheme("h2c", &Https), UpstreamScheme::H2c);
+        assert_eq!(resolve_scheme("https", &Http), UpstreamScheme::Https);
+        // unset appProtocol -> falls back to the upstream-protocol annotation
+        assert_eq!(resolve_scheme("", &Http), UpstreamScheme::Http);
+        assert_eq!(resolve_scheme("", &Https), UpstreamScheme::Https);
+        // any other appProtocol -> plain HTTP, ignoring the annotation
+        assert_eq!(resolve_scheme("grpc", &Https), UpstreamScheme::Http);
+    }
 
     fn meta(ns: &str, name: &str) -> ObjectMeta {
         ObjectMeta {
@@ -524,10 +572,10 @@ mod tests {
         table.set_host_routes(build_host_routes(&eps.iter().collect::<Vec<_>>()));
 
         assert_eq!(
-            table.lookup("web.default.svc.cluster.local:80"),
-            "10.0.0.1:8080"
+            table.lookup("web.default.svc.cluster.local:80").as_deref(),
+            Some("10.0.0.1:8080")
         );
-        assert_eq!(table.lookup("missing.default.svc.cluster.local:80"), "");
+        assert_eq!(table.lookup("missing.default.svc.cluster.local:80"), None);
     }
 
     #[test]
@@ -540,7 +588,7 @@ mod tests {
         let table = crate::route::Table::new();
         table.set_port_routes(build_port_routes(&svcs.iter().collect::<Vec<_>>()));
         table.set_host_routes(build_host_routes(&[&ep]));
-        assert_eq!(table.lookup("web.default.svc.cluster.local:80"), "");
+        assert_eq!(table.lookup("web.default.svc.cluster.local:80"), None);
     }
 
     // --- TestReloadSecret ---
@@ -628,7 +676,7 @@ mod tests {
                     e.kind,
                     RouteKind::Service {
                         target: "web.default.svc.cluster.local:80".into(),
-                        protocol: String::new(),
+                        scheme: UpstreamScheme::Http,
                     }
                 );
             }
@@ -641,8 +689,8 @@ mod tests {
         table.set_host_routes(build_host_routes(&eps.iter().collect::<Vec<_>>()));
         // 2 pods, pre-increment RR -> first pick is index 1
         assert_eq!(
-            table.lookup("web.default.svc.cluster.local:80"),
-            "10.0.0.2:8080"
+            table.lookup("web.default.svc.cluster.local:80").as_deref(),
+            Some("10.0.0.2:8080")
         );
     }
 }

--- a/rust/controller/src/route/rrlb.rs
+++ b/rust/controller/src/route/rrlb.rs
@@ -24,15 +24,15 @@ impl Rrlb {
         &self.ips
     }
 
-    /// Returns the next non-bad IP, or `""` if the set is empty or all bad.
+    /// Returns the next non-bad IP, or `None` if the set is empty or all bad.
     /// `bad` may be `None` (treated as "nothing is bad").
-    pub fn get(&self, bad: Option<&BadAddrs>) -> String {
+    pub fn get(&self, bad: Option<&BadAddrs>) -> Option<String> {
         let l = self.ips.len();
         if l == 0 {
-            return String::new();
+            return None;
         }
         if l == 1 {
-            return self.ips[0].clone();
+            return Some(self.ips[0].clone());
         }
 
         // pre-increment then modulo, matching Go's atomic.AddUint32 semantics
@@ -42,11 +42,11 @@ impl Rrlb {
             let i = (p + k) % l;
             let ip = &self.ips[i];
             if !BadAddrs::is_bad_opt(bad, ip) {
-                return ip.clone();
+                return Some(ip.clone());
             }
         }
-        // all bad: return empty so requests fail fast instead of queueing
-        String::new()
+        // all bad: report none so requests fail fast instead of queueing
+        None
     }
 }
 
@@ -57,17 +57,17 @@ mod tests {
     #[test]
     fn empty() {
         let lb = Rrlb::new(vec![]);
-        assert_eq!(lb.get(None), "");
-        assert_eq!(lb.get(None), "");
-        assert_eq!(lb.get(None), "");
+        assert_eq!(lb.get(None), None);
+        assert_eq!(lb.get(None), None);
+        assert_eq!(lb.get(None), None);
     }
 
     #[test]
     fn single() {
         let lb = Rrlb::new(vec!["192.168.1.1".into()]);
-        assert_eq!(lb.get(None), "192.168.1.1");
-        assert_eq!(lb.get(None), "192.168.1.1");
-        assert_eq!(lb.get(None), "192.168.1.1");
+        assert_eq!(lb.get(None).as_deref(), Some("192.168.1.1"));
+        assert_eq!(lb.get(None).as_deref(), Some("192.168.1.1"));
+        assert_eq!(lb.get(None).as_deref(), Some("192.168.1.1"));
     }
 
     #[test]
@@ -77,10 +77,10 @@ mod tests {
             "192.168.1.2".into(),
             "192.168.1.3".into(),
         ]);
-        assert_eq!(lb.get(None), "192.168.1.2");
-        assert_eq!(lb.get(None), "192.168.1.3");
-        assert_eq!(lb.get(None), "192.168.1.1");
-        assert_eq!(lb.get(None), "192.168.1.2");
+        assert_eq!(lb.get(None).as_deref(), Some("192.168.1.2"));
+        assert_eq!(lb.get(None).as_deref(), Some("192.168.1.3"));
+        assert_eq!(lb.get(None).as_deref(), Some("192.168.1.1"));
+        assert_eq!(lb.get(None).as_deref(), Some("192.168.1.2"));
     }
 
     #[test]
@@ -92,10 +92,10 @@ mod tests {
         ]);
         let bad = BadAddrs::new();
         bad.mark_bad("192.168.1.3");
-        assert_eq!(lb.get(Some(&bad)), "192.168.1.2");
-        assert_eq!(lb.get(Some(&bad)), "192.168.1.1"); // 3 is bad so 1 is returned
-        assert_eq!(lb.get(Some(&bad)), "192.168.1.1"); // next of 3 is 1
-        assert_eq!(lb.get(Some(&bad)), "192.168.1.2");
+        assert_eq!(lb.get(Some(&bad)).as_deref(), Some("192.168.1.2"));
+        assert_eq!(lb.get(Some(&bad)).as_deref(), Some("192.168.1.1")); // 3 is bad so 1 is returned
+        assert_eq!(lb.get(Some(&bad)).as_deref(), Some("192.168.1.1")); // next of 3 is 1
+        assert_eq!(lb.get(Some(&bad)).as_deref(), Some("192.168.1.2"));
     }
 
     #[test]
@@ -109,9 +109,9 @@ mod tests {
         bad.mark_bad("192.168.1.1");
         bad.mark_bad("192.168.1.2");
         bad.mark_bad("192.168.1.3");
-        assert_eq!(lb.get(Some(&bad)), "");
-        assert_eq!(lb.get(Some(&bad)), "");
-        assert_eq!(lb.get(Some(&bad)), "");
-        assert_eq!(lb.get(Some(&bad)), "");
+        assert_eq!(lb.get(Some(&bad)), None);
+        assert_eq!(lb.get(Some(&bad)), None);
+        assert_eq!(lb.get(Some(&bad)), None);
+        assert_eq!(lb.get(Some(&bad)), None);
     }
 }

--- a/rust/controller/src/route/table.rs
+++ b/rust/controller/src/route/table.rs
@@ -21,31 +21,20 @@ impl Table {
         Self::default()
     }
 
-    /// Resolve a `host:port` service address to a `podIP:targetPort`, or `""`.
-    pub fn lookup(&self, addr: &str) -> String {
+    /// Resolve a `host:port` service address to a `podIP:targetPort`, or `None`.
+    pub fn lookup(&self, addr: &str) -> Option<String> {
         // addr is a DNS name of the form service.ns.svc.cluster.local:port
-        let Some(i) = addr.rfind(':') else {
-            return String::new(); // invalid format
-        };
+        let i = addr.rfind(':')?; // invalid format -> None
         let host = &addr[..i];
 
         let target_port = {
             let ports = self.port_routes.read().unwrap();
-            match ports.get(addr) {
-                Some(p) => p.clone(),
-                None => return String::new(),
-            }
+            ports.get(addr)?.clone()
         };
 
         let hosts = self.host_routes.read().unwrap();
-        let Some(lb) = hosts.get(host) else {
-            return String::new();
-        };
-        let ip = lb.get(Some(&self.bad));
-        if ip.is_empty() {
-            return String::new();
-        }
-        format!("{ip}:{target_port}")
+        let ip = hosts.get(host)?.get(Some(&self.bad))?;
+        Some(format!("{ip}:{target_port}"))
     }
 
     pub fn set_host_routes(&self, routes: HashMap<String, Rrlb>) {
@@ -114,20 +103,22 @@ mod tests {
     fn not_found() {
         assert_eq!(
             fixture().lookup("frontend.default.svc.cluster.local:8080"),
-            ""
+            None
         );
     }
 
     #[test]
     fn invalid_format() {
-        assert_eq!(fixture().lookup("api.default.svc.cluster.local"), "");
+        assert_eq!(fixture().lookup("api.default.svc.cluster.local"), None);
     }
 
     #[test]
     fn found_host_and_port() {
         assert_eq!(
-            fixture().lookup("api.default.svc.cluster.local:8080"),
-            "192.168.0.1:9000"
+            fixture()
+                .lookup("api.default.svc.cluster.local:8080")
+                .as_deref(),
+            Some("192.168.0.1:9000")
         );
     }
 
@@ -136,7 +127,7 @@ mod tests {
         // never happens in practice (k8s requires a port name) but must not match
         assert_eq!(
             fixture().lookup("backoffice.default.svc.cluster.local:8080"),
-            ""
+            None
         );
     }
 
@@ -146,8 +137,8 @@ mod tests {
         tb.mark_bad("192.168.1.1");
         for _ in 0..3 {
             assert_eq!(
-                tb.lookup("api.service.svc.cluster.local:8000"),
-                "192.168.1.2:9001"
+                tb.lookup("api.service.svc.cluster.local:8000").as_deref(),
+                Some("192.168.1.2:9001")
             );
         }
     }
@@ -160,8 +151,8 @@ mod tests {
             Some(Rrlb::new(vec!["192.168.3.1".into()])),
         );
         assert_eq!(
-            tb.lookup("about.service.svc.cluster.local:8000"),
-            "192.168.3.1:9003"
+            tb.lookup("about.service.svc.cluster.local:8000").as_deref(),
+            Some("192.168.3.1:9003")
         );
 
         tb.set_host_route(
@@ -169,8 +160,8 @@ mod tests {
             Some(Rrlb::new(vec!["192.168.3.2".into()])),
         );
         assert_eq!(
-            tb.lookup("about.service.svc.cluster.local:8000"),
-            "192.168.3.2:9003"
+            tb.lookup("about.service.svc.cluster.local:8000").as_deref(),
+            Some("192.168.3.2:9003")
         );
     }
 }


### PR DESCRIPTION
Idiomatic-Rust cleanups on the freshly-merged Pingora port (#42), with **no change to routing/proxy behavior**. Each change is independent.

All **71 unit + 1 integration** tests pass; `cargo fmt --check` and clippy are clean on both `default` and `proxy,cluster` feature sets.

## Changes

### 1. `Option<String>` instead of `""`-as-not-found
`Rrlb::get` and `route::Table::lookup` returned an empty string to mean "nothing available," and callers did `if addr.is_empty()`. They now return `Option<String>`; `Table::lookup` collapses to a `?`-chain and the proxy uses `let Some(addr) = … else { 503 }`.

### 2. Typed upstream scheme (was stringly-typed)
`RouteKind::Service { protocol: String }` carried `"h2c"`/`"https"`/`""` and was re-matched as `&str` at request time in `effective_protocol`. Now an `UpstreamScheme { Http, Https, H2c }` enum is resolved **once at reconcile time** via `resolve_scheme(app_protocol, annotation)`. This removes the runtime `EffProto` type and `effective_protocol` entirely — `upstream_peer` matches the enum directly. Go's resolution order is preserved exactly and covered by `resolve_scheme_matches_go_order`.

### 3. Access log via `#[derive(Serialize)]`
The JSON access log was hand-assembled into a `serde_json::Map` with a `put_str` helper and per-field empty/zero checks. It's now an `AccessLog<'a>` struct with `skip_serializing_if`. **Output is byte-identical** — fields are declared in the alphabetical key order the old `BTreeMap` emitted (`serde_json/preserve_order` isn't enabled), and two new tests lock in both the full field ordering and the empty/unset omission rules.

### 4. Minor
`reconcile::ingress_class` borrows (`-> &str`) instead of cloning a `String` per ingress per reload.

## Behavior note
The operational `[proxy-error]` log line's `proto=` field now prints the *effective* scheme (`Http`/`Https`/`H2c`) instead of the raw `appProtocol` string (`""`/`h2c`/`https`). The **JSON access log is unchanged**.

## Not done (deliberately)
The `reflect!` macro in `k8s/cluster.rs` was left as-is — converting it to a generic fn would require reproducing kube's reflector trait bounds in a where-clause longer and less clear than the localized, well-commented macro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)