### PR TITLE
perf(rust): build WAF RequestData once per request, not per ruleset

### DIFF
--- a/rust/controller/src/proxy/mod.rs
+++ b/rust/controller/src/proxy/mod.rs
@@ -277,6 +277,11 @@ pub struct Ctx {
     host_active: Option<(String, &'static str)>,
     // forward-auth response headers to copy upstream
     auth_response_headers: Vec<(String, String)>,
+    // WAF request data, built lazily on the first eval that runs (global or
+    // zone) and reused by the other so the ~15 string allocs + header map +
+    // query parse happen at most once per request. Stays `None` when no WAF
+    // eval runs, preserving the no-rules short-circuit.
+    waf_request: Option<crate::waf::RequestData>,
 }
 
 enum Decision {
@@ -439,8 +444,9 @@ impl ProxyHttp for Proxy {
         // platform block here can't be overridden by a tenant zone. Skipped when
         // disabled or no global rules are loaded (no per-request map built).
         if self.waf_enabled && self.shared.waf.global_has_rules() {
-            let req = self.build_waf_request(session, &host, &ctx.method, ctx);
-            let decision = self.shared.waf.evaluate_global(&req, |id, action| {
+            let built = self.build_waf_request(session, &host, &ctx.method, ctx);
+            let req = ctx.waf_request.insert(built);
+            let decision = self.shared.waf.evaluate_global(req, |id, action| {
                 metrics::waf_match_inc(id, action.as_str(), "global")
             });
             if let WafDecision::Block { status, message } = decision {
@@ -801,8 +807,15 @@ impl Proxy {
                 .and_then(|raw| resolve_zone_key(&ctx.meta.ingress_namespace, raw))
             {
                 if let Some(zone) = self.shared.waf.zone(&key) {
-                    let req = self.build_waf_request(session, host, &ctx.method, ctx);
-                    let decision = self.shared.waf.evaluate_zone(&zone, &req, |id, action| {
+                    // Reuse the request data the global eval already built; only
+                    // build it here when the global WAF was disabled or had no
+                    // rules (so it never ran and the cache is still empty).
+                    if ctx.waf_request.is_none() {
+                        let built = self.build_waf_request(session, host, &ctx.method, ctx);
+                        ctx.waf_request = Some(built);
+                    }
+                    let req = ctx.waf_request.as_ref().unwrap();
+                    let decision = self.shared.waf.evaluate_zone(&zone, req, |id, action| {
                         metrics::waf_match_inc(id, action.as_str(), "zone")
                     });
                     if let WafDecision::Block { status, message } = decision {


### PR DESCRIPTION
## Finding

In `rust/controller/src/proxy/mod.rs`, the WAF `RequestData` was built **twice** per request whenever both global and per-zone WAF rules applied:

- once for the global eval in `request_filter` (`build_waf_request(session, &host, &ctx.method)`)
- again for the zone eval in `apply_route_filters`

Each call allocates ~15 strings, builds a lowercased header `HashMap`, and re-parses the query string and cookies — fully duplicated work on the hot path.

## Fix

Cache the built `RequestData` on `Ctx` as `Option<RequestData>`:

- The global eval builds it on first use and stores it in `ctx.waf_request`.
- The zone eval reuses that cached value, building it itself only when the global WAF was disabled or had no rules (so it never ran and the cache is empty).

The cached value is **owned** (`build_waf_request` already returns owned `RequestData`), so it holds no borrow of `session` — no conflict with the global block's respond-and-return on a block decision, nor with any later session reads. Between the two evals nothing mutates the request headers that feed `RequestData`, so reuse is consistent.

## Preserved short-circuit / no behavior change

- The no-WAF path is unchanged: `waf_request` stays `None` and nothing is built unless at least one eval actually runs. The global branch is still gated by `self.waf_enabled && self.shared.waf.global_has_rules()`; the zone branch still only builds when a zone resolves.
- Both evals receive identical inputs, so there is no observable behavior change. This is internal-only — **SPEC.md is not touched**.

## Verification

- `cargo test -p parapet-ingress-controller --features proxy,cluster` — all pass (104 unit + integration tests).
- `cargo clippy --features proxy,cluster -p parapet-ingress-controller` — clean, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)