### PR TITLE
fix(rust): patch pingora-pool to stop per-peer ConnectionPool leak (pingora#748)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2444,8 +2444,6 @@ dependencies = [
 [[package]]
 name = "pingora-pool"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67f034be36772f318370d058913db43dbd22c3763ad974c995ba2e4afb2bb52a"
 dependencies = [
  "crossbeam-queue",
  "log",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,10 +1,12 @@
 [workspace]
 resolver = "2"
 members = ["spike", "controller", "edge"]
-# Vendored, patched copy of pingora-core (see [patch.crates-io] below). Excluded
-# from the workspace so it builds with its own crates.io deps, not ours.
-exclude = ["vendor/pingora-core"]
+# Vendored, patched copies of pingora-core and pingora-pool (see [patch.crates-io]
+# below). Excluded from the workspace so they build with their own crates.io deps,
+# not ours.
+exclude = ["vendor/pingora-core", "vendor/pingora-pool"]
 
+[patch.crates-io]
 # Add an idle timeout to pingora 0.8's downstream HTTP/2 serve loop, which
 # otherwise has none (its `TODO: add a timeout?`): an idle or half-open H2
 # connection — a client/scanner that finishes the handshake then sends nothing —
@@ -14,8 +16,15 @@ exclude = ["vendor/pingora-core"]
 # http::v2::server::handshake dominate). Our vendored copy closes idle connections
 # (no in-flight streams) after 60s; long-lived streams (SSE) are unaffected. Only
 # src/apps/mod.rs diverges from upstream. Drop once fixed in an upstream release.
-[patch.crates-io]
 pingora-core = { path = "vendor/pingora-core" }
+
+# Fix the unbounded ConnectionPool growth in pingora 0.8 (cloudflare/pingora#748):
+# a PoolNode is created per distinct upstream peer and never removed, so a proxy
+# whose backends churn (k8s pod IPs on every deploy/HPA) leaks one node per peer
+# for the process lifetime — the controller's "Rust RSS climbs to OOM" curve.
+# Our vendored copy removes the node once its last connection is popped. Drop this
+# patch once the fix lands in an upstream pingora-pool release.
+pingora-pool = { path = "vendor/pingora-pool" }
 
 # Release profile tuned for the production container image: a smaller binary
 # (~24M unstripped -> ~13M) and better runtime perf, which feeds the Phase 5

--- a/rust/vendor/pingora-pool/.gitignore
+++ b/rust/vendor/pingora-pool/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/rust/vendor/pingora-pool/Cargo.toml
+++ b/rust/vendor/pingora-pool/Cargo.toml
@@ -1,0 +1,31 @@
+# Vendored from pingora-pool 0.8.0 (crates.io, Apache-2.0) with ONE fix:
+# ConnectionPool no longer leaks a PoolNode per distinct upstream peer
+# (cloudflare/pingora#748). See src/connection.rs `pop_evicted` + `PoolNode::is_empty`,
+# and the `pop_closed_removes_empty_pool_node` regression test. Wired in via
+# `[patch.crates-io]` in ../../Cargo.toml. Only connection.rs diverges from upstream.
+[package]
+name = "pingora-pool"
+version = "0.8.0"
+authors = ["Yuchen Wu <yuchen@cloudflare.com>"]
+license = "Apache-2.0"
+edition = "2021"
+repository = "https://github.com/cloudflare/pingora"
+categories = ["network-programming"]
+keywords = ["async", "pooling", "pingora"]
+description = "A connection pool system for connection reuse (vendored + #748 fix)."
+
+[lib]
+name = "pingora_pool"
+path = "src/lib.rs"
+
+[dependencies]
+tokio = { version = "1", features = ["sync", "io-util"] }
+thread_local = "1.0"
+lru = "0.16.3"
+log = "0.4"
+parking_lot = "0.12"
+crossbeam-queue = "0.3"
+pingora-timeout = "0.8.0"
+
+[dev-dependencies]
+tokio-test = "0.4"

--- a/rust/vendor/pingora-pool/LICENSE
+++ b/rust/vendor/pingora-pool/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/rust/vendor/pingora-pool/src/connection.rs
+++ b/rust/vendor/pingora-pool/src/connection.rs
@@ -1,0 +1,598 @@
+// Copyright 2026 Cloudflare, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Generic connection pooling
+
+use log::{debug, warn};
+use parking_lot::{Mutex, RwLock};
+use pingora_timeout::{sleep, timeout};
+use std::collections::HashMap;
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::sync::{oneshot, watch, Notify, OwnedMutexGuard};
+
+use super::lru::Lru;
+
+type GroupKey = u64;
+#[cfg(unix)]
+type ID = i32;
+#[cfg(windows)]
+type ID = usize;
+
+/// the metadata of a connection
+#[derive(Clone, Debug)]
+pub struct ConnectionMeta {
+    /// The group key. All connections under the same key are considered the same for connection reuse.
+    pub key: GroupKey,
+    /// The unique ID of a connection.
+    pub id: ID,
+}
+
+impl ConnectionMeta {
+    /// Create a new [ConnectionMeta]
+    pub fn new(key: GroupKey, id: ID) -> Self {
+        ConnectionMeta { key, id }
+    }
+}
+
+struct PoolConnection<S> {
+    pub notify_use: oneshot::Sender<bool>,
+    pub connection: S,
+}
+
+impl<S> PoolConnection<S> {
+    pub fn new(notify_use: oneshot::Sender<bool>, connection: S) -> Self {
+        PoolConnection {
+            notify_use,
+            connection,
+        }
+    }
+
+    pub fn release(self) -> S {
+        // notify the idle watcher to release the connection
+        let _ = self.notify_use.send(true);
+        // wait for the watcher to release
+        self.connection
+    }
+}
+
+use crossbeam_queue::ArrayQueue;
+
+/// A pool of exchangeable items
+pub struct PoolNode<T> {
+    connections: Mutex<HashMap<ID, T>>,
+    // a small lock free queue to avoid lock contention
+    hot_queue: ArrayQueue<(ID, T)>,
+    // to avoid race between 2 evictions on the queue
+    hot_queue_remove_lock: Mutex<()>,
+    // TODO: store the GroupKey to avoid hash collision?
+}
+
+// Keep the queue size small because eviction is O(n) in the queue
+const HOT_QUEUE_SIZE: usize = 16;
+
+impl<T> PoolNode<T> {
+    /// Create a new [PoolNode]
+    pub fn new() -> Self {
+        PoolNode {
+            connections: Mutex::new(HashMap::new()),
+            hot_queue: ArrayQueue::new(HOT_QUEUE_SIZE),
+            hot_queue_remove_lock: Mutex::new(()),
+        }
+    }
+
+    /// Get any item from the pool
+    pub fn get_any(&self) -> Option<(ID, T)> {
+        let hot_conn = self.hot_queue.pop();
+        if hot_conn.is_some() {
+            return hot_conn;
+        }
+        let mut connections = self.connections.lock();
+        // find one connection, any connection will do
+        let id = match connections.iter().next() {
+            Some((k, _)) => *k, // OK to copy i32
+            None => return None,
+        };
+        // unwrap is safe since we just found it
+        let connection = connections.remove(&id).unwrap();
+        /* NOTE: we don't resize or drop empty connections hashmap
+         * We may want to do it if they consume too much memory
+         * maybe we should use trees to save memory */
+        Some((id, connection))
+        // connections.lock released here
+    }
+
+    /// True when this node holds no items at all — neither in the hot queue nor
+    /// in the connections table. Used by [`ConnectionPool::pop_evicted`] to drop
+    /// idle nodes so the pool map doesn't grow one entry per peer forever
+    /// (cloudflare/pingora#748).
+    pub fn is_empty(&self) -> bool {
+        self.hot_queue.is_empty() && self.connections.lock().is_empty()
+    }
+
+    /// Insert an item with the given unique ID into the pool
+    pub fn insert(&self, id: ID, conn: T) {
+        if let Err(node) = self.hot_queue.push((id, conn)) {
+            // hot queue is full
+            let mut connections = self.connections.lock();
+            connections.insert(node.0, node.1); // TODO: check dup
+        }
+    }
+
+    // This function acquires 2 locks and iterates over the entire hot queue.
+    // But it should be fine because remove() rarely happens on a busy PoolNode.
+    /// Remove the item associated with the id from the pool. The item is returned
+    /// if it is found and removed.
+    pub fn remove(&self, id: ID) -> Option<T> {
+        // check the table first as least recent used ones are likely there
+        let removed = self.connections.lock().remove(&id);
+        if removed.is_some() {
+            return removed;
+        } // lock drops here
+
+        let _queue_lock = self.hot_queue_remove_lock.lock();
+        // check the hot queue, note that the queue can be accessed in parallel by insert and get
+        let max_len = self.hot_queue.len();
+        for _ in 0..max_len {
+            if let Some((conn_id, conn)) = self.hot_queue.pop() {
+                if conn_id == id {
+                    // this is the item, it is already popped
+                    return Some(conn);
+                } else {
+                    // not this item, put back to hot queue, but it could also be full
+                    self.insert(conn_id, conn);
+                }
+            } else {
+                // other threads grab all the connections
+                return None;
+            }
+        }
+        None
+        // _queue_lock drops here
+    }
+}
+
+/// Connection pool
+///
+/// [ConnectionPool] holds reusable connections. A reusable connection is released to this pool to
+/// be picked up by another user/request.
+pub struct ConnectionPool<S> {
+    // TODO: n-way pools to reduce lock contention
+    pool: RwLock<HashMap<GroupKey, Arc<PoolNode<PoolConnection<S>>>>>,
+    lru: Lru<ID, ConnectionMeta>,
+}
+
+impl<S> ConnectionPool<S> {
+    /// Create a new [ConnectionPool] with a size limit.
+    ///
+    /// When a connection is released to this pool, the least recently used connection will be dropped.
+    pub fn new(size: usize) -> Self {
+        ConnectionPool {
+            pool: RwLock::new(HashMap::with_capacity(size)), // this is oversized since some connections will have the same key
+            lru: Lru::new(size),
+        }
+    }
+
+    /* get or create and insert a pool node for the hash key */
+    fn get_pool_node(&self, key: GroupKey) -> Arc<PoolNode<PoolConnection<S>>> {
+        {
+            let pool = self.pool.read();
+            if let Some(v) = pool.get(&key) {
+                return (*v).clone();
+            }
+        } // read lock released here
+
+        {
+            // write lock section
+            let mut pool = self.pool.write();
+            // check again since another task might have already added it
+            if let Some(v) = pool.get(&key) {
+                return (*v).clone();
+            }
+            let node = Arc::new(PoolNode::new());
+            let node_ret = node.clone();
+            pool.insert(key, node); // TODO: check dup
+            node_ret
+        }
+    }
+
+    // only remove from the pool because lru already removed it
+    fn pop_evicted(&self, meta: &ConnectionMeta) {
+        let pool_node = {
+            let pool = self.pool.read();
+            match pool.get(&meta.key) {
+                Some(v) => (*v).clone(),
+                None => {
+                    warn!("Fail to get pool node for {:?}", meta);
+                    return;
+                } // nothing to pop, should return error?
+            }
+        }; // read lock released here
+
+        pool_node.remove(meta.id);
+        debug!("evict fd: {} from key {}", meta.id, meta.key);
+
+        // Drop the now-idle pool node so the pool map doesn't accumulate one
+        // entry per distinct upstream peer for the process lifetime
+        // (cloudflare/pingora#748): GroupKeys derived from churning backend
+        // addresses (e.g. k8s pod IPs) would otherwise leak a PoolNode each,
+        // forever. Re-check identity AND emptiness under the write lock so we
+        // don't evict a node that a concurrent `put`/`get_pool_node` has already
+        // re-populated or replaced. A narrow race remains (a `put` that fetched
+        // this same Arc just before us may insert into the now-detached node);
+        // that strands at most one connection until it closes — bounded, versus
+        // the unbounded map growth this prevents.
+        if pool_node.is_empty() {
+            let mut pool = self.pool.write();
+            if let Some(node) = pool.get(&meta.key) {
+                if Arc::ptr_eq(node, &pool_node) && node.is_empty() {
+                    pool.remove(&meta.key);
+                }
+            }
+        }
+    }
+
+    pub fn pop_closed(&self, meta: &ConnectionMeta) {
+        // NOTE: which of these should be done first?
+        self.pop_evicted(meta);
+        self.lru.pop(&meta.id);
+    }
+
+    /// Get a connection from this pool under the same group key
+    pub fn get(&self, key: &GroupKey) -> Option<S> {
+        let pool_node = {
+            let pool = self.pool.read();
+            match pool.get(key) {
+                Some(v) => (*v).clone(),
+                None => return None,
+            }
+        }; // read lock released here
+
+        if let Some((id, connection)) = pool_node.get_any() {
+            self.lru.pop(&id); // the notified is not needed
+            Some(connection.release())
+        } else {
+            None
+        }
+    }
+
+    /// Release a connection to this pool for reuse
+    ///
+    /// - The returned [`Arc<Notify>`] will notify any listen when the connection is evicted from the pool.
+    /// - The returned [`oneshot::Receiver<bool>`] will notify when the connection is being picked up by [Self::get()].
+    pub fn put(
+        &self,
+        meta: &ConnectionMeta,
+        connection: S,
+    ) -> (Arc<Notify>, oneshot::Receiver<bool>) {
+        let (notify_close, replaced) = self.lru.add(meta.id, meta.clone());
+        if let Some(meta) = replaced {
+            self.pop_evicted(&meta);
+        };
+        let pool_node = self.get_pool_node(meta.key);
+        let (notify_use, watch_use) = oneshot::channel();
+        let connection = PoolConnection::new(notify_use, connection);
+        pool_node.insert(meta.id, connection);
+        (notify_close, watch_use)
+    }
+
+    /// Actively monitor the health of a connection that is already released to this pool
+    ///
+    /// When the connection breaks, or the optional `timeout` is reached this function will
+    /// remove it from the pool and drop the connection.
+    ///
+    /// If the connection is reused via [Self::get()] or being evicted, this function will just exit.
+    pub async fn idle_poll<Stream>(
+        &self,
+        connection: OwnedMutexGuard<Stream>,
+        meta: &ConnectionMeta,
+        timeout: Option<Duration>,
+        notify_evicted: Arc<Notify>,
+        watch_use: oneshot::Receiver<bool>,
+    ) where
+        Stream: AsyncRead + Unpin + Send,
+    {
+        let read_result = tokio::select! {
+            biased;
+            _ = watch_use => {
+                debug!("idle connection is being picked up");
+                return
+            },
+            _ = notify_evicted.notified() => {
+                debug!("idle connection is being evicted");
+                // TODO: gracefully close the connection?
+                return
+            }
+            read_result = read_with_timeout(connection , timeout) => read_result
+        };
+
+        match read_result {
+            Ok(n) => {
+                if n > 0 {
+                    warn!("Data received on idle client connection, close it")
+                } else {
+                    debug!("Peer closed the idle connection or timeout")
+                }
+            }
+
+            Err(e) => {
+                debug!("error with the idle connection, close it {:?}", e);
+            }
+        }
+        // connection terminated from either peer or timer
+        self.pop_closed(meta);
+    }
+
+    /// Passively wait to close the connection after the timeout
+    ///
+    /// If this connection is not being picked up or evicted before the timeout is reach, this
+    /// function will remove it from the pool and close the connection.
+    pub async fn idle_timeout(
+        &self,
+        meta: &ConnectionMeta,
+        timeout: Option<Duration>,
+        notify_evicted: Arc<Notify>,
+        mut notify_closed: watch::Receiver<bool>,
+        watch_use: oneshot::Receiver<bool>,
+    ) {
+        tokio::select! {
+            biased;
+            _ = watch_use => {
+                debug!("idle connection is being picked up");
+            },
+            _ = notify_evicted.notified() => {
+                debug!("idle connection is being evicted");
+                // TODO: gracefully close the connection?
+            }
+            _ = notify_closed.changed() => {
+                // assume always changed from false to true
+                debug!("idle connection is being closed");
+                self.pop_closed(meta);
+            }
+            // async expression is evaluated if timeout is None but it's never polled, set it to MAX
+            _ = sleep(timeout.unwrap_or(Duration::MAX)), if timeout.is_some() => {
+                debug!("idle connection is being evicted");
+                self.pop_closed(meta);
+            }
+        };
+    }
+}
+
+async fn read_with_timeout<S>(
+    mut connection: OwnedMutexGuard<S>,
+    timeout_duration: Option<Duration>,
+) -> io::Result<usize>
+where
+    S: AsyncRead + Unpin + Send,
+{
+    let mut buf = [0; 1];
+    let read_event = connection.read(&mut buf[..]);
+    match timeout_duration {
+        Some(d) => match timeout(d, read_event).await {
+            Ok(res) => res,
+            Err(e) => {
+                debug!("keepalive timeout {:?} reached, {:?}", d, e);
+                Ok(0)
+            }
+        },
+        _ => read_event.await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use log::debug;
+    use tokio::sync::Mutex as AsyncMutex;
+    use tokio_test::io::{Builder, Mock};
+
+    #[tokio::test]
+    async fn test_lookup() {
+        let meta1 = ConnectionMeta::new(101, 1);
+        let value1 = "v1".to_string();
+        let meta2 = ConnectionMeta::new(102, 2);
+        let value2 = "v2".to_string();
+        let meta3 = ConnectionMeta::new(101, 3);
+        let value3 = "v3".to_string();
+        let cp: ConnectionPool<String> = ConnectionPool::new(3); //#CP3
+        cp.put(&meta1, value1.clone());
+        cp.put(&meta2, value2.clone());
+        cp.put(&meta3, value3.clone());
+
+        let found_b = cp.get(&meta2.key).unwrap();
+        assert_eq!(found_b, value2);
+
+        let found_a1 = cp.get(&meta1.key).unwrap();
+        let found_a2 = cp.get(&meta1.key).unwrap();
+
+        assert!(
+            found_a1 == value1 && found_a2 == value3 || found_a2 == value1 && found_a1 == value3
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pop() {
+        let meta1 = ConnectionMeta::new(101, 1);
+        let value1 = "v1".to_string();
+        let meta2 = ConnectionMeta::new(102, 2);
+        let value2 = "v2".to_string();
+        let meta3 = ConnectionMeta::new(101, 3);
+        let value3 = "v3".to_string();
+        let cp: ConnectionPool<String> = ConnectionPool::new(3); //#CP3
+        cp.put(&meta1, value1);
+        cp.put(&meta2, value2);
+        cp.put(&meta3, value3.clone());
+
+        cp.pop_closed(&meta1);
+
+        let found_a1 = cp.get(&meta1.key).unwrap();
+        assert_eq!(found_a1, value3);
+
+        cp.pop_closed(&meta1);
+        assert!(cp.get(&meta1.key).is_none())
+    }
+
+    // Regression for cloudflare/pingora#748: once a key's last connection is
+    // popped, its PoolNode must be removed from the pool map — otherwise the map
+    // grows one entry per distinct upstream peer for the process lifetime.
+    #[tokio::test]
+    async fn pop_closed_removes_empty_pool_node() {
+        let key_a = ConnectionMeta::new(101, 1);
+        let key_b = ConnectionMeta::new(102, 2);
+        let cp: ConnectionPool<String> = ConnectionPool::new(8);
+        cp.put(&key_a, "a".to_string());
+        cp.put(&key_b, "b".to_string());
+        assert_eq!(cp.pool.read().len(), 2, "two distinct peers -> two nodes");
+
+        // Close key_a's only connection. Its node must be evicted from the map.
+        cp.pop_closed(&key_a);
+        assert!(
+            !cp.pool.read().contains_key(&key_a.key),
+            "empty pool node must be removed (no per-peer leak)"
+        );
+        assert!(
+            cp.pool.read().contains_key(&key_b.key),
+            "a still-populated peer's node is retained"
+        );
+        assert_eq!(cp.pool.read().len(), 1);
+
+        // Churning N distinct peers must not leave N nodes behind.
+        for i in 0..1000u64 {
+            let m = ConnectionMeta::new(1000 + i, (10_000 + i) as i32);
+            cp.put(&m, format!("c{i}"));
+            cp.pop_closed(&m);
+        }
+        assert_eq!(
+            cp.pool.read().len(),
+            1,
+            "1000 churned peers leak no nodes; only the live key_b remains"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_eviction() {
+        let meta1 = ConnectionMeta::new(101, 1);
+        let value1 = "v1".to_string();
+        let meta2 = ConnectionMeta::new(102, 2);
+        let value2 = "v2".to_string();
+        let meta3 = ConnectionMeta::new(101, 3);
+        let value3 = "v3".to_string();
+        let cp: ConnectionPool<String> = ConnectionPool::new(2);
+        let (notify_close1, _) = cp.put(&meta1, value1.clone());
+        let (notify_close2, _) = cp.put(&meta2, value2.clone());
+        let (notify_close3, _) = cp.put(&meta3, value3.clone()); // meta 1 should be evicted
+
+        let closed_item = tokio::select! {
+            _ = notify_close1.notified() => {debug!("notifier1"); 1},
+            _ = notify_close2.notified() => {debug!("notifier2"); 2},
+            _ = notify_close3.notified() => {debug!("notifier3"); 3},
+        };
+        assert_eq!(closed_item, 1);
+
+        let found_a1 = cp.get(&meta1.key).unwrap();
+        assert_eq!(found_a1, value3);
+        assert_eq!(cp.get(&meta1.key), None)
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "There is still data left to read.")]
+    async fn test_read_close() {
+        let meta1 = ConnectionMeta::new(101, 1);
+        let mock_io1 = Arc::new(AsyncMutex::new(Builder::new().read(b"garbage").build()));
+        let meta2 = ConnectionMeta::new(102, 2);
+        let mock_io2 = Arc::new(AsyncMutex::new(
+            Builder::new().wait(Duration::from_secs(99)).build(),
+        ));
+        let meta3 = ConnectionMeta::new(101, 3);
+        let mock_io3 = Arc::new(AsyncMutex::new(
+            Builder::new().wait(Duration::from_secs(99)).build(),
+        ));
+        let cp: ConnectionPool<Arc<AsyncMutex<Mock>>> = ConnectionPool::new(3);
+        let (c1, u1) = cp.put(&meta1, mock_io1.clone());
+        let (c2, u2) = cp.put(&meta2, mock_io2.clone());
+        let (c3, u3) = cp.put(&meta3, mock_io3.clone());
+
+        let closed_item = tokio::select! {
+            _ = cp.idle_poll(mock_io1.try_lock_owned().unwrap(), &meta1, None, c1, u1) => {debug!("notifier1"); 1},
+            _ = cp.idle_poll(mock_io2.try_lock_owned().unwrap(), &meta1, None, c2, u2) => {debug!("notifier2"); 2},
+            _ = cp.idle_poll(mock_io3.try_lock_owned().unwrap(), &meta1, None, c3, u3) => {debug!("notifier3"); 3},
+        };
+        assert_eq!(closed_item, 1);
+
+        let _ = cp.get(&meta1.key).unwrap(); // mock_io3 should be selected
+        assert!(cp.get(&meta1.key).is_none()) // mock_io1 should already be removed by idle_poll
+    }
+
+    #[tokio::test]
+    async fn test_read_timeout() {
+        let meta1 = ConnectionMeta::new(101, 1);
+        let mock_io1 = Arc::new(AsyncMutex::new(
+            Builder::new().wait(Duration::from_secs(99)).build(),
+        ));
+        let meta2 = ConnectionMeta::new(102, 2);
+        let mock_io2 = Arc::new(AsyncMutex::new(
+            Builder::new().wait(Duration::from_secs(99)).build(),
+        ));
+        let meta3 = ConnectionMeta::new(101, 3);
+        let mock_io3 = Arc::new(AsyncMutex::new(
+            Builder::new().wait(Duration::from_secs(99)).build(),
+        ));
+        let cp: ConnectionPool<Arc<AsyncMutex<Mock>>> = ConnectionPool::new(3);
+        let (c1, u1) = cp.put(&meta1, mock_io1.clone());
+        let (c2, u2) = cp.put(&meta2, mock_io2.clone());
+        let (c3, u3) = cp.put(&meta3, mock_io3.clone());
+
+        let closed_item = tokio::select! {
+            _ = cp.idle_poll(mock_io1.try_lock_owned().unwrap(), &meta1, Some(Duration::from_secs(1)), c1, u1) => {debug!("notifier1"); 1},
+            _ = cp.idle_poll(mock_io2.try_lock_owned().unwrap(), &meta1, Some(Duration::from_secs(2)), c2, u2) => {debug!("notifier2"); 2},
+            _ = cp.idle_poll(mock_io3.try_lock_owned().unwrap(), &meta1, Some(Duration::from_secs(3)), c3, u3) => {debug!("notifier3"); 3},
+        };
+        assert_eq!(closed_item, 1);
+
+        let _ = cp.get(&meta1.key).unwrap(); // mock_io3 should be selected
+        assert!(cp.get(&meta1.key).is_none()) // mock_io1 should already be removed by idle_poll
+    }
+
+    #[tokio::test]
+    async fn test_evict_poll() {
+        let meta1 = ConnectionMeta::new(101, 1);
+        let mock_io1 = Arc::new(AsyncMutex::new(
+            Builder::new().wait(Duration::from_secs(99)).build(),
+        ));
+        let meta2 = ConnectionMeta::new(102, 2);
+        let mock_io2 = Arc::new(AsyncMutex::new(
+            Builder::new().wait(Duration::from_secs(99)).build(),
+        ));
+        let meta3 = ConnectionMeta::new(101, 3);
+        let mock_io3 = Arc::new(AsyncMutex::new(
+            Builder::new().wait(Duration::from_secs(99)).build(),
+        ));
+        let cp: ConnectionPool<Arc<AsyncMutex<Mock>>> = ConnectionPool::new(2);
+        let (c1, u1) = cp.put(&meta1, mock_io1.clone());
+        let (c2, u2) = cp.put(&meta2, mock_io2.clone());
+        let (c3, u3) = cp.put(&meta3, mock_io3.clone()); // 1 should be evicted at this point
+
+        let closed_item = tokio::select! {
+            _ = cp.idle_poll(mock_io1.try_lock_owned().unwrap(), &meta1, None, c1, u1) => {debug!("notifier1"); 1},
+            _ = cp.idle_poll(mock_io2.try_lock_owned().unwrap(), &meta1, None, c2, u2) => {debug!("notifier2"); 2},
+            _ = cp.idle_poll(mock_io3.try_lock_owned().unwrap(), &meta1, None, c3, u3) => {debug!("notifier3"); 3},
+        };
+        assert_eq!(closed_item, 1);
+
+        let _ = cp.get(&meta1.key).unwrap(); // mock_io3 should be selected
+        assert!(cp.get(&meta1.key).is_none()) // mock_io1 should already be removed by idle_poll
+    }
+}

--- a/rust/vendor/pingora-pool/src/lib.rs
+++ b/rust/vendor/pingora-pool/src/lib.rs
@@ -1,0 +1,28 @@
+// Copyright 2026 Cloudflare, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Generic connection pooling
+//!
+//! The pool is optimized for high concurrency, high RPS use cases. Each connection group has a
+//! lock free hot pool to reduce the lock contention when some connections are reused and released
+//! very frequently.
+
+#![warn(clippy::all)]
+#![allow(clippy::new_without_default)]
+#![allow(clippy::type_complexity)]
+
+mod connection;
+mod lru;
+
+pub use connection::{ConnectionMeta, ConnectionPool, PoolNode};

--- a/rust/vendor/pingora-pool/src/lru.rs
+++ b/rust/vendor/pingora-pool/src/lru.rs
@@ -1,0 +1,177 @@
+// Copyright 2026 Cloudflare, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::hash::Hash;
+use lru::LruCache;
+use parking_lot::RwLock;
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
+use std::sync::Arc;
+use thread_local::ThreadLocal;
+use tokio::sync::Notify;
+
+pub struct Node<T> {
+    pub close_notifier: Arc<Notify>,
+    pub meta: T,
+}
+
+impl<T> Node<T> {
+    pub fn new(meta: T) -> Self {
+        Node {
+            close_notifier: Arc::new(Notify::new()),
+            meta,
+        }
+    }
+
+    pub fn notify_close(&self) {
+        self.close_notifier.notify_one();
+    }
+}
+
+pub struct Lru<K, T>
+where
+    K: Send,
+    T: Send,
+{
+    lru: RwLock<ThreadLocal<RefCell<LruCache<K, Node<T>>>>>,
+    size: usize,
+    drain: AtomicBool,
+}
+
+impl<K, T> Lru<K, T>
+where
+    K: Hash + Eq + Send,
+    T: Send,
+{
+    pub fn new(size: usize) -> Self {
+        Lru {
+            lru: RwLock::new(ThreadLocal::new()),
+            size,
+            drain: AtomicBool::new(false),
+        }
+    }
+
+    // put a node in and return the meta of the replaced node
+    pub fn put(&self, key: K, value: Node<T>) -> Option<T> {
+        if self.drain.load(Relaxed) {
+            value.notify_close(); // sort of hack to simulate being evicted right away
+            return None;
+        }
+        let lru = self.lru.read(); /* read lock */
+        let lru_cache = &mut *(lru
+            .get_or(|| RefCell::new(LruCache::unbounded()))
+            .borrow_mut());
+        lru_cache.put(key, value);
+        if lru_cache.len() > self.size {
+            match lru_cache.pop_lru() {
+                Some((_, v)) => {
+                    // TODO: drop the lock here?
+                    v.notify_close();
+                    return Some(v.meta);
+                }
+                None => return None,
+            }
+        }
+        None
+        /* read lock dropped */
+    }
+
+    pub fn add(&self, key: K, meta: T) -> (Arc<Notify>, Option<T>) {
+        let node = Node::new(meta);
+        let notifier = node.close_notifier.clone();
+        // TODO: check if the key is already in it
+        (notifier, self.put(key, node))
+    }
+
+    pub fn pop(&self, key: &K) -> Option<Node<T>> {
+        let lru = self.lru.read(); /* read lock */
+        let lru_cache = &mut *(lru
+            .get_or(|| RefCell::new(LruCache::unbounded()))
+            .borrow_mut());
+        lru_cache.pop(key)
+        /* read lock dropped */
+    }
+
+    #[allow(dead_code)]
+    pub fn drain(&self) {
+        self.drain.store(true, Relaxed);
+
+        /* drain need to go through all the local lru cache objects
+         * acquire an exclusive write lock to make it safe */
+        let mut lru = self.lru.write(); /* write lock */
+        let lru_cache_iter = lru.iter_mut();
+        for lru_cache_rc in lru_cache_iter {
+            let mut lru_cache = lru_cache_rc.borrow_mut();
+            for (_, item) in lru_cache.iter() {
+                item.notify_close();
+            }
+            lru_cache.clear();
+        }
+        /* write lock dropped */
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use log::debug;
+
+    #[tokio::test]
+    async fn test_evict_close() {
+        let pool: Lru<i32, ()> = Lru::new(2);
+        let (notifier1, _) = pool.add(1, ());
+        let (notifier2, _) = pool.add(2, ());
+        let (notifier3, _) = pool.add(3, ());
+        let closed_item = tokio::select! {
+            _ = notifier1.notified() => {debug!("notifier1"); 1},
+            _ = notifier2.notified() => {debug!("notifier2"); 2},
+            _ = notifier3.notified() => {debug!("notifier3"); 3},
+        };
+        assert_eq!(closed_item, 1);
+    }
+
+    #[tokio::test]
+    async fn test_evict_close_with_pop() {
+        let pool: Lru<i32, ()> = Lru::new(2);
+        let (notifier1, _) = pool.add(1, ());
+        let (notifier2, _) = pool.add(2, ());
+        pool.pop(&1);
+        let (notifier3, _) = pool.add(3, ());
+        let (notifier4, _) = pool.add(4, ());
+        let closed_item = tokio::select! {
+            _ = notifier1.notified() => {debug!("notifier1"); 1},
+            _ = notifier2.notified() => {debug!("notifier2"); 2},
+            _ = notifier3.notified() => {debug!("notifier3"); 3},
+            _ = notifier4.notified() => {debug!("notifier4"); 4},
+        };
+        assert_eq!(closed_item, 2);
+    }
+
+    #[tokio::test]
+    async fn test_drain() {
+        let pool: Lru<i32, ()> = Lru::new(4);
+        let (notifier1, _) = pool.add(1, ());
+        let (notifier2, _) = pool.add(2, ());
+        let (notifier3, _) = pool.add(3, ());
+        pool.drain();
+        let (notifier4, _) = pool.add(4, ());
+
+        tokio::join!(
+            notifier1.notified(),
+            notifier2.notified(),
+            notifier3.notified(),
+            notifier4.notified()
+        );
+    }
+}


### PR DESCRIPTION
## The leak

The Rust (Pingora) controller's RSS climbs steadily to OOM (~1.8 GB/h/pod); the Go controller is flat on identical traffic.

## Root cause: cloudflare/pingora#748 (ConnectionPool never drops empty nodes)

`pingora-pool`'s `ConnectionPool` keeps `pool: RwLock<HashMap<GroupKey, Arc<PoolNode>>>`. `get_pool_node()` inserts a `PoolNode` per distinct upstream peer; `pop_closed()` → `pop_evicted()` only removes the *connection* from the node (`pool_node.remove(id)`) and **never removes the `GroupKey` entry from the map**. So a proxy whose backends churn — exactly our case, **k8s pod IPs cycling on every deploy/HPA** across 1290 services / 1295 endpoints — leaks one `PoolNode` per distinct peer for the process lifetime.

This matches every observation:
- **Time-correlated, not request-rate-correlated** (the dashboard showed memory climbing regardless of req rate) — pod churn is time-driven.
- **Unbounded & monotonic** — peers (IPs) never repeat.
- **In pingora, not our code** — which is why none of an extensive application-level investigation reproduced it (10 load scenarios + a 1-hour production-fidelity run, all flat).
- **jemalloc (#76) doesn't fix it** — it's live heap (proven by the #77 `jemalloc_allocated_bytes` gauge).

Confirmed three ways: issue symptom match, source inspection of the pinned `pingora-pool 0.8.0`, and a local repro (churning ever-new upstream peers makes `allocated` climb monotonically with peer count, ~4 KB/peer floor, no plateau). The related #212 (orphaned thread-local LRU entries, *bounded* by pool size) likely amplifies the per-peer cost in prod via retained H2 session buffers.

## The fix

Vendor `pingora-pool 0.8.0` (Apache-2.0, LICENSE retained) into `rust/vendor/pingora-pool` and apply it via `[patch.crates-io]`. Only `connection.rs` diverges from upstream:
- add `PoolNode::is_empty()` (checks both the hot queue and the connections table);
- `pop_evicted` now removes the `GroupKey` entry once its node is empty, **re-checked under the pool write lock with `Arc::ptr_eq`** so a concurrent `put`/`get_pool_node` isn't clobbered. A narrow race can strand at most one connection until it closes — bounded, versus the unbounded map growth it prevents.

Pool-size limits (`TR_MAX_IDLE_CONNS_PER_HOST`) do **not** help — #748 leaks the GroupKey map, not the per-node LRU. The upstream issue is open, so there's no fixed release to bump to; drop this patch once one ships.

## Verification

- New regression test `pop_closed_removes_empty_pool_node` (mirrors the issue's failing case + churns 1000 peers → 0 leaked nodes). All 10 `pingora-pool` tests pass.
- Controller + edge build with the patch active (`cargo tree -p pingora-pool` → the vendor path); `cargo fmt --all --check` clean.
- **End-to-end**: replaying the churn repro (1500 ever-new upstream peers) on the patched build holds `jemalloc_allocated_bytes` **flat at ~41 MB** (40.8 @ 94 peers → 41.5 @ 1499 peers), where the unpatched build climbed to 47.8 MB and kept going.

## Notes
- Independent of #77 (jemalloc gauges) and the merged #76 (jemalloc allocator) — both remain worthwhile (jemalloc returns memory to the OS faster; the gauges are how we'll confirm this fix in prod).
- Same vendored crate benefits the edge proxy (also Pingora).

🤖 Generated with [Claude Code](https://claude.com/claude-code)