### PR TITLE
fix(rust): release host concurrency slot on response headers

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -106,8 +106,8 @@ untouched.
 | `LOAD_ALL_CERTS` | `false` | both | Index every TLS secret, not just `spec.tls`-referenced |
 | `TRUST_PROXY` | `""` | both | `true`/`false`/CIDRs (+ `cloudflare`/`google`/`bunny`) |
 | `WAIT_BEFORE_SHUTDOWN` | `30s` | both | Drain delay on SIGTERM |
-| `HOST_CONCURRENT_CAPACITY` / `_SIZE` | `0` | both | Per-host in-flight cap / queue size |
-| `HOST_COUNTRY_CONCURRENT_CAPACITY` / `_SIZE` | `0` | both | Per-host+country cap / queue |
+| `HOST_CONCURRENT_CAPACITY` / `_SIZE` | `0` | both | Per-host in-flight cap / queue size. Slot is released when upstream response headers arrive (or on a 101 upgrade), not at end-of-body — so SSE / WebSocket / long-poll streams don't pin a slot for the stream lifetime. The cap exists to shed load while upstreams are *unresponsive*. |
+| `HOST_COUNTRY_CONCURRENT_CAPACITY` / `_SIZE` | `0` | both | Per-host+country cap / queue (same release semantics as `HOST_CONCURRENT_CAPACITY`) |
 | `HOST_COUNTRY_HEADER` | `""` | both | Header(s) carrying the country code |
 | `TR_MAX_IDLE_CONNS_PER_HOST` | stdlib / 128 | both | Upstream idle pool (Rust: process-global) |
 | `DISABLE_LOG` | `false` | both | Suppress the access log |

