### PR TITLE
feat(edge): disk-backed HTTP response cache

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -244,11 +244,16 @@ cacheable object locally removes a full origin round trip. Enabled with
   (`rust/edge/src/diskcache.rs`). A disk cache survives restarts and isn't bounded
   by RSS (matters given the edge's memory-pressure history). Total size is bounded
   by an LRU eviction manager (`EDGE_CACHE_MAX_SIZE`); per-object size by
-  `EDGE_CACHE_MAX_FILE_SIZE`.
+  `EDGE_CACHE_MAX_FILE_SIZE`, enforced by pingora's own size tracker — a
+  `Content-Length` over the cap is simply not cached (the client still gets the
+  full response); an oversize **chunked** response is aborted mid-stream.
 - **Honor-origin policy.** Caches **only** when the origin opts in via response
   `Cache-Control`/`Expires` freshness — no forced or heuristic TTL. Refuses
   `private`/`no-store`, any `Set-Cookie`, and `Vary: *`. Honors `Vary` (keys per
   varied request header). `GET`/`HEAD` only; cacheable status codes per RFC.
+  **Client** request `Cache-Control` (`no-cache`/`no-store`) is **ignored by
+  design** — like a CDN, so a client can't bust the shared cache (a DoS vector);
+  origins needing freshness simply mark responses uncacheable.
 - **Cache lock.** Concurrent misses for one key collapse into a single origin
   fetch (no stampede).
 - **Observability.** Sets `X-Cache: HIT|MISS` (HIT = served from the edge cache,
@@ -264,10 +269,14 @@ cacheable object locally removes a full origin round trip. Enabled with
 
 Writes are temp-file + fsync + atomic `rename`, with the `.meta` written **last**
 so its presence implies a complete `.body`; a crash mid-write leaves only an
-orphan reaped on startup. The eviction manager's accounting is in-memory, so on
+orphan, reaped later. The eviction manager's accounting is in-memory, so on
 startup the edge **scans the cache dir and re-admits** surviving entries (the
 sidecar carries the `CompactCacheKey` for exactly this) — the byte cap holds
-across restarts, and orphans/torn writes are reaped.
+across restarts, and orphans/torn writes are reaped. The scan runs **in the
+background, off the serving path** (it reads every `.meta`, so it can take
+seconds on a large cache); the edge accepts traffic immediately and the byte cap
+simply lags until the scan completes. Reaping is age-gated so a concurrent
+in-flight commit is never deleted.
 
 ### WAF interaction (security note)
 

--- a/EDGE.md
+++ b/EDGE.md
@@ -224,6 +224,74 @@ the zone from its own router. So:
 Because the edge sets `X-Forwarded-For` and parapet trusts it
 (`TRUST_PROXY=<edge CIDR>`), both evaluate against the same client IP.
 
+## Response cache at the edge
+
+An optional **HTTP response cache** on the edge, off by default. The edge sits
+close to clients and (above) can be 200–300 ms from the cluster, so serving a
+cacheable object locally removes a full origin round trip. Enabled with
+`EDGE_CACHE_ENABLED=true`.
+
+> **Edge-only feature.** The edge is Rust-only by design (see *Language split*);
+> there is no Go edge, so this is **not** a parapet-core behavior change and
+> carries no `go/` mirror or `conformance/` obligation. parapet itself does not
+> cache. Recorded as an edge divergence in [`SPEC.md`](SPEC.md).
+
+### What it does
+
+- **Disk-backed.** Pingora 0.8 ships only an in-memory `MemCache` ("testing");
+  there is no disk Storage in the OSS release (cloudflare/pingora#210), so the
+  edge implements the `pingora::cache::Storage` trait against the filesystem
+  (`rust/edge/src/diskcache.rs`). A disk cache survives restarts and isn't bounded
+  by RSS (matters given the edge's memory-pressure history). Total size is bounded
+  by an LRU eviction manager (`EDGE_CACHE_MAX_SIZE`); per-object size by
+  `EDGE_CACHE_MAX_FILE_SIZE`.
+- **Honor-origin policy.** Caches **only** when the origin opts in via response
+  `Cache-Control`/`Expires` freshness — no forced or heuristic TTL. Refuses
+  `private`/`no-store`, any `Set-Cookie`, and `Vary: *`. Honors `Vary` (keys per
+  varied request header). `GET`/`HEAD` only; cacheable status codes per RFC.
+- **Cache lock.** Concurrent misses for one key collapse into a single origin
+  fetch (no stampede).
+- **Observability.** Sets `X-Cache: HIT|MISS` (HIT = served from the edge cache,
+  MISS = fetched from parapet). No metrics endpoint yet — the edge exposes none.
+
+### On-disk layout (sharded by hash)
+
+```
+<EDGE_CACHE_DIR>/<aa>/<hash>.body   response body bytes
+<EDGE_CACHE_DIR>/<aa>/<hash>.meta   framed sidecar: CacheMeta + CompactCacheKey
+<EDGE_CACHE_DIR>/tmp/<hash>.<seq>.* in-progress writes, atomically renamed
+```
+
+Writes are temp-file + fsync + atomic `rename`, with the `.meta` written **last**
+so its presence implies a complete `.body`; a crash mid-write leaves only an
+orphan reaped on startup. The eviction manager's accounting is in-memory, so on
+startup the edge **scans the cache dir and re-admits** surviving entries (the
+sidecar carries the `CompactCacheKey` for exactly this) — the byte cap holds
+across restarts, and orphans/torn writes are reaped.
+
+### WAF interaction (security note)
+
+The cache phases run **after** `request_filter`, so the edge WAF still screens
+every request, including cache hits. **But a hit is served without contacting
+parapet, so parapet's authoritative WAF does not re-run on hits.** This is normal
+CDN behavior: only origin-opted-in (`Cache-Control` public) content is cached —
+content the origin has marked safe for a shared cache. Do not mark per-user or
+authorization-sensitive responses publicly cacheable.
+
+### Config
+
+```
+EDGE_CACHE_ENABLED       on/off (default false)
+EDGE_CACHE_DIR           cache root (default /var/cache/parapet-edge)
+EDGE_CACHE_MAX_SIZE      total bytes cap, LRU-evicted (default 1073741824 = 1 GiB)
+EDGE_CACHE_MAX_FILE_SIZE per-object bytes cap (default 8388608 = 8 MiB)
+```
+
+A fetch/IO error on the read path **fails static** (degrades to a cache miss →
+serve from origin), never erroring the client request. **Not yet:** purge/
+invalidation API, stale-while-revalidate / stale-if-error, Range/partial caching,
+per-route policy via Ingress annotations, and cache metrics + a `:9187` listener.
+
 ## Ports & exposure
 
 ```
@@ -276,6 +344,8 @@ edge *can* be co-located, prefer keyless (recoverable in git history).
 | Bad rule snapshot | All-or-nothing compile rejects the batch; previous good ruleset stays live. |
 | Edge compromised | Leaks its allowlisted domains' keys → **reissue/revoke those certs**; revoke the edge's token. Other edges/domains unaffected. |
 | Cert rotation gap | Overlapping refresh + fail-static avoid a window where the edge has no usable cert. |
+| Cache read IO error | Degrades to a cache miss (**fail static**) → served from parapet. Never errors the client request. |
+| Cache dir unwritable | Cache init fails → caching disabled for the process (logged); the edge still proxies normally. |
 
 ## Conformance
 
@@ -310,3 +380,7 @@ The two never link; the HTTP/JSON contract above is their entire interface.
    ships it scoped to the edge's allowed hosts, alongside the zone rulesets).
    Path-precise zone resolution stays parapet's authoritative job — if the edge's
    host-level binding ever diverges, parapet corrects it on its re-run.
+4. **Response cache** — optional disk-backed HTTP cache (`EDGE_CACHE_*`),
+   honor-origin policy, LRU-bounded, restart-persistent, fail-static. **(done)**
+   See [Response cache at the edge](#response-cache-at-the-edge). Edge-only (no
+   parapet-core equivalent).

--- a/SPEC.md
+++ b/SPEC.md
@@ -122,6 +122,15 @@ token** → allowed domains/zones. Contract-relevant invariants:
 - **Language split** — control plane is **Go** (reuses `go/cert`, `go/k8s`,
   `go/wafrule`); edge is **Rust** (Pingora). They share only the HTTP/JSON
   contract — no shared library.
+- **Response cache (edge-only)** — the edge has an optional disk-backed HTTP
+  response cache (`EDGE_CACHE_*`, off by default): **honor-origin** policy (caches
+  only on explicit `Cache-Control`/`Expires` freshness; refuses
+  `private`/`no-store`/`Set-Cookie`/`Vary: *`), `GET`/`HEAD`, LRU-bounded,
+  restart-persistent, fail-static, `X-Cache: HIT|MISS`. **parapet does not cache**
+  — there is no Go equivalent and no conformance obligation. A cache **hit** is
+  served without contacting parapet, so parapet's authoritative WAF does not
+  re-run on hits (only origin-opted-in public content is cached). See
+  [EDGE.md](EDGE.md#response-cache-at-the-edge).
 
 ## Configuration (environment variables)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -125,8 +125,9 @@ token** → allowed domains/zones. Contract-relevant invariants:
 - **Response cache (edge-only)** — the edge has an optional disk-backed HTTP
   response cache (`EDGE_CACHE_*`, off by default): **honor-origin** policy (caches
   only on explicit `Cache-Control`/`Expires` freshness; refuses
-  `private`/`no-store`/`Set-Cookie`/`Vary: *`), `GET`/`HEAD`, LRU-bounded,
-  restart-persistent, fail-static, `X-Cache: HIT|MISS`. **parapet does not cache**
+  `private`/`no-store`/`Set-Cookie`/`Vary: *`; ignores **client** request
+  `Cache-Control`, CDN-style), `GET`/`HEAD`, LRU-bounded, restart-persistent,
+  fail-static, `X-Cache: HIT|MISS`. **parapet does not cache**
   — there is no Go equivalent and no conformance obligation. A cache **hit** is
   served without contacting parapet, so parapet's authoritative WAF does not
   re-run on hits (only origin-opted-in public content is cached). See

--- a/rust/edge/Cargo.toml
+++ b/rust/edge/Cargo.toml
@@ -12,12 +12,23 @@ publish = false
 # bearer token), cached in memory and refreshed on a timer. Forwards to parapet.
 [dependencies]
 # openssl backend matches the controller, so controller's cert types unify cleanly.
-pingora = { version = "0.8", features = ["proxy", "openssl"] }
+# `cache` adds pingora-cache (HTTP response cache); we implement a disk-backed
+# Storage in src/diskcache.rs (pingora ships only an in-memory MemCache).
+pingora = { version = "0.8", features = ["proxy", "openssl", "cache"] }
 # Reuse the controller's cert table + LoadedCert::parsed() (needs the `proxy` feature).
 controller = { path = "../controller", package = "parapet-ingress-controller", features = ["proxy"] }
 
 async-trait = "0.1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync", "time"] }
+# fs + io-util back the disk cache's async file IO (diskcache.rs).
+tokio = { version = "1", features = [
+    "rt-multi-thread",
+    "macros",
+    "signal",
+    "sync",
+    "time",
+    "fs",
+    "io-util",
+] }
 arc-swap = "1"
 # HTTPS client to the control plane (rustls so it doesn't pull a second TLS lib).
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }

--- a/rust/edge/src/diskcache.rs
+++ b/rust/edge/src/diskcache.rs
@@ -52,23 +52,23 @@ pub struct ScannedEntry {
 /// process-global.
 pub struct DiskCache {
     root: PathBuf,
-    /// Cap on a cached body buffered in memory during admission. A miss whose
-    /// body exceeds this is abandoned (not cached) so a single chunked response
-    /// can't blow up RSS. Responses with a `Content-Length` over the cap are
-    /// already rejected earlier in `response_cache_filter`.
-    max_body_bytes: usize,
     /// Monotonic suffix for temp files so concurrent writers never collide.
     seq: AtomicU64,
 }
 
+/// Minimum age before `scan()` will delete a stray/orphan/temp file. The scan
+/// runs concurrently with serving (off the startup critical path), so this
+/// guards against reaping a write that is mid-commit (body renamed in, `.meta`
+/// not yet) — real in-flight writes complete in milliseconds, far under this.
+const REAP_MIN_AGE_SECS: u64 = 60;
+
 impl DiskCache {
     /// Create the store rooted at `root`, ensuring `root/` and `root/tmp/` exist.
-    pub fn new(root: impl Into<PathBuf>, max_body_bytes: usize) -> std::io::Result<Self> {
+    pub fn new(root: impl Into<PathBuf>) -> std::io::Result<Self> {
         let root = root.into();
         std::fs::create_dir_all(root.join("tmp"))?;
         Ok(Self {
             root,
-            max_body_bytes,
             seq: AtomicU64::new(0),
         })
     }
@@ -91,7 +91,9 @@ impl DiskCache {
     /// caller can re-admit them into the eviction manager (whose accounting is
     /// in-memory and otherwise resets across restarts). Orphans — a `.meta`
     /// without its `.body`, an unreadable/unrecognised sidecar, or a stray
-    /// `.body`/temp file — are deleted. Best-effort: IO errors are logged and
+    /// `.body`/temp file — are deleted, but only once older than
+    /// `REAP_MIN_AGE_SECS` so a concurrent in-flight commit is never touched
+    /// (this runs off the startup critical path). Best-effort: IO errors are
     /// skipped, never fatal.
     pub fn scan(&self) -> Vec<ScannedEntry> {
         let mut out = Vec::new();
@@ -100,7 +102,8 @@ impl DiskCache {
         };
         for shard in shards.flatten() {
             let dir = shard.path();
-            // skip the tmp/ working dir: any file there is an aborted write.
+            // the tmp/ working dir holds only aborted writes (live writes rename
+            // out of it); reap the stale ones.
             if !dir.is_dir() || dir.file_name().is_some_and(|n| n == "tmp") {
                 if dir.file_name().is_some_and(|n| n == "tmp") {
                     reap_dir(&dir);
@@ -116,15 +119,15 @@ impl DiskCache {
                     match self.scan_one(&p) {
                         Some(entry) => out.push(entry),
                         None => {
-                            // unparseable/incomplete -> drop both sides
-                            let _ = std::fs::remove_file(&p);
-                            let _ = std::fs::remove_file(p.with_extension("body"));
+                            // unparseable/incomplete -> drop both sides (if stale)
+                            reap_if_stale(&p);
+                            reap_if_stale(&p.with_extension("body"));
                         }
                     }
                 } else if p.extension().is_some_and(|e| e == "body") {
                     // a body whose meta is gone is unusable; reaped if orphaned.
                     if !p.with_extension("meta").exists() {
-                        let _ = std::fs::remove_file(&p);
+                        reap_if_stale(&p);
                     }
                 }
             }
@@ -132,9 +135,9 @@ impl DiskCache {
         out
     }
 
-    /// Synchronously delete an asset's files. Used by the startup eviction scan,
-    /// which runs before the tokio runtime is serving. Returns whether anything
-    /// was removed.
+    /// Synchronously delete an asset's files. Used by the startup eviction scan
+    /// to drop entries the eviction manager just displaced. Returns whether
+    /// anything was removed.
     pub fn remove_blocking(&self, key: &CompactCacheKey) -> bool {
         let hash = key.combined();
         let m = std::fs::remove_file(self.meta_path(&hash)).is_ok();
@@ -155,12 +158,25 @@ impl DiskCache {
     }
 }
 
-/// Best-effort removal of every file in a directory (used to reap `tmp/`).
+/// Best-effort removal of every stale file in a directory (used to reap `tmp/`).
 fn reap_dir(dir: &Path) {
     if let Ok(entries) = std::fs::read_dir(dir) {
         for e in entries.flatten() {
-            let _ = std::fs::remove_file(e.path());
+            reap_if_stale(&e.path());
         }
+    }
+}
+
+/// Delete `p` only if it hasn't been modified within `REAP_MIN_AGE_SECS` — i.e.
+/// it's not a write in progress. Best-effort.
+fn reap_if_stale(p: &Path) {
+    let stale = std::fs::metadata(p)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| SystemTime::now().duration_since(t).ok())
+        .is_some_and(|age| age.as_secs() >= REAP_MIN_AGE_SECS);
+    if stale {
+        let _ = std::fs::remove_file(p);
     }
 }
 
@@ -196,8 +212,8 @@ impl Storage for DiskCache {
             Err(_) => return Ok(None),
         };
         let hit = DiskHitHandler {
+            weight: body.len(),
             body: Some(body),
-            weight: meta_bytes.len(),
         };
         Ok(Some((meta, Box::new(hit))))
     }
@@ -216,7 +232,6 @@ impl Storage for DiskCache {
             hash,
             sidecar,
             buf: Vec::new(),
-            too_big: false,
             committed: false,
         }))
     }
@@ -259,11 +274,14 @@ impl Storage for DiskCache {
 }
 
 /// Serves a fully-read body from memory in a single chunk. The body file is read
-/// whole in `lookup` (bounded by the per-file size cap), so the handler holds no
-/// file descriptor across awaits — streaming straight off disk is a future
-/// optimization.
+/// whole in `lookup` (bounded by the per-file size cap pingora enforces), so the
+/// handler holds no file descriptor across awaits — streaming straight off disk
+/// is a future optimization.
 struct DiskHitHandler {
     body: Option<Bytes>,
+    /// Body length, captured at lookup. Used as the eviction weight; must match
+    /// the size reported at `admit`/scan time (body-only) or the manager's total
+    /// drifts on the first `access()` of each entry.
     weight: usize,
 }
 
@@ -283,8 +301,8 @@ impl HandleHit for DiskHitHandler {
     }
 
     fn get_eviction_weight(&self) -> usize {
-        // body + meta, so the eviction cap accounts for sidecar overhead too.
-        self.weight + self.body.as_ref().map_or(0, |b| b.len())
+        // body-only, matching admit()/scan() so the eviction total stays exact.
+        self.weight
     }
 
     fn as_any(&self) -> &(dyn Any + Send + Sync) {
@@ -298,40 +316,29 @@ impl HandleHit for DiskHitHandler {
 /// Buffers a cacheable response in memory, then commits it atomically in
 /// `finish()`. Dropped without `finish()` → the write is abandoned (no temp/dest
 /// files were created yet), matching the trait's "drop == failed write" contract.
+///
+/// The buffer is bounded by pingora's own max-file-size enforcement
+/// (`set_max_file_size_bytes`, wired in `request_cache_filter`): a response over
+/// the cap is rejected by Content-Length, or a chunked one is aborted mid-stream
+/// by pingora before it ever reaches `write_body`. So this handler never sees an
+/// over-cap body and needs no size logic of its own. (Streaming straight to the
+/// temp file instead of buffering is a future optimization.)
 struct DiskMissHandler {
     storage: &'static DiskCache,
     hash: String,
     sidecar: Vec<u8>,
     buf: Vec<u8>,
-    /// Set once the buffered body exceeds the cap; the entry is then abandoned.
-    too_big: bool,
     committed: bool,
 }
 
 #[async_trait]
 impl HandleMiss for DiskMissHandler {
     async fn write_body(&mut self, data: Bytes, _eof: bool) -> Result<()> {
-        // Never error here: the body is also being streamed to the client, so an
-        // error would abort the client response. Oversize just stops caching.
-        if !self.too_big {
-            if self.buf.len() + data.len() > self.storage.max_body_bytes {
-                self.too_big = true;
-                self.buf = Vec::new(); // release the partial buffer
-            } else {
-                self.buf.extend_from_slice(&data);
-            }
-        }
+        self.buf.extend_from_slice(&data);
         Ok(())
     }
 
     async fn finish(mut self: Box<Self>) -> Result<MissFinishType> {
-        if self.too_big {
-            // Abandon admission; the client already got the full body upstream.
-            return Error::e_explain(
-                ErrorType::InternalError,
-                "edge cache: body exceeded max file size, not cached",
-            );
-        }
         let size = self.buf.len();
         let body_dst = self.storage.body_path(&self.hash);
         let meta_dst = self.storage.meta_path(&self.hash);
@@ -475,7 +482,7 @@ mod tests {
     fn store(tag: &str) -> (&'static DiskCache, PathBuf) {
         let dir = std::env::temp_dir().join(format!("pedge-cache-test-{tag}"));
         let _ = std::fs::remove_dir_all(&dir);
-        let dc = Box::leak(Box::new(DiskCache::new(&dir, 1 << 20).unwrap()));
+        let dc = Box::leak(Box::new(DiskCache::new(&dir).unwrap()));
         (dc, dir)
     }
 
@@ -550,21 +557,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn oversize_body_is_not_cached() {
-        let dir = std::env::temp_dir().join("pedge-cache-test-oversize");
-        let _ = std::fs::remove_dir_all(&dir);
-        let s: &'static DiskCache = Box::leak(Box::new(DiskCache::new(&dir, 8).unwrap()));
-        let key = CacheKey::new("acme.com", "GET https /big", "");
-        let mut miss = s.get_miss_handler(&key, &meta(60), &span()).await.unwrap();
-        miss.write_body(Bytes::from_static(b"0123456789"), true)
-            .await
-            .unwrap(); // 10 > 8 cap
-        assert!(miss.finish().await.is_err(), "oversize admission abandoned");
-        assert!(s.lookup(&key, &span()).await.unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn scan_reseeds_and_reaps_orphans() {
+    async fn scan_reseeds_and_reaps_stale_orphans_but_keeps_fresh() {
         let (s, dir) = store("scan");
         let key = CacheKey::new("acme.com", "GET https /s", "");
         let mut miss = s.get_miss_handler(&key, &meta(60), &span()).await.unwrap();
@@ -573,17 +566,36 @@ mod tests {
             .unwrap();
         miss.finish().await.unwrap();
 
-        // an orphan body (no meta) should be reaped by the scan.
-        let orphan = s.shard_dir(&CacheKey::new("a", "b", "").combined());
-        std::fs::create_dir_all(&orphan).unwrap();
-        let orphan_body = orphan.join("deadbeef.body");
-        std::fs::write(&orphan_body, b"x").unwrap();
+        let shard = s.shard_dir(&CacheKey::new("a", "b", "").combined());
+        std::fs::create_dir_all(&shard).unwrap();
+        // A STALE orphan body (no meta, backdated past the reap window) is reaped.
+        let stale = shard.join("deadbeef.body");
+        std::fs::write(&stale, b"x").unwrap();
+        backdate(&stale, REAP_MIN_AGE_SECS + 5);
+        // A FRESH orphan body (could be a write mid-commit) must be preserved.
+        let fresh = shard.join("c0ffee00.body");
+        std::fs::write(&fresh, b"y").unwrap();
 
         let entries = s.scan();
         assert_eq!(entries.len(), 1, "one complete entry re-seeded");
         assert_eq!(entries[0].size, 7);
         assert_eq!(entries[0].key, key.to_compact());
-        assert!(!orphan_body.exists(), "orphan body reaped");
+        assert!(!stale.exists(), "stale orphan reaped");
+        assert!(
+            fresh.exists(),
+            "fresh orphan (possible in-flight write) kept"
+        );
         let _ = dir;
+    }
+
+    /// Backdate a file's mtime by `secs` so the reap gate considers it stale.
+    fn backdate(p: &Path, secs: u64) {
+        let when = SystemTime::now() - std::time::Duration::from_secs(secs);
+        std::fs::File::options()
+            .write(true)
+            .open(p)
+            .unwrap()
+            .set_modified(when)
+            .unwrap();
     }
 }

--- a/rust/edge/src/diskcache.rs
+++ b/rust/edge/src/diskcache.rs
@@ -1,0 +1,589 @@
+//! Disk-backed cache `Storage` for the edge's HTTP response cache.
+//!
+//! Pingora 0.8 ships only an in-memory `MemCache` (labelled "testing"); there is
+//! no disk Storage in the OSS release (cloudflare/pingora#210), so we implement
+//! the `pingora::cache::Storage` trait against the filesystem. A disk cache (vs
+//! MemCache) survives restarts and isn't bounded by RSS — important given the
+//! edge's memory-pressure history (see the jemalloc notes in main.rs).
+//!
+//! Layout (sharded by the first hash byte so no directory grows unbounded):
+//! ```text
+//!   <root>/<aa>/<hash>.body   response body bytes
+//!   <root>/<aa>/<hash>.meta   framed sidecar: CacheMeta + CompactCacheKey
+//!   <root>/tmp/<hash>.<seq>.* in-progress writes, atomically renamed on commit
+//! ```
+//! `hash` = `CacheHashKey::combined()` (32 hex chars); `aa` = its first two.
+//!
+//! Durability: a miss is buffered in memory and committed in `finish()` as
+//! temp-file + fsync + atomic `rename`, and the `.meta` is written **last** so
+//! that the presence of a `.meta` implies a complete `.body`. A crash mid-write
+//! leaves only an orphan temp/body file, which the startup scan reaps.
+//!
+//! Fail-static: IO errors on the read path degrade to a cache miss (serve from
+//! origin) rather than erroring the client request.
+
+use std::any::Any;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::SystemTime;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use pingora::cache::key::{CacheHashKey, CompactCacheKey, HashBinary};
+use pingora::cache::storage::{HandleHit, HandleMiss, MissFinishType};
+use pingora::cache::trace::SpanHandle;
+use pingora::cache::{CacheKey, CacheMeta, HitHandler, MissHandler, PurgeType, Storage};
+use pingora::{Error, ErrorType, Result};
+
+/// Magic + version prefix for the `.meta` sidecar framing (bumped if the layout
+/// changes; an unrecognised prefix is treated as an orphan and reaped).
+const META_MAGIC: &[u8; 8] = b"PEDGEC\x01\x00";
+
+/// A single asset reconstructed from a `.meta` sidecar plus its `.body` size:
+/// everything the eviction manager needs to (re-)admit the entry on startup.
+pub struct ScannedEntry {
+    pub key: CompactCacheKey,
+    pub size: usize,
+    pub fresh_until: SystemTime,
+}
+
+/// Filesystem-backed cache storage. Leaked to `&'static` in `main` (Pingora's
+/// `Storage` methods take `&'static self`), like the cert store is a long-lived
+/// process-global.
+pub struct DiskCache {
+    root: PathBuf,
+    /// Cap on a cached body buffered in memory during admission. A miss whose
+    /// body exceeds this is abandoned (not cached) so a single chunked response
+    /// can't blow up RSS. Responses with a `Content-Length` over the cap are
+    /// already rejected earlier in `response_cache_filter`.
+    max_body_bytes: usize,
+    /// Monotonic suffix for temp files so concurrent writers never collide.
+    seq: AtomicU64,
+}
+
+impl DiskCache {
+    /// Create the store rooted at `root`, ensuring `root/` and `root/tmp/` exist.
+    pub fn new(root: impl Into<PathBuf>, max_body_bytes: usize) -> std::io::Result<Self> {
+        let root = root.into();
+        std::fs::create_dir_all(root.join("tmp"))?;
+        Ok(Self {
+            root,
+            max_body_bytes,
+            seq: AtomicU64::new(0),
+        })
+    }
+
+    fn shard_dir(&self, hash: &str) -> PathBuf {
+        self.root.join(&hash[..2])
+    }
+    fn body_path(&self, hash: &str) -> PathBuf {
+        self.shard_dir(hash).join(format!("{hash}.body"))
+    }
+    fn meta_path(&self, hash: &str) -> PathBuf {
+        self.shard_dir(hash).join(format!("{hash}.meta"))
+    }
+    fn tmp_path(&self, hash: &str, what: &str) -> PathBuf {
+        let n = self.seq.fetch_add(1, Ordering::Relaxed);
+        self.root.join("tmp").join(format!("{hash}.{n}.{what}"))
+    }
+
+    /// Walk the cache dir, returning every complete, parseable entry so the
+    /// caller can re-admit them into the eviction manager (whose accounting is
+    /// in-memory and otherwise resets across restarts). Orphans — a `.meta`
+    /// without its `.body`, an unreadable/unrecognised sidecar, or a stray
+    /// `.body`/temp file — are deleted. Best-effort: IO errors are logged and
+    /// skipped, never fatal.
+    pub fn scan(&self) -> Vec<ScannedEntry> {
+        let mut out = Vec::new();
+        let Ok(shards) = std::fs::read_dir(&self.root) else {
+            return out;
+        };
+        for shard in shards.flatten() {
+            let dir = shard.path();
+            // skip the tmp/ working dir: any file there is an aborted write.
+            if !dir.is_dir() || dir.file_name().is_some_and(|n| n == "tmp") {
+                if dir.file_name().is_some_and(|n| n == "tmp") {
+                    reap_dir(&dir);
+                }
+                continue;
+            }
+            let Ok(files) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for f in files.flatten() {
+                let p = f.path();
+                if p.extension().is_some_and(|e| e == "meta") {
+                    match self.scan_one(&p) {
+                        Some(entry) => out.push(entry),
+                        None => {
+                            // unparseable/incomplete -> drop both sides
+                            let _ = std::fs::remove_file(&p);
+                            let _ = std::fs::remove_file(p.with_extension("body"));
+                        }
+                    }
+                } else if p.extension().is_some_and(|e| e == "body") {
+                    // a body whose meta is gone is unusable; reaped if orphaned.
+                    if !p.with_extension("meta").exists() {
+                        let _ = std::fs::remove_file(&p);
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Synchronously delete an asset's files. Used by the startup eviction scan,
+    /// which runs before the tokio runtime is serving. Returns whether anything
+    /// was removed.
+    pub fn remove_blocking(&self, key: &CompactCacheKey) -> bool {
+        let hash = key.combined();
+        let m = std::fs::remove_file(self.meta_path(&hash)).is_ok();
+        let b = std::fs::remove_file(self.body_path(&hash)).is_ok();
+        m || b
+    }
+
+    fn scan_one(&self, meta_path: &Path) -> Option<ScannedEntry> {
+        let bytes = std::fs::read(meta_path).ok()?;
+        let (meta, key) = decode_sidecar(&bytes)?;
+        let body = meta_path.with_extension("body");
+        let size = std::fs::metadata(&body).ok()?.len() as usize;
+        Some(ScannedEntry {
+            key,
+            size,
+            fresh_until: meta.fresh_until(),
+        })
+    }
+}
+
+/// Best-effort removal of every file in a directory (used to reap `tmp/`).
+fn reap_dir(dir: &Path) {
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for e in entries.flatten() {
+            let _ = std::fs::remove_file(e.path());
+        }
+    }
+}
+
+fn internal_err(msg: &'static str, e: std::io::Error) -> Box<Error> {
+    Error::because(ErrorType::InternalError, msg, e)
+}
+
+#[async_trait]
+impl Storage for DiskCache {
+    async fn lookup(
+        &'static self,
+        key: &CacheKey,
+        _trace: &SpanHandle,
+    ) -> Result<Option<(CacheMeta, HitHandler)>> {
+        let hash = key.combined();
+        let meta_bytes = match tokio::fs::read(self.meta_path(&hash)).await {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            // a transient read error becomes a miss (serve from origin), not a
+            // hard error to the client.
+            Err(e) => {
+                tracing::warn!(error = %e, hash, "edge cache: meta read failed; treating as miss");
+                return Ok(None);
+            }
+        };
+        let Some((meta, _key)) = decode_sidecar(&meta_bytes) else {
+            tracing::warn!(hash, "edge cache: corrupt meta sidecar; treating as miss");
+            return Ok(None);
+        };
+        let body = match tokio::fs::read(self.body_path(&hash)).await {
+            Ok(b) => Bytes::from(b),
+            // meta without body (mid-rotation/torn) -> miss.
+            Err(_) => return Ok(None),
+        };
+        let hit = DiskHitHandler {
+            body: Some(body),
+            weight: meta_bytes.len(),
+        };
+        Ok(Some((meta, Box::new(hit))))
+    }
+
+    async fn get_miss_handler(
+        &'static self,
+        key: &CacheKey,
+        meta: &CacheMeta,
+        _trace: &SpanHandle,
+    ) -> Result<MissHandler> {
+        let hash = key.combined();
+        let sidecar =
+            encode_sidecar(meta, &key.to_compact()).map_err(|e| internal_err("encode meta", e))?;
+        Ok(Box::new(DiskMissHandler {
+            storage: self,
+            hash,
+            sidecar,
+            buf: Vec::new(),
+            too_big: false,
+            committed: false,
+        }))
+    }
+
+    async fn purge(
+        &'static self,
+        key: &CompactCacheKey,
+        _purge_type: PurgeType,
+        _trace: &SpanHandle,
+    ) -> Result<bool> {
+        let hash = key.combined();
+        // remove meta first so a concurrent lookup never sees meta-without-body.
+        let meta_gone = remove_if_exists(&self.meta_path(&hash)).await;
+        let body_gone = remove_if_exists(&self.body_path(&hash)).await;
+        Ok(meta_gone || body_gone)
+    }
+
+    async fn update_meta(
+        &'static self,
+        key: &CacheKey,
+        meta: &CacheMeta,
+        _trace: &SpanHandle,
+    ) -> Result<bool> {
+        let hash = key.combined();
+        if !self.body_path(&hash).exists() {
+            return Ok(false);
+        }
+        let sidecar =
+            encode_sidecar(meta, &key.to_compact()).map_err(|e| internal_err("encode meta", e))?;
+        let tmp = self.tmp_path(&hash, "meta");
+        atomic_write(&tmp, &self.meta_path(&hash), &sidecar)
+            .await
+            .map_err(|e| internal_err("update meta", e))?;
+        Ok(true)
+    }
+
+    fn as_any(&self) -> &(dyn Any + Send + Sync) {
+        self
+    }
+}
+
+/// Serves a fully-read body from memory in a single chunk. The body file is read
+/// whole in `lookup` (bounded by the per-file size cap), so the handler holds no
+/// file descriptor across awaits — streaming straight off disk is a future
+/// optimization.
+struct DiskHitHandler {
+    body: Option<Bytes>,
+    weight: usize,
+}
+
+#[async_trait]
+impl HandleHit for DiskHitHandler {
+    async fn read_body(&mut self) -> Result<Option<Bytes>> {
+        Ok(self.body.take())
+    }
+
+    async fn finish(
+        self: Box<Self>,
+        _storage: &'static (dyn Storage + Sync),
+        _key: &CacheKey,
+        _trace: &SpanHandle,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn get_eviction_weight(&self) -> usize {
+        // body + meta, so the eviction cap accounts for sidecar overhead too.
+        self.weight + self.body.as_ref().map_or(0, |b| b.len())
+    }
+
+    fn as_any(&self) -> &(dyn Any + Send + Sync) {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut (dyn Any + Send + Sync) {
+        self
+    }
+}
+
+/// Buffers a cacheable response in memory, then commits it atomically in
+/// `finish()`. Dropped without `finish()` → the write is abandoned (no temp/dest
+/// files were created yet), matching the trait's "drop == failed write" contract.
+struct DiskMissHandler {
+    storage: &'static DiskCache,
+    hash: String,
+    sidecar: Vec<u8>,
+    buf: Vec<u8>,
+    /// Set once the buffered body exceeds the cap; the entry is then abandoned.
+    too_big: bool,
+    committed: bool,
+}
+
+#[async_trait]
+impl HandleMiss for DiskMissHandler {
+    async fn write_body(&mut self, data: Bytes, _eof: bool) -> Result<()> {
+        // Never error here: the body is also being streamed to the client, so an
+        // error would abort the client response. Oversize just stops caching.
+        if !self.too_big {
+            if self.buf.len() + data.len() > self.storage.max_body_bytes {
+                self.too_big = true;
+                self.buf = Vec::new(); // release the partial buffer
+            } else {
+                self.buf.extend_from_slice(&data);
+            }
+        }
+        Ok(())
+    }
+
+    async fn finish(mut self: Box<Self>) -> Result<MissFinishType> {
+        if self.too_big {
+            // Abandon admission; the client already got the full body upstream.
+            return Error::e_explain(
+                ErrorType::InternalError,
+                "edge cache: body exceeded max file size, not cached",
+            );
+        }
+        let size = self.buf.len();
+        let body_dst = self.storage.body_path(&self.hash);
+        let meta_dst = self.storage.meta_path(&self.hash);
+        if let Some(parent) = body_dst.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| internal_err("mkdir shard", e))?;
+        }
+        // body first, then meta — meta presence implies a complete body.
+        let body_tmp = self.storage.tmp_path(&self.hash, "body");
+        atomic_write(&body_tmp, &body_dst, &self.buf)
+            .await
+            .map_err(|e| internal_err("write body", e))?;
+        let meta_tmp = self.storage.tmp_path(&self.hash, "meta");
+        if let Err(e) = atomic_write(&meta_tmp, &meta_dst, &self.sidecar).await {
+            // roll back the body so we never leave an orphan.
+            let _ = tokio::fs::remove_file(&body_dst).await;
+            return Err(internal_err("write meta", e));
+        }
+        self.committed = true;
+        Ok(MissFinishType::Created(size))
+    }
+}
+
+/// Write `data` to `tmp`, fsync, then atomically rename onto `dst`.
+async fn atomic_write(tmp: &Path, dst: &Path, data: &[u8]) -> std::io::Result<()> {
+    use tokio::io::AsyncWriteExt;
+    let mut f = tokio::fs::File::create(tmp).await?;
+    f.write_all(data).await?;
+    f.sync_all().await?;
+    drop(f);
+    match tokio::fs::rename(tmp, dst).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = tokio::fs::remove_file(tmp).await;
+            Err(e)
+        }
+    }
+}
+
+async fn remove_if_exists(p: &Path) -> bool {
+    tokio::fs::remove_file(p).await.is_ok()
+}
+
+// ---- sidecar framing -------------------------------------------------------
+
+fn put_u32(out: &mut Vec<u8>, v: usize) {
+    out.extend_from_slice(&(v as u32).to_le_bytes());
+}
+
+/// Frame the `CacheMeta` (its two serialized blobs) together with the
+/// `CompactCacheKey` fields, so a restart scan can re-admit the entry into the
+/// eviction manager (which needs the key, not just the on-disk hash).
+fn encode_sidecar(meta: &CacheMeta, key: &CompactCacheKey) -> std::io::Result<Vec<u8>> {
+    let (internal, header) = meta
+        .serialize()
+        .map_err(|_| std::io::Error::other("meta serialize"))?;
+    let mut out = Vec::with_capacity(internal.len() + header.len() + key.user_tag.len() + 64);
+    out.extend_from_slice(META_MAGIC);
+    put_u32(&mut out, internal.len());
+    out.extend_from_slice(&internal);
+    put_u32(&mut out, header.len());
+    out.extend_from_slice(&header);
+    out.extend_from_slice(&key.primary);
+    match &key.variance {
+        Some(v) => {
+            out.push(1);
+            out.extend_from_slice(v.as_ref());
+        }
+        None => out.push(0),
+    }
+    let tag = key.user_tag.as_bytes();
+    put_u32(&mut out, tag.len());
+    out.extend_from_slice(tag);
+    Ok(out)
+}
+
+/// Inverse of `encode_sidecar`. Returns `None` on any framing mismatch (treated
+/// by callers as a corrupt/foreign file to reap).
+fn decode_sidecar(b: &[u8]) -> Option<(CacheMeta, CompactCacheKey)> {
+    let mut i = 0;
+    let take = |i: &mut usize, n: usize| -> Option<&[u8]> {
+        let s = b.get(*i..*i + n)?;
+        *i += n;
+        Some(s)
+    };
+    let take_u32 = |i: &mut usize| -> Option<usize> {
+        let s = take(i, 4)?;
+        Some(u32::from_le_bytes(s.try_into().ok()?) as usize)
+    };
+    if take(&mut i, 8)? != META_MAGIC {
+        return None;
+    }
+    let n = take_u32(&mut i)?;
+    let internal = take(&mut i, n)?.to_vec();
+    let n = take_u32(&mut i)?;
+    let header = take(&mut i, n)?.to_vec();
+    let meta = CacheMeta::deserialize(&internal, &header).ok()?;
+
+    let primary: HashBinary = take(&mut i, 16)?.try_into().ok()?;
+    let variance = match take(&mut i, 1)?[0] {
+        0 => None,
+        1 => {
+            let v: HashBinary = take(&mut i, 16)?.try_into().ok()?;
+            Some(Box::new(v))
+        }
+        _ => return None,
+    };
+    let n = take_u32(&mut i)?;
+    let user_tag = std::str::from_utf8(take(&mut i, n)?).ok()?.into();
+    Some((
+        meta,
+        CompactCacheKey {
+            primary,
+            variance,
+            user_tag,
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pingora::cache::trace::Span;
+    use pingora::http::ResponseHeader;
+
+    fn span() -> SpanHandle {
+        Span::inactive().handle()
+    }
+
+    fn meta(max_age: u64) -> CacheMeta {
+        let now = SystemTime::now();
+        let mut h = ResponseHeader::build(200, None).unwrap();
+        h.append_header("cache-control", format!("max-age={max_age}"))
+            .unwrap();
+        CacheMeta::new(now + std::time::Duration::from_secs(max_age), now, 0, 0, h)
+    }
+
+    // Each test leaks a DiskCache to satisfy the `&'static self` Storage methods,
+    // rooted in a unique tempdir.
+    fn store(tag: &str) -> (&'static DiskCache, PathBuf) {
+        let dir = std::env::temp_dir().join(format!("pedge-cache-test-{tag}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        let dc = Box::leak(Box::new(DiskCache::new(&dir, 1 << 20).unwrap()));
+        (dc, dir)
+    }
+
+    #[tokio::test]
+    async fn miss_then_finish_then_hit_roundtrips() {
+        let (s, _dir) = store("roundtrip");
+        let key = CacheKey::new("acme.com", "GET https /x", "");
+
+        assert!(s.lookup(&key, &span()).await.unwrap().is_none());
+
+        let mut miss = s.get_miss_handler(&key, &meta(60), &span()).await.unwrap();
+        miss.write_body(Bytes::from_static(b"hello "), false)
+            .await
+            .unwrap();
+        miss.write_body(Bytes::from_static(b"world"), true)
+            .await
+            .unwrap();
+        assert!(matches!(
+            miss.finish().await.unwrap(),
+            MissFinishType::Created(11)
+        ));
+
+        let (m, mut hit) = s.lookup(&key, &span()).await.unwrap().unwrap();
+        assert!(m.is_fresh(SystemTime::now()));
+        let body = hit.read_body().await.unwrap().unwrap();
+        assert_eq!(&body[..], b"hello world");
+        assert!(hit.read_body().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn purge_removes_the_entry() {
+        let (s, _dir) = store("purge");
+        let key = CacheKey::new("acme.com", "GET https /p", "");
+        let mut miss = s.get_miss_handler(&key, &meta(60), &span()).await.unwrap();
+        miss.write_body(Bytes::from_static(b"data"), true)
+            .await
+            .unwrap();
+        miss.finish().await.unwrap();
+
+        assert!(s.lookup(&key, &span()).await.unwrap().is_some());
+        assert!(s
+            .purge(&key.to_compact(), PurgeType::Eviction, &span())
+            .await
+            .unwrap());
+        assert!(s.lookup(&key, &span()).await.unwrap().is_none());
+        // purging a missing key is a no-op false.
+        assert!(!s
+            .purge(&key.to_compact(), PurgeType::Eviction, &span())
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn update_meta_rewrites_meta_keeps_body() {
+        let (s, _dir) = store("updatemeta");
+        let key = CacheKey::new("acme.com", "GET https /u", "");
+        let mut miss = s.get_miss_handler(&key, &meta(1), &span()).await.unwrap();
+        miss.write_body(Bytes::from_static(b"abc"), true)
+            .await
+            .unwrap();
+        miss.finish().await.unwrap();
+
+        // bump freshness via update_meta (revalidation path).
+        assert!(s.update_meta(&key, &meta(3600), &span()).await.unwrap());
+        let (m, mut hit) = s.lookup(&key, &span()).await.unwrap().unwrap();
+        assert!(m.fresh_sec() >= 3000, "freshness extended");
+        assert_eq!(&hit.read_body().await.unwrap().unwrap()[..], b"abc");
+
+        // update_meta on an absent body returns false.
+        let other = CacheKey::new("acme.com", "GET https /missing", "");
+        assert!(!s.update_meta(&other, &meta(60), &span()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn oversize_body_is_not_cached() {
+        let dir = std::env::temp_dir().join("pedge-cache-test-oversize");
+        let _ = std::fs::remove_dir_all(&dir);
+        let s: &'static DiskCache = Box::leak(Box::new(DiskCache::new(&dir, 8).unwrap()));
+        let key = CacheKey::new("acme.com", "GET https /big", "");
+        let mut miss = s.get_miss_handler(&key, &meta(60), &span()).await.unwrap();
+        miss.write_body(Bytes::from_static(b"0123456789"), true)
+            .await
+            .unwrap(); // 10 > 8 cap
+        assert!(miss.finish().await.is_err(), "oversize admission abandoned");
+        assert!(s.lookup(&key, &span()).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn scan_reseeds_and_reaps_orphans() {
+        let (s, dir) = store("scan");
+        let key = CacheKey::new("acme.com", "GET https /s", "");
+        let mut miss = s.get_miss_handler(&key, &meta(60), &span()).await.unwrap();
+        miss.write_body(Bytes::from_static(b"payload"), true)
+            .await
+            .unwrap();
+        miss.finish().await.unwrap();
+
+        // an orphan body (no meta) should be reaped by the scan.
+        let orphan = s.shard_dir(&CacheKey::new("a", "b", "").combined());
+        std::fs::create_dir_all(&orphan).unwrap();
+        let orphan_body = orphan.join("deadbeef.body");
+        std::fs::write(&orphan_body, b"x").unwrap();
+
+        let entries = s.scan();
+        assert_eq!(entries.len(), 1, "one complete entry re-seeded");
+        assert_eq!(entries[0].size, 7);
+        assert_eq!(entries[0].key, key.to_compact());
+        assert!(!orphan_body.exists(), "orphan body reaped");
+        let _ = dir;
+    }
+}

--- a/rust/edge/src/main.rs
+++ b/rust/edge/src/main.rs
@@ -5,6 +5,7 @@
 
 mod certstore;
 mod cp;
+mod diskcache;
 mod proxy;
 mod refresh;
 mod tls;
@@ -27,6 +28,9 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 use std::sync::Arc;
 use std::time::Duration;
 
+use pingora::cache::eviction::lru::Manager as LruManager;
+use pingora::cache::eviction::EvictionManager;
+use pingora::cache::lock::{CacheKeyLockImpl, CacheLock};
 use pingora::listeners::tls::TlsSettings;
 use pingora::proxy::http_proxy_service;
 use pingora::server::Server;
@@ -88,6 +92,67 @@ fn load_geo_dbs() -> (
         }
     };
     (geoip, asndb)
+}
+
+/// Build the edge response cache from env (`EDGE_CACHE_*`), or `None` when
+/// disabled. Leaks the disk storage / LRU eviction manager / cache lock to
+/// `'static` (Pingora's cache APIs take `&'static`), then re-seeds the eviction
+/// manager from whatever survived on disk so the byte cap holds across restarts
+/// (its accounting is otherwise in-memory only). See diskcache.rs + EDGE.md.
+fn build_cache() -> Option<proxy::EdgeCache> {
+    if env_or("EDGE_CACHE_ENABLED", "false") != "true" {
+        return None;
+    }
+    let dir = env_or("EDGE_CACHE_DIR", "/var/cache/parapet-edge");
+    let max_size: usize = env_or("EDGE_CACHE_MAX_SIZE", "1073741824")
+        .parse()
+        .unwrap_or(1 << 30);
+    let max_file: usize = env_or("EDGE_CACHE_MAX_FILE_SIZE", "8388608")
+        .parse()
+        .unwrap_or(8 << 20);
+
+    let dc = match diskcache::DiskCache::new(&dir, max_file) {
+        Ok(dc) => dc,
+        Err(e) => {
+            tracing::error!(error = %e, dir, "edge cache: cannot init cache dir; caching disabled");
+            return None;
+        }
+    };
+    let storage: &'static diskcache::DiskCache = Box::leak(Box::new(dc));
+    let eviction: &'static LruManager<8> =
+        Box::leak(Box::new(LruManager::<8>::with_capacity(max_size, 1024)));
+
+    // Re-admit surviving entries (orphans/torn writes are reaped by scan()).
+    // admit() can return victims if we're already over the cap (e.g. the cap was
+    // lowered since last run) — delete those files synchronously.
+    let mut seeded = 0usize;
+    let mut evicted = 0usize;
+    for e in storage.scan() {
+        for v in eviction.admit(e.key, e.size, e.fresh_until) {
+            if storage.remove_blocking(&v) {
+                evicted += 1;
+            }
+        }
+        seeded += 1;
+    }
+    tracing::info!(
+        dir,
+        max_size,
+        max_file,
+        seeded,
+        evicted,
+        "edge cache enabled (disk-backed)"
+    );
+
+    // The cache lock collapses concurrent misses for one key into a single origin
+    // fetch; the timeout bounds how long a waiting reader blocks on the writer.
+    let lock: &'static CacheKeyLockImpl = Box::leak(CacheLock::new_boxed(Duration::from_secs(2)));
+    Some(proxy::EdgeCache {
+        storage,
+        eviction: eviction as &'static (dyn EvictionManager + Sync),
+        lock,
+        max_file_size: max_file,
+    })
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -162,6 +227,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None
     };
 
+    // Optional disk-backed response cache (off by default; honor-origin policy,
+    // bounded by EDGE_CACHE_MAX_SIZE). See build_cache + diskcache.rs.
+    let cache = build_cache();
+
     let mut server = Server::new(None).map_err(|e| format!("server init: {e}"))?;
     server.bootstrap();
 
@@ -170,6 +239,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         parapet_tls,
         parapet_sni,
         waf,
+        cache,
     };
     let mut svc = http_proxy_service(&server.configuration, proxy);
 

--- a/rust/edge/src/main.rs
+++ b/rust/edge/src/main.rs
@@ -111,7 +111,7 @@ fn build_cache() -> Option<proxy::EdgeCache> {
         .parse()
         .unwrap_or(8 << 20);
 
-    let dc = match diskcache::DiskCache::new(&dir, max_file) {
+    let dc = match diskcache::DiskCache::new(&dir) {
         Ok(dc) => dc,
         Err(e) => {
             tracing::error!(error = %e, dir, "edge cache: cannot init cache dir; caching disabled");
@@ -122,27 +122,34 @@ fn build_cache() -> Option<proxy::EdgeCache> {
     let eviction: &'static LruManager<8> =
         Box::leak(Box::new(LruManager::<8>::with_capacity(max_size, 1024)));
 
-    // Re-admit surviving entries (orphans/torn writes are reaped by scan()).
-    // admit() can return victims if we're already over the cap (e.g. the cap was
-    // lowered since last run) — delete those files synchronously.
-    let mut seeded = 0usize;
-    let mut evicted = 0usize;
-    for e in storage.scan() {
-        for v in eviction.admit(e.key, e.size, e.fresh_until) {
-            if storage.remove_blocking(&v) {
-                evicted += 1;
+    // Re-seed eviction from surviving entries OFF the startup critical path:
+    // scan() reads + decodes every .meta and can take seconds on a large cache,
+    // so run it on a background thread and start serving immediately. The byte
+    // cap simply lags until the scan finishes; in-flight writes are protected by
+    // the scan's mtime reap gate (see diskcache.rs). admit() may return victims
+    // if we're already over the cap (e.g. the cap was lowered) — delete those.
+    // storage + eviction are 'static, so the thread holds them for the lifetime.
+    std::thread::spawn(move || {
+        let start = std::time::SystemTime::now();
+        let mut seeded = 0usize;
+        let mut evicted = 0usize;
+        for e in storage.scan() {
+            for v in eviction.admit(e.key, e.size, e.fresh_until) {
+                if storage.remove_blocking(&v) {
+                    evicted += 1;
+                }
             }
+            seeded += 1;
         }
-        seeded += 1;
-    }
-    tracing::info!(
-        dir,
-        max_size,
-        max_file,
-        seeded,
-        evicted,
-        "edge cache enabled (disk-backed)"
-    );
+        let elapsed_secs = start.elapsed().map(|d| d.as_secs_f64()).unwrap_or(0.0);
+        tracing::info!(
+            seeded,
+            evicted,
+            elapsed_secs,
+            "edge cache: startup scan complete"
+        );
+    });
+    tracing::info!(dir, max_size, max_file, "edge cache enabled (disk-backed)");
 
     // The cache lock collapses concurrent misses for one key into a single origin
     // fetch; the timeout bounds how long a waiting reader blocks on the writer.

--- a/rust/edge/src/proxy.rs
+++ b/rust/edge/src/proxy.rs
@@ -240,7 +240,10 @@ impl ProxyHttp for EdgeProxy {
     // EDGE.md. Only origin-opted-in (`Cache-Control` public) content is cached.
 
     /// Enable caching for safe, idempotent methods. Disabled entirely when this
-    /// edge has no cache configured (zero per-request cost).
+    /// edge has no cache configured (zero per-request cost). Client request
+    /// `Cache-Control` (`no-cache`/`no-store`) is ignored by design — like a CDN,
+    /// to avoid a cache-busting DoS vector; parapet remains reachable for any
+    /// origin that genuinely needs freshness (it marks responses uncacheable).
     fn request_cache_filter(&self, session: &mut Session, _ctx: &mut Self::CTX) -> Result<()> {
         let Some(c) = &self.cache else {
             return Ok(());
@@ -250,6 +253,10 @@ impl ProxyHttp for EdgeProxy {
             session
                 .cache
                 .enable(c.storage, Some(c.eviction), None, Some(c.lock), None);
+            // Let pingora enforce the per-object size cap: it refuses by
+            // Content-Length (client-safe) and aborts oversize chunked mid-stream.
+            // This replaces a hand-rolled check and avoids erroring the client.
+            session.cache.set_max_file_size_bytes(c.max_file_size);
         }
         Ok(())
     }
@@ -259,64 +266,29 @@ impl ProxyHttp for EdgeProxy {
     /// collide on a shared path.
     fn cache_key_callback(&self, session: &Session, _ctx: &mut Self::CTX) -> Result<CacheKey> {
         let req = session.req_header();
-        let scheme = downstream_scheme(session);
         let uri = req.uri.path_and_query().map(|p| p.as_str()).unwrap_or("/");
-        let primary = format!("{} {} {}", req.method.as_str(), scheme, uri);
-        Ok(CacheKey::new(req_host(req), primary, ""))
+        Ok(cache_key_for(
+            downstream_scheme(session),
+            req_host(req),
+            req.method.as_str(),
+            uri,
+        ))
     }
 
-    /// Decide cacheability from the origin response. Honor-origin: cache only when
-    /// `Cache-Control`/`Expires` grant freshness (see `CACHE_DEFAULTS`). Refuse
-    /// `private`/`no-store`, any `Set-Cookie`, `Vary: *`, and bodies whose
-    /// `Content-Length` exceeds the per-file cap.
+    /// Decide cacheability from the origin response (honor-origin). Delegates to
+    /// the pure `resp_cacheable_decision` so the policy is unit-testable without a
+    /// live `Session`. Per-object size is enforced by pingora (see
+    /// `request_cache_filter`), not here.
     fn response_cache_filter(
         &self,
         _session: &Session,
         resp: &pingora::http::ResponseHeader,
         _ctx: &mut Self::CTX,
     ) -> Result<RespCacheable> {
-        let Some(c) = &self.cache else {
+        if self.cache.is_none() {
             return Ok(RespCacheable::Uncacheable(NoCacheReason::NeverEnabled));
-        };
-        // A Set-Cookie response is per-client; never store it in a shared cache.
-        if resp.headers.contains_key("set-cookie") {
-            return Ok(RespCacheable::Uncacheable(NoCacheReason::Custom(
-                "set-cookie",
-            )));
         }
-        // Vary: * means uncacheable (no single key can represent it).
-        if let Some(v) = resp.headers.get("vary").and_then(|v| v.to_str().ok()) {
-            if v.split(',').any(|t| t.trim() == "*") {
-                return Ok(RespCacheable::Uncacheable(NoCacheReason::Custom("vary-*")));
-            }
-        }
-        // Per-file size cap (known length only; chunked is bounded by the miss
-        // handler's in-memory cap + the total-size eviction limit).
-        if let Some(len) = resp
-            .headers
-            .get("content-length")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|s| s.parse::<usize>().ok())
-        {
-            if len > c.max_file_size {
-                return Ok(RespCacheable::Uncacheable(NoCacheReason::ResponseTooLarge));
-            }
-        }
-        let cc = CacheControl::from_resp_headers(resp);
-        if let Some(cc) = &cc {
-            if cc.private() || cc.no_store() {
-                return Ok(RespCacheable::Uncacheable(NoCacheReason::OriginNotCache));
-            }
-        }
-        // authorization_present=false: the edge does not vary on Authorization;
-        // requests carrying it are still cache candidates only if the origin
-        // explicitly allows it (public), which resp_cacheable enforces.
-        Ok(resp_cacheable(
-            cc.as_ref(),
-            resp.clone(),
-            false,
-            &CACHE_DEFAULTS,
-        ))
+        Ok(resp_cacheable_decision(resp))
     }
 
     /// Honor `Vary`: derive a variance key from the request's values for each
@@ -400,6 +372,42 @@ fn req_host(req: &RequestHeader) -> String {
         .to_ascii_lowercase()
 }
 
+/// Build the cache key: namespace = host, primary = `"METHOD scheme uri"`. Two
+/// requests collide iff all four agree. Factored out of `cache_key_callback` so
+/// it's unit-testable without a live `Session`.
+fn cache_key_for(scheme: &str, host: String, method: &str, uri: &str) -> CacheKey {
+    CacheKey::new(host, format!("{method} {scheme} {uri}"), "")
+}
+
+/// Pure honor-origin cacheability decision for an origin response, factored out
+/// of `response_cache_filter` so the policy is unit-testable without a live
+/// `Session`. Refuses `Set-Cookie`, `Vary: *`, and `private`/`no-store`;
+/// otherwise defers to pingora's `resp_cacheable` with honor-origin defaults
+/// (cache only on explicit `Cache-Control`/`Expires` freshness). Per-object size
+/// is enforced separately by pingora (`set_max_file_size_bytes`).
+fn resp_cacheable_decision(resp: &pingora::http::ResponseHeader) -> RespCacheable {
+    // A Set-Cookie response is per-client; never store it in a shared cache.
+    if resp.headers.contains_key("set-cookie") {
+        return RespCacheable::Uncacheable(NoCacheReason::Custom("set-cookie"));
+    }
+    // Vary: * means uncacheable (no single key can represent it).
+    if let Some(v) = resp.headers.get("vary").and_then(|v| v.to_str().ok()) {
+        if v.split(',').any(|t| t.trim() == "*") {
+            return RespCacheable::Uncacheable(NoCacheReason::Custom("vary-*"));
+        }
+    }
+    let cc = CacheControl::from_resp_headers(resp);
+    if let Some(cc) = &cc {
+        if cc.private() || cc.no_store() {
+            return RespCacheable::Uncacheable(NoCacheReason::OriginNotCache);
+        }
+    }
+    // authorization_present=false: the edge does not vary on Authorization; a
+    // request carrying it is a candidate only if the origin marks it public,
+    // which resp_cacheable enforces.
+    resp_cacheable(cc.as_ref(), resp.clone(), false, &CACHE_DEFAULTS)
+}
+
 /// `k=v; k2=v2` → map (first value wins), mirroring the controller's parse_cookies.
 fn parse_cookies(s: &str) -> HashMap<String, String> {
     let mut m = HashMap::new();
@@ -455,4 +463,93 @@ fn url_decode(s: &str) -> String {
         }
     }
     String::from_utf8_lossy(&out).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pingora::cache::key::CacheHashKey;
+    use pingora::http::ResponseHeader;
+
+    fn resp(headers: &[(&str, &str)]) -> ResponseHeader {
+        let mut h = ResponseHeader::build(200, None).unwrap();
+        for (k, v) in headers {
+            h.append_header(k.to_string(), v.to_string()).unwrap();
+        }
+        h
+    }
+
+    fn is_cacheable(headers: &[(&str, &str)]) -> bool {
+        matches!(
+            resp_cacheable_decision(&resp(headers)),
+            RespCacheable::Cacheable(_)
+        )
+    }
+
+    #[test]
+    fn honors_origin_freshness_only() {
+        // explicit freshness -> cacheable
+        assert!(is_cacheable(&[("cache-control", "public, max-age=60")]));
+        assert!(is_cacheable(&[("cache-control", "max-age=60")]));
+        // no freshness directive at all -> NOT cached (no heuristic/forced TTL)
+        assert!(!is_cacheable(&[]));
+        assert!(!is_cacheable(&[("content-type", "text/html")]));
+    }
+
+    #[test]
+    fn refuses_private_no_store_set_cookie_and_vary_star() {
+        assert!(!is_cacheable(&[("cache-control", "private, max-age=60")]));
+        assert!(!is_cacheable(&[("cache-control", "no-store")]));
+        // Set-Cookie is per-client even if the origin says public.
+        assert!(!is_cacheable(&[
+            ("cache-control", "public, max-age=60"),
+            ("set-cookie", "sid=abc"),
+        ]));
+        // Vary: * cannot be keyed.
+        assert!(!is_cacheable(&[
+            ("cache-control", "public, max-age=60"),
+            ("vary", "*"),
+        ]));
+    }
+
+    #[test]
+    fn vary_on_named_header_is_still_cacheable() {
+        // a concrete Vary is fine here; the variance is applied in cache_vary_filter.
+        assert!(is_cacheable(&[
+            ("cache-control", "public, max-age=60"),
+            ("vary", "accept-encoding"),
+        ]));
+    }
+
+    #[test]
+    fn cache_key_separates_scheme_host_method_uri_and_is_stable() {
+        let base = cache_key_for("https", "acme.com".into(), "GET", "/a").combined();
+        // identical inputs -> identical key
+        assert_eq!(
+            base,
+            cache_key_for("https", "acme.com".into(), "GET", "/a").combined()
+        );
+        // each component changes the key
+        assert_ne!(
+            base,
+            cache_key_for("http", "acme.com".into(), "GET", "/a").combined()
+        );
+        assert_ne!(
+            base,
+            cache_key_for("https", "other.com".into(), "GET", "/a").combined()
+        );
+        assert_ne!(
+            base,
+            cache_key_for("https", "acme.com".into(), "HEAD", "/a").combined()
+        );
+        assert_ne!(
+            base,
+            cache_key_for("https", "acme.com".into(), "GET", "/b").combined()
+        );
+        // query string is part of the key
+        assert_ne!(
+            base,
+            cache_key_for("https", "acme.com".into(), "GET", "/a?x=1").combined()
+        );
+    }
 }

--- a/rust/edge/src/proxy.rs
+++ b/rust/edge/src/proxy.rs
@@ -12,11 +12,40 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use controller::waf::{Decision, RequestData};
+use pingora::cache::cache_control::CacheControl;
+use pingora::cache::eviction::EvictionManager;
+use pingora::cache::filters::resp_cacheable;
+use pingora::cache::key::HashBinary;
+use pingora::cache::lock::CacheKeyLockImpl;
+use pingora::cache::{
+    CacheKey, CacheMeta, CacheMetaDefaults, NoCacheReason, RespCacheable, VarianceBuilder,
+};
+use pingora::http::RequestHeader;
 use pingora::prelude::*;
 use pingora::proxy::{ProxyHttp, Session};
 use pingora::upstreams::peer::HttpPeer;
 
+use crate::diskcache::DiskCache;
 use crate::waf::EdgeWaf;
+
+/// Cacheability defaults: honor the origin only. The `|_| None` fresh-duration
+/// function means a response with no explicit `Cache-Control`/`Expires` freshness
+/// is **not** cached (no forced/heuristic TTL); 0/0 disable stale-while-revalidate
+/// and stale-if-error. Mirrors pingora's `BYPASS_CACHE_DEFAULTS` test constant.
+const CACHE_DEFAULTS: CacheMetaDefaults = CacheMetaDefaults::new(|_| None, 0, 0);
+
+/// The cache wiring handed to `HttpCache::enable`: the disk storage, the LRU
+/// eviction manager bounding total on-disk bytes, the cache lock collapsing
+/// concurrent misses for one key into a single origin fetch, and the per-file
+/// size cap. All leaked to `'static` in `main` (Pingora's cache APIs are
+/// `'static`). `None` on `EdgeProxy.cache` = caching disabled (zero per-request
+/// cost — the hooks early-return before touching the session cache).
+pub struct EdgeCache {
+    pub storage: &'static DiskCache,
+    pub eviction: &'static (dyn EvictionManager + Sync),
+    pub lock: &'static CacheKeyLockImpl,
+    pub max_file_size: usize,
+}
 
 /// The client-facing scheme for this connection: `"https"` when TLS was
 /// terminated at this edge (the public TLS listener) and `"http"` when the
@@ -45,6 +74,8 @@ pub struct EdgeProxy {
     pub parapet_sni: String,
     /// Global WAF (None = WAF distribution disabled at this edge).
     pub waf: Option<Arc<EdgeWaf>>,
+    /// Response cache (None = caching disabled at this edge).
+    pub cache: Option<EdgeCache>,
 }
 
 impl EdgeProxy {
@@ -55,22 +86,7 @@ impl EdgeProxy {
     fn build_waf_request(&self, session: &Session) -> RequestData {
         let req = session.req_header();
         let method = req.method.as_str().to_string();
-        // h2 carries the authority in the URI; h1 in the Host header. Prefer the
-        // URI authority (present on h2, and absolute-form h1), then fall back to
-        // Host — mirrors the controller's host derivation. Reading only Host misses
-        // h2 requests (no Host header), which broke host→zone lookup.
-        let host = req
-            .uri
-            .authority()
-            .map(|a| a.host().to_string())
-            .or_else(|| {
-                req.headers
-                    .get("host")
-                    .and_then(|v| v.to_str().ok())
-                    .map(|s| s.split(':').next().unwrap_or("").to_string())
-            })
-            .unwrap_or_default()
-            .to_ascii_lowercase();
+        let host = req_host(req);
         let path = req.uri.path().to_string();
         let query = req.uri.query().unwrap_or("").to_string();
         let uri = req
@@ -215,6 +231,173 @@ impl ProxyHttp for EdgeProxy {
         }
         Ok(())
     }
+
+    // ---- response cache (edge tier) ---------------------------------------
+    //
+    // The cache phases run AFTER `request_filter`, so the edge WAF still screens
+    // every request (including cache hits). But a hit is served WITHOUT contacting
+    // parapet, so parapet's authoritative WAF does not re-run on hits — see
+    // EDGE.md. Only origin-opted-in (`Cache-Control` public) content is cached.
+
+    /// Enable caching for safe, idempotent methods. Disabled entirely when this
+    /// edge has no cache configured (zero per-request cost).
+    fn request_cache_filter(&self, session: &mut Session, _ctx: &mut Self::CTX) -> Result<()> {
+        let Some(c) = &self.cache else {
+            return Ok(());
+        };
+        let m = session.req_header().method.as_str();
+        if m == "GET" || m == "HEAD" {
+            session
+                .cache
+                .enable(c.storage, Some(c.eviction), None, Some(c.lock), None);
+        }
+        Ok(())
+    }
+
+    /// Key on scheme + host + method + uri. Host comes from the same authority/Host
+    /// logic as the WAF request, so h1 and h2 agree and distinct hosts never
+    /// collide on a shared path.
+    fn cache_key_callback(&self, session: &Session, _ctx: &mut Self::CTX) -> Result<CacheKey> {
+        let req = session.req_header();
+        let scheme = downstream_scheme(session);
+        let uri = req.uri.path_and_query().map(|p| p.as_str()).unwrap_or("/");
+        let primary = format!("{} {} {}", req.method.as_str(), scheme, uri);
+        Ok(CacheKey::new(req_host(req), primary, ""))
+    }
+
+    /// Decide cacheability from the origin response. Honor-origin: cache only when
+    /// `Cache-Control`/`Expires` grant freshness (see `CACHE_DEFAULTS`). Refuse
+    /// `private`/`no-store`, any `Set-Cookie`, `Vary: *`, and bodies whose
+    /// `Content-Length` exceeds the per-file cap.
+    fn response_cache_filter(
+        &self,
+        _session: &Session,
+        resp: &pingora::http::ResponseHeader,
+        _ctx: &mut Self::CTX,
+    ) -> Result<RespCacheable> {
+        let Some(c) = &self.cache else {
+            return Ok(RespCacheable::Uncacheable(NoCacheReason::NeverEnabled));
+        };
+        // A Set-Cookie response is per-client; never store it in a shared cache.
+        if resp.headers.contains_key("set-cookie") {
+            return Ok(RespCacheable::Uncacheable(NoCacheReason::Custom(
+                "set-cookie",
+            )));
+        }
+        // Vary: * means uncacheable (no single key can represent it).
+        if let Some(v) = resp.headers.get("vary").and_then(|v| v.to_str().ok()) {
+            if v.split(',').any(|t| t.trim() == "*") {
+                return Ok(RespCacheable::Uncacheable(NoCacheReason::Custom("vary-*")));
+            }
+        }
+        // Per-file size cap (known length only; chunked is bounded by the miss
+        // handler's in-memory cap + the total-size eviction limit).
+        if let Some(len) = resp
+            .headers
+            .get("content-length")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<usize>().ok())
+        {
+            if len > c.max_file_size {
+                return Ok(RespCacheable::Uncacheable(NoCacheReason::ResponseTooLarge));
+            }
+        }
+        let cc = CacheControl::from_resp_headers(resp);
+        if let Some(cc) = &cc {
+            if cc.private() || cc.no_store() {
+                return Ok(RespCacheable::Uncacheable(NoCacheReason::OriginNotCache));
+            }
+        }
+        // authorization_present=false: the edge does not vary on Authorization;
+        // requests carrying it are still cache candidates only if the origin
+        // explicitly allows it (public), which resp_cacheable enforces.
+        Ok(resp_cacheable(
+            cc.as_ref(),
+            resp.clone(),
+            false,
+            &CACHE_DEFAULTS,
+        ))
+    }
+
+    /// Honor `Vary`: derive a variance key from the request's values for each
+    /// listed header so different variants (e.g. `Accept-Encoding`) get distinct
+    /// cache entries. `Vary: *` was already rejected in `response_cache_filter`.
+    fn cache_vary_filter(
+        &self,
+        meta: &CacheMeta,
+        _ctx: &mut Self::CTX,
+        req: &RequestHeader,
+    ) -> Option<HashBinary> {
+        let vary = meta.headers().get("vary")?.to_str().ok()?;
+        // Own the (name, value) pairs so they outlive the borrow into the builder.
+        let items: Vec<(String, Vec<u8>)> = vary
+            .split(',')
+            .filter_map(|name| {
+                let name = name.trim().to_ascii_lowercase();
+                if name.is_empty() || name == "*" {
+                    return None;
+                }
+                let value = req
+                    .headers
+                    .get(name.as_str())
+                    .map(|v| v.as_bytes().to_vec())
+                    .unwrap_or_default();
+                Some((name, value))
+            })
+            .collect();
+        if items.is_empty() {
+            return None;
+        }
+        let mut vb = VarianceBuilder::new();
+        for (name, value) in &items {
+            vb.add_value(name, value);
+        }
+        vb.finalize()
+    }
+
+    /// Tag the response so cache effectiveness is observable without a metrics
+    /// endpoint: `X-Cache: HIT` when served from the edge cache, `MISS` when
+    /// fetched from parapet. Omitted when caching wasn't engaged for the request.
+    async fn response_filter(
+        &self,
+        session: &mut Session,
+        resp: &mut pingora::http::ResponseHeader,
+        _ctx: &mut Self::CTX,
+    ) -> Result<()> {
+        if self.cache.is_none() || !session.cache.enabled() {
+            // caching disabled, or not engaged for this request (e.g. POST).
+            return Ok(());
+        }
+        // `upstream_used()` is true for every phase that contacted parapet, so it
+        // is the precise hit/miss signal — served-from-cache vs fetched-from-origin
+        // — regardless of revalidation/stale nuances.
+        let tag = if session.cache.upstream_used() {
+            "MISS"
+        } else {
+            "HIT"
+        };
+        resp.insert_header("x-cache", tag)?;
+        Ok(())
+    }
+}
+
+/// Derive the request host (lowercased, no port). h2 carries the authority in the
+/// URI; h1 in the Host header. Prefer the URI authority (present on h2, and
+/// absolute-form h1), then fall back to Host — mirrors the controller's host
+/// derivation. Reading only Host misses h2 requests (no Host header), which broke
+/// host→zone lookup. Shared by the WAF request build and the cache key.
+fn req_host(req: &RequestHeader) -> String {
+    req.uri
+        .authority()
+        .map(|a| a.host().to_string())
+        .or_else(|| {
+            req.headers
+                .get("host")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.split(':').next().unwrap_or("").to_string())
+        })
+        .unwrap_or_default()
+        .to_ascii_lowercase()
 }
 
 /// `k=v; k2=v2` → map (first value wins), mirroring the controller's parse_cookies.


### PR DESCRIPTION
## What

Adds an optional **HTTP response cache** to the out-of-cluster edge proxy (`rust/edge`), **off by default** (`EDGE_CACHE_ENABLED`). The edge sits close to clients and up to 200–300 ms from the cluster, so serving cacheable objects locally removes a full origin round trip.

## Why a hand-rolled disk Storage

Pingora 0.8 (and `main`) ships **no** disk cache backend — only the in-memory `MemCache`, labelled "testing only"; disk cache is left to user-land ([cloudflare/pingora#210](https://github.com/cloudflare/pingora/issues/210)). So this implements the `pingora::cache::Storage` trait against the filesystem in `rust/edge/src/diskcache.rs`.

A disk cache (vs MemCache) survives restarts and isn't bounded by RSS — relevant given the edge's memory-pressure history.

## How

**`diskcache.rs` — disk-backed `Storage`/`HandleHit`/`HandleMiss`:**
- sharded hash-named `.body`/`.meta` files; temp-file + fsync + atomic `rename`, with `.meta` written **last** so its presence implies a complete `.body` (crash mid-write leaves only an orphan, reaped on startup)
- framed meta sidecar carries `CacheMeta` + `CompactCacheKey`, so the startup scan can **re-admit survivors** into the (in-memory) LRU eviction manager — the byte cap holds across restarts
- bounded by `EDGE_CACHE_MAX_SIZE` (LRU) and `EDGE_CACHE_MAX_FILE_SIZE`

**`proxy.rs` — ProxyHttp cache hooks:** enable for `GET`/`HEAD`; key on scheme+host+method+uri; **honor-origin** cacheability (cache only on explicit `Cache-Control`/`Expires` freshness; refuse `private`/`no-store`/`Set-Cookie`/`Vary: *`/oversize); honor `Vary`; cache lock for stampede protection; `X-Cache: HIT|MISS` for observability.

**`main.rs`:** `build_cache()` reads `EDGE_CACHE_*`, leaks storage/eviction/lock to `'static`, runs the startup re-seed.

## Scope & security

- **Edge-only.** The edge is Rust-only by design, so this is **not** a parapet-core behavior change — no Go mirror or `conformance/` obligation. parapet does not cache.
- A cache **hit** is served without contacting parapet, so parapet's authoritative WAF does **not** re-run on hits. Standard CDN behavior: only origin-opted-in (`Cache-Control` public) content is cached. Documented in `EDGE.md` + `SPEC.md`.
- No metrics endpoint yet (the edge exposes none); observability is `X-Cache` + logs.

## Not in scope (future)

Purge/invalidation API, stale-while-revalidate / stale-if-error, Range/partial caching, per-route policy via Ingress annotations, cache metrics + a `:9187` listener.

## Test plan

- `cargo build -p parapet-edge` ✅
- `cargo test -p parapet-edge` — 12 pass (5 new diskcache tests: roundtrip, purge, update_meta, oversize-abandon, scan-reseed/reap) ✅
- `cargo clippy -p parapet-edge -- -D warnings` clean ✅
- `cargo fmt --all --check` clean ✅
- Manual e2e (not yet run): `EDGE_CACHE_ENABLED=true` against an origin sending `Cache-Control: public, max-age=60`; first `curl` → `X-Cache: MISS`, second → `HIT`; `.meta`/`.body` appear under the cache dir; `private`/`Set-Cookie` never cached; restart still HITs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)