### PR TITLE
fix(rust): reassemble split HTTP/2 Cookie crumbs (forced-logout fix)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -65,6 +65,21 @@ All keys are prefixed `parapet.moonrhythm.io/`. Applied per-Ingress.
 3. routing → per-route: `allow-remote` → **zone WAF** → `redirect-https` → rate limits → body limit → basic-auth → forward-auth
 4. upstream proxy (with retry on connection failure + bad-addr skip)
 
+### Request header normalization (both implementations)
+
+Before the WAF reads the request and before forwarding upstream, an HTTP/2
+request's **`Cookie` header must be reassembled into a single field**. Per RFC
+7540 §8.1.2.5 an H2 client may split `Cookie` into multiple header fields for
+HPACK compression; a proxy must rejoin the crumbs with `"; "` into one
+`Cookie: a=1; b=2` so a backend (or the WAF) that reads only the first field
+doesn't lose cookies — a dropped session cookie shows up as **random forced
+logouts under HTTP/2**, browser-graded (Safari splits most aggressively).
+
+- **Go** gets this for free: `net/http`'s HTTP/2 server reassembles `Cookie`
+  before the request reaches proxy/middleware code.
+- **Rust** must do it explicitly — **Pingora does not** reassemble; the controller
+  and the edge proxy rejoin the crumbs in `request_filter` (`coalesce_cookies`).
+
 ## WAF
 
 Full design in **[WAF.md](WAF.md)**. Summary: a global baseline ruleset

