### PR TITLE
docs(edge): cache purge / invalidation API design (spec only)

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -145,6 +145,19 @@ GET /v1/waf           Authorization: Bearer <token>   [If-None-Match: "<etag>"]
        host_zone_map : host → zoneKey, scoped to the edge's hosts
        (ETag is over the *scoped* payload, so 304 revalidation is per-edge-correct)
 
+GET /v1/purges?since=<seq>   Authorization: Bearer <token>
+  200 {"entries":[{"seq":N,"scope":"url|host|all","host":"…","uri":"…"}],
+       "max_seq": N, "min_seq": M, "flush_required": false}
+       entries        : journal entries with seq > since, SCOPED to the token's hosts
+       flush_required : true when since < min_seq (the edge fell behind / the journal
+                        was trimmed) → the edge does a lazy flush-all and jumps its
+                        cursor to max_seq. Conservative: never under-invalidates.
+  401 (no/invalid token)
+
+POST /v1/purges       Authorization: Bearer <ADMIN token>   ← stronger cred than the read token
+  {"scope":"url|host|all", "host":"…", "uri":"…"}  → appends to the journal, returns {"seq":N}
+  401 (no/invalid admin token)  403 (host ∉ allowed(token))
+
 GET /healthz          (no auth)
   200 always (liveness)
 GET /healthz?ready=1  (no auth)
@@ -294,12 +307,87 @@ EDGE_CACHE_ENABLED       on/off (default false)
 EDGE_CACHE_DIR           cache root (default /var/cache/parapet-edge)
 EDGE_CACHE_MAX_SIZE      total bytes cap, LRU-evicted (default 1073741824 = 1 GiB)
 EDGE_CACHE_MAX_FILE_SIZE per-object bytes cap (default 8388608 = 8 MiB)
+EDGE_CACHE_PURGE_POLL_INTERVAL   poll GET /v1/purges (default 10s; lower than the
+                                 cert/WAF refresh — invalidation latency matters more)
+EDGE_CACHE_PURGE_SWEEP_INTERVAL  background reaper cadence (default 300s)
 ```
 
 A fetch/IO error on the read path **fails static** (degrades to a cache miss →
-serve from origin), never erroring the client request. **Not yet:** purge/
-invalidation API, stale-while-revalidate / stale-if-error, Range/partial caching,
-per-route policy via Ingress annotations, and cache metrics + a `:9187` listener.
+serve from origin), never erroring the client request. **Not yet:**
+stale-while-revalidate / stale-if-error, Range/partial caching, per-route policy
+via Ingress annotations, and cache metrics + a `:9187` listener.
+
+### Purge / invalidation
+
+Invalidation is **pulled from the control plane**, exactly like cert and WAF
+distribution: an operator publishes a purge once at the control plane and every
+sharded edge converges on its own timer. There is **no inbound purge port on the
+edge** (edges are out-of-cluster, often NAT'd), and the per-token host scoping is
+the same boundary that gates `/v1/certs` and `/v1/waf`. Three scopes are
+supported: **exact URL** (all `Vary` variants, both schemes, GET+HEAD),
+**whole host/zone**, and **flush-all**.
+
+**Why lazy epochs, not eager file deletion.** The on-disk filename is
+`combined()` = `hash(primary ⊕ variance)`, where `primary = hash("METHOD scheme
+uri")` and `variance` comes from `Vary`. So from a URL alone you **cannot
+enumerate its variants' filenames** — there's no index, and the hash mixes the
+two. `Storage::purge(CompactCacheKey)` needs the *exact* key (primary+variance),
+which an operator purging a URL doesn't have. But `lookup` receives the full
+`CacheKey` (namespace = host, primary *string* = `"GET https /a?x=1"`), so the
+edge can match a request against a coarse predicate at lookup time regardless of
+variance. That asymmetry is why purge is **lazy epoch invalidation** plus a
+background reaper, not synchronous deletes.
+
+**The invalidation table** (small, in-memory, persisted to
+`<EDGE_CACHE_DIR>/purge-state` with the same temp+fsync+rename as the cache):
+
+```
+global:  Option<SystemTime>
+host:    host                       → SystemTime    (lowercased host)
+url:     hash(host ⊕ uri)           → SystemTime    (uri = path+query; method/scheme-agnostic)
+cursor:  u64   (last journal seq applied — persisted in the SAME atomic write as the maps)
+```
+
+**Lookup gate**, added to `DiskCache::lookup` after decoding the sidecar:
+
+```
+invalid_after = max(global, host[namespace], url[hash(namespace ⊕ uri_of(primary))])  // absent ⇒ epoch 0
+if meta.created() <= invalid_after { reap(.meta,.body) best-effort + notify eviction; return miss }
+```
+
+Keying the `url` map on `host ⊕ uri` (not the full primary) is deliberate: one
+URL purge then covers **all methods, both schemes, and every `Vary` variant** —
+the operator's mental model of "purge `/a`". Issue cost is **O(1)** (no scan, no
+variance enumeration); the hot-path cost is one lock read + ≤3 map lookups + a
+timestamp compare, and only on cache lookups (so zero when caching is disabled).
+
+**Edge-clock epochs — no trusted CP timestamp.** An epoch is *"invalidate
+everything cached before this edge learned of the purge"* = the edge's own wall
+clock at first-apply. This removes any CP↔edge clock-skew dependency; the control
+plane only has to **deliver** the directive. Idempotency comes from the cursor,
+not the timestamp: the edge applies a journal `seq` only if `seq > cursor`, so an
+entry is applied exactly once and "now-at-apply" is never replayed. The one
+inherent gap — an in-flight miss whose origin fetch began before apply but commits
+just after — is the same race every CDN purge has; the next TTL expiry or purge
+covers it. (Clamp epochs to be monotonic non-decreasing so an NTP step back can't
+un-purge.)
+
+**Background reaper** (reuses the startup-scan background-thread pattern, off the
+serving path) periodically applies the table to physically delete invalidated
+files, update the LRU accounting, and **retire** table records: once a full sweep
+completes *after* a record's timestamp, nothing older can remain, so the record is
+dropped. This is what bounds the `url` map (it holds only URLs purged within
+roughly one sweep interval) and reclaims disk; the lazy gate already guarantees
+correctness immediately, and the LRU byte cap holds regardless.
+
+**Distribution loop.** The control plane keeps a bounded append-only journal
+(`{seq, scope, host?, uri?}`, monotonic `seq`, `min_seq` = oldest retained). The
+edge polls `GET /v1/purges?since=<cursor>` on `EDGE_CACHE_PURGE_POLL_INTERVAL`; on
+`flush_required` it bumps the `global` epoch and sets `cursor = max_seq`, else it
+applies each new entry once and atomically persists `{maps, cursor}`. Purges are
+issued by an admin `POST /v1/purges` (a **stronger** credential than the per-edge
+read token); auto-sourcing a `host` purge on cert rotation or Ingress change is a
+natural later addition.
 
 ## Ports & exposure
 
