### PR TITLE
perf(rust): trim per-request allocations in router key lookup

### DIFF
--- a/rust/controller/src/router.rs
+++ b/rust/controller/src/router.rs
@@ -48,7 +48,13 @@ impl<T> Router<T> {
     }
 
     pub fn lookup(&self, host: &str, path: &str) -> Match<'_, T> {
-        let full = format!("{host}{path}");
+        // Single pre-sized allocation for the combined `host + path` key. The
+        // common (matched) path costs exactly this one String; the rare
+        // redirect branch below reuses this same buffer instead of formatting
+        // fresh keys.
+        let mut full = String::with_capacity(host.len() + path.len() + 1);
+        full.push_str(host);
+        full.push_str(path);
 
         // 1. host-specific
         if let Some(v) = self.match_prefixed(&full) {
@@ -58,12 +64,18 @@ impl<T> Router<T> {
         if let Some(v) = self.match_prefixed(path) {
             return Match::Found(v);
         }
-        // 3. trailing-slash redirect
-        if !path.ends_with('/')
-            && (self.map.contains_key(&format!("{full}/"))
-                || self.map.contains_key(&format!("{path}/")))
-        {
-            return Match::Redirect(format!("{path}/"));
+        // 3. trailing-slash redirect. Reuse `full` for the "{full}/" probe (the
+        // capacity above reserved the extra '/'), and slice it for "{path}/"
+        // rather than allocating new keys.
+        if !path.ends_with('/') {
+            full.push('/');
+            let host_slash_matches = self.map.contains_key(&full);
+            // `full` is `host + path + "/"`; the `path + "/"` suffix is the
+            // trailing `path.len() + 1` bytes — a borrow, no allocation.
+            let path_slash = &full[host.len()..];
+            if host_slash_matches || self.map.contains_key(path_slash) {
+                return Match::Redirect(path_slash.to_string());
+            }
         }
         // 4.
         Match::NotFound


### PR DESCRIPTION
## Finding

`rust/controller/src/router.rs` `Router::lookup(host, path)` builds its `HashMap<String, T>` key by allocating `format!("{host}{path}")` on **every** request (~line 51). On the trailing-slash-redirect branch it allocated up to three more (`format!("{full}/")`, `format!("{path}/")`, and the returned `format!("{path}/")`).

This is the weakest of a batch of allocation findings, and the report is honest about that: the common matched path was already only **one** allocation, and that one is genuinely hard to remove because the map is keyed by the combined `host + path` string. So the realistic win here is **modest**.

## What changed (no behavior change)

- Replace `format!("{host}{path}")` with a single **pre-sized** `String::with_capacity(host.len() + path.len() + 1)` + two `push_str`, reserving one byte for the redirect probe.
- On the redirect branch, **reuse that same buffer**: push `'/'` once and probe `{host}{path}/` directly; derive the `{path}/` key as a **borrowed slice** `&full[host.len()..]` instead of two fresh `format!` strings. This drops the redirect path from **4 allocations to 2** (the remaining one is the owned `String` that `Match::Redirect` must carry — unavoidable).

The common matched path still costs exactly one (now pre-sized) `String`.

## Why not the deeper refactor (option c)

Eliminating the combined-key concat entirely would need a nested `HashMap<host, HashMap<path, T>>` or a borrow-keyed lookup. That touches the host-specific-precedence and longest-subtree-prefix resolution order that is verified against Go's `TestMux` / `TestBuildRoutes`. Not worth the risk for a hot-but-already-cheap path, so it was deliberately **not** taken.

## Realistic impact

Common path: unchanged allocation count, but the one allocation is now correctly pre-sized (avoids potential reallocation as the key is built). Redirect path: 4 → 2 allocations, but that branch is rare (only fires on a no-trailing-slash request that misses both host-specific and host-less matches). Net: a small, clean reduction — not a dramatic one.

## Public API

`lookup` signature, `Match` enum, `patterns`, `new`, `len`, `is_empty` all unchanged.

## Verification

- `cargo test -p parapet-ingress-controller --features proxy,cluster` — all pass, including the 6 `router::tests` that encode the Go-verified routing semantics, unchanged.
- `cargo clippy --features proxy,cluster -p parapet-ingress-controller` — clean, no new warnings.

Rust-only internal perf change; no observable behavior change, so `SPEC.md` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)