### PR TITLE
fix(go): retry only on connection errors, not upstream 502/503

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -29,6 +29,14 @@ Endpoint selection is **round-robin**; an address that fails to dial is marked
 **bad for 2s** and skipped (reactive health — no active probing). Host is
 lowercased and port-stripped before matching.
 
+**Retry is connection-only** (both implementations): a dial failure — or a
+connection broken before any response — is retried up to 5× with backoff,
+marking the pod bad and round-robining to another. An upstream that *responds* —
+**including with 502/503** — is **never** retried; its response passes through to
+the client unchanged. A responding upstream has already received and processed
+the request, so retrying could duplicate side effects and amplify load on a
+failing backend. Non-idempotent requests (body already read) are never retried.
+
 ## Annotations
 
 All keys are prefixed `parapet.moonrhythm.io/`. Applied per-Ingress.
@@ -119,9 +127,6 @@ doesn't serve, to bound cardinality under a flood.
 
 ## Intentional Go↔Rust divergences
 
-- **Retry (Rust)** is connection-only — `fail_to_connect` + a broken reused keepalive
-  connection; **never** retries on an upstream HTTP status (Go retried 502/503),
-  since a responding upstream has already processed the request.
 - **WAF cost limit** — cel-rust has none; Rust checks `WAF_EVAL_TIMEOUT` between
   rules. **WAF body inspection** is phase-2 in Rust (`request.body` empty).
 - **Cloud Profiler/Trace** are Go-only (no Rust SDK).

