### PR TITLE
feat(edge): plaintext HTTP listener (no redirect) + rename EDGE_LISTEN→EDGE_HTTPS_LISTEN

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -222,6 +222,8 @@ Because the edge sets `X-Forwarded-For` and parapet trusts it
 ## Ports & exposure
 
 ```
+edge           :443   public TLS (terminated locally)       EDGE_LISTEN
+               :80    public plaintext (optional, off)      EDGE_HTTP_LISTEN
 parapet        :80    data (h2c from edge)                 unchanged role, now behind edge
                :443   data (re-encrypt from edge)
                :9187  metrics
@@ -230,6 +232,18 @@ controlplane   :8443  HTTPS GET (server-TLS + bearer)       NEW — Go, own Serv
                       distributes PRIVATE KEYS; NetworkPolicy: edge sources only;
                       NOT on the public LB
 ```
+
+### Plaintext HTTP listener (no redirect — the core decides)
+
+`EDGE_HTTP_LISTEN` (default empty = off) adds a second, plaintext listener
+(e.g. `0.0.0.0:80`) to the same proxy service. The edge **does not** redirect
+http→https itself; it forwards the request to parapet with `X-Forwarded-Proto:
+http` (the scheme is detected per connection from the TLS digest, so the TLS
+listener still forwards `https`). parapet's per-ingress `redirect-https` plugin
+then makes the decision — 301 to https, or serve — exactly as it does without the
+edge. The global/zone WAF runs on this listener too. Keeping the redirect policy
+in the core means it stays a single source of truth (annotation-driven, with the
+`/.well-known/acme-challenge` carve-out) rather than being duplicated at the edge.
 
 ## The tradeoff
 

