### PR TITLE
fix(rust): never log the query string (error logs + access log)

### DIFF
--- a/rust/controller/src/proxy/mod.rs
+++ b/rust/controller/src/proxy/mod.rs
@@ -751,12 +751,15 @@ impl Ctx {
         let req = session.req_header();
         self.method = req.method.to_string();
         self.host = host.to_string();
-        let pq = req.uri.path_and_query().map(|p| p.as_str()).unwrap_or("/");
-        self.request_url = format!("{scheme}://{host}{pq}");
+        // Path only — never the query string, which can carry sensitive data
+        // (tokens, emails). Same reason `request_summary` redacts pingora's error
+        // logs; this keeps it out of the JSON access log's `requestUrl` too.
+        let path = req.uri.path();
+        self.request_url = format!("{scheme}://{host}{path}");
         self.request_body_size = content_length(session).map(|c| c as i64).unwrap_or(-1);
-        self.referer = header_str(session, "referer")
-            .unwrap_or_default()
-            .to_string();
+        // Strip the Referer's query too — a client-supplied URL can leak secrets
+        // there (e.g. an OAuth code in a redirect Referer).
+        self.referer = strip_query(header_str(session, "referer").unwrap_or_default()).to_string();
         self.user_agent = header_str(session, "user-agent")
             .unwrap_or_default()
             .to_string();
@@ -834,6 +837,12 @@ fn header_str<'a>(session: &'a Session, name: &str) -> Option<&'a str> {
 /// reach the logs. Pure, so it's unit-testable.
 fn redacted_summary(req: &RequestHeader, host: &str) -> String {
     format!("{} {}, Host: {host}", req.method.as_str(), req.uri.path())
+}
+
+/// Drop the `?query` (and anything after) from an arbitrary URL string, so a
+/// query carrying sensitive data never reaches a log. Pure, unit-testable.
+fn strip_query(s: &str) -> &str {
+    s.split('?').next().unwrap_or(s)
 }
 
 fn check_basic_auth(session: &Session, ba: &BasicAuth) -> bool {
@@ -1181,6 +1190,16 @@ mod tests {
         assert!(!summary.contains("token"), "query string must not appear");
         assert!(!summary.contains("s3cret"));
         assert!(!summary.contains('?'));
+    }
+
+    #[test]
+    fn strip_query_drops_query() {
+        assert_eq!(
+            strip_query("https://ref/page?token=s3cret"),
+            "https://ref/page"
+        );
+        assert_eq!(strip_query("/just/a/path"), "/just/a/path");
+        assert_eq!(strip_query(""), "");
     }
 
     #[test]

--- a/rust/controller/src/proxy/mod.rs
+++ b/rust/controller/src/proxy/mod.rs
@@ -530,6 +530,14 @@ impl ProxyHttp for Proxy {
         e
     }
 
+    /// What Pingora prints for this request in its own error logs. The default
+    /// (`Session::request_summary`) includes the full request target *with the
+    /// query string*, which can carry sensitive data (tokens, emails, etc.). We
+    /// keep the same `"{method} {path}, Host: {host}"` shape but drop the query.
+    fn request_summary(&self, session: &Session, _ctx: &Ctx) -> String {
+        redacted_summary(session.req_header(), &req_host(session))
+    }
+
     async fn logging(&self, session: &mut Session, e: Option<&Error>, ctx: &mut Ctx) {
         // always release the host-active + backend in-flight gauges
         if let Some((host, upgrade)) = &ctx.host_active {
@@ -819,6 +827,13 @@ fn content_length(session: &Session) -> Option<u64> {
 
 fn header_str<'a>(session: &'a Session, name: &str) -> Option<&'a str> {
     session.req_header().headers.get(name)?.to_str().ok()
+}
+
+/// Build the request summary Pingora logs on error, without the query string.
+/// `uri.path()` excludes the query, so secrets passed as query params never
+/// reach the logs. Pure, so it's unit-testable.
+fn redacted_summary(req: &RequestHeader, host: &str) -> String {
+    format!("{} {}, Host: {host}", req.method.as_str(), req.uri.path())
 }
 
 fn check_basic_auth(session: &Session, ba: &BasicAuth) -> bool {
@@ -1154,6 +1169,18 @@ mod tests {
         assert!(!is_ip_host("api.example.com"), "domain is not");
         assert!(!is_ip_host(""), "empty is not");
         assert!(!is_ip_host("localhost"), "localhost is not an IP literal");
+    }
+
+    #[test]
+    fn redacted_summary_drops_query_string() {
+        let mut req =
+            RequestHeader::build("GET", b"/pay?token=s3cret&email=a@b.com", None).unwrap();
+        let _ = req.insert_header("host", "api.example.com");
+        let summary = redacted_summary(&req, "api.example.com");
+        assert_eq!(summary, "GET /pay, Host: api.example.com");
+        assert!(!summary.contains("token"), "query string must not appear");
+        assert!(!summary.contains("s3cret"));
+        assert!(!summary.contains('?'));
     }
 
     #[test]


### PR DESCRIPTION
Query strings can carry sensitive data (tokens, emails, OAuth codes). This removes them from **every** log the proxy emits.

## Changes
1. **Pingora error logs** — override `ProxyHttp::request_summary` so it's `"{method} {path}, Host: {host}"` using `uri.path()` (no query) instead of the default summary's raw request target.
2. **JSON access log `requestUrl`** — built from `uri.path()` only, never `path_and_query`.
3. **JSON access log `referer`** — its query is stripped (`strip_query`); a client-supplied Referer can leak secrets (e.g. an OAuth `code` in a redirect Referer).

No other logged field carries request input that can contain a query (the rest are IPs, method, status, sizes, service identity).

## Tested
`redacted_summary_drops_query_string` and `strip_query_drops_query` (pure helpers). The access-log path uses the same `uri.path()` mechanism. fmt + clippy clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)