### PR TITLE
perf(go): update only changed hosts on endpoint reload, not full rebuild

### DIFF
--- a/go/controller.go
+++ b/go/controller.go
@@ -88,11 +88,10 @@ type Controller struct {
 	plugins []plugin.Plugin
 	health  *healthz.Healthz
 
-	reloadIngressDebounce  *debounce.Debounce
-	reloadServiceDebounce  *debounce.Debounce
-	reloadSecretDebounce   *debounce.Debounce
-	reloadEndpointDebounce *debounce.Debounce
-	reloadWAFDebounce      *debounce.Debounce
+	reloadIngressDebounce *debounce.Debounce
+	reloadServiceDebounce *debounce.Debounce
+	reloadSecretDebounce  *debounce.Debounce
+	reloadWAFDebounce     *debounce.Debounce
 }
 
 // New creates new ingress controller
@@ -104,7 +103,6 @@ func New(watchNamespace string, proxy *proxy.Proxy) *Controller {
 	ctrl.reloadIngressDebounce = debounce.New(ctrl.reloadIngressDebounced, 300*time.Millisecond)
 	ctrl.reloadServiceDebounce = debounce.New(ctrl.reloadServiceDebounced, 300*time.Millisecond)
 	ctrl.reloadSecretDebounce = debounce.New(ctrl.reloadSecretDebounced, 300*time.Millisecond)
-	ctrl.reloadEndpointDebounce = debounce.New(ctrl.reloadEndpointDebounced, 300*time.Millisecond)
 	ctrl.reloadWAFDebounce = debounce.New(ctrl.reloadWAFDebounced, 300*time.Millisecond)
 	ctrl.proxy = proxy
 	ctrl.proxy.OnDialError = ctrl.routeTable.MarkBad
@@ -188,6 +186,8 @@ func (ctrl *Controller) firstReload() {
 // into store, and invokes onUpsert / onDelete so the caller triggers the right
 // reload. PT is the pointer type of T (e.g. *networking.Ingress); the
 // metav1.Object constraint gives access to the object's namespace and name.
+// onDelete receives the deleted object so a caller can reload incrementally
+// (e.g. drop just that one host) instead of rebuilding from the whole store.
 func watchResource[T any, PT interface {
 	*T
 	metav1.Object
@@ -197,7 +197,7 @@ func watchResource[T any, PT interface {
 	watchFn func(ctx context.Context, namespace string) (watch.Interface, error),
 	store *sync.Map,
 	onUpsert func(obj PT),
-	onDelete func(),
+	onDelete func(obj PT),
 ) {
 	for {
 		w, err := watchFn(ctx, namespace)
@@ -220,7 +220,7 @@ func watchResource[T any, PT interface {
 				onUpsert(obj)
 			case watch.Deleted:
 				store.Delete(key)
-				onDelete()
+				onDelete(obj)
 			default:
 				continue
 			}
@@ -235,7 +235,7 @@ func (ctrl *Controller) watchIngresses(ctx context.Context) {
 	watchResource(ctx, ctrl.watchNamespace, "ingresses", k8s.WatchIngresses,
 		&ctrl.watchedIngresses,
 		func(_ *networking.Ingress) { ctrl.reloadIngress() },
-		ctrl.reloadIngress,
+		func(_ *networking.Ingress) { ctrl.reloadIngress() },
 	)
 }
 
@@ -249,7 +249,7 @@ func (ctrl *Controller) watchServices(ctx context.Context) {
 	watchResource(ctx, ctrl.watchNamespace, "services", k8s.WatchServices,
 		&ctrl.watchedServices,
 		func(_ *v1.Service) { reload() },
-		reload,
+		func(_ *v1.Service) { reload() },
 	)
 }
 
@@ -257,17 +257,20 @@ func (ctrl *Controller) watchSecrets(ctx context.Context) {
 	watchResource(ctx, ctrl.watchNamespace, "secrets", k8s.WatchSecrets,
 		&ctrl.watchedSecrets,
 		func(_ *v1.Secret) { ctrl.reloadSecret() },
-		ctrl.reloadSecret,
+		func(_ *v1.Secret) { ctrl.reloadSecret() },
 	)
 }
 
 func (ctrl *Controller) watchEndpoints(ctx context.Context) {
-	// upserts only touch a single endpoint's backends, so reload just that one;
-	// a delete needs a full endpoint-table rebuild.
+	// a single endpoint event only touches its own service's host, so both
+	// upsert and delete update just that one host in place instead of rebuilding
+	// the whole endpoint table. The full rebuild (reloadEndpointDebounced) is
+	// reserved for the initial sync / resync in firstReload, where the entire
+	// set is (re)listed.
 	watchResource(ctx, ctrl.watchNamespace, "endpoints", k8s.WatchEndpoints,
 		&ctrl.watchedEndpoints,
 		ctrl.reloadSingleEndpoint,
-		ctrl.reloadEndpoint,
+		ctrl.deleteSingleEndpoint,
 	)
 }
 
@@ -518,10 +521,10 @@ func (ctrl *Controller) reloadSecretDebounced() {
 	ctrl.certTable.Set(certs)
 }
 
-func (ctrl *Controller) reloadEndpoint() {
-	ctrl.reloadEndpointDebounce.Call()
-}
-
+// reloadEndpointDebounced rebuilds the entire host -> pod-IP table from the
+// whole watched-endpoints store. It is the initial-sync / resync path (called
+// from firstReload); steady-state endpoint events are applied incrementally
+// per host by reloadSingleEndpoint / deleteSingleEndpoint and never come here.
 func (ctrl *Controller) reloadEndpointDebounced() {
 	slog.Info("reload endpoints")
 
@@ -547,6 +550,14 @@ func (ctrl *Controller) reloadSingleEndpoint(ep *v1.Endpoints) {
 	slog.Info("reload single endpoint", "namespace", ep.Namespace, "name", ep.Name)
 
 	ctrl.routeTable.SetHostRoute(buildHost(ep.Namespace, ep.Name), endpointToRRLB(ep))
+}
+
+func (ctrl *Controller) deleteSingleEndpoint(ep *v1.Endpoints) {
+	slog.Info("delete single endpoint", "namespace", ep.Namespace, "name", ep.Name)
+
+	// the host is gone, so drop just that one entry; passing nil makes
+	// SetHostRoute delete it, leaving the rest of the table untouched.
+	ctrl.routeTable.SetHostRoute(buildHost(ep.Namespace, ep.Name), nil)
 }
 
 func (ctrl *Controller) GetCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {

--- a/go/controller_endpoint_test.go
+++ b/go/controller_endpoint_test.go
@@ -1,0 +1,101 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func endpoints(namespace, name string, ips ...string) *v1.Endpoints {
+	ep := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+	}
+	if len(ips) > 0 {
+		addrs := make([]v1.EndpointAddress, 0, len(ips))
+		for _, ip := range ips {
+			addrs = append(addrs, v1.EndpointAddress{IP: ip})
+		}
+		ep.Subsets = []v1.EndpointSubset{{Addresses: addrs}}
+	}
+	return ep
+}
+
+// TestReloadSingleEndpoint checks that the per-event endpoint path
+// (reloadSingleEndpoint upsert / deleteSingleEndpoint delete) leaves the route
+// table in the same state a full reloadEndpointDebounced rebuild would, for the
+// four cases that matter on pod churn: add a host, change a host's IPs, delete a
+// host, and a no-op re-upsert.
+func TestReloadSingleEndpoint(t *testing.T) {
+	t.Parallel()
+
+	// port routing so Lookup resolves host -> ip:port
+	setPorts := func(c *Controller) {
+		c.routeTable.SetPortRoutes(map[string]string{
+			"a.default.svc.cluster.local:80": "8080",
+			"b.default.svc.cluster.local:80": "8080",
+		})
+	}
+
+	// incremental controller, driven only through the watch-event entry points
+	var incr Controller
+	setPorts(&incr)
+
+	// full-rebuild controller, kept in lock-step via the watched-endpoints store.
+	// desired is the current intended set; rebuild relists it like initial sync.
+	var full Controller
+	setPorts(&full)
+	desired := map[string]*v1.Endpoints{}
+	rebuild := func() {
+		full.watchedEndpoints.Range(func(k, _ any) bool { full.watchedEndpoints.Delete(k); return true })
+		for _, ep := range desired {
+			full.watchedEndpoints.Store(ep.Namespace+"/"+ep.Name, ep)
+		}
+		full.reloadEndpointDebounced()
+	}
+
+	assertSame := func(host string) {
+		t.Helper()
+		assert.Equal(t,
+			full.routeTable.Lookup(host+":80"),
+			incr.routeTable.Lookup(host+":80"),
+			"incremental and full-rebuild disagree for %s", host)
+	}
+
+	// add host a
+	desired["default/a"] = endpoints("default", "a", "10.0.0.1")
+	incr.reloadSingleEndpoint(desired["default/a"])
+	rebuild()
+	assert.Equal(t, "10.0.0.1:8080", incr.routeTable.Lookup("a.default.svc.cluster.local:80"))
+	assertSame("a.default.svc.cluster.local")
+
+	// add host b
+	desired["default/b"] = endpoints("default", "b", "10.0.1.1", "10.0.1.2")
+	incr.reloadSingleEndpoint(desired["default/b"])
+	rebuild()
+	assertSame("b.default.svc.cluster.local")
+
+	// change host a's IP
+	desired["default/a"] = endpoints("default", "a", "10.0.0.9")
+	incr.reloadSingleEndpoint(desired["default/a"])
+	rebuild()
+	assert.Equal(t, "10.0.0.9:8080", incr.routeTable.Lookup("a.default.svc.cluster.local:80"))
+	assertSame("a.default.svc.cluster.local")
+
+	// no-op re-upsert of host a (same IP)
+	incr.reloadSingleEndpoint(desired["default/a"])
+	rebuild()
+	assert.Equal(t, "10.0.0.9:8080", incr.routeTable.Lookup("a.default.svc.cluster.local:80"))
+	assertSame("a.default.svc.cluster.local")
+
+	// delete host b
+	delete(desired, "default/b")
+	incr.deleteSingleEndpoint(endpoints("default", "b"))
+	rebuild()
+	assert.Empty(t, incr.routeTable.Lookup("b.default.svc.cluster.local:80"))
+	assertSame("b.default.svc.cluster.local")
+	// host a is untouched by b's deletion
+	assert.Equal(t, "10.0.0.9:8080", incr.routeTable.Lookup("a.default.svc.cluster.local:80"))
+	assertSame("a.default.svc.cluster.local")
+}

--- a/go/controller_waf.go
+++ b/go/controller_waf.go
@@ -117,7 +117,7 @@ func (ctrl *Controller) watchConfigMaps(ctx context.Context) {
 	watchResource(ctx, ctrl.watchNamespace, "configmaps", watchFn,
 		&ctrl.watchedConfigMaps,
 		func(_ *v1.ConfigMap) { ctrl.reloadWAF() },
-		ctrl.reloadWAF,
+		func(_ *v1.ConfigMap) { ctrl.reloadWAF() },
 	)
 }
 

--- a/go/controller_watch_test.go
+++ b/go/controller_watch_test.go
@@ -30,7 +30,7 @@ func TestWatchResource(t *testing.T) {
 		func(context.Context, string) (watch.Interface, error) { return w, nil },
 		&store,
 		func(_ *v1.Service) { upserts.Add(1) },
-		func() { deletes.Add(1) },
+		func(_ *v1.Service) { deletes.Add(1) },
 	)
 
 	svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "web"}}

--- a/go/route/table_test.go
+++ b/go/route/table_test.go
@@ -62,4 +62,99 @@ func TestTable(t *testing.T) {
 		res = tb.Lookup("about.service.svc.cluster.local:8000")
 		assert.Equal(t, "192.168.3.2:9003", res)
 	})
+
+	t.Run("SetHostRoute nil deletes", func(t *testing.T) {
+		tb.SetHostRoute("about.service.svc.cluster.local", &RRLB{IPs: []string{"192.168.3.9"}})
+		assert.Equal(t, "192.168.3.9:9003", tb.Lookup("about.service.svc.cluster.local:8000"))
+
+		// passing nil removes just that host; the lookup now misses
+		tb.SetHostRoute("about.service.svc.cluster.local", nil)
+		assert.Empty(t, tb.Lookup("about.service.svc.cluster.local:8000"))
+	})
+}
+
+// hostIPs reads back the IP set the table currently holds for each host so two
+// tables built different ways can be compared for equality.
+func hostIPs(t *Table) map[string][]string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	out := make(map[string][]string, len(t.addrToTargetHost))
+	for host, lb := range t.addrToTargetHost {
+		out[host] = lb.IPs
+	}
+	return out
+}
+
+// TestTableIncrementalMatchesRebuild proves that driving the host table with
+// per-host SetHostRoute calls (the watch-event path) lands in exactly the same
+// state a full SetHostRoutes rebuild (the initial-sync path) would produce, for
+// adding a host, changing a host's IPs, deleting a host, and a no-op re-set.
+func TestTableIncrementalMatchesRebuild(t *testing.T) {
+	t.Parallel()
+
+	type set map[string][]string
+
+	// the sequence of desired states the table passes through
+	states := []set{
+		// initial set
+		{
+			"a.default.svc.cluster.local": {"10.0.0.1"},
+			"b.default.svc.cluster.local": {"10.0.1.1", "10.0.1.2"},
+		},
+		// add a host (c)
+		{
+			"a.default.svc.cluster.local": {"10.0.0.1"},
+			"b.default.svc.cluster.local": {"10.0.1.1", "10.0.1.2"},
+			"c.default.svc.cluster.local": {"10.0.2.1"},
+		},
+		// change a host's IPs (b scaled / pods replaced)
+		{
+			"a.default.svc.cluster.local": {"10.0.0.1"},
+			"b.default.svc.cluster.local": {"10.0.1.3"},
+			"c.default.svc.cluster.local": {"10.0.2.1"},
+		},
+		// no-op: identical to the previous state
+		{
+			"a.default.svc.cluster.local": {"10.0.0.1"},
+			"b.default.svc.cluster.local": {"10.0.1.3"},
+			"c.default.svc.cluster.local": {"10.0.2.1"},
+		},
+		// delete a host (c removed)
+		{
+			"a.default.svc.cluster.local": {"10.0.0.1"},
+			"b.default.svc.cluster.local": {"10.0.1.3"},
+		},
+	}
+
+	toRoutes := func(s set) map[string]*RRLB {
+		m := make(map[string]*RRLB, len(s))
+		for host, ips := range s {
+			m[host] = &RRLB{IPs: ips}
+		}
+		return m
+	}
+
+	// incremental: seed with the first state, then apply each subsequent state
+	// as per-host upserts/deletes, mirroring reloadSingleEndpoint /
+	// deleteSingleEndpoint.
+	var incr Table
+	incr.SetHostRoutes(toRoutes(states[0]))
+	for i := 1; i < len(states); i++ {
+		prev, cur := states[i-1], states[i]
+		for host, ips := range cur { // upserts
+			incr.SetHostRoute(host, &RRLB{IPs: ips})
+		}
+		for host := range prev { // deletes
+			if _, ok := cur[host]; !ok {
+				incr.SetHostRoute(host, nil)
+			}
+		}
+
+		// a full rebuild of the same desired state must match the incremental one
+		var full Table
+		full.SetHostRoutes(toRoutes(cur))
+
+		assert.Equal(t, hostIPs(&full), hostIPs(&incr),
+			"incremental state diverged from full rebuild at step %d", i)
+	}
 }


### PR DESCRIPTION
## Finding

In `go/controller.go`, a single endpoint event (pod restart, scale up/down, rollout) only changes one service's backend set. Upserts were already incremental (`reloadSingleEndpoint` → `route.Table.SetHostRoute`), but the **delete** path (`onDelete` → `reloadEndpoint` → `reloadEndpointDebounced`) rebuilt the **entire** host → pod-IP table by ranging the whole `watchedEndpoints` store and calling `SetHostRoutes`. On a busy cluster, pod churn that deletes/recreates an `Endpoints` object made every such event O(all services), even though only one host changed.

## Approach and why it's correct

The watch layer already had the deleted object in hand on `watch.Deleted` (`event.Object`) — it just discarded it, because `watchResource`'s `onDelete` was `func()`. I changed `onDelete` to receive the typed object (`func(obj PT)`). The endpoint watcher now wires delete to a new `deleteSingleEndpoint`, which removes exactly that one host via `SetHostRoute(host, nil)` instead of rebuilding from the store. The other resources (ingress / service / secret / configmap) ignore the new argument and keep their existing reload behavior.

This produces **identical** route-table state to the old full rebuild:

- A `watch.Deleted` event carries the object that was removed, so we know precisely which host to drop, and `watchResource` has already removed it from the store.
- `SetHostRoute(host, nil)` deletes that single entry and leaves every other host untouched — exactly what a full rebuild would yield, since the rebuild would simply omit the now-gone service.

The full-rebuild path (`reloadEndpointDebounced`) is **preserved** for initial sync / resync via `firstReload`, where the entire endpoint set is (re)listed. The now-orphaned `reloadEndpoint()` debounce wrapper and its `reloadEndpointDebounce` field/init are removed (endpoint events now apply immediately and per-host, which is cheap).

Note: this builds on the already-merged incremental **upsert** work; this PR completes the incremental story for **deletes**.

## No behavior change

The resulting route-table state is identical to a full rebuild, so this is an internal performance change only. **`SPEC.md` is unchanged.**

## Verification

- New `route/table_test.go::TestTableIncrementalMatchesRebuild`: drives a per-host add / change-IPs / no-op / delete sequence and asserts the table equals a full `SetHostRoutes` rebuild at every step. Also extended `TestTable` with a `SetHostRoute(nil)` deletion case.
- New `controller_endpoint_test.go::TestReloadSingleEndpoint`: same four cases end-to-end through `reloadSingleEndpoint` / `deleteSingleEndpoint`, compared against `reloadEndpointDebounced` lock-step, including that deleting one host leaves the others intact.
- `cd go && go test ./... && go vet ./...` pass; touched packages also pass under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)