--- a/EDGE.md
+++ b/EDGE.md
@@ -222,8 +222,8 @@ Because the edge sets `X-Forwarded-For` and parapet trusts it
 ## Ports & exposure
 
 ```
-edge           :443   public TLS (terminated locally)       EDGE_LISTEN
-               :80    public plaintext (optional, off)      EDGE_HTTP_LISTEN
+edge           :443   public TLS (terminated locally)       EDGE_HTTPS_LISTEN
+               :80    public plaintext (on; ""=disable)     EDGE_HTTP_LISTEN
 parapet        :80    data (h2c from edge)                 unchanged role, now behind edge
                :443   data (re-encrypt from edge)
                :9187  metrics
@@ -235,8 +235,8 @@ controlplane   :8443  HTTPS GET (server-TLS + bearer)       NEW — Go, own Serv
 
 ### Plaintext HTTP listener (no redirect — the core decides)
 
-`EDGE_HTTP_LISTEN` (default empty = off) adds a second, plaintext listener
-(e.g. `0.0.0.0:80`) to the same proxy service. The edge **does not** redirect
+`EDGE_HTTP_LISTEN` (default `0.0.0.0:80`; set to `""` to disable) adds a second,
+plaintext listener to the same proxy service. The edge **does not** redirect
 http→https itself; it forwards the request to parapet with `X-Forwarded-Proto:
 http` (the scheme is detected per connection from the TLS digest, so the TLS
 listener still forwards `https`). parapet's per-ingress `redirect-https` plugin

--- a/deploy/edge/e2e/run.sh
+++ b/deploy/edge/e2e/run.sh
@@ -23,6 +23,7 @@ REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 WORK="$(mktemp -d)"
 CP_PORT=18443
 EDGE_PORT=18080
+EDGE_HTTP_PORT=18081
 UP_PORT=18090
 TOKEN="e2e-secret-token"
 DOMAIN="test.local"
@@ -159,7 +160,10 @@ import http.server, socketserver
 class H(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         body=b'hello-from-upstream'
-        self.send_response(200); self.send_header('content-length',str(len(body))); self.end_headers()
+        self.send_response(200); self.send_header('content-length',str(len(body)))
+        # Echo the proto the edge forwarded so the test can assert http vs https.
+        self.send_header('x-seen-forwarded-proto', self.headers.get('x-forwarded-proto',''))
+        self.end_headers()
         self.wfile.write(body)
     def log_message(self,*a): pass
 socketserver.TCPServer(('127.0.0.1',$UP_PORT),H).serve_forever()
@@ -177,7 +181,7 @@ wait_for_port "$CP_PORT" "control plane"
 say "6. start the Rust edge (fetches cert + WAF rules; GeoIP from fixture DB)"
 # Point the edge at the conformance GeoIP fixtures so request.country resolves at
 # the edge. Loopback (127.0.0.1) is unmapped in the country fixture → "XX".
-EDGE_LISTEN="127.0.0.1:$EDGE_PORT" \
+EDGE_HTTPS_LISTEN="127.0.0.1:$EDGE_PORT" EDGE_HTTP_LISTEN="127.0.0.1:$EDGE_HTTP_PORT" \
   EDGE_CP_ENDPOINT="https://localhost:$CP_PORT" EDGE_CP_TOKEN="$TOKEN" \
   EDGE_CP_CA="$WORK/ca.crt" EDGE_DOMAINS="$DOMAIN" \
   EDGE_PARAPET_ADDR="127.0.0.1:$UP_PORT" EDGE_PARAPET_TLS=false \
@@ -187,15 +191,30 @@ EDGE_LISTEN="127.0.0.1:$EDGE_PORT" \
   RUST_LOG=info \
   "$WORK/parapet-edge" > "$WORK/edge.log" 2>&1 & PIDS+=($!)
 wait_for_port "$EDGE_PORT" edge
+wait_for_port "$EDGE_HTTP_PORT" "edge http"
 
 # ---------------------------------------------------------------------------
 say "7. assertions"
 # Phase 1: a normal request terminates TLS with the fetched cert and reaches upstream.
-OUT="$(curl -sS --cacert "$WORK/ca.crt" --resolve "$DOMAIN:$EDGE_PORT:127.0.0.1" \
+OUT="$(curl -sS -D "$WORK/https.hdr" --cacert "$WORK/ca.crt" --resolve "$DOMAIN:$EDGE_PORT:127.0.0.1" \
   "https://$DOMAIN:$EDGE_PORT/" 2>"$WORK/curl.err")" \
   || { cat "$WORK/curl.err" "$WORK/edge.log" "$WORK/cp.log" >&2; fail "curl through edge failed"; }
 [ "$OUT" = "hello-from-upstream" ] || fail "unexpected body for /: $OUT"
-echo "  ✓ TLS terminated with control-plane-fetched cert; / forwarded to upstream"
+# The TLS listener must forward X-Forwarded-Proto: https (echoed back by upstream).
+grep -qiE "^x-seen-forwarded-proto: https[[:space:]]*$" "$WORK/https.hdr" \
+  || { cat "$WORK/https.hdr" >&2; fail "TLS listener did not forward X-Forwarded-Proto: https"; }
+echo "  ✓ TLS terminated with control-plane-fetched cert; / forwarded to upstream (proto=https)"
+
+# Phase 1b: the plaintext HTTP listener forwards to upstream WITHOUT redirecting,
+# tagging the hop X-Forwarded-Proto: http so the in-cluster core (not the edge)
+# owns the http→https redirect decision.
+HTTP_OUT="$(curl -sS -D "$WORK/http.hdr" -H "Host: $DOMAIN" \
+  "http://127.0.0.1:$EDGE_HTTP_PORT/" 2>"$WORK/curlhttp.err")" \
+  || { cat "$WORK/curlhttp.err" "$WORK/edge.log" >&2; fail "curl through edge HTTP listener failed"; }
+[ "$HTTP_OUT" = "hello-from-upstream" ] || fail "unexpected body over http: $HTTP_OUT"
+grep -qiE "^x-seen-forwarded-proto: http[[:space:]]*$" "$WORK/http.hdr" \
+  || { cat "$WORK/http.hdr" >&2; fail "HTTP listener did not forward X-Forwarded-Proto: http"; }
+echo "  ✓ plaintext HTTP listener forwarded to upstream (proto=http, no edge redirect)"
 
 # Phase 2: the global WAF rule blocks /blocked AT THE EDGE with 403 (never upstream).
 CODE="$(curl -s -o "$WORK/blocked.body" -w '%{http_code}' --cacert "$WORK/ca.crt" \

--- a/deploy/edge/edge.yaml
+++ b/deploy/edge/edge.yaml
@@ -33,8 +33,13 @@ spec:
           image: gcr.io/moonrhythm-containers/parapet-ingress-controller:edge-latest
           imagePullPolicy: IfNotPresent
           env:
-            - name: EDGE_LISTEN
+            - name: EDGE_HTTPS_LISTEN
               value: "0.0.0.0:443"
+            # Plaintext HTTP listener. The edge does NOT redirect http→https; it
+            # forwards with X-Forwarded-Proto: http so the core's per-ingress
+            # redirect-https plugin decides. Set "" to disable.
+            - name: EDGE_HTTP_LISTEN
+              value: "0.0.0.0:80"
             # The domains THIS edge serves (its shard) — pre-fetched, and the
             # bearer token must be authorized for them. Leave EMPTY to serve ALL
             # domains (certs fetched on demand per SNI; the token's authz still
@@ -78,6 +83,8 @@ spec:
           ports:
             - name: https
               containerPort: 443
+            - name: http
+              containerPort: 80
           volumeMounts:
             - name: cp-ca
               mountPath: /cp-ca
@@ -107,3 +114,6 @@ spec:
     - name: https
       port: 443
       targetPort: https
+    - name: http
+      port: 80
+      targetPort: http

--- a/rust/edge/src/main.rs
+++ b/rust/edge/src/main.rs
@@ -186,6 +186,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tls.enable_h2();
     svc.add_tls_with_settings(&listen, None, tls);
 
+    // Optional plaintext HTTP listener (default off). The edge does NOT redirect
+    // http→https; it forwards plain-HTTP requests to parapet with
+    // `X-Forwarded-Proto: http` (set in upstream_request_filter) so the core's
+    // per-ingress `redirect-https` plugin makes that decision. The global/zone WAF
+    // runs on this listener too. Empty = disabled (HTTPS only, unchanged default).
+    let http_listen = env_or("EDGE_HTTP_LISTEN", "");
+    if !http_listen.is_empty() {
+        svc.add_tcp(&http_listen);
+        tracing::info!(%http_listen, "parapet edge HTTP listener (plaintext; no redirect, forwards to core)");
+    }
+
     server.add_service(svc);
     tracing::info!(%listen, "parapet edge listening (local TLS termination)");
     let _cp_rt = cp_rt; // keep the refresh runtime alive

--- a/rust/edge/src/main.rs
+++ b/rust/edge/src/main.rs
@@ -95,7 +95,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    let listen = env_or("EDGE_LISTEN", "0.0.0.0:443");
+    let https_listen = env_or("EDGE_HTTPS_LISTEN", "0.0.0.0:443");
     let cp_endpoint = env_or("EDGE_CP_ENDPOINT", "https://controlplane:8443");
     let cp_token = std::env::var("EDGE_CP_TOKEN").map_err(|_| "EDGE_CP_TOKEN is required")?;
     let cp_ca = std::env::var("EDGE_CP_CA")
@@ -184,21 +184,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tls.set_min_proto_version(Some(pingora::tls::ssl::SslVersion::TLS1_2))
         .map_err(|e| format!("min tls version: {e}"))?;
     tls.enable_h2();
-    svc.add_tls_with_settings(&listen, None, tls);
+    svc.add_tls_with_settings(&https_listen, None, tls);
 
-    // Optional plaintext HTTP listener (default off). The edge does NOT redirect
-    // http→https; it forwards plain-HTTP requests to parapet with
-    // `X-Forwarded-Proto: http` (set in upstream_request_filter) so the core's
-    // per-ingress `redirect-https` plugin makes that decision. The global/zone WAF
-    // runs on this listener too. Empty = disabled (HTTPS only, unchanged default).
-    let http_listen = env_or("EDGE_HTTP_LISTEN", "");
+    // Plaintext HTTP listener (default 0.0.0.0:80; set EDGE_HTTP_LISTEN="" to
+    // disable). The edge does NOT redirect http→https; it forwards plain-HTTP
+    // requests to parapet with `X-Forwarded-Proto: http` (set in
+    // upstream_request_filter) so the core's per-ingress `redirect-https` plugin
+    // makes that decision. The global/zone WAF runs on this listener too.
+    let http_listen = env_or("EDGE_HTTP_LISTEN", "0.0.0.0:80");
     if !http_listen.is_empty() {
         svc.add_tcp(&http_listen);
         tracing::info!(%http_listen, "parapet edge HTTP listener (plaintext; no redirect, forwards to core)");
     }
 
     server.add_service(svc);
-    tracing::info!(%listen, "parapet edge listening (local TLS termination)");
+    tracing::info!(%https_listen, "parapet edge listening (local TLS termination)");
     let _cp_rt = cp_rt; // keep the refresh runtime alive
     server.run_forever()
 }

--- a/rust/edge/src/proxy.rs
+++ b/rust/edge/src/proxy.rs
@@ -18,6 +18,24 @@ use pingora::upstreams::peer::HttpPeer;
 
 use crate::waf::EdgeWaf;
 
+/// The client-facing scheme for this connection: `"https"` when TLS was
+/// terminated at this edge (the public TLS listener) and `"http"` when the
+/// request arrived on the plaintext `EDGE_HTTP_LISTEN` listener. Detected from
+/// the connection's TLS digest, so it's correct regardless of which listener the
+/// request came in on. The edge forwards this verbatim as `X-Forwarded-Proto`
+/// and does NOT redirect — parapet's `redirect-https` plugin decides http→https.
+fn downstream_scheme(session: &Session) -> &'static str {
+    let is_tls = session
+        .digest()
+        .and_then(|d| d.ssl_digest.as_ref())
+        .is_some();
+    if is_tls {
+        "https"
+    } else {
+        "http"
+    }
+}
+
 pub struct EdgeProxy {
     /// parapet data-plane address (host:port).
     pub parapet_addr: String,
@@ -61,8 +79,9 @@ impl EdgeProxy {
             .map(|p| p.as_str().to_string())
             .unwrap_or_else(|| path.clone());
         let proto = format!("{:?}", req.version);
-        // The edge always terminates public TLS, so the client-facing scheme is https.
-        let scheme = "https".to_string();
+        // https when TLS was terminated here, http on the plaintext listener — so
+        // an edge-evaluated rule on request.scheme sees what parapet will.
+        let scheme = downstream_scheme(session).to_string();
         let client_ip = session
             .client_addr()
             .and_then(|a| a.as_inet().map(|i| i.ip()));
@@ -172,7 +191,7 @@ impl ProxyHttp for EdgeProxy {
         upstream: &mut pingora::http::RequestHeader,
         _ctx: &mut Self::CTX,
     ) -> Result<()> {
-        upstream.insert_header("x-forwarded-proto", "https")?;
+        upstream.insert_header("x-forwarded-proto", downstream_scheme(session))?;
         let client_ip = session
             .client_addr()
             .and_then(|a| a.as_inet().map(|i| i.ip()));


### PR DESCRIPTION
## What

The edge proxy now serves **plain HTTP by default** and **forwards it to parapet without redirecting** — the core's `redirect-https` plugin makes the http→https decision. Also renames the TLS listener env for symmetry.

## Why

The edge bound only a TLS listener, so `http://` traffic had nowhere to land and http→https couldn't flow through the edge. Rather than reimplement redirect logic at the edge, this forwards plain HTTP to parapet so the existing per-ingress `parapet.moonrhythm.io/redirect-https` annotation stays the single source of truth (including its `/.well-known/acme-challenge` carve-out).