--- a/rust/controller/src/proxy/mod.rs
+++ b/rust/controller/src/proxy/mod.rs
@@ -305,6 +305,12 @@ impl ProxyHttp for Proxy {
     }
 
     async fn request_filter(&self, session: &mut Session, ctx: &mut Ctx) -> Result<bool> {
+        // Reassemble HTTP/2 split Cookie crumbs into one header up front (RFC 7540
+        // §8.1.2.5) — Pingora, unlike Go's h2 server, doesn't. Done here so BOTH
+        // the WAF cookie eval (`build_waf_request`) and the upstream request
+        // (cloned from this session) see a single correct Cookie. See SPEC.md.
+        coalesce_cookies(session.req_header_mut());
+
         let scheme = if self.is_tls { "https" } else { "http" };
         let remote_ip = client_ip(session);
 
@@ -987,6 +993,36 @@ fn is_event_stream(resp: &ResponseHeader) -> bool {
         .unwrap_or(false)
 }
 
+/// Reassemble HTTP/2 split `Cookie` header fields into a single `Cookie` line.
+///
+/// RFC 7540 §8.1.2.5: an HTTP/2 client may split `Cookie` into multiple header
+/// fields for HPACK compression. A proxy forwarding the request MUST concatenate
+/// them back into one `Cookie: a=1; b=2` (Go's `net/http` HTTP/2 server does this
+/// before the request reaches proxy logic). Pingora does NOT, so without this a
+/// split cookie reaches the backend as multiple `Cookie:` lines; frameworks that
+/// read only the first crumb then lose the session cookie -> forced logout. This
+/// is the Go↔Rust divergence behind the "Rust controller logs users out (Safari
+/// worst, Chrome random), Go works" report. See SPEC.md.
+fn coalesce_cookies(req: &mut RequestHeader) {
+    // 0 or 1 Cookie field: forward verbatim (the common HTTP/1.1 case).
+    if req.headers.get_all("cookie").iter().count() <= 1 {
+        return;
+    }
+    // >1 field: the client split it. Rejoin the non-empty crumbs with "; " (the
+    // cookie-pair separator) into a single header. `insert_header` replaces all
+    // existing `cookie` fields with the one joined value.
+    let joined = req
+        .headers
+        .get_all("cookie")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("; ");
+    let _ = req.insert_header("cookie", joined);
+}
+
 /// Parse a `Cookie` header into a name->value map (last write wins, matching Go's
 /// `Request.Cookies` behavior). Values are not unquoted (a minor divergence).
 fn parse_cookies(s: &str) -> std::collections::HashMap<String, String> {
@@ -1412,6 +1448,64 @@ mod tests {
         assert!(!summary.contains("token"), "query string must not appear");
         assert!(!summary.contains("s3cret"));
         assert!(!summary.contains('?'));
+    }
+
+    // --- HTTP/2 split-Cookie reassembly (RFC 7540 §8.1.2.5) ----------------
+    // Repro for the "Rust controller logs users out under HTTP/2 (Safari worst,
+    // Chrome random); Go works" report. Browsers split Cookie into multiple
+    // header fields over H2; the proxy must rejoin them before forwarding.
+
+    fn cookie_values(req: &RequestHeader) -> Vec<String> {
+        req.headers
+            .get_all("cookie")
+            .iter()
+            .map(|v| v.to_str().unwrap().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn coalesce_cookies_joins_split_h2_crumbs() {
+        // Three crumbs as an H2 client would send them; must become ONE header
+        // "a; b; c" (order preserved). A backend reading only the first crumb
+        // otherwise loses `session` -> forced logout. FAILS before the fix.
+        let mut req = RequestHeader::build("GET", b"/", None).unwrap();
+        req.append_header("cookie", "session=abc").unwrap();
+        req.append_header("cookie", "csrf=xyz").unwrap();
+        req.append_header("cookie", "theme=dark").unwrap();
+
+        coalesce_cookies(&mut req);
+
+        assert_eq!(
+            cookie_values(&req),
+            vec!["session=abc; csrf=xyz; theme=dark"],
+            "split H2 Cookie crumbs must be rejoined into one '; '-separated header"
+        );
+    }
+
+    #[test]
+    fn coalesce_cookies_leaves_single_cookie_unchanged() {
+        // Guard: a single (already-joined) Cookie must pass through verbatim —
+        // no trailing "; ", no duplication.
+        let mut req = RequestHeader::build("GET", b"/", None).unwrap();
+        req.append_header("cookie", "session=abc; csrf=xyz")
+            .unwrap();
+
+        coalesce_cookies(&mut req);
+
+        assert_eq!(cookie_values(&req), vec!["session=abc; csrf=xyz"]);
+    }
+
+    #[test]
+    fn coalesce_cookies_absent_stays_absent() {
+        // Guard: never synthesize an empty Cookie header when there was none.
+        let mut req = RequestHeader::build("GET", b"/", None).unwrap();
+
+        coalesce_cookies(&mut req);
+
+        assert!(
+            req.headers.get("cookie").is_none(),
+            "must not add a Cookie header when the request had none"
+        );
     }
 
     #[test]

--- a/rust/edge/src/proxy.rs
+++ b/rust/edge/src/proxy.rs
@@ -170,6 +170,12 @@ impl ProxyHttp for EdgeProxy {
     /// A block short-circuits with the rule's status/message (returns true =
     /// response sent). parapet re-runs the full WAF authoritatively regardless.
     async fn request_filter(&self, session: &mut Session, _ctx: &mut Self::CTX) -> Result<bool> {
+        // Reassemble HTTP/2 split Cookie crumbs into one header (RFC 7540
+        // §8.1.2.5) before the edge WAF reads cookies and before forwarding to
+        // parapet — Pingora, unlike Go's h2 server, doesn't. Done unconditionally
+        // (even with the WAF off) so parapet always receives a single Cookie.
+        coalesce_cookies(session.req_header_mut());
+
         let Some(waf) = &self.waf else {
             return Ok(false);
         };
@@ -408,6 +414,27 @@ fn resp_cacheable_decision(resp: &pingora::http::ResponseHeader) -> RespCacheabl
     resp_cacheable(cc.as_ref(), resp.clone(), false, &CACHE_DEFAULTS)
 }
 
+/// Reassemble HTTP/2 split `Cookie` header fields into one `Cookie: a=1; b=2`
+/// (RFC 7540 §8.1.2.5). Browsers split Cookie over H2 for HPACK compression;
+/// Pingora (unlike Go's h2 server) forwards the crumbs as-is, so without this a
+/// backend reading only the first crumb loses the session cookie. Mirrors the
+/// controller's `coalesce_cookies`. See ../../EDGE.md / SPEC.md.
+fn coalesce_cookies(req: &mut RequestHeader) {
+    if req.headers.get_all("cookie").iter().count() <= 1 {
+        return;
+    }
+    let joined = req
+        .headers
+        .get_all("cookie")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("; ");
+    let _ = req.insert_header("cookie", joined);
+}
+
 /// `k=v; k2=v2` → map (first value wins), mirroring the controller's parse_cookies.
 fn parse_cookies(s: &str) -> HashMap<String, String> {
     let mut m = HashMap::new();
@@ -519,6 +546,34 @@ mod tests {
             ("cache-control", "public, max-age=60"),
             ("vary", "accept-encoding"),
         ]));
+    }
+
+    #[test]
+    fn coalesce_cookies_joins_split_h2_crumbs() {
+        // HTTP/2 split Cookie crumbs must be rejoined into one header before the
+        // edge WAF reads them and before forwarding to parapet (RFC 7540 §8.1.2.5).
+        let mut req = RequestHeader::build("GET", b"/", None).unwrap();
+        req.append_header("cookie", "session=abc").unwrap();
+        req.append_header("cookie", "csrf=xyz").unwrap();
+        coalesce_cookies(&mut req);
+        let got: Vec<&str> = req
+            .headers
+            .get_all("cookie")
+            .iter()
+            .map(|v| v.to_str().unwrap())
+            .collect();
+        assert_eq!(got, vec!["session=abc; csrf=xyz"]);
+
+        // a single Cookie is untouched; an absent one is not synthesized
+        let mut single = RequestHeader::build("GET", b"/", None).unwrap();
+        single
+            .append_header("cookie", "session=abc; csrf=xyz")
+            .unwrap();
+        coalesce_cookies(&mut single);
+        assert_eq!(single.headers.get_all("cookie").iter().count(), 1);
+        let mut none = RequestHeader::build("GET", b"/", None).unwrap();
+        coalesce_cookies(&mut none);
+        assert!(none.headers.get("cookie").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Symptom

Deploying the **Rust** controller caused **random forced logouts under HTTP/2** — **Safari couldn't log in at all, Chrome logged out intermittently**. Swapping the image back to the **Go** controller fixed it. No TLS/cert warning; purely application-layer.

## Root cause

Under HTTP/2 a browser may split the `Cookie` header into **multiple header fields** for HPACK compression (RFC 7540 §8.1.2.5). A proxy converting/forwarding must rejoin them into a single `Cookie: a=1; b=2`.

- **Go** gets this for free — `net/http`'s HTTP/2 server reassembles `Cookie` before the request reaches proxy/middleware code.
- **Pingora does not** — confirmed in its source (`pingora-core .../http/v2/server.rs::from_h2_conn` stores the h2 headers verbatim; there is no cookie-join logic anywhere in pingora-core). The Rust controller then cloned that header to the upstream (`pingora-proxy/proxy_h1.rs:44`) and forwarded **multiple `Cookie:` lines** to the backend.

A backend that reads only the first crumb loses the session cookie whenever it isn't first → forced logout. The browser asymmetry is the tell: Safari splits cookies most aggressively (consistently broken), Chrome less so (intermittent). This is the Go↔Rust divergence behind the report — not the refactor PRs originally suspected.

## Fix

`coalesce_cookies` joins the crumbs with `"; "` in `request_filter`, on the **downstream session**, **before** the WAF reads cookies and **before** Pingora clones the request upstream — so both the WAF cookie eval and the backend see a single correct `Cookie`. Applied to the **controller** and the **edge** proxy (same Pingora behavior). A single or absent `Cookie` is left untouched (no trailing `"; "`, no synthesized empty header).

This also fixes a latent bug where the WAF's cookie map (`parse_cookies(header_str(.., "cookie"))`) only saw the first crumb under H2.

## Scope

- `rust/controller/src/proxy/mod.rs` — `coalesce_cookies` + call at top of `request_filter`.
- `rust/edge/src/proxy.rs` — same.
- `SPEC.md` — records the H2 `Cookie`-reassembly requirement as shared contract (Go free, Rust explicit).

## Tests

Added `coalesce_cookies` tests in **both** crates: joins split crumbs (this one **fails before the fix**), leaves a single cookie unchanged, and never synthesizes an empty `Cookie`. Controller 108 unit + integration green; edge 23 green; `cargo fmt`/clippy clean on both.

> Edge-only/edge note: the edge fix is defense-in-depth (its WAF + forwarding); even without it, parapet now reassembles. No `go/` change needed — Go already conforms via `net/http`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)