--- a/rust/controller/src/proxy/mod.rs
+++ b/rust/controller/src/proxy/mod.rs
@@ -259,7 +259,12 @@ pub struct Ctx {
     meta: RouteMeta,
     pattern: String,
     skip_log: bool,
-    // host concurrency
+    // host concurrency — host + country slots acquired in `request_filter`.
+    // Cleared in `response_filter` (i.e. when upstream response headers arrive),
+    // matching Go's `ReleaseOnWriteHeader` + `ReleaseOnHijacked` so that
+    // long-lived streaming responses (SSE `text/event-stream`, WebSocket-style
+    // 101 upgrades) don't hold a slot for the entire stream lifetime. Any
+    // guards still alive at end-of-request release on `Ctx` drop.
     limit_guards: Vec<Guard>,
     host_active: Option<(String, &'static str)>,
     // forward-auth response headers to copy upstream
@@ -610,6 +615,14 @@ impl ProxyHttp for Proxy {
         upstream_response: &mut ResponseHeader,
         ctx: &mut Ctx,
     ) -> Result<()> {
+        // Release host/country concurrency slots as soon as upstream response
+        // headers arrive. Matches Go's `ReleaseOnWriteHeader` + `ReleaseOnHijacked`
+        // (101 Switching Protocols hits this hook too): the cap exists to shed
+        // load while upstreams are unresponsive, not to count long-lived streams
+        // (SSE, WebSocket, long-poll) which would otherwise pin a slot for the
+        // whole stream lifetime.
+        ctx.limit_guards.clear();
+
         // Server-Sent Events: Pingora's compressor treats text/event-stream as
         // compressible (it matches the `text/*` allowlist) and buffers it instead
         // of flushing per event, which stalls the stream in the browser. Disable

--- a/rust/controller/tests/host_concurrency_release.rs
+++ b/rust/controller/tests/host_concurrency_release.rs
@@ -1,0 +1,197 @@
+//! Integration: `HOST_CONCURRENT_CAPACITY` releases its slot when upstream
+//! response headers arrive (matches Go's `ReleaseOnWriteHeader`). Regression
+//! test for the SSE / long-lived-stream case where a slot would otherwise
+//! stay pinned for the entire stream lifetime, exhausting the per-host cap
+//! with no DDoS actually happening.
+//!
+//! Strategy: spin up the real binary in `fs` mode with `HOST_CONCURRENT_CAPACITY=1`
+//! and `HOST_CONCURRENT_SIZE=0` (no queue, immediate-reject). A slow upstream
+//! sends `200 OK text/event-stream` headers + one chunked event, then holds
+//! the connection open. We read the headers on conn 1 (which is only possible
+//! after `response_filter` has run on the proxy), then open conn 2 to the
+//! same host. Pre-fix: conn 2 returns `503` because the slot is still held
+//! by conn 1's still-streaming body. Post-fix: the slot was released on
+//! headers, so conn 2 is admitted.
+//!
+//! Only built with `proxy,cluster`; a no-op otherwise.
+#![cfg(all(feature = "proxy", feature = "cluster"))]
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process::{Child, Command};
+use std::thread;
+use std::time::{Duration, Instant};
+
+struct Controller(Child);
+impl Drop for Controller {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+/// SSE-like upstream: send `200 OK text/event-stream` + one chunked event,
+/// then hold the connection open without sending more. The proxy sees a
+/// long-lived streaming body, which is the case that used to pin the slot.
+fn spawn_sse_upstream() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            thread::spawn(move || {
+                let mut s = stream;
+                let mut buf = [0u8; 4096];
+                let mut head = Vec::new();
+                loop {
+                    match s.read(&mut buf) {
+                        Ok(0) | Err(_) => return,
+                        Ok(n) => head.extend_from_slice(&buf[..n]),
+                    }
+                    if head.windows(4).any(|w| w == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                // chunk body is "data: hi\n" (9 bytes) framed as one chunk;
+                // no terminating 0-chunk, so the body stays open.
+                let _ = s.write_all(
+                    b"HTTP/1.1 200 OK\r\n\
+                      Content-Type: text/event-stream\r\n\
+                      Cache-Control: no-cache\r\n\
+                      Transfer-Encoding: chunked\r\n\r\n\
+                      9\r\ndata: hi\n\r\n",
+                );
+                let _ = s.flush();
+                // Park the stream so the body stays open for the duration of
+                // the test. The controller subprocess is killed on test exit,
+                // which closes its end and unblocks this thread.
+                let _ = s.set_read_timeout(Some(Duration::from_secs(30)));
+                let _ = s.read(&mut buf);
+            });
+        }
+    });
+    port
+}
+
+fn write_manifests(dir: &std::path::Path, upstream_port: u16, host: &str) {
+    let yaml = format!(
+        "apiVersion: networking.k8s.io/v1\n\
+         kind: Ingress\n\
+         metadata: {{name: sse, namespace: default}}\n\
+         spec:\n  ingressClassName: parapet\n  rules:\n  - host: {host}\n    http:\n      paths:\n      - path: /\n        pathType: Prefix\n        backend: {{service: {{name: sse, port: {{number: {p}}}}}}}\n\
+         ---\n\
+         apiVersion: v1\nkind: Service\nmetadata: {{name: sse, namespace: default}}\nspec: {{type: ClusterIP, ports: [{{port: {p}, targetPort: {p}}}]}}\n\
+         ---\n\
+         apiVersion: v1\nkind: Endpoints\nmetadata: {{name: sse, namespace: default}}\nsubsets: [{{addresses: [{{ip: 127.0.0.1}}], ports: [{{port: {p}}}]}}]\n",
+        p = upstream_port,
+        host = host,
+    );
+    std::fs::write(dir.join("sse.yaml"), yaml).unwrap();
+}
+
+fn wait_ready(port: u16) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while Instant::now() < deadline {
+        if let Ok(mut c) = TcpStream::connect(("127.0.0.1", port)) {
+            let _ = c.set_read_timeout(Some(Duration::from_millis(500)));
+            if c.write_all(b"GET /healthz HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+                .is_ok()
+            {
+                let mut resp = Vec::new();
+                let _ = c.read_to_end(&mut resp);
+                if String::from_utf8_lossy(&resp).contains("200") {
+                    return;
+                }
+            }
+        }
+        thread::sleep(Duration::from_millis(150));
+    }
+    panic!("controller did not become ready on :{port}");
+}
+
+/// Read until either headers (\r\n\r\n) are seen or the read times out / EOFs.
+fn read_response_head(c: &mut TcpStream) -> String {
+    let mut acc = Vec::new();
+    let mut buf = [0u8; 1024];
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        match c.read(&mut buf) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => {
+                acc.extend_from_slice(&buf[..n]);
+                if acc.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+        }
+    }
+    String::from_utf8_lossy(&acc).to_string()
+}
+
+#[test]
+fn host_cap_releases_slot_on_response_headers() {
+    let upstream_port = spawn_sse_upstream();
+    let http_port = free_port();
+
+    let dir = std::env::temp_dir().join(format!("parapet-sse-cap-test-{http_port}"));
+    std::fs::create_dir_all(&dir).unwrap();
+    write_manifests(&dir, upstream_port, "sse.test");
+
+    let child = Command::new(env!("CARGO_BIN_EXE_parapet-ingress-controller"))
+        .env("KUBERNETES_BACKEND", "fs")
+        .env("KUBERNETES_FS", &dir)
+        .env("HTTP_PORT", http_port.to_string())
+        .env("HTTPS_PORT", "")
+        .env("DISABLE_LOG", "true")
+        // capacity=1, no queue: any second concurrent request is immediately
+        // 503'd unless the first one released its slot before #2's acquire.
+        .env("HOST_CONCURRENT_CAPACITY", "1")
+        .env("HOST_CONCURRENT_SIZE", "0")
+        .spawn()
+        .expect("spawn controller binary");
+    let _ctrl = Controller(child);
+
+    wait_ready(http_port);
+
+    // conn 1: open the SSE stream. Reading the response head proves the
+    // proxy has run `response_filter` (where the guard is released).
+    let mut c1 = TcpStream::connect(("127.0.0.1", http_port)).unwrap();
+    c1.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    c1.write_all(b"GET /events HTTP/1.1\r\nHost: sse.test\r\nAccept: text/event-stream\r\n\r\n")
+        .unwrap();
+    let resp1 = read_response_head(&mut c1);
+    assert!(
+        resp1.contains("200 OK") && resp1.to_lowercase().contains("text/event-stream"),
+        "expected 200 OK SSE on conn 1, got:\n{resp1}"
+    );
+
+    // conn 2: while conn 1's body is still streaming, a second request to the
+    // same host. Pre-fix this was rejected with 503; post-fix it must be admitted.
+    let mut c2 = TcpStream::connect(("127.0.0.1", http_port)).unwrap();
+    c2.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    c2.write_all(
+        b"GET /events HTTP/1.1\r\nHost: sse.test\r\n\
+          Accept: text/event-stream\r\nConnection: close\r\n\r\n",
+    )
+    .unwrap();
+    let resp2 = read_response_head(&mut c2);
+    assert!(
+        !resp2.contains("503"),
+        "got 503 on conn 2 — host concurrency slot was not released on response headers:\n{resp2}"
+    );
+    assert!(
+        resp2.contains("200 OK"),
+        "expected 200 OK on conn 2 (slot should release on conn 1's headers), got:\n{resp2}"
+    );
+
+    drop(c1);
+    drop(c2);
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Summary

Brings the Rust implementation in line with Go's `ReleaseOnWriteHeader: true` + `ReleaseOnHijacked: true` for the `HOST_CONCURRENT_CAPACITY` / `HOST_COUNTRY_CONCURRENT_CAPACITY` caps. Fixes a real-world bug where hosts serving lots of long-lived **SSE / WebSocket / long-poll** streams would exhaust the per-host concurrency cap (and start returning `503`) with no DDoS actually happening.

## Why

`limit_guards: Vec<Guard>` lives on `Ctx`, which Pingora keeps around for the full request. `Guard` releases its slot on `Drop`, so the slot was only released when `Ctx` dropped — i.e. **after** the response body finished streaming. For an SSE stream that's open for minutes/hours, the slot was pinned the whole time.

Go has never had this problem because `parapet`'s `ratelimit.RateLimiter` is configured with `ReleaseOnWriteHeader: true` (and `ReleaseOnHijacked: true` for WebSocket upgrades), so the slot is released as soon as the response headers go downstream.

The per-host cap exists to **shed load when an upstream is unresponsive**, not to count long-lived streams against capacity. Holding the slot for the whole stream lifetime is the wrong semantics.

## What changed

- `rust/controller/src/proxy/mod.rs`: clear `ctx.limit_guards` at the top of `response_filter`. Pingora calls this hook once per upstream response, **including for `101 Switching Protocols`**, so this single line covers both Go's release-on-header and release-on-hijack semantics.
- Updated the comment on the `limit_guards` field to explain the lifecycle.
- `SPEC.md`: documented the release semantics on the `HOST_CONCURRENT_CAPACITY` row so the contract is explicit and both implementations stay aligned.

## Behavioral matrix

| Response kind | Before (Rust) | After (Rust) | Go (unchanged) |
|---|---|---|---|
| Normal `200` w/ body | slot held until body end | slot released on headers | slot released on headers |
| SSE (`text/event-stream`) | **slot held for entire stream** | slot released on headers | slot released on headers |
| WebSocket `101` upgrade | slot held for entire conn | slot released on `101` | released on hijack |
| Upstream connect fail / retry | slot held across retries (still correct — cap is *for* this) | unchanged (no `response_filter` until headers arrive) | same |
| WAF / overload reject before upstream | slot released on `Ctx` drop | unchanged | n/a |

## Test plan

- [x] `cargo test -p parapet-ingress-controller` — 54 passing
- [x] `cargo test -p parapet-ingress-controller --features proxy,cluster` — websocket integration test passes (most sensitive to this hook)
- [x] `cargo clippy --features proxy,cluster -- -D warnings` — clean
- [ ] Manual: deploy to a cluster with `HOST_CONCURRENT_CAPACITY=10` and open >10 concurrent SSE clients against the same host; before, the 11th gets `503`; after, it connects and `parapet_host_active_requests` shows >10 while in-flight stays low.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PZW9vG9D8hZRkJRmxvQ9ez)_