### PR TITLE
perf(go): skip WAF recompile for unchanged zones on reload

### DIFF
--- a/go/controller.go
+++ b/go/controller.go
@@ -73,6 +73,13 @@ type Controller struct {
 	globalWAF *waf.WAF
 	zones     atomic.Pointer[map[string]*waf.WAF]
 
+	// WAF rule-input fingerprints from the last reload, used to skip recompiling
+	// CEL rulesets whose effective input (the sorted concatenated rule YAML) is
+	// byte-for-byte unchanged. Only ever read/written from reloadWAFDebounced,
+	// which the debounce serializes, so they need no lock.
+	globalWAFFingerprint string
+	zoneFingerprints     map[string]string
+
 	// holds current k8s state
 	watchedIngresses  sync.Map
 	watchedServices   sync.Map

--- a/go/controller_waf.go
+++ b/go/controller_waf.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -54,6 +56,7 @@ func (ctrl *Controller) InitWAF() {
 	ctrl.globalWAF = ctrl.newWAF(wafRoleGlobal)
 	empty := map[string]*waf.WAF{}
 	ctrl.zones.Store(&empty)
+	ctrl.zoneFingerprints = map[string]string{}
 }
 
 // GlobalWAF returns the global WAF middleware to mount in the server chain, or
@@ -163,32 +166,81 @@ func (ctrl *Controller) reloadWAFDebounced() {
 		return true
 	})
 
-	// global
-	if rules, err := wafrule.Parse(globalDocs...); err != nil {
-		slog.Error("waf: invalid global ruleset, keeping previous", "error", err)
-	} else if err := ctrl.globalWAF.SetRules(rules); err != nil {
-		slog.Error("waf: global ruleset rejected, keeping previous", "error", err)
+	// global: recompile only when the rule input changed. The fingerprint is over
+	// the exact (sorted, deterministic) docs that feed SetRules, so an identical
+	// input skips the CEL compile and leaves the live ruleset untouched.
+	globalFP := fingerprintDocs(globalDocs)
+	if globalFP != ctrl.globalWAFFingerprint {
+		if rules, err := wafrule.Parse(globalDocs...); err != nil {
+			slog.Error("waf: invalid global ruleset, keeping previous", "error", err)
+		} else if err := ctrl.globalWAF.SetRules(rules); err != nil {
+			slog.Error("waf: global ruleset rejected, keeping previous", "error", err)
+		} else {
+			// Only advance the fingerprint once the new input compiled cleanly, so a
+			// rejected edit is retried (not skipped) on the next reload.
+			ctrl.globalWAFFingerprint = globalFP
+		}
 	}
 
-	// zones: reuse the existing *waf.WAF per zone so a bad edit keeps that zone's
-	// last-good ruleset (SetRules is all-or-nothing on the same instance).
+	// zones: reuse the existing *waf.WAF per zone. An unchanged zone keeps its
+	// compiled instance with no recompile (fingerprint match); a changed zone is
+	// rebuilt via SetRules on the same instance, which is all-or-nothing so a bad
+	// edit keeps that zone's last-good ruleset. Zones absent from zoneDocs are
+	// dropped, new zones get a fresh instance — the post-reload registry is
+	// identical to a full rebuild.
 	cur := ctrl.zones.Load()
 	newZones := make(map[string]*waf.WAF, len(zoneDocs))
+	newFingerprints := make(map[string]string, len(zoneDocs))
 	for key, docs := range zoneDocs {
-		w := ctrl.newWAF(wafRoleZone)
+		fp := fingerprintDocs(docs)
+		var w *waf.WAF
+		reused := false
 		if cur != nil {
 			if existing, ok := (*cur)[key]; ok {
 				w = existing
+				reused = true
 			}
+		}
+		// Skip the recompile only when we are reusing an instance whose loaded
+		// input fingerprint matches; a new/changed zone compiles below.
+		if reused && fp == ctrl.zoneFingerprints[key] {
+			newZones[key] = w
+			newFingerprints[key] = fp
+			continue
+		}
+		if !reused {
+			w = ctrl.newWAF(wafRoleZone)
 		}
 		if rules, err := wafrule.Parse(docs...); err != nil {
 			slog.Error("waf: invalid zone ruleset, keeping previous", "zone", key, "error", err)
+			// keep the prior fingerprint (if any) so the bad input is retried.
+			newFingerprints[key] = ctrl.zoneFingerprints[key]
 		} else if err := w.SetRules(rules); err != nil {
 			slog.Error("waf: zone ruleset rejected, keeping previous", "zone", key, "error", err)
+			newFingerprints[key] = ctrl.zoneFingerprints[key]
+		} else {
+			newFingerprints[key] = fp
 		}
 		newZones[key] = w
 	}
 	ctrl.zones.Store(&newZones)
+	ctrl.zoneFingerprints = newFingerprints
+}
+
+// fingerprintDocs returns a content fingerprint of the rule documents that feed
+// a single WAF. Callers pass the already-sorted, deterministic doc slice
+// (sortedDataValues), so equal effective input yields an equal fingerprint
+// regardless of ConfigMap map iteration order. The length prefix per doc keeps
+// concatenation unambiguous (so ["a","bc"] and ["ab","c"] differ).
+func fingerprintDocs(docs []string) string {
+	h := sha256.New()
+	var lenbuf [8]byte
+	for _, d := range docs {
+		binary.LittleEndian.PutUint64(lenbuf[:], uint64(len(d)))
+		h.Write(lenbuf[:])
+		h.Write([]byte(d))
+	}
+	return string(h.Sum(nil))
 }
 
 // sortedDataValues returns the ConfigMap data values ordered by key, so rule

