### PR TITLE
ci: build + push images on pull requests

### DIFF
--- a/.github/workflows/edge-build.yaml
+++ b/.github/workflows/edge-build.yaml
@@ -17,6 +17,14 @@ on:
       - 'rust/**'
       - 'deploy/edge/**'
       - '.github/workflows/edge-build.yaml'
+  # Also build + push on PRs (tagged with the PR's commit SHA) so a PR image can
+  # be deployed/tested before merge. Same-repo PRs only (needs registry creds).
+  pull_request:
+    paths:
+      - 'go/**'
+      - 'rust/**'
+      - 'deploy/edge/**'
+      - '.github/workflows/edge-build.yaml'
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -6,6 +6,12 @@ on:
     paths:
     - 'go/**'
     - '.github/workflows/go-build.yaml'
+  # Also build + push on PRs (tagged with the PR's commit SHA) so a PR image can
+  # be deployed/tested before merge. Same-repo PRs only (needs registry creds).
+  pull_request:
+    paths:
+    - 'go/**'
+    - '.github/workflows/go-build.yaml'
   workflow_dispatch: {}
 jobs:
   build:

--- a/.github/workflows/rust-build.yaml
+++ b/.github/workflows/rust-build.yaml
@@ -6,6 +6,12 @@ on:
     paths:
       - 'rust/**'
       - '.github/workflows/rust-build.yaml'
+  # Also build + push on PRs (tagged with the PR's commit SHA) so a PR image can
+  # be deployed/tested before merge. Same-repo PRs only (needs registry creds).
+  pull_request:
+    paths:
+      - 'rust/**'
+      - '.github/workflows/rust-build.yaml'
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
## Why
The `rust-build` / `go-build` / `edge-build` workflows only ran on **push to `main`**, so a PR's image was never built — let alone publishable — until after merge. The **test** workflows already run on PRs; the **build** workflows didn't.

## What
Add a path-filtered `pull_request` trigger to all three build workflows. That's the **only** change — PR builds run exactly like main builds: they authenticate and **push to the registry**, tagged with the PR commit SHA (`:<sha>` / `:rust-<sha>` / `:controlplane-<sha>` / `:edge-<sha>`).

So a PR image can be **pulled and deployed to a cluster to test before merge** — e.g. to validate a fix under real traffic.

- Same-repo PRs only (the push needs `secrets.GOOGLE_CREDENTIALS`; fork PRs won't have them).
- Push-to-`main` behaviour is unchanged.

## Effect
Every PR touching `rust/**`, `go/**`, or the edge paths now builds and publishes its image, giving both an early build-breakage signal and a deployable artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)