### PR TITLE
ci: run all workflows on self-hosted runners

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch: {}
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Build
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/go-release.yaml
+++ b/.github/workflows/go-release.yaml
@@ -5,7 +5,7 @@ on:
     - '*'
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Build
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -10,7 +10,7 @@ on:
       - '.github/workflows/go-test.yaml'
 jobs:
   runner-job:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     defaults:
       run:
         working-directory: go

--- a/.github/workflows/rust-build.yaml
+++ b/.github/workflows/rust-build.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Build (rust)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: google-github-actions/auth@v2

--- a/.github/workflows/rust-test.yaml
+++ b/.github/workflows/rust-test.yaml
@@ -18,7 +18,7 @@ jobs:
   # features — no pingora/kube, so no native deps and no OpenSSL needed).
   lint-test:
     name: fmt + clippy + test (default features)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -36,7 +36,7 @@ jobs:
   # (cluster) features, which pull native deps and OpenSSL.
   proxy:
     name: clippy + test + build (proxy,cluster)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - name: Install native build deps


### PR DESCRIPTION
## Summary

Switch `runs-on` from `ubuntu-latest` to `self-hosted` across all five workflows.

| Workflow | Job(s) |
|---|---|
| `go-build.yaml` | `build` |
| `go-release.yaml` | `build` |
| `go-test.yaml` | `runner-job` |
| `rust-build.yaml` | `build` |
| `rust-test.yaml` | `lint-test`, `proxy` |

## Runner requirements

These jobs assume the self-hosted runner(s) provide:

- A working **Docker daemon** + Buildx (`docker/setup-buildx-action`) for the build/release jobs.
- **Debian-family `apt` + passwordless `sudo`** — `rust-test.yaml`'s `proxy` job runs `sudo apt-get install ... cmake clang pkg-config libssl-dev`.
- The Go/Rust toolchains are still provisioned per-run by `actions/setup-go` / `dtolnay/rust-toolchain`, so no host toolchain is required.

If runners are tagged more specifically (e.g. `linux`/`x64`), the bare `self-hosted` label can be tightened in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)