### PR TITLE
perf(rust): cache parsed TLS cert/key (stop per-handshake PEM parsing)

### DIFF
--- a/rust/controller/src/cert.rs
+++ b/rust/controller/src/cert.rs
@@ -23,6 +23,41 @@ pub struct LoadedCert {
     dns_names: Vec<String>,
     pub cert_pem: Vec<u8>,
     pub key_pem: Vec<u8>,
+    /// Full chain + key parsed once from the PEM and cached, so the TLS handshake
+    /// path doesn't re-parse per connection (a CPU cost under handshake floods).
+    /// Proxy-only — the parsed types are OpenSSL, absent from the pure core.
+    #[cfg(feature = "proxy")]
+    parsed: std::sync::OnceLock<Option<ParsedCert>>,
+}
+
+/// A [`LoadedCert`]'s chain + private key, parsed and ready to install on a
+/// handshake. `chain` is leaf-first (`chain[0]`) followed by any intermediates —
+/// all must be sent so clients can build the path to a trusted root. See
+/// [`LoadedCert::parsed`].
+#[cfg(feature = "proxy")]
+pub struct ParsedCert {
+    pub chain: Vec<pingora::tls::x509::X509>,
+    pub key: pingora::tls::pkey::PKey<pingora::tls::pkey::Private>,
+}
+
+#[cfg(feature = "proxy")]
+impl LoadedCert {
+    /// Lazily parse and cache the full chain + key. Returns `None` if the PEM has
+    /// no certificate or the key fails to parse (e.g. a missing/invalid
+    /// `tls.key`); the negative result is cached too, so a broken secret isn't
+    /// re-parsed on every handshake.
+    pub fn parsed(&self) -> Option<&ParsedCert> {
+        self.parsed
+            .get_or_init(|| {
+                let chain = pingora::tls::x509::X509::stack_from_pem(&self.cert_pem).ok()?;
+                if chain.is_empty() {
+                    return None;
+                }
+                let key = pingora::tls::pkey::PKey::private_key_from_pem(&self.key_pem).ok()?;
+                Some(ParsedCert { chain, key })
+            })
+            .as_ref()
+    }
 }
 
 impl HasDnsNames for LoadedCert {
@@ -41,6 +76,8 @@ impl LoadedCert {
             dns_names,
             cert_pem,
             key_pem,
+            #[cfg(feature = "proxy")]
+            parsed: std::sync::OnceLock::new(),
         })
     }
 }
@@ -193,5 +230,29 @@ mod tests {
             "empty SNI (no SNI / IP connect) misses"
         );
         assert!(t.get("10.0.0.5").is_none(), "IP-literal SNI misses");
+    }
+
+    #[cfg(feature = "proxy")]
+    #[test]
+    fn parsed_caches_full_chain_and_rejects_bad_key() {
+        // tls.crt is a fullchain (leaf + intermediate); both must be cached so the
+        // resolver can send the whole chain. Use a second self-signed cert as a
+        // stand-in intermediate (parsing doesn't verify the chain links).
+        let leaf = rcgen::generate_simple_self_signed(vec!["x.example.com".into()]).unwrap();
+        let intermediate = rcgen::generate_simple_self_signed(vec!["ca.example".into()]).unwrap();
+        let mut fullchain = leaf.cert.pem().into_bytes();
+        fullchain.extend_from_slice(intermediate.cert.pem().as_bytes());
+
+        let lc =
+            LoadedCert::from_pem(fullchain, leaf.key_pair.serialize_pem().into_bytes()).unwrap();
+        let p1 = lc.parsed().expect("valid chain/key parses");
+        assert_eq!(p1.chain.len(), 2, "leaf + intermediate both cached");
+        let p2 = lc.parsed().expect("cached on second call");
+        assert!(std::ptr::eq(p1, p2), "same cached ParsedCert is reused");
+
+        // cert present but key missing -> parsed() is None (and caches the miss)
+        let only = rcgen::generate_simple_self_signed(vec!["y.example.com".into()]).unwrap();
+        let no_key = LoadedCert::from_pem(only.cert.pem().into_bytes(), Vec::new()).unwrap();
+        assert!(no_key.parsed().is_none(), "missing tls.key -> None");
     }
 }