--- a/go/controller_waf_test.go
+++ b/go/controller_waf_test.go
@@ -128,6 +128,157 @@ rules:
 	assert.Equal(t, []string{"ok"}, zone.Rules(), "bad edit must not drop the live ruleset")
 }
 
+func TestReloadWAF_UnchangedZoneReusesInstance(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newWAFController()
+
+	const acmeRules = `
+rules:
+  - id: block-admin
+    expression: request.path.startsWith("/admin")
+    action: block
+`
+	ctrl.watchedConfigMaps.Store("cust1/acme", wafCM("cust1", "acme", wafRoleZone, acmeRules))
+	ctrl.watchedConfigMaps.Store("cust2/beta", wafCM("cust2", "beta", wafRoleZone, `
+rules:
+  - id: block-x
+    expression: request.path.startsWith("/x")
+    action: block
+`))
+	ctrl.reloadWAFDebounced()
+
+	acme1 := ctrl.LookupZone("cust1/acme")
+	beta1 := ctrl.LookupZone("cust2/beta")
+	require.NotNil(t, acme1)
+	require.NotNil(t, beta1)
+
+	// Reload again with byte-for-byte identical ConfigMaps: every zone's compiled
+	// instance must be reused (same pointer), i.e. no recompile happened.
+	ctrl.reloadWAFDebounced()
+	assert.Same(t, acme1, ctrl.LookupZone("cust1/acme"),
+		"unchanged zone reuses its compiled instance across reloads")
+	assert.Same(t, beta1, ctrl.LookupZone("cust2/beta"),
+		"unchanged zone reuses its compiled instance across reloads")
+
+	// A reload triggered by an unrelated zone change must still reuse the
+	// untouched zone's instance.
+	ctrl.watchedConfigMaps.Store("cust2/beta", wafCM("cust2", "beta", wafRoleZone, `
+rules:
+  - id: block-y
+    expression: request.path.startsWith("/y")
+    action: block
+`))
+	ctrl.reloadWAFDebounced()
+	assert.Same(t, acme1, ctrl.LookupZone("cust1/acme"),
+		"a sibling zone's edit must not recompile an unchanged zone")
+	assert.Equal(t, []string{"block-y"}, ctrl.LookupZone("cust2/beta").Rules(),
+		"the edited zone is recompiled")
+}
+
+func TestReloadWAF_ChangedZoneRebuilt(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newWAFController()
+	ctrl.watchedConfigMaps.Store("cust1/acme", wafCM("cust1", "acme", wafRoleZone, `
+rules:
+  - id: block-admin
+    expression: request.path.startsWith("/admin")
+    action: block
+`))
+	ctrl.reloadWAFDebounced()
+	require.Equal(t, []string{"block-admin"}, ctrl.LookupZone("cust1/acme").Rules())
+
+	// Change the rule input -> recompiled, new ruleset live (same reused instance).
+	ctrl.watchedConfigMaps.Store("cust1/acme", wafCM("cust1", "acme", wafRoleZone, `
+rules:
+  - id: block-api
+    expression: request.path.startsWith("/api")
+    action: block
+`))
+	ctrl.reloadWAFDebounced()
+	assert.Equal(t, []string{"block-api"}, ctrl.LookupZone("cust1/acme").Rules(),
+		"changed zone is recompiled to the new ruleset")
+}
+
+func TestReloadWAF_AddRemoveZones(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newWAFController()
+	ctrl.watchedConfigMaps.Store("cust1/acme", wafCM("cust1", "acme", wafRoleZone, `
+rules:
+  - id: block-admin
+    expression: request.path.startsWith("/admin")
+    action: block
+`))
+	ctrl.reloadWAFDebounced()
+	acme1 := ctrl.LookupZone("cust1/acme")
+	require.NotNil(t, acme1)
+
+	// Add a second zone; the first must remain (and reuse its instance).
+	ctrl.watchedConfigMaps.Store("cust2/beta", wafCM("cust2", "beta", wafRoleZone, `
+rules:
+  - id: block-x
+    expression: request.path.startsWith("/x")
+    action: block
+`))
+	ctrl.reloadWAFDebounced()
+	assert.Same(t, acme1, ctrl.LookupZone("cust1/acme"), "existing zone survives an add")
+	require.NotNil(t, ctrl.LookupZone("cust2/beta"), "added zone is compiled")
+
+	// Remove the first zone; it must drop out of the registry.
+	ctrl.watchedConfigMaps.Delete("cust1/acme")
+	ctrl.reloadWAFDebounced()
+	assert.Nil(t, ctrl.LookupZone("cust1/acme"), "removed zone drops from the registry")
+	require.NotNil(t, ctrl.LookupZone("cust2/beta"), "untouched zone remains")
+
+	// Re-add the first zone with the original rules; it gets a fresh instance and
+	// must be recompiled (its prior fingerprint was dropped with it).
+	ctrl.watchedConfigMaps.Store("cust1/acme", wafCM("cust1", "acme", wafRoleZone, `
+rules:
+  - id: block-admin
+    expression: request.path.startsWith("/admin")
+    action: block
+`))
+	ctrl.reloadWAFDebounced()
+	readd := ctrl.LookupZone("cust1/acme")
+	require.NotNil(t, readd)
+	assert.NotSame(t, acme1, readd, "a re-added zone is a fresh compiled instance")
+	assert.Equal(t, []string{"block-admin"}, readd.Rules())
+}
+
+func TestReloadWAF_GlobalReusedAndRebuilt(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newWAFController()
+	ctrl.watchedConfigMaps.Store("ctrl-ns/waf-global", wafCM("ctrl-ns", "waf-global", wafRoleGlobal, `
+rules:
+  - id: block-scanners
+    expression: request.user_agent.contains("sqlmap")
+    action: block
+`))
+	ctrl.reloadWAFDebounced()
+	require.Equal(t, []string{"block-scanners"}, ctrl.globalWAF.Rules())
+	fp1 := ctrl.globalWAFFingerprint
+	require.NotEmpty(t, fp1)
+
+	// Unchanged global input: fingerprint stays put (no recompile path taken).
+	ctrl.reloadWAFDebounced()
+	assert.Equal(t, fp1, ctrl.globalWAFFingerprint, "unchanged global input is not recompiled")
+	assert.Equal(t, []string{"block-scanners"}, ctrl.globalWAF.Rules())
+
+	// Changed global input: recompiled, fingerprint advances.
+	ctrl.watchedConfigMaps.Store("ctrl-ns/waf-global", wafCM("ctrl-ns", "waf-global", wafRoleGlobal, `
+rules:
+  - id: block-bots
+    expression: request.user_agent.contains("bot")
+    action: block
+`))
+	ctrl.reloadWAFDebounced()
+	assert.NotEqual(t, fp1, ctrl.globalWAFFingerprint, "changed global input advances the fingerprint")
+	assert.Equal(t, []string{"block-bots"}, ctrl.globalWAF.Rules())
+}
+
 func TestReloadWAF_DisabledIsNoop(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Finding

`reloadWAFDebounced` (`go/controller_waf.go`) recompiled **every** WAF ruleset on **every** WAF ConfigMap event — including events for unrelated/non-WAF ConfigMaps and edits to a single zone. For each reload it:

- built a fresh `waf.WAF` per zone and re-ran the CEL compile (`SetRules`) for that zone, even when the zone's rule documents were byte-for-byte unchanged;
- recompiled the global ruleset on every reload regardless of change.

With many zones, an edit to one zone (or any unrelated ConfigMap churn) became a full recompile of all rulesets — pure wasted CEL compilation on the reload path. (Request path is untouched.)

## Fix

Fingerprint the exact, deterministic rule input that feeds each WAF — the already-sorted concatenated rule YAML (`sortedDataValues`), hashed with `crypto/sha256` and a per-doc length prefix so concatenation is unambiguous. The per-WAF fingerprints from the last reload are stored on the controller (`globalWAFFingerprint`, `zoneFingerprints`); they are only touched from `reloadWAFDebounced`, which the debounce serializes, so no lock is needed.

On reload, a global/zone whose fingerprint matches the loaded one **reuses its compiled `waf.WAF` instance with no recompile**. Only WAFs whose input actually changed are rebuilt via `SetRules`.

## No behavior change

The post-reload state is identical to before for every case:
- **removed** zones drop from the registry,
- **added** zones get a fresh compiled instance,
- **changed** zones recompile,
- only **byte-for-byte-unchanged** zones are reused.

WAF evaluation is unchanged — this is purely about skipping redundant compilation. SPEC.md is unchanged (no observable behavior change).

## Preserved semantics

- **All-or-nothing `SetRules`**: changed zones reuse the existing instance and call `SetRules`, which keeps the last-good ruleset on a bad edit. The fingerprint is advanced **only after a clean compile**, so a rejected edit is retried on the next reload rather than being incorrectly skipped.
- **Atomic zone-registry swap**: a new map is built and stored via the existing `atomic.Pointer` swap.

## Verification

- `cd go && go test ./...` — all pass
- `cd go && go vet ./...` — clean
- New tests in `go/controller_waf_test.go`:
  - unchanged zone reuses its instance across reloads (pointer identity), incl. when a *sibling* zone changes;
  - changed zone is rebuilt to the new ruleset;
  - add/remove/re-add zones behave correctly (removed zone drops; re-added zone is a fresh instance, not stale);
  - global ruleset reused when unchanged, recompiled when changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)