### PR TITLE
perf(go): cache GeoIP country/ASN lookups to skip repeat mmdb+ParseInt

### DIFF
--- a/go/cmd/parapet-ingress-controller/main.go
+++ b/go/cmd/parapet-ingress-controller/main.go
@@ -81,7 +81,9 @@ func main() {
 			default:
 				slog.Info("waf: geoip database loaded", "path", path)
 				wafConfig.Country = func(r *http.Request) string {
-					if cc := db.Country(geoip.ClientIP(r)); cc != "" {
+					// CountryCached memoizes by client IP so repeat IPs skip the
+					// mmdb lookup; semantics are identical to db.Country.
+					if cc := db.CountryCached(geoip.ClientIP(r)); cc != "" {
 						return cc
 					}
 					return "XX" // DB loaded but IP unresolved
@@ -101,7 +103,10 @@ func main() {
 			default:
 				slog.Info("waf: asn database loaded", "path", path)
 				wafConfig.ASN = func(r *http.Request) int64 {
-					return db.ASN(geoip.ClientIP(r))
+					// ASNCached memoizes by client IP so repeat IPs skip the mmdb
+					// lookup and the per-call strconv.ParseInt; semantics are
+					// identical to db.ASN.
+					return db.ASNCached(geoip.ClientIP(r))
 				}
 			}
 		}

--- a/go/geoip/cache.go
+++ b/go/geoip/cache.go
@@ -1,0 +1,69 @@
+package geoip
+
+import "sync"
+
+// cacheCap bounds each result cache to at most this many distinct client IPs.
+//
+// GeoIP results are tiny (a 2-byte country string or an int64 ASN keyed by an
+// IP string), so 16384 entries is only on the order of ~1 MB per cache yet large
+// enough to absorb the working set of distinct client IPs a single proxy sees in
+// the lifetime of one cache generation. When a cache fills past the cap it is
+// cleared wholesale (see resultCache.get); the cap is the knob that trades worst-
+// case memory for how often that cold-start clear happens. 16384 keeps memory
+// trivially small while making a full clear a rare event under realistic traffic.
+const cacheCap = 16384
+
+// resultCache is a tiny, bounded, concurrency-safe memo from a client-IP string
+// to a GeoIP lookup result of type V (a country string or an int64 ASN). It is
+// deliberately not a true LRU: GeoIP results are stable and cheap, so when the
+// map grows past cacheCap we simply clear it and start a fresh generation. That
+// keeps the hot path a single map read under an RWMutex with no per-entry
+// bookkeeping, and bounds memory at roughly cacheCap entries.
+//
+// Negative results (an unplaceable IP -> "XX" or 0) are cached too: that matches
+// the underlying lookup's semantics exactly (it always returns a value, never an
+// error to the caller) and stops repeat unplaceable IPs from re-hitting the mmdb.
+type resultCache[V any] struct {
+	mu sync.RWMutex
+	m  map[string]V
+}
+
+func newResultCache[V any]() *resultCache[V] {
+	return &resultCache[V]{m: make(map[string]V)}
+}
+
+// get returns the memoized result for key, computing it via compute on a miss.
+// compute is the existing uncached lookup; its output is stored verbatim, so the
+// cache is fully transparent (same value for every key as calling compute would
+// give). On a miss that would push the map past cacheCap, the map is cleared
+// before inserting, bounding it at cacheCap+1 entries momentarily and then
+// starting a fresh generation.
+func (c *resultCache[V]) get(key string, compute func() V) V {
+	c.mu.RLock()
+	v, ok := c.m[key]
+	c.mu.RUnlock()
+	if ok {
+		return v
+	}
+
+	// Compute outside the write lock: the lookup may touch the mmap, and two
+	// goroutines racing the same cold key just both compute the same value.
+	v = compute()
+
+	c.mu.Lock()
+	if len(c.m) >= cacheCap {
+		// Bounded "clear when full": drop the whole generation rather than do
+		// per-entry eviction. Cheap, and GeoIP results are cheap to recompute.
+		c.m = make(map[string]V)
+	}
+	c.m[key] = v
+	c.mu.Unlock()
+	return v
+}
+
+// len reports the current number of cached entries (test helper / introspection).
+func (c *resultCache[V]) len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.m)
+}