--- a/rust/controller/src/proxy/cert.rs
+++ b/rust/controller/src/proxy/cert.rs
@@ -2,7 +2,9 @@
 //! hot-swappable cert table in `Shared` (PEM, indexed by SAN) and installs the
 //! matching leaf on the in-flight handshake, falling back to a generated
 //! self-signed cert for unknown SNI. Mirrors the Phase-0 spike, wired to live
-//! state. (Parsing PEM per handshake is a known Phase-5 optimization target.)
+//! state. The matched chain + key are parsed once and cached on the `LoadedCert`
+//! (see `LoadedCert::parsed`), so a TLS handshake flood doesn't re-parse PEM per
+//! connection.
 
 use std::sync::Arc;
 
@@ -49,25 +51,22 @@ impl TlsAccept for SniResolver {
         let reason = if sni.is_empty() {
             "no_sni"
         } else if let Some(loaded) = self.shared.certs.load().get(&sni) {
-            // tls.crt is a full chain (leaf first, then intermediates). Install the
-            // leaf AND every intermediate: `X509::from_pem` reads only the first
-            // block, so sending leaf-only leaves clients that don't fetch missing
-            // intermediates (notably Go's crypto/tls — no AIA chasing) unable to
-            // build the chain to a trusted root, i.e. "x509: certificate signed by
-            // unknown authority". Browsers cache/fetch intermediates and so mask it.
-            match (
-                X509::stack_from_pem(&loaded.cert_pem),
-                PKey::private_key_from_pem(&loaded.key_pem),
-            ) {
-                (Ok(chain), Ok(key)) if !chain.is_empty() => {
-                    let _ = ext::ssl_use_certificate(ssl, &chain[0]);
-                    for intermediate in &chain[1..] {
+            // Parsed once and cached (LoadedCert::parsed). Install the leaf AND
+            // every intermediate: sending leaf-only leaves clients that don't fetch
+            // missing intermediates (notably Go's crypto/tls — no AIA chasing)
+            // unable to build the chain to a trusted root, i.e. "x509: certificate
+            // signed by unknown authority". Browsers cache/fetch intermediates and
+            // so mask it.
+            match loaded.parsed() {
+                Some(p) => {
+                    let _ = ext::ssl_use_certificate(ssl, &p.chain[0]);
+                    for intermediate in &p.chain[1..] {
                         let _ = ext::ssl_add_chain_cert(ssl, intermediate);
                     }
-                    let _ = ext::ssl_use_private_key(ssl, &key);
+                    let _ = ext::ssl_use_private_key(ssl, &p.key);
                     return;
                 }
-                _ => "parse_error",
+                None => "parse_error",
             }
         } else {
             "no_match"


### PR DESCRIPTION
**Stacked on #45** — the perf item of the DDoS-hardening set. Merge #45 first; GitHub retargets this to `master` after.

## Problem
After the #45 chain fix, `SniResolver` parses the **full chain** (`X509::stack_from_pem`) + key on **every** TLS handshake. Under a handshake flood that's per-connection CPU.

## Fix
Parse once and cache the leaf + intermediates + key on the `LoadedCert` via a lazily-initialized `OnceLock<Option<ParsedCert>>` (proxy-feature-gated — OpenSSL types, kept out of the pure `~1s` core build). Repeat handshakes for a known SNI reuse the parsed chain; a chain/key that fails to parse caches the negative result too. Resolves the Phase-5 per-handshake parsing TODO.

## Tested
`parsed_caches_full_chain_and_rejects_bad_key`: a 2-cert fullchain caches `chain.len() == 2`, the same `&ParsedCert` is reused across calls, and a missing key yields `None`. Both feature sets green (core 52, proxy 73 + 1), clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)