### PR TITLE
refactor(edge): rename EDGE_PARAPET_* env vars to EDGE_UPSTREAM_*

### DIFF
--- a/deploy/edge/e2e/run.sh
+++ b/deploy/edge/e2e/run.sh
@@ -184,7 +184,7 @@ say "6. start the Rust edge (fetches cert + WAF rules; GeoIP from fixture DB)"
 EDGE_HTTPS_LISTEN="127.0.0.1:$EDGE_PORT" EDGE_HTTP_LISTEN="127.0.0.1:$EDGE_HTTP_PORT" \
   EDGE_CP_ENDPOINT="https://localhost:$CP_PORT" EDGE_CP_TOKEN="$TOKEN" \
   EDGE_CP_CA="$WORK/ca.crt" EDGE_DOMAINS="$DOMAIN" \
-  EDGE_PARAPET_ADDR="127.0.0.1:$UP_PORT" EDGE_PARAPET_TLS=false \
+  EDGE_UPSTREAM_ADDR="127.0.0.1:$UP_PORT" EDGE_UPSTREAM_TLS=false \
   EDGE_WAF_ENABLED=true \
   WAF_GEOIP_DB="$REPO/conformance/geoip/iplocate-country.mmdb" \
   WAF_ASN_DB="$REPO/conformance/geoip/iplocate-asn.mmdb" \

--- a/deploy/edge/edge.yaml
+++ b/deploy/edge/edge.yaml
@@ -59,11 +59,11 @@ spec:
             - name: EDGE_CP_CA
               value: /cp-ca/ca.crt
             # Where to forward (the in-cluster parapet, reached via the same private
-            # path). Plaintext h2c by default; set EDGE_PARAPET_TLS=true to
+            # path). Plaintext h2c by default; set EDGE_UPSTREAM_TLS=true to
             # re-encrypt across an untrusted hop.
-            - name: EDGE_PARAPET_ADDR
+            - name: EDGE_UPSTREAM_ADDR
               value: "parapet-ingress-controller.parapet-ingress-controller.svc:80"
-            - name: EDGE_PARAPET_TLS
+            - name: EDGE_UPSTREAM_TLS
               value: "false"
             - name: EDGE_REFRESH_INTERVAL
               value: "300"

--- a/deploy/edge/run-edge-docker.sh
+++ b/deploy/edge/run-edge-docker.sh
@@ -18,9 +18,9 @@
 #   EDGE_CP_CA        path to the CA cert that signs the control plane's server
 #                     cert (mounted read-only); unset if the CP cert is publicly
 #                     trusted or the CP runs plaintext http://
-#   EDGE_PARAPET_ADDR parapet:80
-#   EDGE_PARAPET_TLS  false
-#   EDGE_PARAPET_SNI  ""               SNI to present to parapet when re-encrypting
+#   EDGE_UPSTREAM_ADDR parapet:80
+#   EDGE_UPSTREAM_TLS  false
+#   EDGE_UPSTREAM_SNI  ""              SNI to present to the upstream when re-encrypting
 #   EDGE_REFRESH_INTERVAL  300
 #   EDGE_WAF_ENABLED  true
 #   WAF_GEOIP_DB      /geoip/ip-to-country.mmdb   (baked into the image; "" disables)
@@ -39,9 +39,9 @@ EDGE_NAME="${EDGE_NAME:-parapet-edge}"
 EDGE_LISTEN="${EDGE_LISTEN:-0.0.0.0:443}"
 EDGE_DOMAINS="${EDGE_DOMAINS:-}"
 EDGE_CP_ENDPOINT="${EDGE_CP_ENDPOINT:-https://controlplane:8443}"