--- a/go/CLAUDE.md
+++ b/go/CLAUDE.md
@@ -71,7 +71,7 @@ TLS secrets are loaded from `Secret.Data["tls.crt"]` / `["tls.key"]`. The `cert.
 ### Proxy
 `proxy.Proxy` wraps `httputil.ReverseProxy`. The upstream URL is resolved at request time via `route.Table.Lookup`. Protocol is controlled by the `parapet.moonrhythm.io/upstream-protocol` annotation (default: `http`).
 
-On an upstream failure (dial error, upstream 502/503), the proxy's `ErrorHandler` panics; `retryMiddleware` (`retry.go`) recovers it and retries the request (up to 5 times with backoff) — but only when the body hasn't been read, so non-idempotent requests aren't replayed. `proxy.IsRetryable` decides which errors qualify.
+On a **connection failure** (dial error — no response from upstream), the proxy's `ErrorHandler` panics; `retryMiddleware` (`retry.go`) recovers it and retries the request (up to 5 times with backoff) — but only when the body hasn't been read, so non-idempotent requests aren't replayed. `proxy.IsRetryable` is **dial-error-only**: an upstream that *responds* — including 502/503 — has processed the request, so its response passes through to the client unchanged rather than being retried (retrying could duplicate side effects and amplify load on a failing backend). This matches the Rust port; see [`../SPEC.md`](../SPEC.md).
 
 ### WAF (opt-in, `WAF_ENABLED=true`)
 A CEL-rule firewall on top of `parapet/pkg/waf`. **Full design in [`../WAF.md`](../WAF.md).** Two rulesets, both fed by label-marked ConfigMaps (`parapet.moonrhythm.io/waf: global|zone`), watched as a 5th resource:

--- a/go/proxy/proxy.go
+++ b/go/proxy/proxy.go
@@ -8,11 +8,6 @@ import (
 	"net/http/httputil"
 )
 
-var (
-	errBadGateway         = errors.New("bad gateway")
-	errServiceUnavailable = errors.New("service unavailable")
-)
-
 type Proxy struct {
 	OnDialError func(addr string)
 
@@ -35,16 +30,10 @@ func New() *Proxy {
 			Default: p.httpTransport,
 			H2C:     p.h2cTransport,
 		},
-		ModifyResponse: func(resp *http.Response) error {
-			switch resp.StatusCode {
-			case http.StatusBadGateway:
-				return errBadGateway
-			case http.StatusServiceUnavailable:
-				return errServiceUnavailable
-			default:
-				return nil
-			}
-		},
+		// No ModifyResponse: an upstream that responded — including with 502/503 —
+		// has processed the request, so its response passes through to the client
+		// unchanged (status, headers, body). Only connection failures (no response)
+		// reach ErrorHandler and may be retried.
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			if errors.Is(err, context.Canceled) {
 				// client canceled request
@@ -79,15 +68,11 @@ func (p *Proxy) ConfigTransport(f func(tr *http.Transport)) {
 	f(p.httpTransport)
 }
 
+// IsRetryable reports whether err is a connection failure that's safe to retry.
+// Only dial/connection errors qualify — an upstream that *responded* (even with
+// 502/503) has already received and processed the request, so retrying could
+// duplicate side effects and amplify load on a failing backend. Those responses
+// pass through to the client unchanged instead of being retried.
 func IsRetryable(err error) bool {
-	if isDialError(err) {
-		return true
-	}
-	if errors.Is(err, errBadGateway) {
-		return true
-	}
-	if errors.Is(err, errServiceUnavailable) {
-		return true
-	}
-	return false
+	return isDialError(err)
 }

--- a/go/proxy/proxy_test.go
+++ b/go/proxy/proxy_test.go
@@ -1,6 +1,9 @@
 package proxy
 
 import (
+	"context"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -28,11 +31,42 @@ func TestProxy(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, "OK", w.Body.String())
 	})
+
+	t.Run("upstream 5xx passes through unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		// An upstream that responds — even 503 — has processed the request, so its
+		// response (status + body) reaches the client verbatim and the upstream is
+		// hit exactly once. The proxy no longer rewrites it into an error to retry.
+		var calls int
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte("upstream-503"))
+		}))
+		defer ts.Close()
+
+		proxy := New()
+		r := httptest.NewRequest(http.MethodGet, ts.URL, nil)
+		w := httptest.NewRecorder()
+		proxy.ServeHTTP(w, r)
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+		assert.Equal(t, "upstream-503", w.Body.String())
+		assert.Equal(t, 1, calls)
+	})
 }
 
 func TestIsRetryable(t *testing.T) {
 	t.Parallel()
 
-	assert.True(t, IsRetryable(errBadGateway))
-	assert.True(t, IsRetryable(errServiceUnavailable))
+	// Only connection failures are retryable.
+	assert.True(t, IsRetryable(&net.OpError{Op: "dial", Err: errors.New("connection refused")}))
+	assert.True(t, IsRetryable(context.DeadlineExceeded))
+
+	// An upstream that responded (even 5xx) has processed the request — not a
+	// connection error, so not retryable. Neither is a mid-flight (non-dial)
+	// transport error or nil.
+	assert.False(t, IsRetryable(errors.New("upstream returned 503")))
+	assert.False(t, IsRetryable(&net.OpError{Op: "read", Err: errors.New("connection reset")}))
+	assert.False(t, IsRetryable(nil))
 }

--- a/go/retry_test.go
+++ b/go/retry_test.go
@@ -1,0 +1,58 @@
+package controller
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// retryMiddleware must retry only on connection failures. An upstream that
+// *responded* (even 502/503) has processed the request, so retrying it could
+// duplicate side effects and amplify load on a failing backend.
+func TestRetryMiddleware(t *testing.T) {
+	t.Parallel()
+
+	dialErr := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+
+	serve := func(h http.Handler) *httptest.ResponseRecorder {
+		r := httptest.NewRequest(http.MethodGet, "http://svc/", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		return w
+	}
+
+	t.Run("retries a connection error up to maxRetry", func(t *testing.T) {
+		var calls atomic.Int32
+		w := serve(retryMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			calls.Add(1)
+			panic(error(dialErr))
+		})))
+		assert.Equal(t, int32(5), calls.Load())
+		assert.Equal(t, http.StatusBadGateway, w.Code)
+	})
+
+	t.Run("does NOT retry an upstream 503 response", func(t *testing.T) {
+		var calls atomic.Int32
+		w := serve(retryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			calls.Add(1)
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+		})))
+		assert.Equal(t, int32(1), calls.Load(), "a responded 503 is served once, not retried")
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	})
+
+	t.Run("does NOT retry a non-connection panic", func(t *testing.T) {
+		var calls atomic.Int32
+		w := serve(retryMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			calls.Add(1)
+			panic(errors.New("boom"))
+		})))
+		assert.Equal(t, int32(1), calls.Load(), "non-retryable error served once")
+		assert.Equal(t, http.StatusBadGateway, w.Code)
+	})
+}

--- a/rust/README.md
+++ b/rust/README.md
@@ -209,8 +209,10 @@ state — no Pingora `ConnState` equivalent) and `go_*` runtime metrics.
 - **Retry is connection-only.** The proxy retries (up to 5×, marking the bad pod
   and round-robining) only on *connection* failures — `fail_to_connect` and a
   reused keepalive connection breaking before a response. It **never** retries on
-  an upstream HTTP status (Go retried 502/503): once the upstream responds it has
-  processed the request, so retrying could duplicate side effects and amplify load.
+  an upstream HTTP status: once the upstream responds it has processed the
+  request, so retrying could duplicate side effects and amplify load. (The Go
+  implementation matches this — `IsRetryable` is dial-error-only; see
+  [`../SPEC.md`](../SPEC.md).)
 - **DDoS resilience.** Bounded upstream connect timeouts (above), host/method
   metric-cardinality bounding, a downstream `keepalive_request_limit`, and a 60s
   default downstream read timeout (Slowloris).


### PR DESCRIPTION
## The bug

`go/`'s proxy retried on **upstream HTTP 502/503**, not just connection errors:

- `ModifyResponse` converted an upstream **response** of 502/503 into `errBadGateway` / `errServiceUnavailable`.
- `IsRetryable` treated those as retryable → `ErrorHandler` panics → `retryMiddleware` replays the request (up to 5×).

But a 502/503 means the upstream **received and processed** the request. Retrying it can **duplicate side effects** and **amplify load** on an already-failing/overloaded backend (503 = overloaded → 5 retries with backoff hammer it harder). This is the exact anti-pattern the Rust port was deliberately written to avoid.

## The fix

Retry on **connection failures only**:

- **Removed `ModifyResponse`** — an upstream that responds (including 502/503) now passes through to the client **unchanged** (status, headers, body), instead of being swallowed and rewritten into a retry/bare-502.
- **`IsRetryable` is now `isDialError(err)` only** — a dial failure (or connection broken before any response) reaches `ErrorHandler` and is retried; an HTTP response never is. The non-idempotent guard (body-read check in `retryMiddleware`) is unchanged.

This makes Go match the Rust implementation, so retry is no longer a Go↔Rust divergence. Docs reconciled: `SPEC.md` (retry moved to shared behavior), `go/CLAUDE.md`, `rust/README.md`.

## Tests

- `proxy_test.go`: an upstream 503 **passes through** (client gets 503 + body, upstream hit exactly once); `IsRetryable` is true for dial errors / `DeadlineExceeded`, false for a responded-5xx error, a non-dial (read) error, and nil.
- `retry_test.go` (new): `retryMiddleware` retries a connection error 5×, but serves a responded **503 once** (no retry) and a non-connection panic once.

`cd go && go vet ./... && go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