--- a/go/geoip/cache.go
+++ b/go/geoip/cache.go
@@ -16,9 +16,9 @@ const cacheCap = 16384
 // resultCache is a tiny, bounded, concurrency-safe memo from a client-IP string
 // to a GeoIP lookup result of type V (a country string or an int64 ASN). It is
 // deliberately not a true LRU: GeoIP results are stable and cheap, so when the
-// map grows past cacheCap we simply clear it and start a fresh generation. That
-// keeps the hot path a single map read under an RWMutex with no per-entry
-// bookkeeping, and bounds memory at roughly cacheCap entries.
+// map grows past cacheCap we simply clear it in place and start a fresh
+// generation. That keeps the hot path a single map read under an RWMutex with no
+// per-entry bookkeeping, and bounds memory at roughly cacheCap entries.
 //
 // Negative results (an unplaceable IP -> "XX" or 0) are cached too: that matches
 // the underlying lookup's semantics exactly (it always returns a value, never an
@@ -35,8 +35,8 @@ func newResultCache[V any]() *resultCache[V] {
 // get returns the memoized result for key, computing it via compute on a miss.
 // compute is the existing uncached lookup; its output is stored verbatim, so the
 // cache is fully transparent (same value for every key as calling compute would
-// give). On a miss that would push the map past cacheCap, the map is cleared
-// before inserting, bounding it at cacheCap+1 entries momentarily and then
+// give). On a miss that would push the map past cacheCap, the map is cleared in
+// place before inserting, bounding it at cacheCap+1 entries momentarily and then
 // starting a fresh generation.
 func (c *resultCache[V]) get(key string, compute func() V) V {
 	c.mu.RLock()
@@ -54,7 +54,10 @@ func (c *resultCache[V]) get(key string, compute func() V) V {
 	if len(c.m) >= cacheCap {
 		// Bounded "clear when full": drop the whole generation rather than do
 		// per-entry eviction. Cheap, and GeoIP results are cheap to recompute.
-		c.m = make(map[string]V)
+		// clear() empties in place and keeps the backing array (already sized for
+		// cacheCap), so the next generation refills with no map regrowth/rehash;
+		// the retained capacity is bounded by cacheCap, the memory cap we accept.
+		clear(c.m)
 	}
 	c.m[key] = v
 	c.mu.Unlock()

--- a/go/geoip/cache_test.go
+++ b/go/geoip/cache_test.go
@@ -1,0 +1,117 @@
+package geoip
+
+import (
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResultCacheGet proves get returns compute's value on a miss, the same
+// value (without recomputing) on a hit, and caches negative results too.
+func TestResultCacheGet(t *testing.T) {
+	t.Parallel()
+	c := newResultCache[string]()
+
+	calls := map[string]int{}
+	compute := func(key, ret string) func() string {
+		return func() string {
+			calls[key]++
+			return ret
+		}
+	}
+
+	cases := []struct {
+		name, key, ret string
+	}{
+		{"placeable", "8.8.8.8", "US"},
+		{"negative (unplaceable cached too)", "192.0.2.1", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// miss computes
+			assert.Equal(t, tc.ret, c.get(tc.key, compute(tc.key, tc.ret)))
+			assert.Equal(t, 1, calls[tc.key])
+			// hit returns the same value without recomputing
+			assert.Equal(t, tc.ret, c.get(tc.key, compute(tc.key, "SHOULD-NOT-RUN")))
+			assert.Equal(t, 1, calls[tc.key], "hit must not recompute")
+		})
+	}
+}
+
+// TestResultCacheCapBounds proves the map is bounded: after inserting well past
+// cacheCap distinct keys, the map never exceeds cacheCap entries (it clears a
+// generation when full).
+func TestResultCacheCapBounds(t *testing.T) {
+	t.Parallel()
+	c := newResultCache[int64]()
+
+	for i := 0; i < cacheCap*3; i++ {
+		k := strconv.Itoa(i)
+		got := c.get(k, func() int64 { return int64(i) })
+		require.Equal(t, int64(i), got)
+		require.LessOrEqual(t, c.len(), cacheCap,
+			"cache must stay bounded at cacheCap entries")
+	}
+}
+
+// TestCachedMethodsMatchUncached proves the cached lookups are byte-for-byte
+// transparent: CountryCached == Country and ASNCached == ASN for every IP, on
+// both the cold (miss) and warm (hit) call.
+func TestCachedMethodsMatchUncached(t *testing.T) {
+	t.Parallel()
+
+	country, err := Open(testDB)
+	require.NoError(t, err)
+	asn, err := OpenASN(asnTestDB)
+	require.NoError(t, err)
+
+	ips := []string{"8.8.8.8", "1.1.1.1", "203.0.113.5", "2001:db8::1", "192.0.2.1", "10.0.0.1"}
+	for _, s := range ips {
+		ip := net.ParseIP(s)
+		// twice each: first call is a miss, second is a hit
+		assert.Equal(t, country.Country(ip), country.CountryCached(ip))
+		assert.Equal(t, country.Country(ip), country.CountryCached(ip))
+		assert.Equal(t, asn.ASN(ip), asn.ASNCached(ip))
+		assert.Equal(t, asn.ASN(ip), asn.ASNCached(ip))
+	}
+}
+
+// TestCachedMethodsNilSafe proves a nil DB / nil IP bypasses the cache and keeps
+// the uncached zero-value semantics ("" / 0).
+func TestCachedMethodsNilSafe(t *testing.T) {
+	t.Parallel()
+	var d *DB
+	var a *ASNDB
+	assert.Equal(t, "", d.CountryCached(net.ParseIP("8.8.8.8")))
+	assert.Equal(t, int64(0), a.ASNCached(net.ParseIP("8.8.8.8")))
+
+	// loaded DB but nil IP also bypasses cleanly.
+	country, err := Open(testDB)
+	require.NoError(t, err)
+	assert.Equal(t, "", country.CountryCached(nil))
+}
+
+// TestResultCacheConcurrent exercises the RWMutex under concurrent readers and
+// writers; run with -race it proves the cache is data-race free.
+func TestResultCacheConcurrent(t *testing.T) {
+	t.Parallel()
+	c := newResultCache[int64]()
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 2000; i++ {
+				k := strconv.Itoa(i % 64)
+				v := c.get(k, func() int64 { return int64(i % 64) })
+				assert.Equal(t, int64(i%64), v)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/go/geoip/geoip.go
+++ b/go/geoip/geoip.go
@@ -16,15 +16,18 @@ import (
 // DB is a loaded IPLocate ip-to-country database.
 type DB struct {
 	reader *maxminddb.Reader
+	cache  *resultCache[string] // memoizes Country results by client-IP string
 }
 
-// Open reads a .mmdb file (the IPLocate ip-to-country DB) into memory.
+// Open reads a .mmdb file (the IPLocate ip-to-country DB) into memory. The
+// result cache is allocated here, so it only exists when a DB is actually loaded
+// (i.e. when the WAF GeoIP feature is on) — disabled GeoIP allocates nothing.
 func Open(path string) (*DB, error) {
 	r, err := maxminddb.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	return &DB{reader: r}, nil
+	return &DB{reader: r, cache: newResultCache[string]()}, nil
 }
 
 // Country returns the ISO 3166-1 alpha-2 country code for ip, or "" if the IP
@@ -44,18 +47,31 @@ func (d *DB) Country(ip net.IP) string {
 	return rec.CountryCode
 }
 
+// CountryCached returns Country(ip), memoizing the result by IP so repeat client
+// IPs (the common case on a busy proxy) skip the mmdb lookup. The cached value is
+// byte-for-byte what Country(ip) returns — including "" for a nil/unplaceable IP
+// — so it is fully transparent. nil DB or nil IP bypass the cache and return "".
+func (d *DB) CountryCached(ip net.IP) string {
+	if d == nil || ip == nil || d.cache == nil {
+		return d.Country(ip)
+	}
+	return d.cache.get(ip.String(), func() string { return d.Country(ip) })
+}
+
 // ASNDB is a loaded IPLocate ip-to-asn database.
 type ASNDB struct {
 	reader *maxminddb.Reader
+	cache  *resultCache[int64] // memoizes ASN results by client-IP string
 }
 
-// OpenASN reads a .mmdb file (the IPLocate ip-to-asn DB) into memory.
+// OpenASN reads a .mmdb file (the IPLocate ip-to-asn DB) into memory. As with
+// Open, the result cache is allocated here so disabled GeoIP allocates nothing.
 func OpenASN(path string) (*ASNDB, error) {
 	r, err := maxminddb.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	return &ASNDB{reader: r}, nil
+	return &ASNDB{reader: r, cache: newResultCache[int64]()}, nil
 }
 
 // ASN returns the autonomous system number for ip, or 0 if the IP is nil or has
@@ -76,6 +92,18 @@ func (d *ASNDB) ASN(ip net.IP) int64 {
 		return 0
 	}
 	return n
+}
+
+// ASNCached returns ASN(ip), memoizing the result by IP so repeat client IPs
+// skip both the mmdb lookup and the strconv.ParseInt that ASN does on every call
+// (IPLocate stores the ASN as a string). The cached value is exactly what
+// ASN(ip) returns — including 0 for a nil/unplaceable/unparseable IP — so it is
+// fully transparent. nil DB or nil IP bypass the cache and return 0.
+func (d *ASNDB) ASNCached(ip net.IP) int64 {
+	if d == nil || ip == nil || d.cache == nil {
+		return d.ASN(ip)
+	}
+	return d.cache.get(ip.String(), func() int64 { return d.ASN(ip) })
 }
 
 // ClientIP returns the best-known client IP, matching the precedence parapet's


### PR DESCRIPTION
## Finding

In the Go impl, every WAF-evaluated request resolves `request.country` and `request.asn` with a fresh memory-mapped IPLocate lookup for the client IP. The ASN path additionally runs `strconv.ParseInt` on every request, because IPLocate stores the ASN as a string (e.g. `"15169"`). There was **no caching**, so repeat client IPs — the common case on a busy proxy — redid identical work, including the ParseInt, on every request. See `go/geoip/geoip.go` (`Country`, `ASN`) and the resolver closures in `go/cmd/parapet-ingress-controller/main.go`.

## Fix

A small bounded, concurrency-safe in-memory result cache (`go/geoip/cache.go`) in front of both lookups:

- New `CountryCached` / `ASNCached` methods memoize by client-IP string and are **byte-for-byte transparent** to the existing `Country` / `ASN` (same `""` / `"XX"` / `0` for unplaceable IPs). The `main.go` resolvers now call the cached variants.
- Negative results are cached too — matching current semantics (the lookups always return a value, never surface an error) — so unplaceable IPs stop re-hitting the mmdb.
- Simple `map` under a `sync.RWMutex` with a **16384-entry cap**; on overflow it clears the generation rather than doing per-entry LRU eviction (results are stable and cheap to recompute, the hot path stays a single RWMutex read). 16384 keeps worst-case memory ~1 MB per cache while making a full clear a rare event under realistic traffic.
- **No new dependency** (no `go.mod` change).

## No behavior change

Identical output for every IP, so `SPEC.md` is unchanged. This is a pure internal performance change.

## Zero-cost when disabled

The cache is allocated in `Open` / `OpenASN`, which only run when WAF GeoIP is enabled. Disabled GeoIP opens no DB, allocates no cache, and the resolvers aren't mounted at all — no per-request cost, honoring the repo's disabled-features-do-zero-work rule.

## Realistic impact (honest)

The mmdb lookup itself is already fast (~1-2µs). The concrete wins are skipping the per-request `strconv.ParseInt` on the ASN path and serving repeat IPs from a lock-light map read. The expected effect is **modest** rather than dramatic — but it's effectively free given the constraints (bounded memory, no new deps, zero cost when disabled).

## Verification

- `cd go && go test ./...` — all pass
- `cd go && go vet ./...` — clean
- `cd go && go test -race ./geoip/` — clean (covers the concurrent get path)

Tests added (`go/geoip/cache_test.go`, table-driven testify): miss/hit, negative caching, cap bounding, `cached == uncached` for every fixture IP, nil-safety, and a `-race` concurrency exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)