### PR TITLE
fix(edge): gate readiness on a loaded cert (it was always ready)

### DIFF
--- a/go/cmd/edge-proxy/main.go
+++ b/go/cmd/edge-proxy/main.go
@@ -164,6 +164,7 @@ func main() {
 	}
 
 	health := healthz.New()
+	health.SetReady(false) // healthz defaults to ready; gate it on a usable cert below
 
 	// Shared middleware chain (both listeners use it). Order mirrors the
 	// controller: host normalization, then WAF (global, then host-bound zone)


### PR DESCRIPTION
## Bug

The Go edge's readiness probe (`GET /healthz?ready=1`) reported **Ready even when it had loaded no cert**.

`parapet`'s `healthz.New()` defaults `ready=1`, and `cmd/edge-proxy` only ever called `SetReady(true)` (never `SetReady(false)`). So in **pinned mode** (`EDGE_DOMAINS` set) with the control plane **unreachable at startup**, the edge stayed at the default-ready state — the LoadBalancer would route traffic to an edge that can only serve the self-signed fallback (clients get cert errors). The "readiness flips green after the first cert load" intent never actually gated anything.

## Fix

Call `health.SetReady(false)` right after `healthz.New()` (matching the controller's pattern). Readiness then flips true only via the existing paths:
- **serve-all** (`EDGE_DOMAINS` empty): ready immediately (certs are fetched on demand per SNI).
- **pinned**: ready once the initial or periodic cert refresh lands a cert.

Liveness (`GET /healthz`) is unchanged — 200 while the process is up, 503 during graceful drain.

## Verification (ran the binary)

| scenario | liveness | readiness |
|---|---|---|
| serve-all (`EDGE_DOMAINS=""`) | 200 | **200** |
| pinned, control plane down (no cert) | 200 | **503** |
| pinned, cert loaded | 200 | 200 (the e2e path) |

Before the fix, the pinned-CP-down case returned readiness **200** (the bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)