### PR TITLE
chore: update master → main references after default branch rename

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -2,7 +2,7 @@ name: Go Build
 on:
   push:
     branches:
-    - master
+    - main
     paths:
     - 'go/**'
     - '.github/workflows/go-build.yaml'

--- a/.github/workflows/rust-build.yaml
+++ b/.github/workflows/rust-build.yaml
@@ -2,7 +2,7 @@ name: Rust Build
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - 'rust/**'
       - '.github/workflows/rust-build.yaml'

--- a/.github/workflows/rust-release.yaml
+++ b/.github/workflows/rust-release.yaml
@@ -30,7 +30,7 @@ jobs:
           version: latest
           platforms: linux/amd64
       # default GOAMD64-equivalent: x86-64-v3. Reuses the rust-build cache scope
-      # so a tagged commit already built on master hits the layer cache.
+      # so a tagged commit already built on main hits the layer cache.
       - uses: docker/build-push-action@v6
         with:
           context: rust

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # parapet-ingress-controller
 
-[![Go Test](https://github.com/moonrhythm/parapet-ingress-controller/actions/workflows/go-test.yaml/badge.svg?branch=master)](https://github.com/moonrhythm/parapet-ingress-controller/actions/workflows/go-test.yaml)
-[![Rust Test](https://github.com/moonrhythm/parapet-ingress-controller/actions/workflows/rust-test.yaml/badge.svg?branch=master)](https://github.com/moonrhythm/parapet-ingress-controller/actions/workflows/rust-test.yaml)
-[![codecov](https://codecov.io/gh/moonrhythm/parapet-ingress-controller/branch/master/graph/badge.svg)](https://codecov.io/gh/moonrhythm/parapet-ingress-controller)
+[![Go Test](https://github.com/moonrhythm/parapet-ingress-controller/actions/workflows/go-test.yaml/badge.svg?branch=main)](https://github.com/moonrhythm/parapet-ingress-controller/actions/workflows/go-test.yaml)
+[![Rust Test](https://github.com/moonrhythm/parapet-ingress-controller/actions/workflows/rust-test.yaml/badge.svg?branch=main)](https://github.com/moonrhythm/parapet-ingress-controller/actions/workflows/rust-test.yaml)
+[![codecov](https://codecov.io/gh/moonrhythm/parapet-ingress-controller/branch/main/graph/badge.svg)](https://codecov.io/gh/moonrhythm/parapet-ingress-controller)
 [![Go Report Card](https://goreportcard.com/badge/github.com/moonrhythm/parapet-ingress-controller)](https://goreportcard.com/report/github.com/moonrhythm/parapet-ingress-controller)
 
 A Kubernetes ingress controller. The page you're reading is the **usage**
@@ -26,7 +26,7 @@ Pick per deployment; they're interchangeable behind the same contract.
 
 ## Deploy
 
-See deploy config at [deploy](https://github.com/moonrhythm/parapet-ingress-controller/tree/master/deploy)
+See deploy config at [deploy](https://github.com/moonrhythm/parapet-ingress-controller/tree/main/deploy)
 directory.
 
 ## Usage
@@ -84,7 +84,7 @@ both implementations track); the Go plugins live in [`go/plugin`](go/plugin).
 ## Configuration
 
 The controller is configured through environment variables (see the
-[deploy](https://github.com/moonrhythm/parapet-ingress-controller/tree/master/deploy)
+[deploy](https://github.com/moonrhythm/parapet-ingress-controller/tree/main/deploy)
 manifests for the full set). Notable options:
 
 - `INGRESS_CLASS` (default `parapet`) — the `ingressClassName` to handle.
@@ -105,7 +105,7 @@ design and the complete CEL reference: [WAF.md](WAF.md).
 
 Set `WAF_ENABLED=true` on the controller (off by default; when off the WAF does no
 work). The controller's ServiceAccount needs `list`/`watch` on `configmaps` —
-already in the [deploy](https://github.com/moonrhythm/parapet-ingress-controller/tree/master/deploy)
+already in the [deploy](https://github.com/moonrhythm/parapet-ingress-controller/tree/main/deploy)
 role manifests.
 
 ### Write rules

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -15,17 +15,17 @@ images bake both IPLocate DBs at `/geoip/ip-to-country.mmdb` and
 filtering work without mounting anything. See [`../WAF.md`](../WAF.md).
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/moonrhythm/parapet-ingress-controller/master/deploy/00-namespace.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/moonrhythm/parapet-ingress-controller/main/deploy/00-namespace.yaml
 
 # for cluster ingress
-$ kubectl apply -f https://raw.githubusercontent.com/moonrhythm/parapet-ingress-controller/master/deploy/role-cluster.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/moonrhythm/parapet-ingress-controller/main/deploy/role-cluster.yaml
 
 # for namespaced ingress
-$ kubectl apply -f https://raw.githubusercontent.com/moonrhythm/parapet-ingress-controller/master/deploy/role-namespaced.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/moonrhythm/parapet-ingress-controller/main/deploy/role-namespaced.yaml
 
-$ kubectl apply -f https://raw.githubusercontent.com/moonrhythm/parapet-ingress-controller/master/deploy/01-serviceaccount.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/moonrhythm/parapet-ingress-controller/main/deploy/01-serviceaccount.yaml
 
-$ kubectl apply -f https://raw.githubusercontent.com/moonrhythm/parapet-ingress-controller/master/deploy/02-service.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/moonrhythm/parapet-ingress-controller/main/deploy/02-service.yaml
 
-$ kubectl apply -f https://raw.githubusercontent.com/moonrhythm/parapet-ingress-controller/master/deploy/deployment.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/moonrhythm/parapet-ingress-controller/main/deploy/deployment.yaml
 ```

--- a/go/CLAUDE.md
+++ b/go/CLAUDE.md
@@ -121,7 +121,7 @@ go build -o parapet-ingress-controller \
 
 All path-filtered to `go/**` so they never fire on Rust-only changes:
 - **Push & PR touching `go/**`** → `go-test.yaml`: `go vet` + `go test -race` with coverage → Codecov
-- **Push to `master`** → `go-build.yaml`: pushes two images tagged with `$GITHUB_SHA` (`:$sha` GOAMD64=v3, `:$sha-amd64v1` GOAMD64=v1). Docker build context is `go/`.
+- **Push to `main`** → `go-build.yaml`: pushes two images tagged with `$GITHUB_SHA` (`:$sha` GOAMD64=v3, `:$sha-amd64v1` GOAMD64=v1). Docker build context is `go/`.
 - **Push a tag** → `go-release.yaml`: same plus `:latest` and `:{tag}`
 - Registries: `us-docker.pkg.dev/moonrhythm-containers/gcr.io/` and `asia-southeast3-docker.pkg.dev/moonrhythm-core/public/`
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -246,7 +246,7 @@ docker build --build-arg TARGET_CPU=x86-64-v3 -t ...:rust rust/
 
 - `.github/workflows/rust-test.yaml` — fmt + clippy + test on push/PR.
 - `.github/workflows/rust-build.yaml` — builds and pushes `rust-<sha>` images
-  on `master`.
+  on `main`.
 - `.github/workflows/rust-release.yaml` — on a tag push, builds and pushes
   `rust-<tag>` and `rust-latest` (plus the `-amd64v1` compatibility variants).
 


### PR DESCRIPTION
The GitHub default branch was renamed `master` → `main`. This updates the references that the rename would otherwise break.

## Critical (CI would stop firing)
- `go-build.yaml` / `rust-build.yaml` push triggers `master` → `main`

## Links / badges
- README badges (Go Test, Rust Test, codecov) `?branch=master` / `branch/master`
- README + `deploy/README.md` `tree/master` / `raw.githubusercontent.com/.../master/` manifest URLs

## Doc mentions
- `go/CLAUDE.md`, `rust/README.md`, `rust-release.yaml` comment

## Intentionally left as `master`
- `dtolnay/rust-toolchain@master` — third-party action ref, not our branch
- `WAF.md` links to the `moonrhythm/parapet` and `google/cel-spec` repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)