### PR TITLE
feat(edgecp): support "*" catch-all token authorized for all domains

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -97,8 +97,10 @@ Each edge holds a **per-edge bearer token** presented as `Authorization: Bearer
 <token>` on every control-plane request, over server-side HTTPS. The token maps
 (control-plane side) to an **allowed set of domains/zones** — Phase 1 from a
 static config (token → domains), later from a k8s Secret/ConfigMap. Allowed
-hosts match exact + single-label-wildcard like `cert.Table`. Deny by default. One
-`authorize(token, host|zone)` check gates both endpoints:
+hosts match exact + single-label-wildcard like `cert.Table`, plus a bare `"*"`
+catch-all entry in the domain list that authorizes the token for **every** host
+(the serve-all case below). Deny by default. One `authorize(token, host|zone)`
+check gates both endpoints:
 
 - `GET /v1/certs/{sni}` → require `sni ∈ allowed(token)`.
 - `GET /v1/waf` → return only the zones / host-map entries for the token's domains.
@@ -120,7 +122,10 @@ to blunt enumeration.
 
 > This isolation only buys anything if **edges are sharded by domain**. If every
 > edge may serve every domain (pure anycast/failover), every allowlist is "all"
-> and the per-edge scoping is moot. Decide sharding first.
+> and the per-edge scoping is moot. Decide sharding first. For that case give the
+> token a single `"*"` entry — an explicit all-domains grant — instead of trying
+> to enumerate every domain; the token then carries the full blast radius, so
+> rotate it aggressively.
 
 ## The HTTPS API (REST)
 

--- a/go/cmd/edge-controlplane/main.go
+++ b/go/cmd/edge-controlplane/main.go
@@ -30,7 +30,7 @@ func main() {
 	podNamespace := os.Getenv("POD_NAMESPACE")     // bounds the global WAF ruleset
 	tlsCert := os.Getenv("CP_TLS_CERT")            // server cert (with CP_TLS_KEY → HTTPS)
 	tlsKey := os.Getenv("CP_TLS_KEY")              // server key
-	tokensJSON := os.Getenv("CP_TOKENS")           // {"<token>":["acme.com","*.acme.com"]}
+	tokensJSON := os.Getenv("CP_TOKENS")           // {"<token>":["acme.com","*.acme.com"]} ("*" = all domains)
 	tokensFile := os.Getenv("CP_TOKENS_FILE")      // alternative: path to that JSON
 	wafEnabled := os.Getenv("CP_WAF_ENABLED") == "true"
 

--- a/go/edgecp/authz.go
+++ b/go/edgecp/authz.go
@@ -17,7 +17,8 @@ type Authz struct {
 }
 
 // NewAuthz builds the table from a token→domains map. Domain patterns are
-// lowercased; matching mirrors cert.Table (exact, then single-label wildcard).
+// lowercased; matching mirrors cert.Table (exact, then single-label wildcard),
+// plus a bare "*" catch-all that authorizes the token for every host.
 func NewAuthz(tokens map[string][]string) *Authz {
 	t := make(map[string][]string, len(tokens))
 	for tok, domains := range tokens {
@@ -31,9 +32,12 @@ func NewAuthz(tokens map[string][]string) *Authz {
 }
 
 // Allowed reports whether the token is known and authorized for host. An unknown
-// token (or empty host) is denied. The returned bool is the only signal — callers
-// must not distinguish "unknown token" from "known but unauthorized" to the
-// client beyond 401 vs 403 (handled in the server).
+// token (or empty host) is denied. A token whose domain list contains a bare "*"
+// is authorized for every (non-empty) host — the catch-all for a serve-all edge
+// that may front any domain (pure anycast/failover, where per-edge sharding buys
+// nothing; see EDGE.md). The returned bool is the only signal — callers must not
+// distinguish "unknown token" from "known but unauthorized" to the client beyond
+// 401 vs 403 (handled in the server).
 func (a *Authz) Allowed(token, host string) bool {
 	domains, ok := a.tokens[token]
 	if !ok {
@@ -44,7 +48,7 @@ func (a *Authz) Allowed(token, host string) bool {
 		return false
 	}
 	for _, d := range domains {
-		if d == name {
+		if d == "*" || d == name {
 			return true
 		}
 	}

--- a/go/edgecp/edgecp_test.go
+++ b/go/edgecp/edgecp_test.go
@@ -69,7 +69,8 @@ func TestCertStoreSNIMatch(t *testing.T) {
 
 func TestAuthz(t *testing.T) {
 	a := NewAuthz(map[string][]string{
-		"tok-eu": {"acme.com", "*.acme.com"},
+		"tok-eu":  {"acme.com", "*.acme.com"},
+		"tok-all": {"*"},
 	})
 	if !a.Allowed("tok-eu", "acme.com") {
 		t.Error("exact allow failed")
@@ -82,6 +83,17 @@ func TestAuthz(t *testing.T) {
 	}
 	if a.Allowed("unknown", "acme.com") {
 		t.Error("should deny unknown token")
+	}
+	// A bare "*" is the serve-all catch-all: any non-empty host, including
+	// an apex, a deep subdomain, and a domain no other token lists.
+	if !a.Allowed("tok-all", "acme.com") {
+		t.Error("catch-all should allow apex")
+	}
+	if !a.Allowed("tok-all", "a.b.evil.com") {
+		t.Error("catch-all should allow deep subdomain")
+	}
+	if a.Allowed("tok-all", "") {
+		t.Error("catch-all should still deny empty host")
 	}
 	if !a.Known("tok-eu") || a.Known("nope") {
 		t.Error("Known() wrong")


### PR DESCRIPTION
## What

Adds a `"*"` catch-all to the edge control plane's per-token authorization. A token whose domain list contains a bare `"*"` is now authorized for **every** host.

## Why

`Authz.Allowed` only matched exact hosts and single-label wildcards (`*.acme.com`). A *serve-all* edge — pure anycast/failover with no per-domain sharding, the case already called out in `EDGE.md` — had no way to say "this token may fetch any cert" short of enumerating every domain. And a bare `"*"` in the list matched **nothing** (it's neither an exact host nor a derived `*.apex` pattern), so it silently failed.

## Change

- **`go/edgecp/authz.go`** — `Allowed()` short-circuits to `true` when the token's domain list contains `"*"`. Empty host is still denied; unknown tokens are still denied. Gates both `/v1/certs` and `/v1/waf` scoping, same as before.
- **`go/edgecp/edgecp_test.go`** — extends `TestAuthz` with a `{"*"}` token: allows apex, allows deep subdomain, still denies empty host.
- **`EDGE.md`** + **`CP_TOKENS` comment in `main.go`** — document the catch-all and note it carries the full blast radius (rotate aggressively).

## Notes

- Go-only: authorization is entirely server-side in the Go control plane; the Rust edge just presents its bearer token, so nothing to mirror in `rust/`.
- `gofmt -l` clean; `go test ./edgecp/` and `go vet` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)