-EDGE_PARAPET_ADDR="${EDGE_PARAPET_ADDR:-parapet:80}"
-EDGE_PARAPET_TLS="${EDGE_PARAPET_TLS:-false}"
-EDGE_PARAPET_SNI="${EDGE_PARAPET_SNI:-}"
+EDGE_UPSTREAM_ADDR="${EDGE_UPSTREAM_ADDR:-parapet:80}"
+EDGE_UPSTREAM_TLS="${EDGE_UPSTREAM_TLS:-false}"
+EDGE_UPSTREAM_SNI="${EDGE_UPSTREAM_SNI:-}"
 EDGE_REFRESH_INTERVAL="${EDGE_REFRESH_INTERVAL:-300}"
 EDGE_WAF_ENABLED="${EDGE_WAF_ENABLED:-true}"
 WAF_GEOIP_DB="${WAF_GEOIP_DB:-/geoip/ip-to-country.mmdb}"
@@ -63,9 +63,9 @@ args=(
   -e EDGE_DOMAINS="$EDGE_DOMAINS"
   -e EDGE_CP_ENDPOINT="$EDGE_CP_ENDPOINT"
   -e EDGE_CP_TOKEN="$EDGE_CP_TOKEN"
-  -e EDGE_PARAPET_ADDR="$EDGE_PARAPET_ADDR"
-  -e EDGE_PARAPET_TLS="$EDGE_PARAPET_TLS"
-  -e EDGE_PARAPET_SNI="$EDGE_PARAPET_SNI"
+  -e EDGE_UPSTREAM_ADDR="$EDGE_UPSTREAM_ADDR"
+  -e EDGE_UPSTREAM_TLS="$EDGE_UPSTREAM_TLS"
+  -e EDGE_UPSTREAM_SNI="$EDGE_UPSTREAM_SNI"
   -e EDGE_REFRESH_INTERVAL="$EDGE_REFRESH_INTERVAL"
   -e EDGE_WAF_ENABLED="$EDGE_WAF_ENABLED"
   -e WAF_GEOIP_DB="$WAF_GEOIP_DB"

--- a/rust/edge/src/main.rs
+++ b/rust/edge/src/main.rs
@@ -173,9 +173,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cp_ca = std::env::var("EDGE_CP_CA")
         .ok()
         .and_then(|p| std::fs::read(p).ok());
-    let parapet_addr = env_or("EDGE_PARAPET_ADDR", "parapet:80");
-    let parapet_tls = env_or("EDGE_PARAPET_TLS", "false") == "true";
-    let parapet_sni = env_or("EDGE_PARAPET_SNI", "");
+    let parapet_addr = env_or("EDGE_UPSTREAM_ADDR", "parapet:80");
+    let parapet_tls = env_or("EDGE_UPSTREAM_TLS", "false") == "true";
+    let parapet_sni = env_or("EDGE_UPSTREAM_SNI", "");
     let refresh_secs: u64 = env_or("EDGE_REFRESH_INTERVAL", "300")
         .parse()
         .unwrap_or(300);


### PR DESCRIPTION
## What

Renames the edge's upstream-address config knobs from `EDGE_PARAPET_*` to `EDGE_UPSTREAM_*`:

| Old | New |
|---|---|
| `EDGE_PARAPET_ADDR` | `EDGE_UPSTREAM_ADDR` |
| `EDGE_PARAPET_TLS`  | `EDGE_UPSTREAM_TLS`  |
| `EDGE_PARAPET_SNI`  | `EDGE_UPSTREAM_SNI`  |

## Why

The edge forwards everything to a single configured upstream `host:port` passed straight to `HttpPeer::new` (`rust/edge/src/proxy.rs`); routing/virtual-hosting happens inside the upstream, not at the edge. Naming the knobs after "parapet" specifically is misleading — the value is just an upstream endpoint. `EDGE_UPSTREAM_*` describes what it is.

## Scope

- `rust/edge/src/main.rs` — the three `env_or` lookups.
- `deploy/edge/edge.yaml` — env names + comment.

Internal struct fields (`parapet_addr`/`_tls`/`_sni`) are left as-is — they still refer to parapet as the concrete in-cluster target. This is a Phase-1 feature with no deployed consumers needing a back-compat alias. Edge-only (Rust) change; no `go/` mirror or `conformance/` obligation. `cargo fmt --all --check` clean; `parapet-edge` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)