### PR TITLE
feat(rust): jemalloc alloc-stats gauges to diagnose RSS growth (leak vs retention)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2109,6 +2109,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
  "x509-parser",
@@ -2142,6 +2143,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -3343,6 +3350,17 @@ checksum = "83d957f535b242b91aa9f47bde08080f9a6fef276477e55b0079979d002759d5"
 dependencies = [
  "byteorder",
  "trackable",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/rust/controller/Cargo.toml
+++ b/rust/controller/Cargo.toml
@@ -63,7 +63,13 @@ maxminddb = { version = "0.28", optional = true }
 tikv-jemallocator = { version = "0.6", features = [
     "unprefixed_malloc_on_supported_platforms",
     "background_threads",
+    "stats",
 ], optional = true }
+# Reads jemalloc's internal stats (allocated/active/resident/retained) via
+# mallctl, exported as Prometheus gauges (proxy/allocmetrics.rs). `allocated`
+# (live bytes) vs `resident` (RSS) separates a true leak from allocator
+# retention — the diagnostic for unbounded RSS growth.
+tikv-jemalloc-ctl = { version = "0.6", features = ["stats"], optional = true }
 
 [features]
 cluster = ["dep:kube", "dep:tokio", "dep:futures", "dep:rustls", "waf"]
@@ -81,6 +87,7 @@ proxy = [
     "dep:env_logger",
     "dep:libc",
     "dep:tikv-jemallocator",
+    "dep:tikv-jemalloc-ctl",
     "waf",
 ]
 # The CEL WAF engine. Enabled by both `proxy` (evaluates) and `cluster`

--- a/rust/controller/src/main.rs
+++ b/rust/controller/src/main.rs
@@ -102,6 +102,12 @@ fn main() {
     #[cfg(target_os = "linux")]
     controller::proxy::procmetrics::start();
 
+    // jemalloc allocated/resident/retained gauges: lets Grafana separate a true
+    // leak (allocated climbs) from allocator retention (resident climbs while
+    // allocated is flat) on the live /metrics endpoint. See allocmetrics.rs.
+    #[cfg(not(target_env = "msvc"))]
+    controller::proxy::allocmetrics::start();
+
     let ingress_class = env_or("INGRESS_CLASS", "parapet");
     let load_all_certs = std::env::var("LOAD_ALL_CERTS").ok().as_deref() == Some("true");
     let http_port = env_or("HTTP_PORT", "80");

--- a/rust/controller/src/proxy/allocmetrics.rs
+++ b/rust/controller/src/proxy/allocmetrics.rs
@@ -1,0 +1,98 @@
+//! jemalloc internal allocator stats, exported as Prometheus gauges so unbounded
+//! RSS growth can be diagnosed in Grafana instead of guessed at.
+//!
+//! The decisive pair is `jemalloc_allocated_bytes` (bytes the application has
+//! malloc'd and not yet freed — the *live* heap) vs `jemalloc_resident_bytes`
+//! (physically resident pages, ~RSS):
+//!
+//!   - `allocated` climbing monotonically  => a genuine **leak** (live memory
+//!     that is never freed); no allocator can return it.
+//!   - `allocated` flat while `resident`/`retained` climb => allocator
+//!     **retention/fragmentation** (freed but not handed back); tune decay
+//!     (`_RJEM_MALLOC_CONF=dirty_decay_ms:...`) rather than hunt a leak.
+//!
+//! Only meaningful when jemalloc is the global allocator (see `main.rs`), so this
+//! is compiled out on msvc, where the system allocator is used.
+
+#![cfg(not(target_env = "msvc"))]
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use prometheus::{register_int_gauge, IntGauge};
+use tikv_jemalloc_ctl::{epoch, stats};
+
+struct AllocMetrics {
+    allocated: IntGauge,
+    active: IntGauge,
+    resident: IntGauge,
+    retained: IntGauge,
+    mapped: IntGauge,
+}
+
+fn metrics() -> &'static AllocMetrics {
+    static M: OnceLock<AllocMetrics> = OnceLock::new();
+    M.get_or_init(|| AllocMetrics {
+        allocated: register_int_gauge!(
+            "jemalloc_allocated_bytes",
+            "Bytes allocated by the application and not yet freed (live heap)"
+        )
+        .expect("register jemalloc_allocated_bytes"),
+        active: register_int_gauge!(
+            "jemalloc_active_bytes",
+            "Bytes in active pages used by the application"
+        )
+        .expect("register jemalloc_active_bytes"),
+        resident: register_int_gauge!(
+            "jemalloc_resident_bytes",
+            "Bytes in physically resident data pages (approximates RSS)"
+        )
+        .expect("register jemalloc_resident_bytes"),
+        retained: register_int_gauge!(
+            "jemalloc_retained_bytes",
+            "Bytes mapped but retained (not returned to the OS, virtual only)"
+        )
+        .expect("register jemalloc_retained_bytes"),
+        mapped: register_int_gauge!(
+            "jemalloc_mapped_bytes",
+            "Bytes in active extents mapped by the allocator"
+        )
+        .expect("register jemalloc_mapped_bytes"),
+    })
+}
+
+/// Register the jemalloc gauges and start a 5s background refresher (mirrors
+/// `procmetrics::start`). Call once at startup, after the allocator is active.
+pub fn start() {
+    let m = metrics();
+    std::thread::spawn(|| loop {
+        refresh(metrics());
+        std::thread::sleep(Duration::from_secs(5));
+    });
+    // prime once so the series exist immediately
+    refresh(m);
+}
+
+fn refresh(m: &AllocMetrics) {
+    // jemalloc's stats are cached and only recomputed when the epoch advances;
+    // without this the gauges would never move. A failed advance/read just skips
+    // this tick (the previous value stays).
+    if epoch::advance().is_err() {
+        return;
+    }
+    if let Ok(v) = stats::allocated::read() {
+        m.allocated.set(v as i64);
+    }
+    if let Ok(v) = stats::active::read() {
+        m.active.set(v as i64);
+    }
+    if let Ok(v) = stats::resident::read() {
+        m.resident.set(v as i64);
+    }
+    if let Ok(v) = stats::retained::read() {
+        m.retained.set(v as i64);
+    }
+    if let Ok(v) = stats::mapped::read() {
+        m.mapped.set(v as i64);
+    }
+}

--- a/rust/controller/src/proxy/mod.rs
+++ b/rust/controller/src/proxy/mod.rs
@@ -3,6 +3,7 @@
 //! / X-Forwarded-* handling, the JSON access log, and request metrics. Mirrors
 //! the Go controller's request path.
 
+pub mod allocmetrics;
 pub mod cert;
 pub mod limit;
 pub mod metrics;


### PR DESCRIPTION
Follow-up to #76 (jemalloc allocator). #76 switched the allocator but left the root cause of the controller's unbounded RSS climb undetermined — and `MALLOC_ARENA_MAX=2` did **not** flatten it, which rules out multi-arena fragmentation but not the two remaining causes:

- **glibc brk-heap retention** — freed but not returned to the OS; **jemalloc fixes this**.
- **a genuine leak** — live memory never freed; **no allocator fixes this**.

Rather than guess, this makes the jemalloc build **self-diagnosing**: it exports jemalloc's internal stats (via `tikv-jemalloc-ctl`, 5s refresher — same pattern as `procmetrics`) as Prometheus gauges on the existing `/metrics` endpoint:

- `jemalloc_allocated_bytes` — **live heap** (malloc'd, not yet freed)
- `jemalloc_active_bytes`, `jemalloc_resident_bytes` (~RSS), `jemalloc_retained_bytes`, `jemalloc_mapped_bytes`

## How to read it after deploy (one pod is enough)

- `jemalloc_allocated_bytes` **flat** while `resident`/`retained` climb → **allocator retention**; jemalloc returns it (tune `_RJEM_MALLOC_CONF=dirty_decay_ms:...` if it lags). Effectively fixed by #76.
- `jemalloc_allocated_bytes` **climbs monotonically** → **true leak**; next step is a jemalloc heap profile (`profiling` feature + `_RJEM_MALLOC_CONF=prof:true,prof_active:true`) to pinpoint the call site (likely pingora internals — our code audits clean).

## Verification
- Builds (incl. fast core) + `cargo fmt --all --check` clean; `Cargo.lock` updated.
- Confirmed `tikv-jemalloc-ctl` reads live values at runtime (`allocated` moved across ticks).
- Controller only — the edge proxy has no Prometheus endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)