@@ -355,6 +443,9 @@ edge *can* be co-located, prefer keyless (recoverable in git history).
 | Cert rotation gap | Overlapping refresh + fail-static avoid a window where the edge has no usable cert. |
 | Cache read IO error | Degrades to a cache miss (**fail static**) → served from parapet. Never errors the client request. |
 | Cache dir unwritable | Cache init fails → caching disabled for the process (logged); the edge still proxies normally. |
+| `GET /v1/purges` unreachable | Edge keeps its applied epochs + cursor (**fail static**); retries with backoff. Pending purges are *delayed, not lost* — the journal+cursor catch up. Stale-serving window bounded by object TTL. |
+| Purge cursor gap (`since < min_seq`) | CP returns `flush_required` → edge bumps the global epoch (lazy flush-all) and jumps to `max_seq`. Conservative; never under-invalidates. |
+| `purge-state` lost/corrupt | Cursor resets to 0 → next poll is a gap → flush-all. Cursor + maps share **one atomic write** so they can't desync. |
 
 ## Conformance
 
@@ -393,3 +484,10 @@ The two never link; the HTTP/JSON contract above is their entire interface.
    honor-origin policy, LRU-bounded, restart-persistent, fail-static. **(done)**
    See [Response cache at the edge](#response-cache-at-the-edge). Edge-only (no
    parapet-core equivalent).
+5. **Cache purge / invalidation** — CP purge journal + `GET`/`POST /v1/purges`,
+   edge poll loop with a persisted cursor, lazy epoch invalidation (global / host /
+   url) checked at lookup, and a background reaper for disk reclaim. Scopes:
+   exact-URL (all variants), whole-host/zone, flush-all. **(design)** See
+   [Purge / invalidation](#purge--invalidation). Edge-only. Path-prefix and
+   Cache-Tag purge are deferred (prefix needs a scan; tags must be recorded at
+   admit time) — the epoch table extends to both later.

--- a/SPEC.md
+++ b/SPEC.md
@@ -147,6 +147,16 @@ token** → allowed domains/zones. Contract-relevant invariants:
   served without contacting parapet, so parapet's authoritative WAF does not
   re-run on hits (only origin-opted-in public content is cached). See
   [EDGE.md](EDGE.md#response-cache-at-the-edge).
+- **Cache purge (edge-only, design)** — invalidation is **pulled** from the
+  control plane (`GET`/`POST /v1/purges`, a per-edge-scoped journal + cursor),
+  mirroring cert/WAF distribution; no inbound port on the edge. Lazy **epoch**
+  invalidation (global / host / url-keyed-on-`host⊕uri`) is checked at lookup —
+  chosen because the on-disk hash mixes primary+`Vary` variance, so a URL's
+  variants can't be enumerated for eager deletion. Epochs use the **edge's own
+  clock** at apply time (no trusted CP timestamp; the cursor makes apply
+  idempotent); a background reaper reclaims disk. Scopes: exact-URL (all
+  variants), whole-host/zone, flush-all. Edge-only — no Go mirror, no conformance
+  obligation. See [EDGE.md](EDGE.md#purge--invalidation).
 
 ## Configuration (environment variables)
 


### PR DESCRIPTION
Specifies the edge response-cache **purge / invalidation API** design — **docs only, no implementation**. Marked **(design)**; the edge proxy is migrating to Go, and the implementation will follow there.

## What's in this PR
- **EDGE.md** — new *Purge / invalidation* section under *Response cache*: the `GET`/`POST /v1/purges` contract (per-edge-scoped journal + cursor, `flush_required`), the lazy-epoch invalidation model (global / host / url-keyed-on `host⊕uri`), edge-clock epochs + cursor-based idempotency, the background reaper, fail modes, and a Phase 5 entry marked **(design)**.
- **SPEC.md** — an edge-divergence bullet recording the contract: pull-based, lazy epochs, three scopes (exact-URL all-variants, whole-host/zone, flush-all). Edge-only — no `go/` mirror, no conformance obligation.

## Scope notes
- **Design only.** No code. Scopes covered: exact-URL (all variants), whole-host/zone, flush-all. Path-prefix and Cache-Tag purge are explicitly deferred.
- The earlier Rust prototype of this (edge consumer + Go control-plane journal/endpoints) is **dropped** — the edge proxy is moving to Go, so the implementation will be redone there against this spec.
- Rebased clean on current `main`; does not disturb the HTTP/2 `Cookie`-reassembly section added in #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)