### PR TITLE
feat: bound metric cardinality (known_host) + host-less rejected_requests

### DIFF
--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -110,15 +110,15 @@ func main() {
 	m.Use(ctrl.Healthz())
 	m.Use(host.StripPort())
 	m.Use(host.ToLower())
-	m.Use(metric.HostActiveTracker())
-	m.Use(hostCountryRateLimit())
-	m.Use(hostRateLimit())
+	m.Use(metric.HostActiveTracker(ctrl.IsKnownHost))
+	m.Use(hostCountryRateLimit(ctrl.IsKnownHost))
+	m.Use(hostRateLimit(ctrl.IsKnownHost))
 
 	if !disableLog {
 		m.Use(logger.Stdout())
 	}
 	m.Use(state.Middleware())
-	m.Use(metric.Requests())
+	m.Use(metric.Requests(ctrl.IsKnownHost))
 	m.Use(compress.Gzip())
 	m.Use(compress.BrWithQuality(4))
 	m.Use(ctrl)
@@ -233,7 +233,7 @@ func configTransport(tr *http.Transport) {
 }
 
 // hostRateLimit protects from unresponsive upstreams by limit concurrent requests to the same host.
-func hostRateLimit() parapet.Middleware {
+func hostRateLimit(isKnownHost func(host string) bool) parapet.Middleware {
 	concurrentCapacity := config.Int("HOST_CONCURRENT_CAPACITY") // concurrent requests
 	concurrentSize := config.Int("HOST_CONCURRENT_SIZE")         // queue size
 
@@ -247,7 +247,8 @@ func hostRateLimit() parapet.Middleware {
 
 	exceededHandler := func(w http.ResponseWriter, r *http.Request, _ time.Duration) {
 		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
-		metric.HostRatelimitRequest(keyFromRequest(r))
+		metric.HostRatelimitRequest(metric.HostLabel(r.Host, isKnownHost))
+		metric.RejectedRequest("host_limit")
 	}
 
 	if concurrentSize > 0 {
@@ -277,7 +278,7 @@ func hostRateLimit() parapet.Middleware {
 }
 
 // hostCountryRateLimit protects from unresponsive upstreams by limit concurrent requests to the same host and country.
-func hostCountryRateLimit() parapet.Middleware {
+func hostCountryRateLimit(isKnownHost func(host string) bool) parapet.Middleware {
 	concurrentCapacity := config.Int("HOST_COUNTRY_CONCURRENT_CAPACITY") // concurrent requests
 	concurrentSize := config.Int("HOST_COUNTRY_CONCURRENT_SIZE")         // queue size
 	countryHeaderRaw := strings.TrimSpace(config.String("HOST_COUNTRY_HEADER"))
@@ -315,7 +316,8 @@ func hostCountryRateLimit() parapet.Middleware {
 
 	exceededHandler := func(w http.ResponseWriter, r *http.Request, _ time.Duration) {
 		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
-		metric.HostRatelimitRequest(keyFromRequest(r))
+		metric.HostRatelimitRequest(metric.HostLabel(r.Host, isKnownHost))
+		metric.RejectedRequest("host_limit")
 	}
 
 	if concurrentSize > 0 {

--- a/controller.go
+++ b/controller.go
@@ -41,6 +41,12 @@ type Controller struct {
 	// mu is the mutex for mux
 	mu  sync.RWMutex
 	mux *http.ServeMux
+	// knownHosts is the set of hosts the current mux serves (the host part of
+	// each registered route). Guarded by mu and swapped atomically with mux on
+	// reload. Used to bound host-labeled metric cardinality: a Host the router
+	// doesn't serve collapses to a sentinel label instead of creating an
+	// unbounded number of series under a random-Host flood.
+	knownHosts map[string]struct{}
 
 	// namespace to watch, or empty to watch all
 	watchNamespace string
@@ -356,10 +362,34 @@ func (ctrl *Controller) reloadIngressDebounced() {
 	})
 
 	mux := buildRoutes(routes)
+	knownHosts := buildKnownHosts(routes)
 	ctrl.mu.Lock()
 	ctrl.mux = mux
+	ctrl.knownHosts = knownHosts
 	ctrl.mu.Unlock()
 	ctrl.reloadSecret()
+}
+
+// buildKnownHosts extracts the distinct host part (everything before the first
+// '/') of each registered route key. Host-less routes (keys starting with '/')
+// contribute nothing.
+func buildKnownHosts(routes map[string]http.Handler) map[string]struct{} {
+	hosts := make(map[string]struct{}, len(routes))
+	for r := range routes {
+		if i := strings.IndexByte(r, '/'); i > 0 {
+			hosts[r[:i]] = struct{}{}
+		}
+	}
+	return hosts
+}
+
+// IsKnownHost reports whether the current routes serve host (already lowercased
+// and port-stripped by the upstream middleware, matching the registered keys).
+func (ctrl *Controller) IsKnownHost(host string) bool {
+	ctrl.mu.RLock()
+	_, ok := ctrl.knownHosts[host]
+	ctrl.mu.RUnlock()
+	return ok
 }
 
 func (ctrl *Controller) reloadService() {

--- a/controller_test.go
+++ b/controller_test.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/moonrhythm/parapet"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
+	"github.com/moonrhythm/parapet-ingress-controller/metric"
 	"github.com/moonrhythm/parapet-ingress-controller/proxy"
 )
 
@@ -192,6 +194,33 @@ func TestBuildRoutes_Duplicate(t *testing.T) {
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, r)
 	assert.True(t, called)
+}
+
+// The health check must answer regardless of Host — k8s probes hit the pod IP,
+// never a configured ingress host. This guards that the known_host metric
+// bounding (and its wiring order) never gates /healthz on a "known" host.
+func TestHealthzPassesUnknownHost(t *testing.T) {
+	t.Parallel()
+
+	ctrl := New("default", proxy.New())
+	ctrl.firstReload() // ready; rebuilds knownHosts (empty: no ingresses here)
+	assert.False(t, ctrl.IsKnownHost("10.0.0.5"), "a probe host is not a known host")
+
+	// the edge chain as wired in main(): Healthz first, then the
+	// known_host-bounded metric middlewares.
+	m := parapet.Middlewares{}
+	m.Use(ctrl.Healthz())
+	m.Use(metric.HostActiveTracker(ctrl.IsKnownHost))
+	m.Use(metric.Requests(ctrl.IsKnownHost))
+	h := m.ServeHandler(http.NotFoundHandler())
+
+	// liveness and readiness both succeed with a Host that isn't a known host
+	for _, target := range []string{"http://10.0.0.5/healthz", "http://10.0.0.5/healthz?ready=1"} {
+		r := httptest.NewRequest(http.MethodGet, target, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		assert.Equal(t, http.StatusOK, w.Code, target)
+	}
 }
 
 func TestBuildKnownHosts(t *testing.T) {

--- a/controller_test.go
+++ b/controller_test.go
@@ -196,31 +196,40 @@ func TestBuildRoutes_Duplicate(t *testing.T) {
 	assert.True(t, called)
 }
 
-// The health check must answer regardless of Host — k8s probes hit the pod IP,
-// never a configured ingress host. This guards that the known_host metric
-// bounding (and its wiring order) never gates /healthz on a "known" host.
-func TestHealthzPassesUnknownHost(t *testing.T) {
+// /healthz is served only when the request is addressed to an IP — k8s probes
+// hit the pod IP, never a configured domain (parapet healthz Host:false). A
+// request with a domain Host falls through to normal routing, so external
+// callers can't probe health and a backend's own /healthz is reachable. This
+// also confirms the known_host metric wiring (run after Healthz) doesn't change
+// that.
+func TestHealthzServedOnlyOnIPHost(t *testing.T) {
 	t.Parallel()
 
 	ctrl := New("default", proxy.New())
 	ctrl.firstReload() // ready; rebuilds knownHosts (empty: no ingresses here)
-	assert.False(t, ctrl.IsKnownHost("10.0.0.5"), "a probe host is not a known host")
 
 	// the edge chain as wired in main(): Healthz first, then the
-	// known_host-bounded metric middlewares.
+	// known_host-bounded metric middlewares, then routing (404 here).
 	m := parapet.Middlewares{}
 	m.Use(ctrl.Healthz())
 	m.Use(metric.HostActiveTracker(ctrl.IsKnownHost))
 	m.Use(metric.Requests(ctrl.IsKnownHost))
 	h := m.ServeHandler(http.NotFoundHandler())
 
-	// liveness and readiness both succeed with a Host that isn't a known host
-	for _, target := range []string{"http://10.0.0.5/healthz", "http://10.0.0.5/healthz?ready=1"} {
+	get := func(target string) int {
 		r := httptest.NewRequest(http.MethodGet, target, nil)
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, r)
-		assert.Equal(t, http.StatusOK, w.Code, target)
+		return w.Code
 	}
+
+	// IP Host (probe style): liveness + readiness are served.
+	assert.Equal(t, http.StatusOK, get("http://10.0.0.5/healthz"), "liveness on IP host")
+	assert.Equal(t, http.StatusOK, get("http://10.0.0.5/healthz?ready=1"), "readiness on IP host")
+
+	// domain Host: not intercepted — falls through to routing (404, not 200).
+	assert.Equal(t, http.StatusNotFound, get("http://app.example.com/healthz"),
+		"/healthz on a domain host must route normally, not hit the health check")
 }
 
 func TestBuildKnownHosts(t *testing.T) {

--- a/controller_test.go
+++ b/controller_test.go
@@ -194,6 +194,26 @@ func TestBuildRoutes_Duplicate(t *testing.T) {
 	assert.True(t, called)
 }
 
+func TestBuildKnownHosts(t *testing.T) {
+	t.Parallel()
+
+	routes := map[string]http.Handler{
+		"example.com/":        http.NotFoundHandler(),
+		"example.com/path":    http.NotFoundHandler(),
+		"api.example.com/v1/": http.NotFoundHandler(),
+		"/host-less-path":     http.NotFoundHandler(), // host-less => no host
+	}
+	known := buildKnownHosts(routes)
+
+	_, ok := known["example.com"]
+	assert.True(t, ok, "example.com is known")
+	_, ok = known["api.example.com"]
+	assert.True(t, ok, "api.example.com is known")
+	assert.Len(t, known, 2, "only the two distinct hosts; host-less route contributes none")
+	_, ok = known["evil.example.com"]
+	assert.False(t, ok, "unconfigured host is not known")
+}
+
 func TestGetIngressClass(t *testing.T) {
 	t.Parallel()
 

--- a/metric/host.go
+++ b/metric/host.go
@@ -51,13 +51,16 @@ func (p *host) getM(host, upgrade string) prometheus.Gauge {
 	})
 }
 
-type promHostTracker struct{}
+type promHostTracker struct {
+	isKnownHost func(host string) bool
+}
 
 func (p promHostTracker) ServeHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		upgrade := strings.ToLower(strings.TrimSpace(header.Get(r.Header, header.Upgrade)))
 
-		m := _host.getM(r.Host, upgrade)
+		// Sanitize once so the Inc/Dec pair use the same (bounded) label.
+		m := _host.getM(HostLabel(r.Host, p.isKnownHost), upgrade)
 		m.Inc()
 		defer m.Dec()
 
@@ -65,8 +68,11 @@ func (p promHostTracker) ServeHandler(h http.Handler) http.Handler {
 	})
 }
 
-func HostActiveTracker() parapet.Middleware {
-	return promHostTracker{}
+// HostActiveTracker returns middleware tracking in-flight requests per host.
+// isKnownHost (may be nil) bounds the `host` label to the "other" sentinel for
+// hosts the router doesn't serve.
+func HostActiveTracker(isKnownHost func(host string) bool) parapet.Middleware {
+	return promHostTracker{isKnownHost: isKnownHost}
 }
 
 var _hostRatelimit promHostRatelimit

--- a/metric/rejected.go
+++ b/metric/rejected.go
@@ -1,0 +1,72 @@
+package metric
+
+import (
+	"net/http"
+
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// unknownHostLabel is substituted for a Host the router doesn't serve, so a
+// flood of random Host headers can't create unbounded host-labeled series.
+const unknownHostLabel = "other"
+
+// HostLabel returns host if the router serves it, else the "other" sentinel. A
+// nil isKnownHost (e.g. in tests) passes the host through unchanged.
+func HostLabel(host string, isKnownHost func(host string) bool) string {
+	if isKnownHost == nil || isKnownHost(host) {
+		return host
+	}
+	return unknownHostLabel
+}
+
+var _rejected = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: prom.Namespace,
+	Name:      "rejected_requests",
+}, []string{"reason"})
+
+func init() {
+	prom.Registry().MustRegister(_rejected)
+}
+
+// RejectedRequest records a request rejected at the edge, by reason. `reason` is
+// a small bounded set (never host-derived), so this metric's cardinality can't
+// be driven by request input — unlike `requests`, it stays safe to scrape under
+// a flood.
+func RejectedRequest(reason string) {
+	_rejected.WithLabelValues(reason).Inc()
+}
+
+// rejectReason maps an edge-rejection HTTP status to a bounded reason label, or
+// "" if the status isn't a tracked rejection. The caller must only apply it when
+// the request did NOT reach a backend, so a backend responding with one of these
+// codes isn't miscounted as an ingress rejection. host_limit is recorded
+// directly at the host-concurrency limiter (it short-circuits before the request
+// metric runs), not here.
+// edgeRejectReason returns the reason for a request rejected at the edge, or ""
+// if it isn't a tracked rejection. reachedBackend gates it: once the request has
+// been proxied, the status is the backend's own response, not an ingress
+// rejection, so nothing is counted.
+func edgeRejectReason(reachedBackend bool, status int) string {
+	if reachedBackend {
+		return ""
+	}
+	return rejectReason(status)
+}
+
+func rejectReason(status int) string {
+	switch status {
+	case http.StatusNotFound: // 404 — no matching ingress route
+		return "no_route"
+	case http.StatusForbidden: // 403 — allow-remote
+		return "forbidden"
+	case http.StatusUnauthorized: // 401 — basic/forward auth
+		return "unauthorized"
+	case http.StatusRequestEntityTooLarge: // 413 — body limit
+		return "body_limit"
+	case http.StatusTooManyRequests: // 429 — per-route rate limit
+		return "rate_limit"
+	default:
+		return ""
+	}
+}

--- a/metric/rejected_test.go
+++ b/metric/rejected_test.go
@@ -1,0 +1,35 @@
+package metric
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostLabel(t *testing.T) {
+	known := func(h string) bool { return h == "a.example.com" }
+	assert.Equal(t, "a.example.com", HostLabel("a.example.com", known), "known host kept")
+	assert.Equal(t, "other", HostLabel("evil.example.com", known), "unknown host collapses")
+	assert.Equal(t, "x", HostLabel("x", nil), "nil isKnownHost passes through")
+}
+
+func TestRejectReason(t *testing.T) {
+	assert.Equal(t, "no_route", rejectReason(404))
+	assert.Equal(t, "forbidden", rejectReason(403))
+	assert.Equal(t, "unauthorized", rejectReason(401))
+	assert.Equal(t, "body_limit", rejectReason(413))
+	assert.Equal(t, "rate_limit", rejectReason(429))
+	assert.Equal(t, "", rejectReason(200), "success is not a rejection")
+	assert.Equal(t, "", rejectReason(502), "a backend error is not a tracked edge reason")
+}
+
+func TestEdgeRejectReason(t *testing.T) {
+	// not reached + tracked status => the edge rejected it
+	assert.Equal(t, "no_route", edgeRejectReason(false, 404))
+	assert.Equal(t, "rate_limit", edgeRejectReason(false, 429))
+	// reached a backend => the status is the backend's, never an edge rejection
+	assert.Equal(t, "", edgeRejectReason(true, 404))
+	assert.Equal(t, "", edgeRejectReason(true, 429))
+	// not reached but not a tracked status (success / backend-style error)
+	assert.Equal(t, "", edgeRejectReason(false, 200))
+}

--- a/metric/requests.go
+++ b/metric/requests.go
@@ -16,8 +16,11 @@ import (
 
 const requestSizeHint = 1000
 
-// Requests returns middleware that collect request information
-func Requests() parapet.Middleware {
+// Requests returns middleware that collect request information. isKnownHost (may
+// be nil) bounds the `host` label: a host the router doesn't serve collapses to
+// the "other" sentinel so a random-Host flood can't grow series cardinality.
+func Requests(isKnownHost func(host string) bool) parapet.Middleware {
+	_promRequests.isKnownHost = isKnownHost
 	return &_promRequests
 }
 
@@ -28,6 +31,8 @@ type promRequests struct {
 	durations *prometheus.HistogramVec
 
 	cache *cache[requestKey, *requestMetric]
+
+	isKnownHost func(host string) bool
 }
 
 // requestKey is the cache key for the per-label-set metric handles. Using a
@@ -70,8 +75,18 @@ func (p *promRequests) Inc(r *http.Request, status int, start time.Time) {
 	ctx := r.Context()
 	s := state.Get(ctx)
 
+	host := HostLabel(r.Host, p.isKnownHost)
+
+	// Edge rejection: a tracked rejection status where the request never reached
+	// a backend (makeHandler sets serviceTarget only when it proxies). Counted in
+	// the host-less rejected_requests metric, so an abusive flood can't grow its
+	// cardinality the way the host-labeled `requests` metric otherwise would.
+	if reason := edgeRejectReason(s["serviceTarget"] != "", status); reason != "" {
+		RejectedRequest(reason)
+	}
+
 	key := requestKey{
-		host:        r.Host,
+		host:        host,
 		namespace:   s["namespace"],
 		ingress:     s["ingress"],
 		serviceName: s["serviceName"],
@@ -83,7 +98,7 @@ func (p *promRequests) Inc(r *http.Request, status int, start time.Time) {
 	rm := p.cache.getOrCreate(key, func() *requestMetric {
 		return &requestMetric{
 			counter: p.vec.With(prometheus.Labels{
-				"host":              r.Host,
+				"host":              host,
 				"method":            r.Method,
 				"ingress_name":      s["ingress"],
 				"ingress_namespace": s["namespace"],


### PR DESCRIPTION
Ports the Rust port's metric-cardinality hardening (#46) to the **Go controller (production)**, plus the new rejected-requests metric in both.

## 1. `known_host` cardinality bound
`requests{host}`, `host_active_requests{host}`, and `host_ratelimit_requests{host}` labeled by the raw `r.Host` (and cached a handle per host) — a flood of random `Host` headers blew up Prometheus series **and** the in-process handle cache.

Now a `Host` the router doesn't serve collapses to the **`other`** sentinel. The controller derives its served-host set from the route keys on each reload (`buildKnownHosts`) and exposes `IsKnownHost`; the metric middlewares (`metric.Requests`, `metric.HostActiveTracker`) and the host-limit `exceededHandler` take it as a func.

## 2. `parapet_rejected_requests{reason}` (host-less)
A new counter labeled **only** by a bounded `reason` — `no_route | host_limit | rate_limit | body_limit | forbidden | unauthorized` — and never by host, so abusive traffic can't drive its cardinality. A safe-to-scrape view of *why* requests are shed.

Attribution is accurate **without touching each plugin**: per-route rejections (403/401/413/429) and `no_route` (404) all flow back through the request-metric middleware, where a tracked status **+ "never reached a backend"** gives the reason. The "reached backend" signal is `serviceTarget` in request state, which `makeHandler` sets only when it actually proxies — so a backend returning e.g. 404/429 is **not** miscounted as an ingress rejection. Host-concurrency limits short-circuit *before* that middleware, so they're recorded directly at the limiter (`host_limit`).

## Already in Go (the other Rust DDoS protections)
- **Upstream connect timeout** — `proxy/dialer.go` already uses `net.Dialer{Timeout: 2s}`.
- **Cert pre-parse** — `cert/table.go` already caches the parsed leaf for `SupportsCertificate`.

So the cardinality bound was the DDoS protection actually missing in Go. (`keepalive_request_limit` has no Go stdlib equivalent; `ReadHeaderTimeout` lives in the external `parapet.Server` — both noted, neither in scope here.)

## Minor behavior change
The host-concurrency `host_ratelimit_requests` label previously carried `host|country` for the country limiter; it now carries the (bounded) host. The per-country breakdown wasn't cardinality-safe and is better served by the new `rejected_requests{host_limit}` count.

## Tests
`buildKnownHosts` edge cases (incl. host-less routes), `HostLabel`, `rejectReason`, and `edgeRejectReason` (the reached-backend gating). `go vet` + full suite green; no new module dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)