## Listeners / env

| Env | Default | Listener | Forwards `X-Forwarded-Proto` | Edge redirects? |
|---|---|---|---|---|
| `EDGE_HTTPS_LISTEN` *(was `EDGE_LISTEN`)* | `0.0.0.0:443` | public TLS (terminated here) | `https` | no |
| `EDGE_HTTP_LISTEN` | `0.0.0.0:80` (set `""` to disable) | public plaintext | `http` | no — parapet's `redirect-https` decides |

## Change

- **`rust/edge/src/proxy.rs`** — per-connection scheme detection (`downstream_scheme`) from the session TLS digest instead of a hardcoded `"https"`; feeds both `X-Forwarded-Proto` and `request.scheme` (edge WAF). The global/zone WAF runs on **both** listeners.
- **`rust/edge/src/main.rs`** — `EDGE_HTTPS_LISTEN` (renamed) + `add_tcp(EDGE_HTTP_LISTEN)` defaulting to `:80`.
- **`deploy/edge/edge.yaml`** — renamed env, added `EDGE_HTTP_LISTEN`, exposed the `:80` container + Service port.
- **`EDGE.md`** — ports table + "Plaintext HTTP listener (no redirect — the core decides)" section.

## ⚠️ Breaking

`EDGE_LISTEN` is renamed to `EDGE_HTTPS_LISTEN` (no fallback). Deployments setting the old name must update it; the bundled `deploy/edge/edge.yaml` is already updated.

## Notes

- `cargo build -p parapet-edge`, `cargo test -p parapet-edge` (7 passed), `cargo fmt --all --check` all pass.
- Edge-only (Rust); no Go/SPEC contract change — the redirect contract already lives in the Go core and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)