### PR TITLE
feat(rust): harden the proxy against light DDoS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ A Kubernetes ingress controller built on the [parapet](https://github.com/moonrh
 
 A from-scratch rewrite on the [Pingora](https://github.com/cloudflare/pingora) framework lives in `rust/`, intended to replace the Go controller once it clears a load-test perf-parity gate. **The Go controller remains the production binary until that cutover.** GCP Cloud Profiler and Cloud Trace are dropped from the port by design (no Rust SDK).
 
+The operational reference for the port — build/run, the full **environment-variable** table (including the Rust-only `UPSTREAM_CONNECT_TIMEOUT` / `UPSTREAM_TOTAL_CONNECT_TIMEOUT` connect-phase timeouts), metrics, and DDoS-resilience notes — is [`rust/README.md`](rust/README.md). The env table below is the Go controller's.
+
 ```
 rust/
   controller/         # the real crate (lib `controller`, bin `parapet-ingress-controller`)

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,214 @@
+# parapet-ingress-controller (Rust port)
+
+A from-scratch rewrite of the [parapet](https://github.com/moonrhythm/parapet)-based
+Kubernetes ingress controller on top of [Pingora](https://github.com/cloudflare/pingora).
+It watches Ingress / Service / Secret / Endpoints and hot-reloads its routing and
+TLS tables without restarting.
+
+> **Status: in progress.** The **Go controller remains the production binary**
+> until this port clears a load-test perf-parity gate (see `PHASE5.md`). GCP Cloud
+> Profiler and Cloud Trace are intentionally dropped (no Rust SDK).
+
+The request data path is at parity with Go: routing (all PathTypes), TLS/SNI with
+full-chain serving, h2c, all `parapet.moonrhythm.io/*` annotations, host/country
+concurrency, per-route rate limits, forward/basic auth, trust-proxy, graceful
+drain, JSON access log, and response compression. See the annotation reference in
+the repo-root [`CLAUDE.md`](../CLAUDE.md) — annotation behavior is shared with the
+Go controller.
+
+## Layout
+
+```
+rust/
+  controller/         # the crate (lib `controller`, bin `parapet-ingress-controller`)
+    src/proxy/        # Pingora ProxyHttp: routing, upstream (http/https/h2c),
+                      #   retry + bad-addr, middleware, metrics, SNI, server wiring
+    src/{router,route,cert,config,reconcile,shared,k8s}.rs
+                      #   pure routing/reconcile core (no pingora/kube deps)
+  spike/              # throwaway Phase-0 de-risk proof (see PHASE0 findings)
+  bench/              # k6 load harness (load.js + run.sh)
+  Dockerfile          # multi-stage; distroless/cc-debian13 runtime (~41 MB)
+  PHASE{0,3,5}.md     # de-risk findings / cluster validation / perf-parity gate
+```
+
+The core (`router`, `route`, `cert`, `config`, `reconcile`, `shared`, `k8s::fs`)
+has no async / kube / pingora dependencies, so it builds and unit-tests in ~1s.
+
+## Build & test
+
+```bash
+cd rust
+
+# fast core (default features) — pure routing/reconcile/cert logic
+cargo test -p parapet-ingress-controller
+
+# full surface (proxy + cluster watch)
+cargo test -p parapet-ingress-controller --features proxy,cluster
+
+# lint / format (CI runs these)
+cargo clippy -p parapet-ingress-controller --features proxy,cluster --all-targets
+cargo fmt -p parapet-ingress-controller --check
+```
+
+### Cargo features
+
+| Feature   | Pulls in            | Purpose |
+|-----------|---------------------|---------|
+| `cluster` | `kube-rs`           | live in-cluster watch (reflector stores) |
+| `proxy`   | `pingora` (openssl) | the HTTP/HTTPS proxy server |
+
+The binary requires **both** (`required-features = ["proxy", "cluster"]`). The
+default (no-feature) build is the pure core used for fast iteration and tests.
+
+> macOS: a gitignored `rust/.cargo/config.toml` points at Homebrew OpenSSL. CI and
+> Docker resolve TLS via `pkg-config` / `libssl-dev` instead.
+
+## Run
+
+Against the live cluster (uses the in-cluster service account or your kubeconfig):
+
+```bash
+HTTP_PORT=8080 HTTPS_PORT=8443 \
+  cargo run -p parapet-ingress-controller --features proxy,cluster
+```
+
+Against static manifests, no cluster (local dev / smoke tests):
+
+```bash
+KUBERNETES_BACKEND=fs KUBERNETES_FS=./path/to/manifests \
+HTTP_PORT=8080 HTTPS_PORT=8443 \
+  cargo run -p parapet-ingress-controller --features proxy,cluster
+```
+
+The Prometheus endpoint is served on `0.0.0.0:9187` (`/metrics`).
+
+## Configuration (environment variables)
+
+### Listeners & routing
+
+| Variable | Default | Description |
+|---|---|---|
+| `HTTP_PORT` | `80` | Plaintext (+ h2c) listener port |
+| `HTTPS_PORT` | `443` | TLS listener port. **Set empty** (`HTTPS_PORT=`) to disable HTTPS and run HTTP-only (e.g. an internal-ingress controller); *unset* still defaults to 443 |
+| `INGRESS_CLASS` | `parapet` | `ingressClassName` to handle |
+| `WATCH_NAMESPACE` | `""` (all) | Restrict the watch to one namespace |
+| `POD_NAMESPACE` | `""` | Current pod's namespace (informational; logged at startup) |
+
+### Kubernetes data source
+
+| Variable | Default | Description |
+|---|---|---|
+| `KUBERNETES_BACKEND` | `cluster` | `cluster` (kube-rs watch) or `fs` (static manifests, one-shot) |
+| `KUBERNETES_FS` | — | Directory of YAML/JSON manifests; **required** when `KUBERNETES_BACKEND=fs` |
+
+### TLS
+
+| Variable | Default | Description |
+|---|---|---|
+| `LOAD_ALL_CERTS` | `false` | Load every `kubernetes.io/tls` secret in the watched namespace, not just those referenced by an Ingress's `spec.tls.secretName` (lets a wildcard cert serve SNI without per-ingress wiring) |
+
+The TLS resolver serves the **full chain** from each secret's `tls.crt` (leaf +
+intermediates) and selects the leaf by SNI (exact, then a single-label wildcard
+climb). Unknown SNI gets a self-signed fallback — watch
+`parapet_tls_sni_no_cert_total` if clients report `unknown authority`.
+
+### Proxy / trust
+
+| Variable | Default | Description |
+|---|---|---|
+| `TRUST_PROXY` | `""` | `true`, `false`, or a comma-separated list of CIDRs and/or shorthands (`cloudflare`, `google`, `bunny`). Controls whether incoming `X-Forwarded-*` is trusted |
+
+### Connection timeouts & pooling
+
+| Variable | Default | Description |
+|---|---|---|
+| `UPSTREAM_CONNECT_TIMEOUT` | `2s` | TCP connect timeout to an upstream pod (connect phase only — never data transfer) |
+| `UPSTREAM_TOTAL_CONNECT_TIMEOUT` | `3s` | Connect + TLS-handshake timeout to an upstream pod |
+| `TR_MAX_IDLE_CONNS_PER_HOST` | Pingora default (128) | Maps to Pingora's **process-global** upstream keepalive pool size (not per-host like Go's `Transport.MaxIdleConnsPerHost`) |
+
+The connect-timeout defaults are sized for same-zone, intra-cluster pods
+(single-digit-ms connects); they bound worst-case `MAX_RETRY × timeout` pileup
+when a backend is overwhelmed. Raise them for cross-zone/region upstreams. Values
+use Go-duration syntax: `1500ms`, `2s`, `1m`, `1h`, or a bare integer (seconds).
+
+### Concurrency limits (opt-in)
+
+| Variable | Default | Description |
+|---|---|---|
+| `HOST_CONCURRENT_CAPACITY` | `0` (off) | Max in-flight requests per host; reject (503) above it |
+| `HOST_CONCURRENT_SIZE` | `0` | Extra queued requests allowed to wait (0 = no queue, reject immediately) |
+| `HOST_COUNTRY_CONCURRENT_CAPACITY` | `0` (off) | Per-host+country in-flight cap |
+| `HOST_COUNTRY_CONCURRENT_SIZE` | `0` | Per-host+country queue size |
+| `HOST_COUNTRY_HEADER` | `""` | Comma-separated header names carrying the country code (enables the per-country limit) |
+
+### Lifecycle, logging & debug
+
+| Variable | Default | Description |
+|---|---|---|
+| `WAIT_BEFORE_SHUTDOWN` | `30s` | On SIGTERM, mark not-ready and keep serving this long before draining, so the LB/endpoints deregister this pod first (Go-duration syntax) |
+| `DISABLE_LOG` | `false` | Suppress the JSON access log |
+| `DEBUG_ENDPOINTS` | `false` | Serve `GET /debug/routes` (loaded route keys + cert SNIs + readiness) for diagnosis |
+| `RUST_LOG` | `info` | Log filter for Pingora's internal `log` output (h2 handshake errors, etc.) |
+
+> Not configurable in this port: `TR_MAX_CONNS_PER_HOST` and
+> `HTTP_SERVER_MAX_HEADER_BYTES` (no Pingora 0.8 equivalent). The metrics endpoint
+> address (`:9187`) is fixed.
+
+## Metrics
+
+Registered in the process-default registry and served at `:9187/metrics`. Names
+and labels match the Go controller so existing dashboards keep working:
+
+- `parapet_requests{host,status,method,ingress_name,ingress_namespace,service_type,service_name}`
+- `parapet_service_duration_seconds{service_type,service_namespace,service_name}`
+- `parapet_reload{success}`
+- `parapet_host_active_requests{host,upgrade}`, `parapet_host_ratelimit_requests{host}`
+- `parapet_backend_network_read_bytes{addr}` / `_write_bytes{addr}` (body bytes)
+- `parapet_backend_connections{addr}` (in-flight-per-addr approximation; Pingora pools connections)
+- `parapet_network_request_bytes` / `parapet_network_response_bytes`
+- `parapet_tls_sni_no_cert_total{reason}` — TLS handshakes served the self-signed
+  fallback (`reason` = `no_sni` | `no_match` | `parse_error`); a rising rate means
+  clients see `unknown authority`
+- `process_*` (Linux only; a custom `/proc` collector — `process_cpu_seconds_total`
+  is float, ms-precision)
+
+To bound cardinality under a flood, a `Host` the router doesn't serve (and any
+non-standard HTTP method) is collapsed to the label value `other` rather than
+creating an unbounded number of series.
+
+**Known metric gaps vs Go:** `parapet_connections` (downstream connection gauge by
+state — no Pingora `ConnState` equivalent) and `go_*` runtime metrics.
+
+## Behavior notes / differences from Go
+
+- **Retry is connection-only.** The proxy retries (up to 5×, marking the bad pod
+  and round-robining) only on *connection* failures — `fail_to_connect` and a
+  reused keepalive connection breaking before a response. It **never** retries on
+  an upstream HTTP status (Go retried 502/503): once the upstream responds it has
+  processed the request, so retrying could duplicate side effects and amplify load.
+- **DDoS resilience.** Bounded upstream connect timeouts (above), host/method
+  metric-cardinality bounding, a downstream `keepalive_request_limit`, and a 60s
+  default downstream read timeout (Slowloris).
+- **Two services share one state.** A plaintext+h2c service and a TLS+SNI service
+  share one hot-swappable `Shared` (router/cert table behind `ArcSwap`); reloads
+  are coalesced with a 300ms debounce.
+
+## Docker
+
+```bash
+docker build -t parapet-ingress-controller:rust rust/
+# optional CPU baseline (mirrors the Go GOAMD64 split):
+docker build --build-arg TARGET_CPU=x86-64-v3 -t ...:rust rust/
+```
+
+- Builder: `rust` toolchain image; runtime: `gcr.io/distroless/cc-debian13` (~41 MB).
+- `TARGET_CPU` build-arg sets `-C target-cpu=...`; use `x86-64-v3` for modern CPUs
+  or `x86-64` (baseline, Go's `GOAMD64=v1` equivalent) for the compatibility image.
+
+## CI
+
+- `.github/workflows/rust-test.yaml` — fmt + clippy + test on push/PR.
+- `.github/workflows/rust-build.yaml` — builds and pushes `rust-`-prefixed images
+  on `master`.
+
+Both are path-filtered to `rust/**`, so Go-only changes never trigger them.

--- a/rust/controller/src/k8s/fs.rs
+++ b/rust/controller/src/k8s/fs.rs
@@ -171,6 +171,11 @@ subsets:
                 .as_deref(),
             Some("10.0.0.1:8080")
         );
+
+        // metric-cardinality bound: the router's host is known; anything else
+        // (a random-Host flood) is not, and collapses to the sentinel label.
+        assert!(shared.is_known_host("example.com"));
+        assert!(!shared.is_known_host("evil.attacker.example"));
     }
 
     #[test]

--- a/rust/controller/src/main.rs
+++ b/rust/controller/src/main.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use controller::k8s;
 use controller::proxy::limit::HostConcurrency;
 use controller::proxy::server::{run, ServeConfig};
-use controller::proxy::{Limits, TrustProxy};
+use controller::proxy::{Limits, TrustProxy, UpstreamTimeouts};
 use controller::shared::Shared;
 
 fn env_or(key: &str, default: &str) -> String {
@@ -111,13 +111,29 @@ fn main() {
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
         .filter(|&n| n > 0);
+    // Upstream connect-phase timeouts. Defaults are same-zone-tight (see
+    // UpstreamTimeouts::default); loosen for cross-zone/region with these env vars
+    // (Go-duration syntax, e.g. "1500ms", "3s").
+    let default_timeouts = UpstreamTimeouts::default();
+    let upstream_timeouts = UpstreamTimeouts {
+        connect: std::env::var("UPSTREAM_CONNECT_TIMEOUT")
+            .ok()
+            .and_then(|s| parse_duration(&s))
+            .unwrap_or(default_timeouts.connect),
+        total_connect: std::env::var("UPSTREAM_TOTAL_CONNECT_TIMEOUT")
+            .ok()
+            .and_then(|s| parse_duration(&s))
+            .unwrap_or(default_timeouts.total_connect),
+    };
     // POD_NAMESPACE is informational (parity with the Go controller's startup log).
     let pod_namespace = env_or("POD_NAMESPACE", "");
     eprintln!(
         "[config] ingress_class={ingress_class} watch_namespace={} pod_namespace={pod_namespace} \
          load_all_certs={load_all_certs} http_port={http_port} https_port={https_port} \
-         log={log_enabled} backend={backend}",
-        watch_namespace.as_deref().unwrap_or("(all)")
+         log={log_enabled} backend={backend} upstream_connect_timeout={:?} upstream_total_connect_timeout={:?}",
+        watch_namespace.as_deref().unwrap_or("(all)"),
+        upstream_timeouts.connect,
+        upstream_timeouts.total_connect,
     );
 
     let shared = Shared::new(ingress_class, load_all_certs);
@@ -167,6 +183,7 @@ fn main() {
             metrics_addr: "0.0.0.0:9187".to_string(),
             trust,
             limits,
+            upstream_timeouts,
             log_enabled,
             debug,
             wait_before_shutdown,

--- a/rust/controller/src/proxy/metrics.rs
+++ b/rust/controller/src/proxy/metrics.rs
@@ -175,6 +175,20 @@ pub struct RequestMetric<'a> {
     pub duration_secs: f64,
 }
 
+/// Collapse an unrecognized HTTP method to `"other"`. HTTP permits arbitrary
+/// method tokens, so without this an attacker could grow the `method` label set
+/// without bound (same OOM class as the host label).
+fn known_method(method: &str) -> &str {
+    const KNOWN: [&str; 9] = [
+        "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE",
+    ];
+    if KNOWN.contains(&method) {
+        method
+    } else {
+        "other"
+    }
+}
+
 pub fn record_request(m: &RequestMetric) {
     let metrics = metrics();
     let status = m.status.to_string();
@@ -183,7 +197,7 @@ pub fn record_request(m: &RequestMetric) {
         .with_label_values(&[
             m.host,
             &status,
-            m.method,
+            known_method(m.method),
             m.ingress_name,
             m.ingress_namespace,
             m.service_type,
@@ -202,4 +216,19 @@ pub fn inc_reload(success: bool) {
         .reload
         .with_label_values(&[if success { "1" } else { "0" }])
         .inc();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::known_method;
+
+    #[test]
+    fn known_method_collapses_unknown() {
+        assert_eq!(known_method("GET"), "GET");
+        assert_eq!(known_method("DELETE"), "DELETE");
+        // arbitrary/extension method tokens collapse to a single label
+        assert_eq!(known_method("BREW"), "other");
+        assert_eq!(known_method(""), "other");
+        assert_eq!(known_method("get"), "other"); // standard methods arrive upper-cased
+    }
 }

--- a/rust/controller/src/proxy/metrics.rs
+++ b/rust/controller/src/proxy/metrics.rs
@@ -27,6 +27,7 @@ struct Metrics {
     net_request: IntCounter,
     net_response: IntCounter,
     tls_no_cert: IntCounterVec,
+    rejected: IntCounterVec,
 }
 
 fn metrics() -> &'static Metrics {
@@ -114,11 +115,28 @@ fn metrics() -> &'static Metrics {
             &["reason"]
         )
         .expect("register parapet_tls_sni_no_cert_total"),
+        // Requests rejected at the edge before reaching a backend. Labeled only by
+        // `reason` (a bounded set) and NOT by host, so an abusive flood can't grow
+        // its cardinality — unlike `parapet_requests`, this stays safe to scrape
+        // under attack.
+        rejected: register_int_counter_vec!(
+            "parapet_rejected_requests",
+            "Requests rejected at the edge, by reason",
+            &["reason"]
+        )
+        .expect("register parapet_rejected_requests"),
     })
 }
 
 pub fn tls_no_cert_inc(reason: &str) {
     metrics().tls_no_cert.with_label_values(&[reason]).inc();
+}
+
+/// Record an edge rejection. `reason` is a small bounded set (`no_route`,
+/// `host_limit`, `rate_limit`, `body_limit`, `forbidden`, `unauthorized`) — never
+/// host-derived — so this metric's cardinality can't be driven by request input.
+pub fn rejected_inc(reason: &str) {
+    metrics().rejected.with_label_values(&[reason]).inc();
 }
 
 pub fn backend_read_add(addr: &str, n: u64) {

--- a/rust/controller/src/proxy/mod.rs
+++ b/rust/controller/src/proxy/mod.rs
@@ -37,6 +37,13 @@ use crate::shared::Shared;
 
 const MAX_RETRY: usize = 5;
 const ACME_PREFIX: &str = "/.well-known/acme-challenge";
+/// TCP connect timeout to an upstream pod (connect phase only).
+const UPSTREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+/// Connect + TLS-handshake timeout to an upstream pod (connect phase only).
+const UPSTREAM_TOTAL_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Metric label substituted for a Host the router doesn't serve, so a flood of
+/// random `Host` headers can't create unbounded Prometheus series (OOM vector).
+const UNKNOWN_HOST_LABEL: &str = "other";
 
 /// Which downstream remotes are trusted to set X-Forwarded-* headers.
 pub enum TrustProxy {
@@ -131,6 +138,11 @@ pub struct Ctx {
     timestamp: String,
     method: String,
     host: String,
+    /// `host` if the router serves it, else the [`UNKNOWN_HOST_LABEL`] sentinel.
+    /// Used for every host-labeled Prometheus series so a random-Host flood can't
+    /// grow cardinality without bound. The raw `host` is still used for the
+    /// access log and proxy-error log.
+    metric_host: String,
     request_url: String,
     request_body_size: i64,
     referer: String,
@@ -182,6 +194,14 @@ impl ProxyHttp for Proxy {
         ctx.timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
         ctx.remote_ip = remote_ip.map(|i| i.to_string()).unwrap_or_default();
         ctx.capture(session, &host, scheme);
+        // Sanitize the Host for metric labels: a Host the router doesn't serve
+        // (e.g. a random-Host flood, scanners) collapses to one sentinel series
+        // instead of creating an unbounded number of them.
+        ctx.metric_host = if self.shared.is_known_host(&host) {
+            host.clone()
+        } else {
+            UNKNOWN_HOST_LABEL.to_string()
+        };
 
         // health checks (run before logging, like the Go middleware order)
         if path == "/healthz" {
@@ -229,9 +249,13 @@ impl ProxyHttp for Proxy {
         let upgrade = header_str(session, "upgrade")
             .map(|s| s.trim().to_ascii_lowercase())
             .unwrap_or_default();
-        metrics::host_active_inc(&host, &upgrade);
-        ctx.host_active = Some((host.clone(), upgrade));
+        metrics::host_active_inc(&ctx.metric_host, &upgrade);
+        ctx.host_active = Some((ctx.metric_host.clone(), upgrade));
 
+        // Concurrency-limit keys use the sanitized host (see `metric_host`): for a
+        // known host this is the host itself (unchanged behavior); unknown hosts
+        // all share one bucket, which both caps the limiter's internal map and
+        // lets the bucket shed a random-Host flood instead of growing per-host.
         if let Some(country_limit) = &self.limits.country {
             let country = self
                 .limits
@@ -240,15 +264,17 @@ impl ProxyHttp for Proxy {
                 .find_map(|h| header_str(session, h))
                 .filter(|s| !s.is_empty())
                 .unwrap_or("XX");
-            match country_limit.acquire(&format!("{host}|{country}")).await {
+            let key = format!("{}|{country}", ctx.metric_host);
+            match country_limit.acquire(&key).await {
                 Some(g) => ctx.limit_guards.push(g),
-                None => return self.reject_overloaded(session, ctx, &host).await,
+                None => return self.reject_overloaded(session, ctx).await,
             }
         }
         if let Some(host_limit) = &self.limits.host {
-            match host_limit.acquire(&host).await {
+            let key = ctx.metric_host.clone();
+            match host_limit.acquire(&key).await {
                 Some(g) => ctx.limit_guards.push(g),
-                None => return self.reject_overloaded(session, ctx, &host).await,
+                None => return self.reject_overloaded(session, ctx).await,
             }
         }
 
@@ -310,7 +336,7 @@ impl ProxyHttp for Proxy {
             ctx.backend_conn_addr = Some(addr.clone());
         }
 
-        let peer = match ctx.scheme {
+        let mut peer = match ctx.scheme {
             UpstreamScheme::H2c => {
                 let mut p = HttpPeer::new(addr.as_str(), false, String::new());
                 p.options.alpn = ALPN::H2;
@@ -329,6 +355,15 @@ impl ProxyHttp for Proxy {
                 p
             }
         };
+        // Bound the connect phase. Pingora defaults these to None (unbounded), so
+        // when a backend is overwhelmed — exactly what a DDoS does — each request
+        // would otherwise block on connect for the OS default (minutes), piling up
+        // in-flight until the proxy itself exhausts fds/memory. A bounded connect
+        // fails fast into fail_to_connect -> mark_bad -> round-robin to a healthy
+        // pod. These cover only the connect/TLS handshake, NOT data transfer, so
+        // long-lived streams (SSE / websockets / long-poll) are unaffected.
+        peer.options.connection_timeout = Some(UPSTREAM_CONNECT_TIMEOUT);
+        peer.options.total_connection_timeout = Some(UPSTREAM_TOTAL_CONNECT_TIMEOUT);
         Ok(Box::new(peer))
     }
 
@@ -496,7 +531,7 @@ impl ProxyHttp for Proxy {
         let duration = ctx.start.map(|s| s.elapsed()).unwrap_or_default();
 
         metrics::record_request(&metrics::RequestMetric {
-            host: &ctx.host,
+            host: &ctx.metric_host,
             status,
             method: &ctx.method,
             ingress_name: &ctx.meta.ingress_name,
@@ -624,13 +659,8 @@ impl Proxy {
         self.is_tls || header_str(session, "x-forwarded-proto") == Some("https")
     }
 
-    async fn reject_overloaded(
-        &self,
-        session: &mut Session,
-        ctx: &mut Ctx,
-        host: &str,
-    ) -> Result<bool> {
-        metrics::host_ratelimit_inc(host);
+    async fn reject_overloaded(&self, session: &mut Session, ctx: &mut Ctx) -> Result<bool> {
+        metrics::host_ratelimit_inc(&ctx.metric_host);
         ctx.skip_log = true; // ratelimited responses aren't access-logged (Go order)
         respond_status(session, 503).await?;
         Ok(true)

--- a/rust/controller/src/proxy/mod.rs
+++ b/rust/controller/src/proxy/mod.rs
@@ -37,10 +37,14 @@ use crate::shared::Shared;
 
 const MAX_RETRY: usize = 5;
 const ACME_PREFIX: &str = "/.well-known/acme-challenge";
-/// TCP connect timeout to an upstream pod (connect phase only).
-const UPSTREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-/// Connect + TLS-handshake timeout to an upstream pod (connect phase only).
-const UPSTREAM_TOTAL_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Default TCP connect timeout to an upstream pod (connect phase only).
+/// Sized for same-zone, intra-cluster pods (single-digit-ms connects), bounding
+/// worst-case `MAX_RETRY × timeout` pileup under load. Override per deployment
+/// with `UPSTREAM_CONNECT_TIMEOUT`.
+const DEFAULT_UPSTREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+/// Default connect + TLS-handshake timeout (connect phase only). Override with
+/// `UPSTREAM_TOTAL_CONNECT_TIMEOUT`.
+const DEFAULT_UPSTREAM_TOTAL_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 /// Metric label substituted for a Host the router doesn't serve, so a flood of
 /// random `Host` headers can't create unbounded Prometheus series (OOM vector).
 const UNKNOWN_HOST_LABEL: &str = "other";
@@ -92,11 +96,29 @@ pub struct Limits {
     pub country_headers: Vec<String>,
 }
 
+/// Upstream connect-phase timeouts (see the `DEFAULT_UPSTREAM_*` consts). Applied
+/// to every `HttpPeer`; cover connect + TLS handshake only, never data transfer.
+#[derive(Clone, Copy)]
+pub struct UpstreamTimeouts {
+    pub connect: Duration,
+    pub total_connect: Duration,
+}
+
+impl Default for UpstreamTimeouts {
+    fn default() -> Self {
+        Self {
+            connect: DEFAULT_UPSTREAM_CONNECT_TIMEOUT,
+            total_connect: DEFAULT_UPSTREAM_TOTAL_CONNECT_TIMEOUT,
+        }
+    }
+}
+
 pub struct Proxy {
     shared: Arc<Shared>,
     is_tls: bool,
     trust: Arc<TrustProxy>,
     limits: Arc<Limits>,
+    timeouts: UpstreamTimeouts,
     log_enabled: bool,
     /// When set (DEBUG_ENDPOINTS=true), serves GET /debug/routes.
     debug: bool,
@@ -108,6 +130,7 @@ impl Proxy {
         is_tls: bool,
         trust: Arc<TrustProxy>,
         limits: Arc<Limits>,
+        timeouts: UpstreamTimeouts,
         log_enabled: bool,
         debug: bool,
     ) -> Self {
@@ -116,6 +139,7 @@ impl Proxy {
             is_tls,
             trust,
             limits,
+            timeouts,
             log_enabled,
             debug,
         }
@@ -362,8 +386,8 @@ impl ProxyHttp for Proxy {
         // fails fast into fail_to_connect -> mark_bad -> round-robin to a healthy
         // pod. These cover only the connect/TLS handshake, NOT data transfer, so
         // long-lived streams (SSE / websockets / long-poll) are unaffected.
-        peer.options.connection_timeout = Some(UPSTREAM_CONNECT_TIMEOUT);
-        peer.options.total_connection_timeout = Some(UPSTREAM_TOTAL_CONNECT_TIMEOUT);
+        peer.options.connection_timeout = Some(self.timeouts.connect);
+        peer.options.total_connection_timeout = Some(self.timeouts.total_connect);
         Ok(Box::new(peer))
     }
 

--- a/rust/controller/src/proxy/mod.rs
+++ b/rust/controller/src/proxy/mod.rs
@@ -325,6 +325,7 @@ impl ProxyHttp for Proxy {
 
         match decision {
             Decision::NotFound => {
+                metrics::rejected_inc("no_route");
                 respond_status(session, 404).await?;
                 Ok(true)
             }
@@ -619,6 +620,7 @@ impl Proxy {
             let allowed = client_ip(session)
                 .is_some_and(|ip| cfg.allow_remote.iter().any(|net| net.contains(&ip)));
             if !allowed {
+                metrics::rejected_inc("forbidden");
                 respond_status(session, 403).await?;
                 return Ok(true);
             }
@@ -645,12 +647,14 @@ impl Proxy {
             || over(1, cfg.ratelimit_m, Duration::from_secs(60))
             || over(2, cfg.ratelimit_h, Duration::from_secs(3600))
         {
+            metrics::rejected_inc("rate_limit");
             respond_status(session, 429).await?;
             return Ok(true);
         }
 
         if let Some(limit) = cfg.body_limit {
             if content_length(session).is_some_and(|cl| cl > limit as u64) {
+                metrics::rejected_inc("body_limit");
                 respond_status(session, 413).await?;
                 return Ok(true);
             }
@@ -658,6 +662,7 @@ impl Proxy {
 
         if let Some(ba) = &cfg.basic_auth {
             if !check_basic_auth(session, ba) {
+                metrics::rejected_inc("unauthorized");
                 let mut resp = ResponseHeader::build(401, None)?;
                 resp.insert_header("WWW-Authenticate", "Basic realm=\"Restricted\"")?;
                 session.write_response_header(Box::new(resp), true).await?;
@@ -670,6 +675,7 @@ impl Proxy {
             match forward_auth(session, fa, host).await {
                 ForwardAuthOutcome::Allow(headers) => ctx.auth_response_headers = headers,
                 ForwardAuthOutcome::Deny(code, body) => {
+                    metrics::rejected_inc("unauthorized");
                     respond_with_body(session, code, body).await?;
                     return Ok(true);
                 }
@@ -685,6 +691,7 @@ impl Proxy {
 
     async fn reject_overloaded(&self, session: &mut Session, ctx: &mut Ctx) -> Result<bool> {
         metrics::host_ratelimit_inc(&ctx.metric_host);
+        metrics::rejected_inc("host_limit");
         ctx.skip_log = true; // ratelimited responses aren't access-logged (Go order)
         respond_status(session, 503).await?;
         Ok(true)

--- a/rust/controller/src/proxy/server.rs
+++ b/rust/controller/src/proxy/server.rs
@@ -18,6 +18,10 @@ use super::cert::SniResolver;
 use super::{Limits, Proxy, TrustProxy};
 use crate::shared::Shared;
 
+/// Max requests served per downstream keepalive connection before it is closed,
+/// so per-connection memory is reclaimed under sustained load.
+const DOWNSTREAM_KEEPALIVE_REQUEST_LIMIT: u32 = 10_000;
+
 pub struct ServeConfig {
     pub http_addr: String,
     pub https_addr: Option<String>,
@@ -112,6 +116,10 @@ pub fn run(shared: Arc<Shared>, cfg: ServeConfig) {
     );
     let mut opts = HttpServerOptions::default();
     opts.h2c = true;
+    // Cap requests per downstream keepalive connection so per-connection memory is
+    // periodically reclaimed (nginx keepalive_requests analog; Pingora defaults to
+    // unlimited). Generous so it never throttles legitimate keepalive throughput.
+    opts.keepalive_request_limit = Some(DOWNSTREAM_KEEPALIVE_REQUEST_LIMIT);
     plain.app_logic_mut().unwrap().server_options = Some(opts);
     plain.threads = Some(threads);
     plain.add_tcp(&cfg.http_addr);
@@ -133,6 +141,9 @@ pub fn run(shared: Arc<Shared>, cfg: ServeConfig) {
         let resolver = SniResolver::new(shared.clone());
         let mut tls = TlsSettings::with_callbacks(Box::new(resolver)).expect("tls settings");
         tls.enable_h2();
+        let mut tls_opts = HttpServerOptions::default();
+        tls_opts.keepalive_request_limit = Some(DOWNSTREAM_KEEPALIVE_REQUEST_LIMIT);
+        tls_svc.app_logic_mut().unwrap().server_options = Some(tls_opts);
         tls_svc.threads = Some(threads);
         tls_svc.add_tls_with_settings(&https_addr, None, tls);
         server.add_service(tls_svc);

--- a/rust/controller/src/proxy/server.rs
+++ b/rust/controller/src/proxy/server.rs
@@ -15,7 +15,7 @@ use pingora::services::listening::Service;
 use tokio::signal::unix::{signal, SignalKind};
 
 use super::cert::SniResolver;
-use super::{Limits, Proxy, TrustProxy};
+use super::{Limits, Proxy, TrustProxy, UpstreamTimeouts};
 use crate::shared::Shared;
 
 /// Max requests served per downstream keepalive connection before it is closed,
@@ -28,6 +28,7 @@ pub struct ServeConfig {
     pub metrics_addr: String,
     pub trust: Arc<TrustProxy>,
     pub limits: Arc<Limits>,
+    pub upstream_timeouts: UpstreamTimeouts,
     pub log_enabled: bool,
     pub debug: bool,
     /// On SIGTERM, mark not-ready then keep serving this long before draining,
@@ -110,6 +111,7 @@ pub fn run(shared: Arc<Shared>, cfg: ServeConfig) {
             false,
             cfg.trust.clone(),
             cfg.limits.clone(),
+            cfg.upstream_timeouts,
             cfg.log_enabled,
             cfg.debug,
         ),
@@ -134,6 +136,7 @@ pub fn run(shared: Arc<Shared>, cfg: ServeConfig) {
                 true,
                 cfg.trust.clone(),
                 cfg.limits.clone(),
+                cfg.upstream_timeouts,
                 cfg.log_enabled,
                 cfg.debug,
             ),

--- a/rust/controller/src/shared.rs
+++ b/rust/controller/src/shared.rs
@@ -4,7 +4,7 @@
 //! point — it runs the reconcile functions over a [`Snapshot`] and swaps the
 //! results in, mirroring the Go controller's `mux` swap under `RWMutex`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -23,6 +23,9 @@ pub struct Shared {
     pub router: ArcSwap<Router<RouteEntry>>,
     pub route_table: Arc<RouteTable>,
     pub certs: ArcSwap<CertTable<LoadedCert>>,
+    /// Distinct hosts the router serves, for bounding host-labeled metric
+    /// cardinality (an unknown Host is collapsed to a sentinel label).
+    known_hosts: ArcSwap<HashSet<String>>,
     ready: AtomicBool,
     ingress_class: String,
     load_all_certs: bool,
@@ -34,6 +37,7 @@ impl Shared {
             router: ArcSwap::from_pointee(Router::new(HashMap::new())),
             route_table: Arc::new(RouteTable::new()),
             certs: ArcSwap::from_pointee(CertTable::empty()),
+            known_hosts: ArcSwap::from_pointee(HashSet::new()),
             ready: AtomicBool::new(false),
             ingress_class: ingress_class.into(),
             load_all_certs,
@@ -48,6 +52,12 @@ impl Shared {
     /// Flip to not-ready on shutdown so k8s/load balancers deregister this pod.
     pub fn set_not_ready(&self) {
         self.ready.store(false, Ordering::Relaxed);
+    }
+
+    /// Whether the router serves any route for `host` (already lowercased by the
+    /// caller). Used to bound host-labeled metric cardinality.
+    pub fn is_known_host(&self, host: &str) -> bool {
+        self.known_hosts.load().contains(host)
     }
 
     /// Rebuild every table from `snap` and atomically swap them in.
@@ -66,6 +76,18 @@ impl Shared {
 
         let router = build_router(&ingresses, &svc_map, &self.ingress_class);
         let n_routes = router.len();
+        // Distinct hosts the router serves (the substring before the first '/' of
+        // each `host+path` pattern; host-less patterns contribute nothing). Drives
+        // metric-label sanitization so unknown Hosts can't blow up cardinality.
+        let known_hosts: HashSet<String> = router
+            .patterns()
+            .iter()
+            .filter_map(|p| {
+                let host = p.split('/').next().unwrap_or("");
+                (!host.is_empty()).then(|| host.to_ascii_lowercase())
+            })
+            .collect();
+        self.known_hosts.store(Arc::new(known_hosts));
         self.router.store(Arc::new(router));
         self.route_table
             .set_port_routes(build_port_routes(&services));


### PR DESCRIPTION
Three independent, **streaming-safe** defenses so the proxy degrades gracefully under a connection/request/Host flood instead of falling over. All keep tests green (72 unit + 1 integration), clippy + fmt clean.

## 1. Upstream connect timeouts (env-configurable)
Pingora leaves `connection_timeout` / `total_connection_timeout` **unset (unbounded)**. When a backend is overwhelmed — exactly what a DDoS causes — each proxied request blocks on connect for the OS default (minutes), and with `MAX_RETRY=5` the worst-case connect pileup is `5 × timeout` per request, piling up in-flight until the *proxy* exhausts fds/memory.

Defaults are **same-zone-tight: connect 2s, total 3s** (intra-cluster connects are single-digit-ms; this tolerates ~one SYN retransmit / transient accept-queue pressure while failing over fast into the existing `fail_to_connect → mark_bad → round-robin`). Override per deployment with **`UPSTREAM_CONNECT_TIMEOUT`** / **`UPSTREAM_TOTAL_CONNECT_TIMEOUT`** (Go-duration syntax, e.g. `1500ms`, `3s`) for cross-zone/region. **Connect phase only** — does not touch data transfer, so SSE / websockets / long-poll streams are unaffected.

## 2. Bound host/method metric cardinality (OOM vector)
A flood of random `Host` values (or arbitrary HTTP method tokens) previously created **unbounded** `parapet_requests` / `parapet_host_active_requests` / `parapet_host_ratelimit_requests` series → Prometheus + proxy OOM. A `Host` the router doesn't serve now collapses to `"other"` (`Shared::is_known_host`, rebuilt each reload); unknown methods collapse likewise. The concurrency-limit key uses the same sanitized host, so the limiter's internal map stays bounded and the `"other"` bucket sheds the flood. Access log / `[proxy-error]` log keep the raw host.

## 3. `keepalive_request_limit`
Cap requests per downstream keepalive connection (10k, both HTTP and TLS services) so per-connection memory is reclaimed under sustained load. Nginx `keepalive_requests` analog; Pingora defaults to unlimited.

## Already-good posture (context)
Downstream H1 has a 60s default read timeout (Slowloris largely bounded); per-host/country concurrency + per-route rate limits (opt-in); bad-addr + retry failover; forward-auth has a 10s timeout. Cert pre-parse (handshake-flood CPU) is the stacked #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)