### PR TITLE
fix(go): count backend ReadFrom bytes as writes, not reads

### DIFF
--- a/go/metric/backendconns.go
+++ b/go/metric/backendconns.go
@@ -111,10 +111,14 @@ func (conn *trackBackendConn) Close() error {
 	return conn.Conn.Close()
 }
 
+// ReadFrom implements io.ReaderFrom so the sendfile/splice fast path
+// (io.Copy(conn, r), used by the transport when flushing request bodies)
+// stays zero-copy. Data flows from r into the socket — i.e. it is written
+// to the backend — so it counts toward writes, not reads.
 func (conn *trackBackendConn) ReadFrom(r io.Reader) (n int64, err error) {
 	n, err = conn.Conn.(io.ReaderFrom).ReadFrom(r)
 	if n > 0 {
-		conn.m.reads.Add(float64(n))
+		conn.m.writes.Add(float64(n))
 	}
 	if err != nil {
 		conn.trackClose()


### PR DESCRIPTION
## Problem

`parapet_backend_network_read_bytes` / `_write_bytes` looked **reversed** in the Go implementation versus Rust.

## Root cause

`metric/backendconns.go` wraps the backend `net.Conn`. The direction contract (SPEC.md:171/181) is:

- `read_bytes` = bytes **read from** the backend → response (backend → controller)
- `write_bytes` = bytes **written to** the backend → request (controller → backend)

`Read()` → `reads` and `Write()` → `writes` were correct, but `ReadFrom()` was wired backwards:

```go
func (conn *trackBackendConn) ReadFrom(r io.Reader) (n int64, err error) {
	n, err = conn.Conn.(io.ReaderFrom).ReadFrom(r)
	if n > 0 {
		conn.m.reads.Add(float64(n))   // ← wrong
	}
```

`net.Conn.ReadFrom` is the `io.ReaderFrom` interface (`io.Copy(conn, r)` / sendfile fast path): it reads from `r` and **writes into the socket — toward the backend**. That's a *write to backend*. It fires on **request bodies** — `http.Transport` flushes the request body through `bufio.Writer`, which delegates to the conn's `ReadFrom` as its buffer drains.

### Effect on graphs
- `read_bytes` inflated by upload/request-body traffic
- `write_bytes` undercounting it
- The more upload-heavy the traffic, the more reversed it looked vs Rust (which counts request bytes in `request_body_filter` → `write_bytes`)

## Fix

One line: `ReadFrom` now increments `writes`. No SPEC/Rust/conformance change — Go was simply violating the existing contract.

Note (already in SPEC.md:181-185): even after this, Go (wire bytes incl. headers/TLS framing) and Rust (body bytes only) differ in magnitude — compare by shape/direction, not absolute value. The directions now agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)