### PR TITLE
docs: add Rust Test CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # parapet-ingress-controller
 
-![Build Status](https://github.com/moonrhythm/parapet-ingress-controller/actions/workflows/go-test.yaml/badge.svg?branch=master)
+[![Go Test](https://github.com/moonrhythm/parapet-ingress-controller/actions/workflows/go-test.yaml/badge.svg?branch=master)](https://github.com/moonrhythm/parapet-ingress-controller/actions/workflows/go-test.yaml)
+[![Rust Test](https://github.com/moonrhythm/parapet-ingress-controller/actions/workflows/rust-test.yaml/badge.svg?branch=master)](https://github.com/moonrhythm/parapet-ingress-controller/actions/workflows/rust-test.yaml)
 [![codecov](https://codecov.io/gh/moonrhythm/parapet-ingress-controller/branch/master/graph/badge.svg)](https://codecov.io/gh/moonrhythm/parapet-ingress-controller)
 [![Go Report Card](https://goreportcard.com/badge/github.com/moonrhythm/parapet-ingress-controller)](https://goreportcard.com/report/github.com/moonrhythm/parapet-ingress-controller)
 


### PR DESCRIPTION
Adds the `rust-test` workflow status badge next to the Go one, and makes both workflow badges clickable links to their Actions pages — reflecting the two co-maintained implementations.

Before: a single unlabeled "Build Status" badge (go-test only).
After: **Go Test** + **Rust Test** badges, then codecov + Go Report Card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)