### PR TITLE
feat: web application firewall (global + zone CEL rulesets)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ A CEL-rule firewall on top of `parapet/pkg/waf`. **Full design in [WAF.md](WAF.m
 - **Global** (`globalWAF`, mounted in `main.go`'s `m` chain before `ctrl`) — one baseline ruleset, honored only from `POD_NAMESPACE`, applied to all traffic.
 - **Zones** (`zones atomic.Pointer[map[string]*waf.WAF]`, key `<namespace>/<name>`) — tenant rulesets an ingress binds via `parapet.moonrhythm.io/waf-zone`; `plugin.WAFZone` resolves the key (namespace-local, or `ns/id` cross-ref) and looks up the live registry per request.
 
-Global runs first and is authoritative. **WAF reload is decoupled from the mux**: ConfigMap changes call `reloadWAFDebounced` (recompile + atomic swap) and never rebuild routes; `SetRules` is all-or-nothing so a bad ruleset keeps the last-good one. Rules parse via `wafrule/`; matches count `parapet_waf_matches_total{rule_id,action,scope}` (`metric/waf.go`). Code: `controller_waf.go`, `plugin/waf.go`, `wafrule/`.
+Global runs first and is authoritative. **WAF reload is decoupled from the mux**: ConfigMap changes call `reloadWAFDebounced` (recompile + atomic swap) and never rebuild routes; `SetRules` is all-or-nothing so a bad ruleset keeps the last-good one. Rules parse via `wafrule/`; matches count `parapet_waf_matches{rule_id,action,scope}` (`metric/waf.go`). Code: `controller_waf.go`, `plugin/waf.go`, `wafrule/`.
 
 ## Annotation reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,14 @@ CI: `.github/workflows/rust-test.yaml` (fmt + clippy + test on push/PR) and `rus
 ```
 cmd/parapet-ingress-controller/   # binary entry-point (main.go, config.go)
 controller.go                     # Controller struct — watch/reload logic (generic watchResource)
+controller_waf.go                 # WAF wiring: global instance + zone registry, ConfigMap watch
 retry.go                          # retryMiddleware — retries idempotent requests on upstream failure
+WAF.md                            # WAF feature design (global + zone CEL rulesets)
+wafrule/                          # WAF rule YAML DTO + parser (-> []waf.Rule)
 plugin/                           # annotation-driven middleware plugins
   plugin.go                       # core plugin type + built-in plugins
   auth.go                         # BasicAuth, ForwardAuth
+  waf.go                          # WAFZone — bind ingress to a WAF zone by reference
   trace.go                        # OpenTelemetry tracing
 proxy/                            # reverse-proxy implementation
   proxy.go, transport.go          # http.ReverseProxy wrapper
@@ -60,7 +64,7 @@ cert/                             # TLS certificate table (SNI lookup)
 k8s/                              # Kubernetes client helpers
   k8s.go, cluster.go, fs.go      # in-cluster / local kubeconfig init + list/watch helpers
 metric/                           # Prometheus metrics
-  requests.go, backendconns.go, host.go, reload.go
+  requests.go, backendconns.go, host.go, reload.go, waf.go
   cache.go                        # generic lock+map cache for per-label-set metric handles
 state/                            # per-request state map (passed via context)
 debounce/                         # debounce helper used for reload coalescing
@@ -71,7 +75,7 @@ deploy/                           # raw Kubernetes YAML manifests
 ## Key concepts
 
 ### Controller lifecycle
-`Controller.Watch()` starts four goroutines that continuously watch Ingress, Service, Secret, and Endpoints resources. Changes are coalesced through a 300 ms `debounce.Debounce` before triggering a reload. On reload, a new `http.ServeMux` is built and swapped in under a `sync.RWMutex` — zero downtime.
+`Controller.Watch()` starts four goroutines that continuously watch Ingress, Service, Secret, and Endpoints resources (plus a fifth, ConfigMaps, when `WAF_ENABLED=true`). Changes are coalesced through a 300 ms `debounce.Debounce` before triggering a reload. On reload, a new `http.ServeMux` is built and swapped in under a `sync.RWMutex` — zero downtime. WAF ConfigMap changes are the exception: they recompile rulesets without rebuilding the mux (see the WAF concept below).
 
 ### Plugins
 A `Plugin` is `func(ctx plugin.Context)` where `Context` carries:
@@ -97,6 +101,13 @@ TLS secrets are loaded from `Secret.Data["tls.crt"]` / `["tls.key"]`. The `cert.
 
 On an upstream failure (dial error, upstream 502/503), the proxy's `ErrorHandler` panics; `retryMiddleware` (`retry.go`) recovers it and retries the request (up to 5 times with backoff) — but only when the body hasn't been read, so non-idempotent requests aren't replayed. `proxy.IsRetryable` decides which errors qualify.
 
+### WAF (opt-in, `WAF_ENABLED=true`)
+A CEL-rule firewall on top of `parapet/pkg/waf`. **Full design in [WAF.md](WAF.md).** Two rulesets, both fed by label-marked ConfigMaps (`parapet.moonrhythm.io/waf: global|zone`), watched as a 5th resource:
+- **Global** (`globalWAF`, mounted in `main.go`'s `m` chain before `ctrl`) — one baseline ruleset, honored only from `POD_NAMESPACE`, applied to all traffic.
+- **Zones** (`zones atomic.Pointer[map[string]*waf.WAF]`, key `<namespace>/<name>`) — tenant rulesets an ingress binds via `parapet.moonrhythm.io/waf-zone`; `plugin.WAFZone` resolves the key (namespace-local, or `ns/id` cross-ref) and looks up the live registry per request.
+
+Global runs first and is authoritative. **WAF reload is decoupled from the mux**: ConfigMap changes call `reloadWAFDebounced` (recompile + atomic swap) and never rebuild routes; `SetRules` is all-or-nothing so a bad ruleset keeps the last-good one. Rules parse via `wafrule/`; matches count `parapet_waf_matches_total{rule_id,action,scope}` (`metric/waf.go`). Code: `controller_waf.go`, `plugin/waf.go`, `wafrule/`.
+
 ## Annotation reference
 
 | Annotation | Values | Effect |
@@ -115,6 +126,7 @@ On an upstream failure (dial error, upstream 502/503), the proxy's `ErrorHandler
 | `parapet.moonrhythm.io/strip-prefix` | path prefix | Strip prefix from request path |
 | `parapet.moonrhythm.io/basic-auth` | see auth.go | HTTP Basic Auth |
 | `parapet.moonrhythm.io/forward-auth` | URL | Delegate auth to external service |
+| `parapet.moonrhythm.io/waf-zone` | zone id, or `ns/id` | Bind the ingress to a WAF zone (see [WAF.md](WAF.md)) |
 
 ## Configuration (environment variables)
 
@@ -139,6 +151,12 @@ On an upstream failure (dial error, upstream 502/503), the proxy's `ErrorHandler
 | `PROFILER` | `false` | Enable Cloud Profiler |
 | `PROFILER_NAME` | | Cloud Profiler service name |
 | `DISABLE_LOG` | `false` | Suppress access log |
+| `WAF_ENABLED` | `false` | Master switch for the WAF (global + zone rulesets from ConfigMaps; see [WAF.md](WAF.md)) |
+| `WAF_FAIL_MODE` | `open` | `open` (rule eval error → allow + log) or `closed` (→ 500) |
+| `WAF_EVAL_TIMEOUT` | `5ms` | Per-request deadline for the whole ruleset |
+| `WAF_COST_LIMIT` | `1000000` | CEL cost cap per rule |
+| `WAF_INSPECT_BODY` | `0` | Inspect up to N request-body bytes (0 = `request.body` is empty) |
+| `WAF_DISABLE_MACROS` | `false` | Refuse rules using `all`/`exists`/`map`/`filter` |
 
 ## Build & run
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,107 @@ manifests for the full set). Notable options:
   namespace, not just those referenced by an Ingress's `spec.tls`. Lets a
   wildcard certificate serve SNI without wiring its secret into each ingress.
 
+## Web Application Firewall (WAF)
+
+An opt-in CEL-rule firewall with a platform-wide **global** ruleset plus
+per-tenant **zones** that an ingress binds by reference. Rules live in ConfigMaps
+and hot-reload without restarting the controller or rebuilding routes. Full
+design and the complete CEL reference: [WAF.md](WAF.md).
+
+### Enable it
+
+Set `WAF_ENABLED=true` on the controller (off by default; when off the WAF does no
+work). The controller's ServiceAccount needs `list`/`watch` on `configmaps` —
+already in the [deploy](https://github.com/moonrhythm/parapet-ingress-controller/tree/master/deploy)
+role manifests.
+
+### Write rules
+
+Each ConfigMap `data` value is a YAML document of rules. A rule is a CEL
+expression returning a bool plus an action — `log` (record, continue), `allow`
+(short-circuit this ruleset and pass), or `block`:
+
+```yaml
+rules:
+  - id: block-sqli
+    expression: regexMatch(lower(urlDecode(request.query)), "(union\\s+select|or\\s+1=1)")
+    action: block
+  - id: allow-office
+    expression: ipInCidr(request.remote_ip, "203.0.113.0/24")
+    action: allow
+    priority: 0          # lower priority runs first
+```
+
+Variables (`request.method`, `.path`, `.query`, `.headers[...]`, `.remote_ip`, …)
+and functions (`ipInCidr`, `regexMatch`, `containsAny`, `hasPrefixAny`, `lower`,
+`upper`, `urlDecode`) are documented in [WAF.md](WAF.md).
+
+### Global ruleset
+
+Applies to all traffic. Create it in the controller's own namespace
+(`POD_NAMESPACE`) with the label `parapet.moonrhythm.io/waf: global`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: waf-global
+  namespace: parapet-ingress-controller
+  labels:
+    parapet.moonrhythm.io/waf: global
+data:
+  rules.yaml: |
+    rules:
+      - id: block-scanners
+        expression: containsAny(lower(request.user_agent), ["sqlmap", "nikto"])
+        action: block
+```
+
+### Zones (per-tenant)
+
+A zone is a ConfigMap labeled `parapet.moonrhythm.io/waf: zone`; its **name** is
+the zone id. Create it in the tenant's namespace and bind ingresses to it with the
+`parapet.moonrhythm.io/waf-zone` annotation:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: acme                 # zone id
+  namespace: acme-prod
+  labels:
+    parapet.moonrhythm.io/waf: zone
+data:
+  rules.yaml: |
+    rules:
+      - id: block-admin
+        expression: hasPrefixAny(request.path, ["/admin", "/internal"])
+        action: block
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  namespace: acme-prod
+  annotations:
+    parapet.moonrhythm.io/waf-zone: acme       # -> acme-prod/acme
+spec:
+  ingressClassName: parapet
+  # ...
+```
+
+A bare id resolves to a zone in the ingress's own namespace; use `namespace/zone`
+to reference a shared zone elsewhere (e.g. `team-x/acme`). The global ruleset runs
+first and is authoritative — a zone cannot `allow`-override a global `block`.
+Editing a tenant's zone affects only the ingresses bound to it.
+
+### Rollout
+
+Ship rules with `action: log` first (shadow mode), watch
+`parapet_waf_matches{action="log"}` for false positives, then switch to `block`.
+Keep `WAF_FAIL_MODE=open` (the default) so a rule evaluation error fails open
+rather than dropping legitimate traffic.
+
 ## Metrics
 
 Parapet ingress controller support prometheus metrics by add prometheus annotations to pod template.
@@ -100,6 +201,7 @@ annotations:
 - parapet_reload{success}
 - parapet_host_ratelimit_requests{host}
 - parapet_host_active_requests{host, upgrade}
+- parapet_waf_matches{rule_id, action, scope}
 
 #### Metrics directly use from parapet
 

--- a/WAF.md
+++ b/WAF.md
@@ -1,0 +1,281 @@
+# WAF (Web Application Firewall)
+
+A CEL-rule firewall in the request path, with a **global** baseline ruleset
+(platform-owned) plus opt-in **zones** (tenant-owned) that an ingress binds by
+reference. The engine is [`parapet/pkg/waf`](https://github.com/moonrhythm/parapet/tree/master/pkg/waf)
+reused verbatim in the Go controller, and reimplemented on
+[cel-rust](https://github.com/cel-rust/cel-rust) in the Rust port (`rust/`) for
+CEL-string parity.
+
+> Status: **design** (this doc) → Go implementation in progress → Rust port to
+> follow against a shared CEL test corpus. The Go controller is the production
+> binary; see `CLAUDE.md`.
+
+## Why this shape
+
+The controller is multi-tenant: many customers, many domains, one proxy. The
+design goals, in order:
+
+1. **A platform baseline that tenants can't punch through** — block scanners,
+   SQLi, known-bad bots globally; a tenant rule must never `allow`-override it.
+2. **Tenant self-service without blast radius** — a customer edits *one* place
+   and it lands on *all* their domains and *nobody else's*.
+3. **Rule edits decoupled from routing** — a rule change must not rebuild the
+   router or churn every ingress.
+4. **One rule language across Go and Rust** — a rule authored once works in both
+   binaries while the migration runs.
+
+The Cloudflare "zone" model satisfies all four: rules live in ConfigMaps, an
+ingress references a zone by ID, and the global ruleset is always-on.
+
+## Rule schema (the contract)
+
+Both delivery channels and both languages parse this YAML. It maps 1:1 onto
+`waf.Rule`.
+
+```yaml
+rules:
+  - id: block-sqli            # required, unique within a ruleset
+    description: classic SQLi in query string
+    expression: regexMatch(lower(urlDecode(request.query)), "(union\\s+select|or\\s+1=1)")
+    action: block             # log | allow | block   (default: log)
+    status: 403               # block only; default 403
+    message: Forbidden        # block only; default "Forbidden"
+    priority: 100             # ascending — lower runs first
+```
+
+- `expression` is a CEL expression returning `bool`. Variables and functions are
+  fixed by `pkg/waf` (see [CEL surface](#cel-surface)).
+- `action`:
+  - `block` — terminate with `status`/`message`.
+  - `allow` — short-circuit **this ruleset only** and proceed down the normal
+    chain (allowlists, e.g. trusted health checkers). It does **not** bypass
+    other rulesets (a global `allow` still enters zone evaluation).
+  - `log` — record the match (metric + log) and keep evaluating. The default, so
+    a rule with no `action` is a safe shadow rule.
+- Rules run in ascending `priority`; equal priorities keep declaration order.
+- `SetRules` compiles the whole batch **all-or-nothing**: one bad rule rejects
+  the batch and the previous good ruleset stays live. A bad ConfigMap can't
+  brick the WAF.
+
+## CEL surface
+
+Top-level `request` map (snake_case, ModSecurity-style):
+
+```
+request.method  host  path  query  uri  proto  scheme  remote_ip
+        content_length  headers{}  cookies{}  args{}  user_agent  referer  body
+```
+
+`headers`/`args`/`cookies` are single-valued maps; header keys are lowercased.
+`body` is empty unless body inspection is enabled (off by default).
+
+Custom functions: `ipInCidr(ip,cidr)`, `regexMatch(s,pattern)` (RE2, cached),
+`containsAny(s,list)`, `hasPrefixAny(s,list)`, `lower(s)`, `upper(s)`,
+`urlDecode(s)`. Query strings are **not** auto-decoded — apply `urlDecode`
+yourself so `?q=1+UNION+SELECT` is normalized before a regex sees it.
+
+## Delivery: ConfigMaps, one marker label
+
+A single label key **`parapet.moonrhythm.io/waf`** marks a ConfigMap as WAF
+input; its value selects the role:
+
+| Label | Meaning | Where it's honored |
+|---|---|---|
+| `parapet.moonrhythm.io/waf: global` | contributes to the global ruleset | only in the controller's own namespace (`POD_NAMESPACE`) |
+| `parapet.moonrhythm.io/waf: zone` | one zone; zone ID = ConfigMap **name** | any watched namespace |
+
+One label key means one watch with one existence selector
+(`LabelSelector: "parapet.moonrhythm.io/waf"`) catches both; the controller
+splits global vs zone by value. Each ConfigMap's `data` values are each a
+`rules:` document; multiple keys (and multiple global ConfigMaps) are
+concatenated.
+
+Restricting `global` to `POD_NAMESPACE` is the security boundary: only whoever
+controls the controller's namespace (the platform team) can define baseline
+rules. Tenants get RBAC `edit` on their own zone ConfigMaps and nothing else.
+
+### Zone binding
+
+An ingress binds a zone with one annotation:
+
+```yaml
+metadata:
+  annotations:
+    parapet.moonrhythm.io/waf-zone: acme
+```
+
+Every domain/path on that ingress is now governed by the `acme` zone. **Resolution is namespace-local with explicit cross-ref:**
+
+```
+val = annotations["parapet.moonrhythm.io/waf-zone"]
+key = val.contains("/") ? val                          # "team-x/acme"  → that exact (ns, name)
+                        : ingress.namespace + "/" + val # "acme"         → same-namespace zone
+zone = registry[key]   # miss → no zone rules (global still applies); not an error
+```
+
+A bare ID resolves to a zone ConfigMap of that name in the ingress's own
+namespace; `team-x/acme` references a zone in another namespace (e.g. a shared
+platform zone). Cross-ref only resolves if the controller watches that namespace
+(`WATCH_NAMESPACE=""`, the default, watches all). Cross-namespace binding lets a
+tenant *apply* another's ruleset to their own traffic (harmless to the owner);
+*editing* is still RBAC-gated per ConfigMap.
+
+## Evaluation order
+
+Per request: **global WAF (always) → zone WAF (if bound and resolves).** Global
+runs first and is authoritative — a platform `block` terminates before the zone
+is consulted, so a tenant can't override it. `allow` is per-ruleset (see above).
+
+## The key property: WAF reload is decoupled from the router
+
+Binding is by **ID resolved at request time**, so rule lifecycle and routing
+lifecycle are independent:
+
+- Ingress / Service / Secret / Endpoint change → rebuild the router (as today).
+- Global or zone ConfigMap change → recompile *that one ruleset* and atomically
+  swap the registry. **No mux rebuild, no plugin re-run.** A new zone, or a
+  tenant editing rules, is just a `SetRules` on a stable instance / a map swap,
+  picked up on the next request. A broken zone ConfigMap fails `SetRules`
+  all-or-nothing: that zone keeps its last-good rules; global and every other
+  zone are untouched.
+
+## Go controller design
+
+The engine is free (`pkg/waf`); the work is plumbing.
+
+- **Shared parser** (`wafrule/`): YAML `rules:` doc → `[]waf.Rule`, `action`
+  string → `waf.Action`. Used by both the global and zone paths.
+- **k8s** (`k8s/`): `GetConfigMaps` / `WatchConfigMaps` with a label selector
+  (cluster client applies it server-side; fs client returns all and the
+  controller filters).
+- **Controller** holds `globalWAF *waf.WAF` and
+  `zones atomic.Pointer[map[string]*waf.WAF]` (key `<namespace>/<name>`). A 5th
+  watch (ConfigMaps), debounced like the others, feeds both via
+  `reloadWAF` — and does **not** touch `ctrl.mux`. Zone instances are reused
+  across reloads so a bad edit keeps the zone's last-good ruleset.
+  `newWAF(scope)` applies the env config and wires `OnMatch` → metrics + log.
+- **`plugin.WAFZone(lookup)`**: reads `waf-zone`, resolves the key, injects a
+  middleware that does a live `lookup(key)` per request and evaluates the zone's
+  `*waf.WAF`. Registered after `AllowRemote`, before `RedirectHTTPS`.
+- **Global mount**: `m.Use(ctrl.GlobalWAF())` in `main.go`, immediately before
+  `m.Use(ctrl)` — so blocks are access-logged and counted, and `request.host`
+  is already normalized.
+- **Metrics/log**: `metric.WAFMatch(ruleID, action, scope)` →
+  `parapet_waf_matches_total{rule_id,action,scope}` (bounded: rule IDs are
+  operator-defined, action∈3, scope∈{global,zone}). Eval errors and match lines
+  go to slog.
+
+### Configuration (env)
+
+| Env | Default | Description |
+|---|---|---|
+| `WAF_ENABLED` | `false` | Master switch — when off, no watch, no mount, zero per-request cost |
+| `WAF_FAIL_MODE` | `open` | `open` (rule eval error → allow + log) or `closed` (→ 500) |
+| `WAF_EVAL_TIMEOUT` | `5ms` | Per-request deadline for the whole ruleset |
+| `WAF_COST_LIMIT` | `1000000` | CEL cost cap per rule |
+| `WAF_INSPECT_BODY` | `0` | Inspect up to N body bytes (0 = `request.body` is empty) |
+| `WAF_DISABLE_MACROS` | `false` | Refuse rules using `all`/`exists`/`map`/`filter` |
+
+### RBAC
+
+The controller needs `get/list/watch configmaps` (added to
+`deploy/role-cluster.yaml` and `deploy/role-namespaced.yaml`). Tenants get
+`edit` on their own zone ConfigMaps via their own RBAC.
+
+## Rust port design (`rust/`)
+
+Reimplement the engine on cel-rust; the integration is *simpler* than the Go
+plugin model because nothing compiled lives in the router.
+
+- **Fast core preserved**: `config.rs` parses `waf_zone: Option<String>` (a pure
+  string — no cel). The cel engine lives in a new `waf.rs` behind a `waf` cargo
+  feature (pulls `cel` + `regex`); `proxy` enables it.
+- **State**: `Shared.global_waf: Arc<Waf>` and
+  `Shared.zones: ArcSwap<HashMap<ZoneId, Arc<Waf>>>` (`arc-swap` is already a
+  dep — the Rust analog of Go's `atomic.Pointer` swap). A ConfigMap reflector
+  (mirroring `cluster.rs`'s `reflect!`) compiles and swaps them, independent of
+  `Shared::rebuild` (the router reconcile).
+- **Phases**: global in `request_filter` (before `router.lookup`); zone in
+  `apply_route_filters` via `ctx.config.waf_zone → shared.zones.load().get(key)`,
+  after `allow_remote`, before `redirect_https` — mirroring the Go order. All
+  request-time lookups; nothing compiled on the hot path.
+- **Metrics**: `parapet_waf_matches_total` in `proxy/metrics.rs`, same labels.
+
+### Intentional divergences (document like the retry note)
+
+- **Cost limit**: cel-rust has none. Approximate it with a wall-clock deadline
+  checked **between** rules (cel-rust eval isn't mid-expression interruptible);
+  inputs are small maps. Use the `regex` crate (RE2-style, linear) for
+  `regexMatch` so a single rule can't backtrack-blow-up — same guarantee Go's
+  `regexp` gives.
+- **Body inspection**: ships in a later phase. v1 is header-only
+  (`request.body == ""`), matching Go's default (`InspectBody=0`). Phase 2
+  buffers up to N bytes in `request_body_filter` for body-dependent rules.
+- **Dialect drift**: cel-rust ≠ cel-go on macro semantics and some
+  type-coercion edges. Mitigation: a shared `(expression, request, expected)`
+  fixture exercised by both the Go and Rust test suites.
+
+## Rollout
+
+Ship rules `action: log` first (shadow mode), watch
+`parapet_waf_matches_total{action="log"}` for false positives, then flip to
+`block`. Keep `WAF_FAIL_MODE=open` in production: during a config bug,
+fail-open (one rule briefly inactive) beats fail-closed (every request 500s).
+
+## Examples
+
+Global baseline (in the controller's namespace):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: waf-global
+  namespace: parapet-ingress-controller
+  labels:
+    parapet.moonrhythm.io/waf: global
+data:
+  rules.yaml: |
+    rules:
+      - id: block-scanners
+        expression: containsAny(lower(request.user_agent), ["sqlmap", "nikto", "acunetix"])
+        action: block
+      - id: block-sqli
+        expression: regexMatch(lower(urlDecode(request.query)), "(union\\s+select|or\\s+1=1)")
+        action: block
+```
+
+A tenant zone (in the tenant's namespace), bound by their ingresses:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: acme
+  namespace: acme-prod
+  labels:
+    parapet.moonrhythm.io/waf: zone
+data:
+  rules.yaml: |
+    rules:
+      - id: allow-office
+        expression: ipInCidr(request.remote_ip, "203.0.113.0/24")
+        action: allow
+        priority: 0
+      - id: block-admin-external
+        expression: hasPrefixAny(request.path, ["/admin", "/internal"])
+        action: block
+        priority: 100
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  namespace: acme-prod
+  annotations:
+    parapet.moonrhythm.io/waf-zone: acme   # → acme-prod/acme
+spec:
+  ingressClassName: parapet
+  rules: [ ... ]
+```

--- a/WAF.md
+++ b/WAF.md
@@ -162,7 +162,7 @@ The engine is free (`pkg/waf`); the work is plumbing.
   `m.Use(ctrl)` — so blocks are access-logged and counted, and `request.host`
   is already normalized.
 - **Metrics/log**: `metric.WAFMatch(ruleID, action, scope)` →
-  `parapet_waf_matches_total{rule_id,action,scope}` (bounded: rule IDs are
+  `parapet_waf_matches{rule_id,action,scope}` (bounded: rule IDs are
   operator-defined, action∈3, scope∈{global,zone}). Eval errors and match lines
   go to slog.
 
@@ -200,7 +200,7 @@ plugin model because nothing compiled lives in the router.
   `apply_route_filters` via `ctx.config.waf_zone → shared.zones.load().get(key)`,
   after `allow_remote`, before `redirect_https` — mirroring the Go order. All
   request-time lookups; nothing compiled on the hot path.
-- **Metrics**: `parapet_waf_matches_total` in `proxy/metrics.rs`, same labels.
+- **Metrics**: `parapet_waf_matches` in `proxy/metrics.rs`, same labels.
 
 ### Intentional divergences (document like the retry note)
 
@@ -219,7 +219,7 @@ plugin model because nothing compiled lives in the router.
 ## Rollout
 
 Ship rules `action: log` first (shadow mode), watch
-`parapet_waf_matches_total{action="log"}` for false positives, then flip to
+`parapet_waf_matches{action="log"}` for false positives, then flip to
 `block`. Keep `WAF_FAIL_MODE=open` in production: during a config bug,
 fail-open (one rule briefly inactive) beats fail-closed (every request 500s).
 

--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -44,6 +44,15 @@ func main() {
 	httpServerMaxHeaderBytes := config.IntDefault("HTTP_SERVER_MAX_HEADER_BYTES", 1<<14) // 16K
 	loadAllCerts := config.Bool("LOAD_ALL_CERTS")
 
+	wafConfig := controller.WAFConfig{
+		Enabled:       config.Bool("WAF_ENABLED"),
+		FailClosed:    config.String("WAF_FAIL_MODE") == "closed",
+		EvalTimeout:   config.DurationDefault("WAF_EVAL_TIMEOUT", 5*time.Millisecond),
+		CostLimit:     uint64(config.Int("WAF_COST_LIMIT")),
+		InspectBody:   int64(config.Int("WAF_INSPECT_BODY")),
+		DisableMacros: config.Bool("WAF_DISABLE_MACROS"),
+	}
+
 	hostname, _ := os.Hostname()
 
 	if ingressClass != "" {
@@ -61,6 +70,7 @@ func main() {
 		"profiler", enableProfiler,
 		"http_server_max_header_bytes", httpServerMaxHeaderBytes,
 		"load_all_certs", loadAllCerts,
+		"waf_enabled", wafConfig.Enabled,
 	)
 
 	if enableProfiler {
@@ -90,8 +100,14 @@ func main() {
 
 	ctrl := controller.New(watchNamespace, proxy)
 	ctrl.LoadAllCerts = loadAllCerts
+	ctrl.PodNamespace = podNamespace
+	ctrl.WAFConfig = wafConfig
+	ctrl.InitWAF()
 	ctrl.Use(plugin.InjectStateIngress)
 	ctrl.Use(plugin.AllowRemote)
+	if wafConfig.Enabled {
+		ctrl.Use(plugin.WAFZone(ctrl.LookupZone))
+	}
 	ctrl.Use(plugin.RedirectHTTPS)
 	ctrl.Use(plugin.InjectHSTS)
 	ctrl.Use(plugin.RedirectRules)
@@ -121,6 +137,12 @@ func main() {
 	m.Use(metric.Requests(ctrl.IsKnownHost))
 	m.Use(compress.Gzip())
 	m.Use(compress.BrWithQuality(4))
+	if wafConfig.Enabled {
+		// Global WAF runs just before routing: blocks are access-logged and
+		// counted above, and request.host is already normalized. Per-zone WAF
+		// runs inside the per-ingress chain (plugin.WAFZone).
+		m.Use(ctrl.GlobalWAF())
+	}
 	m.Use(ctrl)
 
 	var trustProxy parapet.Conditional

--- a/controller.go
+++ b/controller.go
@@ -8,10 +8,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/moonrhythm/parapet"
 	"github.com/moonrhythm/parapet/pkg/healthz"
+	"github.com/moonrhythm/parapet/pkg/waf"
 	v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,11 +61,24 @@ type Controller struct {
 	// matching secret into each ingress. Off by default to preserve behavior.
 	LoadAllCerts bool
 
+	// WAFConfig configures the web application firewall; PodNamespace is the
+	// controller's own namespace, which bounds where the global ruleset may be
+	// defined. Both are set before Watch(). See controller_waf.go.
+	WAFConfig    WAFConfig
+	PodNamespace string
+
+	// globalWAF is the always-on baseline firewall; zones holds the tenant zone
+	// registry keyed by <namespace>/<name>, swapped atomically on WAF reload.
+	// WAF reloads are decoupled from the mux — they never rebuild routes.
+	globalWAF *waf.WAF
+	zones     atomic.Pointer[map[string]*waf.WAF]
+
 	// holds current k8s state
-	watchedIngresses sync.Map
-	watchedServices  sync.Map
-	watchedSecrets   sync.Map
-	watchedEndpoints sync.Map
+	watchedIngresses  sync.Map
+	watchedServices   sync.Map
+	watchedSecrets    sync.Map
+	watchedEndpoints  sync.Map
+	watchedConfigMaps sync.Map
 
 	certTable  cert.Table
 	routeTable route.Table
@@ -77,6 +92,7 @@ type Controller struct {
 	reloadServiceDebounce  *debounce.Debounce
 	reloadSecretDebounce   *debounce.Debounce
 	reloadEndpointDebounce *debounce.Debounce
+	reloadWAFDebounce      *debounce.Debounce
 }
 
 // New creates new ingress controller
@@ -89,6 +105,7 @@ func New(watchNamespace string, proxy *proxy.Proxy) *Controller {
 	ctrl.reloadServiceDebounce = debounce.New(ctrl.reloadServiceDebounced, 300*time.Millisecond)
 	ctrl.reloadSecretDebounce = debounce.New(ctrl.reloadSecretDebounced, 300*time.Millisecond)
 	ctrl.reloadEndpointDebounce = debounce.New(ctrl.reloadEndpointDebounced, 300*time.Millisecond)
+	ctrl.reloadWAFDebounce = debounce.New(ctrl.reloadWAFDebounced, 300*time.Millisecond)
 	ctrl.proxy = proxy
 	ctrl.proxy.OnDialError = ctrl.routeTable.MarkBad
 	return ctrl
@@ -121,6 +138,9 @@ func (ctrl *Controller) Watch() {
 	go ctrl.watchServices(ctx)
 	go ctrl.watchSecrets(ctx)
 	go ctrl.watchEndpoints(ctx)
+	if ctrl.WAFConfig.Enabled {
+		go ctrl.watchConfigMaps(ctx)
+	}
 }
 
 func (ctrl *Controller) preloadResources(ctx context.Context) {
@@ -143,6 +163,13 @@ func (ctrl *Controller) preloadResources(ctx context.Context) {
 	for _, e := range endpoints {
 		ctrl.watchedEndpoints.Store(e.Namespace+"/"+e.Name, &e)
 	}
+
+	if ctrl.WAFConfig.Enabled {
+		configmaps, _ := k8s.GetConfigMaps(ctx, ctrl.watchNamespace, wafLabelKey)
+		for _, cm := range configmaps {
+			ctrl.watchedConfigMaps.Store(cm.Namespace+"/"+cm.Name, &cm)
+		}
+	}
 }
 
 func (ctrl *Controller) firstReload() {
@@ -150,6 +177,7 @@ func (ctrl *Controller) firstReload() {
 	ctrl.reloadIngressDebounced()
 	ctrl.reloadSecretDebounced()
 	ctrl.reloadEndpointDebounced()
+	ctrl.reloadWAFDebounced() // no-op when WAF disabled
 
 	// ready to serve requests
 	ctrl.health.SetReady(true)

--- a/controller_waf.go
+++ b/controller_waf.go
@@ -1,0 +1,199 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/moonrhythm/parapet"
+	"github.com/moonrhythm/parapet/pkg/waf"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/moonrhythm/parapet-ingress-controller/k8s"
+	"github.com/moonrhythm/parapet-ingress-controller/metric"
+	"github.com/moonrhythm/parapet-ingress-controller/wafrule"
+)
+
+// wafLabelKey marks a ConfigMap as WAF input. Its value selects the role:
+// "global" (baseline ruleset, honored only in the controller's own namespace)
+// or "zone" (a tenant zone whose ID is the ConfigMap name). A single key means
+// one watch with one existence selector catches both roles.
+const (
+	wafLabelKey   = "parapet.moonrhythm.io/waf"
+	wafRoleGlobal = "global"
+	wafRoleZone   = "zone"
+)
+
+// WAFConfig configures the WAF. It is set on the Controller before Watch().
+// When Enabled is false the WAF does no work: no ConfigMap watch, no mount.
+type WAFConfig struct {
+	Enabled       bool
+	FailClosed    bool          // rule eval error -> 500 instead of fail-open
+	EvalTimeout   time.Duration // per-request deadline for the whole ruleset
+	CostLimit     uint64        // CEL cost cap per rule (0 = waf default)
+	InspectBody   int64         // inspect up to N body bytes (0 = body empty)
+	DisableMacros bool          // refuse all/exists/map/filter in rules
+}
+
+// InitWAF builds the global WAF instance and the (empty) zone registry. Call
+// after setting WAFConfig and PodNamespace, before Watch(). No-op when disabled.
+func (ctrl *Controller) InitWAF() {
+	if !ctrl.WAFConfig.Enabled {
+		return
+	}
+	ctrl.globalWAF = ctrl.newWAF(wafRoleGlobal)
+	empty := map[string]*waf.WAF{}
+	ctrl.zones.Store(&empty)
+}
+
+// GlobalWAF returns the global WAF middleware to mount in the server chain, or
+// nil when the WAF is disabled. An enabled WAF with no rules loaded is a cheap
+// pass-through.
+func (ctrl *Controller) GlobalWAF() parapet.Middleware {
+	if ctrl.globalWAF == nil {
+		return nil
+	}
+	return ctrl.globalWAF
+}
+
+// LookupZone returns the compiled WAF for a zone registry key
+// (<namespace>/<name>), or nil if no such zone is loaded. Looked up live on the
+// request path so zone edits and new zones propagate without a mux rebuild.
+func (ctrl *Controller) LookupZone(key string) *waf.WAF {
+	m := ctrl.zones.Load()
+	if m == nil {
+		return nil
+	}
+	return (*m)[key]
+}
+
+// newWAF builds a WAF instance with the configured tunables and wires match
+// events to metrics + logging. scope ("global"/"zone") is the metric label.
+func (ctrl *Controller) newWAF(scope string) *waf.WAF {
+	w := waf.New()
+	if ctrl.WAFConfig.FailClosed {
+		w.FailMode = waf.FailClosed
+	}
+	w.EvalTimeout = ctrl.WAFConfig.EvalTimeout
+	w.CostLimit = ctrl.WAFConfig.CostLimit
+	w.InspectBody = ctrl.WAFConfig.InspectBody
+	w.DisableMacros = ctrl.WAFConfig.DisableMacros
+	// Logger catches eval errors (the fail-open path) and the module's own match
+	// lines; kept at debug so a flood of matches can't spam the log (the metric
+	// below is the always-on signal).
+	w.Logger = waf.LoggerFunc(func(format string, args ...any) {
+		slog.Debug(fmt.Sprintf(format, args...))
+	})
+	w.OnMatch = func(ev waf.MatchEvent) {
+		metric.WAFMatch(ev.RuleID, ev.Action.String(), scope)
+		lvl := slog.LevelDebug
+		if ev.Action == waf.ActionBlock {
+			lvl = slog.LevelInfo
+		}
+		slog.Log(context.Background(), lvl, "waf match",
+			"scope", scope, "rule", ev.RuleID, "action", ev.Action.String(),
+			"status", ev.Status, "ip", ev.ClientIP, "method", ev.Request.Method,
+			"host", ev.Request.Host, "path", ev.Request.URL.Path)
+	}
+	return w
+}
+
+func (ctrl *Controller) watchConfigMaps(ctx context.Context) {
+	watchFn := func(ctx context.Context, namespace string) (watch.Interface, error) {
+		return k8s.WatchConfigMaps(ctx, namespace, wafLabelKey)
+	}
+	watchResource(ctx, ctrl.watchNamespace, "configmaps", watchFn,
+		&ctrl.watchedConfigMaps,
+		func(_ *v1.ConfigMap) { ctrl.reloadWAF() },
+		ctrl.reloadWAF,
+	)
+}
+
+func (ctrl *Controller) reloadWAF() {
+	ctrl.reloadWAFDebounce.Call()
+}
+
+// reloadWAFDebounced rebuilds the global ruleset and the zone registry from the
+// watched ConfigMaps. It never touches ctrl.mux: WAF rules are decoupled from
+// routing, so a rule edit is just a SetRules + registry swap. Bad config is
+// kept all-or-nothing by SetRules — the previous good ruleset stays live.
+func (ctrl *Controller) reloadWAFDebounced() {
+	if !ctrl.WAFConfig.Enabled || ctrl.globalWAF == nil {
+		return
+	}
+	slog.Info("reload waf")
+
+	defer func() {
+		if err := recover(); err != nil {
+			slog.Error("reload waf failed", "error", err)
+		}
+	}()
+
+	var globalDocs []string
+	zoneDocs := map[string][]string{}
+
+	ctrl.watchedConfigMaps.Range(func(_, value any) bool {
+		cm := value.(*v1.ConfigMap)
+		switch cm.Labels[wafLabelKey] {
+		case wafRoleGlobal:
+			// Global rules are platform-owned: only honored from the controller's
+			// own namespace so a tenant can't inject baseline rules.
+			if cm.Namespace != ctrl.PodNamespace {
+				slog.Warn("waf: ignoring global ruleset outside controller namespace",
+					"configmap", cm.Namespace+"/"+cm.Name, "pod_namespace", ctrl.PodNamespace)
+				return true
+			}
+			globalDocs = append(globalDocs, sortedDataValues(cm.Data)...)
+		case wafRoleZone:
+			key := cm.Namespace + "/" + cm.Name
+			zoneDocs[key] = append(zoneDocs[key], sortedDataValues(cm.Data)...)
+		}
+		return true
+	})
+
+	// global
+	if rules, err := wafrule.Parse(globalDocs...); err != nil {
+		slog.Error("waf: invalid global ruleset, keeping previous", "error", err)
+	} else if err := ctrl.globalWAF.SetRules(rules); err != nil {
+		slog.Error("waf: global ruleset rejected, keeping previous", "error", err)
+	}
+
+	// zones: reuse the existing *waf.WAF per zone so a bad edit keeps that zone's
+	// last-good ruleset (SetRules is all-or-nothing on the same instance).
+	cur := ctrl.zones.Load()
+	newZones := make(map[string]*waf.WAF, len(zoneDocs))
+	for key, docs := range zoneDocs {
+		w := ctrl.newWAF(wafRoleZone)
+		if cur != nil {
+			if existing, ok := (*cur)[key]; ok {
+				w = existing
+			}
+		}
+		if rules, err := wafrule.Parse(docs...); err != nil {
+			slog.Error("waf: invalid zone ruleset, keeping previous", "zone", key, "error", err)
+		} else if err := w.SetRules(rules); err != nil {
+			slog.Error("waf: zone ruleset rejected, keeping previous", "zone", key, "error", err)
+		}
+		newZones[key] = w
+	}
+	ctrl.zones.Store(&newZones)
+}
+
+// sortedDataValues returns the ConfigMap data values ordered by key, so rule
+// declaration order (which matters within equal priority) is deterministic
+// across reloads regardless of map iteration order.
+func sortedDataValues(data map[string]string) []string {
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, data[k])
+	}
+	return out
+}

--- a/controller_waf_test.go
+++ b/controller_waf_test.go
@@ -1,0 +1,110 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/moonrhythm/parapet-ingress-controller/proxy"
+)
+
+func newWAFController() *Controller {
+	ctrl := New("", proxy.New())
+	ctrl.PodNamespace = "ctrl-ns"
+	ctrl.WAFConfig = WAFConfig{Enabled: true}
+	ctrl.InitWAF()
+	return ctrl
+}
+
+func wafCM(namespace, name, role, rules string) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels:    map[string]string{wafLabelKey: role},
+		},
+		Data: map[string]string{"rules.yaml": rules},
+	}
+}
+
+func TestReloadWAF(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newWAFController()
+
+	ctrl.watchedConfigMaps.Store("ctrl-ns/waf-global", wafCM("ctrl-ns", "waf-global", wafRoleGlobal, `
+rules:
+  - id: block-scanners
+    expression: request.user_agent.contains("sqlmap")
+    action: block
+`))
+	ctrl.watchedConfigMaps.Store("cust1/acme", wafCM("cust1", "acme", wafRoleZone, `
+rules:
+  - id: block-admin
+    expression: request.path.startsWith("/admin")
+    action: block
+`))
+	// a global ruleset outside the controller's namespace must be ignored
+	// (tenants can't inject baseline rules).
+	ctrl.watchedConfigMaps.Store("cust1/waf-global", wafCM("cust1", "waf-global", wafRoleGlobal, `
+rules:
+  - id: tenant-injected-global
+    expression: "true"
+    action: block
+`))
+
+	ctrl.reloadWAFDebounced()
+
+	assert.Equal(t, []string{"block-scanners"}, ctrl.globalWAF.Rules(),
+		"only the in-namespace global ruleset is honored")
+
+	zone := ctrl.LookupZone("cust1/acme")
+	require.NotNil(t, zone, "zone resolves by <namespace>/<name>")
+	assert.Equal(t, []string{"block-admin"}, zone.Rules())
+
+	assert.Nil(t, ctrl.LookupZone("cust1/missing"), "unknown zone resolves to nil")
+}
+
+func TestReloadWAF_BadZoneKeepsLastGood(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newWAFController()
+
+	ctrl.watchedConfigMaps.Store("cust1/acme", wafCM("cust1", "acme", wafRoleZone, `
+rules:
+  - id: ok
+    expression: request.path.startsWith("/x")
+    action: block
+`))
+	ctrl.reloadWAFDebounced()
+	require.Equal(t, []string{"ok"}, ctrl.LookupZone("cust1/acme").Rules())
+
+	// push a broken rule (uncompilable expression) into the same zone
+	ctrl.watchedConfigMaps.Store("cust1/acme", wafCM("cust1", "acme", wafRoleZone, `
+rules:
+  - id: broken
+    expression: this is not cel
+    action: block
+`))
+	ctrl.reloadWAFDebounced()
+
+	// the zone keeps its last-good ruleset — the instance is reused and SetRules
+	// is all-or-nothing, so a bad edit can't drop the live ruleset.
+	zone := ctrl.LookupZone("cust1/acme")
+	require.NotNil(t, zone)
+	assert.Equal(t, []string{"ok"}, zone.Rules(), "bad edit must not drop the live ruleset")
+}
+
+func TestReloadWAF_DisabledIsNoop(t *testing.T) {
+	t.Parallel()
+
+	ctrl := New("", proxy.New())
+	// WAF disabled: InitWAF builds nothing, reload is a no-op, no panic.
+	ctrl.InitWAF()
+	assert.NotPanics(t, ctrl.reloadWAFDebounced)
+	assert.Nil(t, ctrl.GlobalWAF())
+	assert.Nil(t, ctrl.LookupZone("any/zone"))
+}

--- a/deploy/role-cluster.yaml
+++ b/deploy/role-cluster.yaml
@@ -18,6 +18,7 @@ rules:
   - services
   - secrets
   - endpoints
+  - configmaps
   verbs:
   - list
   - watch

--- a/deploy/role-namespaced.yaml
+++ b/deploy/role-namespaced.yaml
@@ -19,6 +19,7 @@ rules:
   - services
   - secrets
   - endpoints
+  - configmaps
   verbs:
   - list
   - watch

--- a/go.mod
+++ b/go.mod
@@ -21,12 +21,14 @@ require (
 )
 
 require (
+	cel.dev/expr v0.25.1 // indirect
 	cloud.google.com/go v0.123.0 // indirect
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/trace v1.16.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.56.0 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -39,6 +41,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/google/brotli/go/cbrotli v0.0.0-20240919160234-350100a5bb9d // indirect
+	github.com/google/cel-go v0.28.1 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260507013755-92041b743c96 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
@@ -65,6 +68,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.56.0/go.mod h1:6ZZMQhZKDvUvkJw2rc+oDP90tMMzuU/J+5HG1ZmPOmE=
 github.com/acoshift/configfile v1.9.0 h1:/t8DhgBdYIr15f4BkkM4bDSBWi0+ImKwWgJN/M5Hbb0=
 github.com/acoshift/configfile v1.9.0/go.mod h1:4T3q2BRRhEW4lcS0vc1Pruv0/TuBVKOb7F5vUp6ZyAY=
+github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
+github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -77,6 +79,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/brotli/go/cbrotli v0.0.0-20240919160234-350100a5bb9d h1:0TtWOcS8HiKXekwxgCCYDcFN8n2DaFVRmb7SQwvFNA4=
 github.com/google/brotli/go/cbrotli v0.0.0-20240919160234-350100a5bb9d/go.mod h1:nOPhAkwVliJdNTkj3gXpljmWhjc4wCaVqbMJcPKWP4s=
+github.com/google/cel-go v0.28.1 h1:YWIwi77J4xIsYUwAF/iIuS6haffzIHS8yWI8glSbLWM=
+github.com/google/cel-go v0.28.1/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=
 github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -181,6 +185,8 @@ go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa h1:Zt3DZoOFFYkKhDT3v7Lm9FDMEV06GpzjG2jrqW+QTE0=
+golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa/go.mod h1:K79w1Vqn7PoiZn+TkNpx3BUWUQksGO3JcVX6qIjytmA=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=

--- a/k8s/cluster.go
+++ b/k8s/cluster.go
@@ -61,3 +61,15 @@ func (c *clusterClient) GetEndpoints(ctx context.Context, namespace string) ([]v
 func (c *clusterClient) WatchEndpoints(ctx context.Context, namespace string) (watch.Interface, error) {
 	return c.client.CoreV1().Endpoints(namespace).Watch(ctx, metav1.ListOptions{})
 }
+
+func (c *clusterClient) GetConfigMaps(ctx context.Context, namespace, labelSelector string) ([]v1.ConfigMap, error) {
+	list, err := c.client.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+func (c *clusterClient) WatchConfigMaps(ctx context.Context, namespace, labelSelector string) (watch.Interface, error) {
+	return c.client.CoreV1().ConfigMaps(namespace).Watch(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+}

--- a/k8s/fs.go
+++ b/k8s/fs.go
@@ -21,12 +21,13 @@ import (
 )
 
 type fsClient struct {
-	mu        sync.RWMutex
-	dir       string
-	ingresses []networking.Ingress
-	services  []v1.Service
-	endpoints []v1.Endpoints
-	secrets   []v1.Secret
+	mu         sync.RWMutex
+	dir        string
+	ingresses  []networking.Ingress
+	services   []v1.Service
+	endpoints  []v1.Endpoints
+	secrets    []v1.Secret
+	configmaps []v1.ConfigMap
 }
 
 func newFSClient(dir string) (*fsClient, error) {
@@ -45,6 +46,7 @@ func (c *fsClient) reset() {
 	c.services = nil
 	c.endpoints = nil
 	c.secrets = nil
+	c.configmaps = nil
 }
 
 func (c *fsClient) load() error {
@@ -179,6 +181,17 @@ func (c *fsClient) addObject(raw []byte) {
 		}
 		c.autofillMeta(&s.ObjectMeta)
 		c.secrets = append(c.secrets, s)
+	case runtime.TypeMeta{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+	}:
+		var cm v1.ConfigMap
+		err := c.decode(raw, &cm)
+		if err != nil {
+			return
+		}
+		c.autofillMeta(&cm.ObjectMeta)
+		c.configmaps = append(c.configmaps, cm)
 	}
 	ok = true
 }
@@ -229,6 +242,20 @@ func (c *fsClient) GetEndpoints(ctx context.Context, namespace string) ([]v1.End
 }
 
 func (c *fsClient) WatchEndpoints(ctx context.Context, namespace string) (watch.Interface, error) {
+	ch := make(chan watch.Event)
+	return watch.NewProxyWatcher(ch), nil
+}
+
+// GetConfigMaps returns all loaded config maps. The label selector is ignored
+// here (the fs backend has no label index); the controller filters by the
+// parapet.moonrhythm.io/waf label value after listing.
+func (c *fsClient) GetConfigMaps(ctx context.Context, namespace, labelSelector string) ([]v1.ConfigMap, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.configmaps, nil
+}
+
+func (c *fsClient) WatchConfigMaps(ctx context.Context, namespace, labelSelector string) (watch.Interface, error) {
 	ch := make(chan watch.Event)
 	return watch.NewProxyWatcher(ch), nil
 }

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -57,6 +57,8 @@ var client interface {
 	WatchSecrets(ctx context.Context, namespace string) (watch.Interface, error)
 	GetEndpoints(ctx context.Context, namespace string) ([]v1.Endpoints, error)
 	WatchEndpoints(ctx context.Context, namespace string) (watch.Interface, error)
+	GetConfigMaps(ctx context.Context, namespace, labelSelector string) ([]v1.ConfigMap, error)
+	WatchConfigMaps(ctx context.Context, namespace, labelSelector string) (watch.Interface, error)
 }
 
 // WatchIngresses watches ingresses for given namespace
@@ -97,4 +99,14 @@ func GetEndpoints(ctx context.Context, namespace string) ([]v1.Endpoints, error)
 // WatchEndpoints watches endpoints
 func WatchEndpoints(ctx context.Context, namespace string) (watch.Interface, error) {
 	return client.WatchEndpoints(ctx, namespace)
+}
+
+// GetConfigMaps lists config maps for given namespace, filtered by labelSelector
+func GetConfigMaps(ctx context.Context, namespace, labelSelector string) ([]v1.ConfigMap, error) {
+	return client.GetConfigMaps(ctx, namespace, labelSelector)
+}
+
+// WatchConfigMaps watches config maps for given namespace, filtered by labelSelector
+func WatchConfigMaps(ctx context.Context, namespace, labelSelector string) (watch.Interface, error) {
+	return client.WatchConfigMaps(ctx, namespace, labelSelector)
 }

--- a/metric/waf.go
+++ b/metric/waf.go
@@ -1,0 +1,46 @@
+package metric
+
+import (
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const wafSizeHint = 100
+
+var _waf wafMetric
+
+type wafMetric struct {
+	vec   *prometheus.CounterVec
+	cache *cache[wafKey, prometheus.Counter]
+}
+
+// wafKey is the cache key for the per-(rule,action,scope) counter handle. All
+// three labels are bounded: rule IDs are operator-defined (a fixed ruleset),
+// action is one of log|allow|block, and scope is global|zone — so this cannot
+// be inflated into unbounded series by request input.
+type wafKey struct {
+	ruleID string
+	action string
+	scope  string
+}
+
+func init() {
+	_waf.vec = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "waf_matches",
+	}, []string{"rule_id", "action", "scope"})
+	_waf.cache = newCache[wafKey, prometheus.Counter](wafSizeHint)
+	prom.Registry().MustRegister(_waf.vec)
+}
+
+// WAFMatch increments the WAF match counter for a rule that fired. scope is
+// "global" or "zone".
+func WAFMatch(ruleID, action, scope string) {
+	_waf.cache.getOrCreate(wafKey{ruleID: ruleID, action: action, scope: scope}, func() prometheus.Counter {
+		return _waf.vec.With(prometheus.Labels{
+			"rule_id": ruleID,
+			"action":  action,
+			"scope":   scope,
+		})
+	}).Inc()
+}

--- a/plugin/waf.go
+++ b/plugin/waf.go
@@ -1,0 +1,54 @@
+package plugin
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/moonrhythm/parapet"
+	"github.com/moonrhythm/parapet/pkg/waf"
+)
+
+// WAFZone binds an ingress to a WAF zone via the parapet.moonrhythm.io/waf-zone
+// annotation. The value is a zone reference: a bare id resolves to a zone in the
+// ingress's own namespace; "ns/id" references a zone in another namespace.
+//
+// lookup resolves the registry key to the live zone WAF on the request path, so
+// zone rule edits and newly-created zones take effect without a mux rebuild. A
+// key that resolves to no zone (deleted / not yet created) simply passes the
+// request through — the global WAF still applies upstream.
+func WAFZone(lookup func(key string) *waf.WAF) Plugin {
+	return func(ctx Context) {
+		key, ok := ZoneKey(ctx.Ingress.Namespace, ctx.Ingress.Annotations[namespace+"/waf-zone"])
+		if !ok {
+			return
+		}
+		ctx.Use(parapet.MiddlewareFunc(func(h http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if zw := lookup(key); zw != nil {
+					zw.ServeHandler(h).ServeHTTP(w, r)
+					return
+				}
+				h.ServeHTTP(w, r)
+			})
+		}))
+	}
+}
+
+// ZoneKey resolves a waf-zone annotation value to a zone registry key
+// (<namespace>/<name>). A bare id uses the ingress's namespace; "ns/id" is used
+// verbatim. Returns ok=false for an empty or malformed value.
+func ZoneKey(ingressNamespace, annotation string) (key string, ok bool) {
+	v := strings.TrimSpace(annotation)
+	if v == "" {
+		return "", false
+	}
+	if i := strings.IndexByte(v, '/'); i >= 0 {
+		ns := strings.TrimSpace(v[:i])
+		name := strings.TrimSpace(v[i+1:])
+		if ns == "" || name == "" || strings.Contains(name, "/") {
+			return "", false
+		}
+		return ns + "/" + name, true
+	}
+	return ingressNamespace + "/" + v, true
+}

--- a/plugin/waf_test.go
+++ b/plugin/waf_test.go
@@ -1,0 +1,112 @@
+package plugin_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/moonrhythm/parapet"
+	"github.com/moonrhythm/parapet/pkg/waf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	networking "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/moonrhythm/parapet-ingress-controller/plugin"
+)
+
+func TestZoneKey(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		ns, ann, key string
+		ok           bool
+	}{
+		{"cust1", "acme", "cust1/acme", true},
+		{"cust1", "  acme  ", "cust1/acme", true},
+		{"cust1", "team-x/acme", "team-x/acme", true},
+		{"cust1", "", "", false},
+		{"cust1", "   ", "", false},
+		{"cust1", "ns/", "", false},
+		{"cust1", "/name", "", false},
+		{"cust1", "a/b/c", "", false},
+	}
+	for _, tc := range cases {
+		key, ok := ZoneKey(tc.ns, tc.ann)
+		assert.Equal(t, tc.ok, ok, "ann=%q", tc.ann)
+		if tc.ok {
+			assert.Equal(t, tc.key, key, "ann=%q", tc.ann)
+		}
+	}
+}
+
+func TestWAFZone(t *testing.T) {
+	t.Parallel()
+
+	zone := waf.New()
+	require.NoError(t, zone.SetRules([]waf.Rule{{
+		ID:         "block-admin",
+		Expression: `request.path.startsWith("/admin")`,
+		Action:     waf.ActionBlock,
+	}}))
+
+	newCtx := func(ann map[string]string) Context {
+		return Context{
+			Middlewares: &parapet.Middlewares{},
+			Ingress: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "cust1", Annotations: ann},
+			},
+		}
+	}
+
+	serve := func(ctx Context, target string) (*httptest.ResponseRecorder, bool) {
+		r := httptest.NewRequest(http.MethodGet, target, nil)
+		w := httptest.NewRecorder()
+		var called bool
+		ctx.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(w, r)
+		return w, called
+	}
+
+	t.Run("blocks matched request via resolved zone", func(t *testing.T) {
+		ctx := newCtx(map[string]string{"parapet.moonrhythm.io/waf-zone": "acme"})
+		var gotKey string
+		WAFZone(func(key string) *waf.WAF { gotKey = key; return zone })(ctx)
+
+		w, called := serve(ctx, "/admin/users")
+		assert.Equal(t, "cust1/acme", gotKey)
+		assert.False(t, called)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("non-matching request passes through resolved zone", func(t *testing.T) {
+		ctx := newCtx(map[string]string{"parapet.moonrhythm.io/waf-zone": "acme"})
+		WAFZone(func(string) *waf.WAF { return zone })(ctx)
+
+		w, called := serve(ctx, "/public")
+		assert.True(t, called)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("passes through when zone resolves to nil", func(t *testing.T) {
+		ctx := newCtx(map[string]string{"parapet.moonrhythm.io/waf-zone": "acme"})
+		WAFZone(func(string) *waf.WAF { return nil })(ctx)
+
+		w, called := serve(ctx, "/admin/users")
+		assert.True(t, called)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("no annotation injects no middleware", func(t *testing.T) {
+		ctx := newCtx(nil)
+		var lookupCalled bool
+		WAFZone(func(string) *waf.WAF { lookupCalled = true; return zone })(ctx)
+
+		w, called := serve(ctx, "/admin")
+		assert.True(t, called)
+		assert.False(t, lookupCalled)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+}

--- a/wafrule/wafrule.go
+++ b/wafrule/wafrule.go
@@ -1,0 +1,87 @@
+// Package wafrule parses the YAML rule documents carried in WAF ConfigMaps
+// (the global ruleset and per-zone rulesets) into parapet waf.Rule values.
+//
+// It is deliberately a thin DTO layer: it converts YAML to []waf.Rule and maps
+// the `action` string onto waf.Action, then hands off to waf.WAF.SetRules,
+// which is the single source of truth for the heavier validation (empty ID,
+// duplicate ID, empty/non-bool/uncompilable expression) and for the
+// all-or-nothing compile.
+package wafrule
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/moonrhythm/parapet/pkg/waf"
+	"gopkg.in/yaml.v3"
+)
+
+// Document is the YAML shape of a WAF ConfigMap data value.
+type Document struct {
+	Rules []Rule `yaml:"rules"`
+}
+
+// Rule mirrors waf.Rule with YAML tags. Action is a string here ("log",
+// "allow", "block") and converted to waf.Action by Parse.
+type Rule struct {
+	ID          string `yaml:"id"`
+	Description string `yaml:"description"`
+	Expression  string `yaml:"expression"`
+	Action      string `yaml:"action"`
+	Status      int    `yaml:"status"`
+	Message     string `yaml:"message"`
+	Priority    int    `yaml:"priority"`
+}
+
+// ParseAction maps an action string onto waf.Action. An empty action defaults
+// to ActionLog (a safe shadow rule that never blocks), matching waf.Action's
+// zero value.
+func ParseAction(s string) (waf.Action, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "log":
+		return waf.ActionLog, nil
+	case "allow":
+		return waf.ActionAllow, nil
+	case "block":
+		return waf.ActionBlock, nil
+	default:
+		return 0, fmt.Errorf("unknown action %q (want log|allow|block)", s)
+	}
+}
+
+// Parse parses one or more YAML rule documents (each ConfigMap data value is one
+// document) and returns the concatenated []waf.Rule. A YAML or action error in
+// any document is collected and returned joined; the caller (SetRules) rejects
+// the whole batch on any error, so a bad document never partially applies.
+func Parse(docs ...string) ([]waf.Rule, error) {
+	var out []waf.Rule
+	var errs []error
+	for _, doc := range docs {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		var d Document
+		if err := yaml.Unmarshal([]byte(doc), &d); err != nil {
+			errs = append(errs, fmt.Errorf("waf: parse document: %w", err))
+			continue
+		}
+		for i, r := range d.Rules {
+			action, err := ParseAction(r.Action)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("waf: rule[%d] %q: %w", i, r.ID, err))
+				continue
+			}
+			out = append(out, waf.Rule{
+				ID:          r.ID,
+				Description: r.Description,
+				Expression:  r.Expression,
+				Action:      action,
+				Status:      r.Status,
+				Message:     r.Message,
+				Priority:    r.Priority,
+			})
+		}
+	}
+	return out, errors.Join(errs...)
+}

--- a/wafrule/wafrule_test.go
+++ b/wafrule/wafrule_test.go
@@ -1,0 +1,111 @@
+package wafrule_test
+
+import (
+	"testing"
+
+	"github.com/moonrhythm/parapet/pkg/waf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet-ingress-controller/wafrule"
+)
+
+func TestParseAction(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want waf.Action
+		err  bool
+	}{
+		{"", waf.ActionLog, false},
+		{"log", waf.ActionLog, false},
+		{"LOG", waf.ActionLog, false},
+		{" allow ", waf.ActionAllow, false},
+		{"block", waf.ActionBlock, false},
+		{"deny", 0, true},
+	}
+	for _, tc := range cases {
+		got, err := wafrule.ParseAction(tc.in)
+		if tc.err {
+			assert.Error(t, err, "in=%q", tc.in)
+			continue
+		}
+		require.NoError(t, err, "in=%q", tc.in)
+		assert.Equal(t, tc.want, got, "in=%q", tc.in)
+	}
+}
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single document", func(t *testing.T) {
+		rules, err := wafrule.Parse(`
+rules:
+  - id: block-admin
+    description: block admin paths
+    expression: request.path.startsWith("/admin")
+    action: block
+    status: 401
+    message: nope
+    priority: 5
+`)
+		require.NoError(t, err)
+		require.Len(t, rules, 1)
+		assert.Equal(t, "block-admin", rules[0].ID)
+		assert.Equal(t, waf.ActionBlock, rules[0].Action)
+		assert.Equal(t, 401, rules[0].Status)
+		assert.Equal(t, "nope", rules[0].Message)
+		assert.Equal(t, 5, rules[0].Priority)
+	})
+
+	t.Run("concatenates multiple documents", func(t *testing.T) {
+		rules, err := wafrule.Parse(
+			"rules:\n  - id: a\n    expression: \"true\"\n    action: log",
+			"rules:\n  - id: b\n    expression: \"false\"\n    action: block",
+		)
+		require.NoError(t, err)
+		require.Len(t, rules, 2)
+		assert.Equal(t, "a", rules[0].ID)
+		assert.Equal(t, waf.ActionLog, rules[0].Action)
+		assert.Equal(t, "b", rules[1].ID)
+		assert.Equal(t, waf.ActionBlock, rules[1].Action)
+	})
+
+	t.Run("empty action defaults to log", func(t *testing.T) {
+		rules, err := wafrule.Parse("rules:\n  - id: a\n    expression: \"true\"")
+		require.NoError(t, err)
+		require.Len(t, rules, 1)
+		assert.Equal(t, waf.ActionLog, rules[0].Action)
+	})
+
+	t.Run("blank documents skipped", func(t *testing.T) {
+		rules, err := wafrule.Parse("", "   \n", "rules:\n  - id: a\n    expression: \"true\"")
+		require.NoError(t, err)
+		assert.Len(t, rules, 1)
+	})
+
+	t.Run("bad action reported", func(t *testing.T) {
+		_, err := wafrule.Parse("rules:\n  - id: a\n    expression: \"true\"\n    action: nuke")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown action")
+	})
+
+	t.Run("invalid yaml reported", func(t *testing.T) {
+		_, err := wafrule.Parse("rules: [ this is : not : valid")
+		require.Error(t, err)
+	})
+
+	t.Run("rules feed waf.SetRules", func(t *testing.T) {
+		rules, err := wafrule.Parse(`
+rules:
+  - id: r1
+    expression: request.method == "GET"
+    action: block
+`)
+		require.NoError(t, err)
+		w := waf.New()
+		require.NoError(t, w.SetRules(rules))
+		assert.Equal(t, []string{"r1"}, w.Rules())
+	})
+}


### PR DESCRIPTION
Opt-in WAF on top of [`parapet/pkg/waf`](https://github.com/moonrhythm/parapet/tree/master/pkg/waf). Off by default (`WAF_ENABLED`), so this is inert until switched on. **Go side only — Rust port follows in a separate PR.**

## Model

One rule schema, two delivery channels (Cloudflare-style zones):

- **Global** — one baseline ruleset, applied to all traffic, honored **only** from the controller's own namespace (`POD_NAMESPACE`) so tenants can't inject baseline rules. Mounted in the `main.go` `m` chain just before `ctrl`.
- **Zones** — tenant rulesets in their own ConfigMaps; an ingress binds one with `parapet.moonrhythm.io/waf-zone: <id>`. Resolution is **namespace-local** (`acme` → `<ingress-ns>/acme`) with explicit cross-ref (`team-x/acme`).

Both are delivered via a single marker label `parapet.moonrhythm.io/waf: global|zone`, watched as a 5th resource. Global runs first and is **authoritative** (a tenant cannot `allow`-override a global `block`).

## Key property: WAF reload is decoupled from routing

Binding is by ID resolved at request time. So:
- Ingress/Service/Secret/Endpoint change → rebuild the router (unchanged).
- WAF ConfigMap change → `reloadWAFDebounced` recompiles that ruleset and atomically swaps the registry — **no mux rebuild, no plugin re-run**. `SetRules` is all-or-nothing, so a broken ConfigMap keeps the zone's last-good rules; global and other zones are untouched.

## What to review

- `WAF.md` — full design rationale (start here).
- `controller_waf.go` — global instance + zone registry + ConfigMap watch + match metrics/log wiring.
- `plugin/waf.go` — `WAFZone` plugin + `ZoneKey` resolution.
- `wafrule/` — shared rule YAML → `[]waf.Rule`.
- `k8s/` — ConfigMap list/watch (label selector server-side; fs backend filters in-controller).
- RBAC: `configmaps` `list/watch` added to both role manifests.

## Verification

`go vet ./...` clean, `gofmt` clean, `go test -race ./...` green. New tests cover rule parsing, zone-key resolution, `WAFZone` block/passthrough, and the controller reload (global namespace restriction + bad-config-keeps-last-good). No live end-to-end serve test yet.

## Notes

- Disjoint from the open `go-bound-upgrade-label` branch; based on current `master`.
- Rust port (the `waf` cargo feature + cel-rust, against a shared CEL test corpus) is intentionally deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)