### PR TITLE
ci: add Rust release workflow (tag-triggered)

### DIFF
--- a/.github/workflows/rust-release.yaml
+++ b/.github/workflows/rust-release.yaml
@@ -1,0 +1,63 @@
+name: Rust Release
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Build (rust)
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        id: auth
+        with:
+          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+          token_format: access_token
+      - uses: docker/login-action@v3
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+      - uses: docker/login-action@v3
+        with:
+          registry: asia-southeast3-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+      - uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+          platforms: linux/amd64
+      # default GOAMD64-equivalent: x86-64-v3. Reuses the rust-build cache scope
+      # so a tagged commit already built on master hits the layer cache.
+      - uses: docker/build-push-action@v6
+        with:
+          context: rust
+          provenance: false
+          build-args: |
+            TARGET_CPU=x86-64-v3
+          push: true
+          cache-from: type=gha,scope=rust-v3
+          cache-to: type=gha,mode=max,scope=rust-v3
+          tags: |
+            us-docker.pkg.dev/moonrhythm-containers/gcr.io/parapet-ingress-controller:rust-${{ github.ref_name }}
+            us-docker.pkg.dev/moonrhythm-containers/gcr.io/parapet-ingress-controller:rust-latest
+            asia-southeast3-docker.pkg.dev/moonrhythm-core/public/parapet-ingress-controller:rust-${{ github.ref_name }}
+            asia-southeast3-docker.pkg.dev/moonrhythm-core/public/parapet-ingress-controller:rust-latest
+      # compatibility image: x86-64 baseline (Go's GOAMD64=v1 equivalent;
+      # LLVM has no "x86-64-v1" — the baseline microarch level is just "x86-64")
+      - uses: docker/build-push-action@v6
+        with:
+          context: rust
+          provenance: false
+          build-args: |
+            TARGET_CPU=x86-64
+          push: true
+          cache-from: type=gha,scope=rust-v1
+          cache-to: type=gha,mode=max,scope=rust-v1
+          tags: |
+            us-docker.pkg.dev/moonrhythm-containers/gcr.io/parapet-ingress-controller:rust-${{ github.ref_name }}-amd64v1
+            us-docker.pkg.dev/moonrhythm-containers/gcr.io/parapet-ingress-controller:rust-latest-amd64v1
+            asia-southeast3-docker.pkg.dev/moonrhythm-core/public/parapet-ingress-controller:rust-${{ github.ref_name }}-amd64v1
+            asia-southeast3-docker.pkg.dev/moonrhythm-core/public/parapet-ingress-controller:rust-latest-amd64v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,10 @@ vars, and metric names.
 SPEC.md  WAF.md  README.md  CLAUDE.md  LICENSE  SKILL.md
 deploy/                 # shared Kubernetes manifests + RBAC (image-agnostic)
 conformance/            # shared cross-impl fixtures (waf-cel-corpus.md, …)
-.github/workflows/      # go-{test,build,release}.yaml + rust-{test,build}.yaml
-                        #   each path-filtered (go/** vs rust/**) so a change to
-                        #   one implementation never runs the other's CI
+.github/workflows/      # go-{test,build,release}.yaml + rust-{test,build,release}.yaml
+                        #   test/build are path-filtered (go/** vs rust/**) so a
+                        #   change to one impl never runs the other's CI; the
+                        #   tag-triggered *-release builds both
 go/                     # Go implementation — module .../parapet-ingress-controller/go
   CLAUDE.md             #   Go-specific architecture guide
   go.mod  cmd/  controller*.go  plugin/  proxy/  route/  cert/  k8s/

--- a/rust/README.md
+++ b/rust/README.md
@@ -245,7 +245,12 @@ docker build --build-arg TARGET_CPU=x86-64-v3 -t ...:rust rust/
 ## CI
 
 - `.github/workflows/rust-test.yaml` — fmt + clippy + test on push/PR.
-- `.github/workflows/rust-build.yaml` — builds and pushes `rust-`-prefixed images
+- `.github/workflows/rust-build.yaml` — builds and pushes `rust-<sha>` images
   on `master`.
+- `.github/workflows/rust-release.yaml` — on a tag push, builds and pushes
+  `rust-<tag>` and `rust-latest` (plus the `-amd64v1` compatibility variants).
 
-Both are path-filtered to `rust/**`, so Go-only changes never trigger them.
+`rust-test` / `rust-build` are path-filtered to `rust/**`, so Go-only changes
+never trigger them. `rust-release` is tag-triggered (tags can't be path-filtered),
+so a tag release builds **both** implementations — Go publishes `:<tag>`/`:latest`,
+Rust publishes `rust-<tag>`/`rust-latest`.


### PR DESCRIPTION
## What

Adds `.github/workflows/rust-release.yaml`. The Rust implementation had **build** (`rust-<sha>` on `master`) and **test**, but no **release** — this fills the gap so tagged releases publish Rust images alongside Go's.

## Design

Mirrors `go-release.yaml`'s trigger (`push: tags: ['*']`) and `rust-build.yaml`'s two-microarch build, on `self-hosted`:

| Build | `TARGET_CPU` | Tags |
|---|---|---|
| default | `x86-64-v3` | `rust-<tag>`, `rust-latest` |
| compatibility | `x86-64` (Go's `GOAMD64=v1` equivalent) | `rust-<tag>-amd64v1`, `rust-latest-amd64v1` |

Pushed to both registries (`us-docker.pkg.dev/...`, `asia-southeast3-docker.pkg.dev/...`), reusing the `rust-v3`/`rust-v1` gha cache scopes so a tagged commit already built on `master` hits the layer cache.

## Notes

- The Rust `Dockerfile` takes no version build-arg (only `TARGET_CPU`), so the version rides purely in the image tag (`rust-<tag>`), matching the documented `rust-<sha>` scheme. `rust-latest` is the Rust analog of Go's `:latest`, kept distinct by the `rust-` prefix so the two implementations never collide.
- Tag pushes **can't** be path-filtered, so a tag now triggers **both** `go-release` and `rust-release` — a release builds both implementations (Go → `:<tag>`/`:latest`, Rust → `rust-<tag>`/`rust-latest`).
- Docs updated to match: `rust/README.md` CI section and the root `CLAUDE.md` workflow listing (→ `rust-{test,build,release}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)