### PR TITLE
feat(rust): pin downstream TLS floor to 1.2 explicitly

### DIFF
--- a/rust/controller/src/proxy/server.rs
+++ b/rust/controller/src/proxy/server.rs
@@ -143,6 +143,12 @@ pub fn run(shared: Arc<Shared>, cfg: ServeConfig) {
         );
         let resolver = SniResolver::new(shared.clone());
         let mut tls = TlsSettings::with_callbacks(Box::new(resolver)).expect("tls settings");
+        // Pin the downstream TLS floor at 1.2, matching the Go controller's explicit
+        // `MinVersion: tls.VersionTLS12`. Pingora's `mozilla_intermediate_v5` default
+        // already disables TLS 1.0/1.1, but setting it explicitly keeps the floor
+        // from silently shifting if that upstream default ever changes.
+        tls.set_min_proto_version(Some(pingora::tls::ssl::SslVersion::TLS1_2))
+            .expect("set min tls version");
         tls.enable_h2();
         let mut tls_opts = HttpServerOptions::default();
         tls_opts.keepalive_request_limit = Some(DOWNSTREAM_KEEPALIVE_REQUEST_LIMIT);


### PR DESCRIPTION
## What

Set the HTTPS listener's minimum TLS version explicitly to **TLS 1.2** in `proxy/server.rs`:

```rust
tls.set_min_proto_version(Some(pingora::tls::ssl::SslVersion::TLS1_2))
    .expect("set min tls version");
```

## Why

The floor was previously **implicit** — inherited from Pingora's `TlsSettings::with_callbacks` default, which builds on OpenSSL's `SslAcceptor::mozilla_intermediate_v5` (that preset disables TLS 1.0/1.1). So behavior is unchanged today, but:

- It now **matches the Go controller's explicit floor** (`cmd/parapet-ingress-controller/main.go`: `MinVersion: tls.VersionTLS12`) instead of relying on a dependency default.
- It **can't silently shift** if a future Pingora/OpenSSL bump changes that default — the floor is stated in our code and self-documents the intent.

## Verification

Built clean (fmt + clippy + full test suite green), and verified at runtime against the running listener (self-signed fallback cert):

| Client | Result |
|--------|--------|
| TLS 1.1 ClientHello (forced via `SECLEVEL=0`) | **rejected by server** — `tlsv1 alert protocol version` (alert 70) |
| TLS 1.2 | handshake succeeds |
| TLS 1.3 | handshake succeeds |

🤖 Generated with [Claude Code](https://claude.com/claude-code)