### PR TITLE
docs(edge): draft auto-trust-edge spec (EDGE-AUTOTRUST.md)

### DIFF
--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -7,7 +7,8 @@
 > core. It builds on the edge architecture in [`EDGE.md`](EDGE.md). Per
 > [`CLAUDE.md`](CLAUDE.md), the behavior contract changes in [`SPEC.md`](SPEC.md)
 > first; on acceptance, the contract bits (the trust predicate, the new env vars,
-> the per-request order) fold into `SPEC.md` and the architecture into `EDGE.md`.
+> the new `POST /v1/edge-cert` endpoint, the per-request order) fold into `SPEC.md`
+> and the architecture into `EDGE.md`.
 
 ## The problem
 
@@ -56,25 +57,31 @@ comes from*.
 Authenticate the **edge → core hop with mutual TLS**. Trust follows a private key,
 not a source IP.
 
-1. **A dedicated, single-purpose edge CA.** Created once (cert-manager self-signed
-   `Issuer` + CA `Certificate` `parapet-edge-ca`, or an operator-managed
-   self-signed CA). It signs **nothing else**, so "chains to this CA" means exactly
-   "is a sanctioned-edge credential." Its private key stays in-cluster; only leaf
-   cert+key ever reach an edge.
+1. **A dedicated, single-purpose edge CA.** Created once. It signs **nothing else**,
+   so "chains to this CA" means exactly "is a sanctioned-edge credential." Under
+   `EDGE_CA_MODE=direct` (the Docker-friendly default) the CA key **lives with the
+   control plane** (its own RBAC-locked Secret); under `EDGE_CA_MODE=cert-manager`
+   it stays inside cert-manager. Either way the key never reaches an edge — only
+   leaf certs do. See [Control-plane wiring](#control-plane-wiring-cp-issues-the-client-cert).
 
-2. **Each edge gets a short-lived client cert** from that CA (cert-manager
-   `Certificate`, `usages: [client auth]`, with a stable SPIFFE-style URI SAN
-   `spiffe://parapet.moonrhythm.io/edge/<name>` — a free, greppable per-edge
-   identity and a clean future SPIRE migration path). `renewBefore` is generous
-   (renew at ~⅓ lifetime) so renewal never races expiry.
+2. **Each edge gets a short-lived client cert with a stable URI SAN
+   `spiffe://parapet.moonrhythm.io/edge/<id>`.** By default the **control plane
+   issues it** over the edge's existing bearer-authenticated HTTPS channel — the
+   edge sends a CSR to `POST /v1/edge-cert`, the CP signs it with the in-cluster
+   edge CA and returns only the cert chain; the **private key never leaves the
+   edge**, and the **CP decides the SAN from the token identity** (ignoring any SAN
+   in the CSR), so a compromised edge cannot request a SAN it isn't entitled to.
+   cert-manager (a per-edge `Certificate`, `usages: [client auth]`) is a
+   **k8s-only alternative** for operators who already run it. Renewal is generous
+   (renew at ~⅓ lifetime *remaining*) so it never races expiry — see
+   [Edge wiring](#edge-wiring).
 
 3. **The edge presents it** on the re-encrypt hop. `edge/forward.go`'s
-   `EDGE_UPSTREAM_TLS=true` path gets a client cert via
-   `tls.Config.GetClientCertificate` — a **live disk-reading callback** (mtime
-   cached), *not* a one-shot `tls.X509KeyPair` at startup — so a cert-manager
-   renewal is picked up with **no edge restart**. A client cert can only ride TLS,
-   so edge trust is conferred **only on the core's `:443` listener**; the plaintext
-   `:80` listener can present none and is never mTLS-trusted.
+   `EDGE_UPSTREAM_TLS=true` path gets the client cert via
+   `tls.Config.GetClientCertificate` — a **live callback** reading the in-memory
+   cert, so a renewal is picked up with **no edge restart**. A client cert can only
+   ride TLS, so edge trust is conferred **only on the core's `:443` listener**; the
+   plaintext `:80` listener can present none and is never mTLS-trusted.
 
 4. **The core verifies it.** The `:443` `tls.Config` gets
    `ClientAuth = tls.VerifyClientCertIfGiven` (the cert is **optional** —
@@ -95,26 +102,87 @@ not a source IP.
 
    The SAN check is re-evaluated **per request** against an `atomic.Pointer`-held
    allow-set, so **dropping a SAN distrusts that edge within ~300 ms** — even on
-   existing keep-alive / HTTP-2 connections. That is the fast revocation lever.
+   existing keep-alive / HTTP-2 connections. That is the fast revocation lever, and
+   (per the security model) the *only* bound on a cert minted from a leaked token.
 
 ### Single source of truth (onboard in one place)
 
 The SAN allow-set is derived from the **same `edge-controlplane-tokens` Secret the
 control plane already authorizes against** (`edgecp.Authz`, `edgecp/authz.go`).
-Each edge's token entry carries (or deterministically derives) its SPIFFE SAN.
+The registry shape becomes `{ "<token>": { "id": "<edge-id>", "domains": [...] } }`,
+where `id` is an **explicit, separate opt-in grant** of a data-plane identity.
+
 **Onboarding/offboarding touches one registry:**
 
-- Adding a token → the control plane issues that edge its certs/WAF **and** the
-  core adds its SAN to the data-plane allow-set. Both planes converge from one
-  object, in ~300 ms, with no restart of either.
-- **Deleting a token = data-plane revoke**, closing the split-brain where revoking
-  only the control-plane token left the edge trusted on the data plane until its
-  cert expired.
+- Adding an entry with an `id` → the control plane issues that edge's data-plane
+  cert (stamping its SAN) **and** the core adds the same SAN to its allow-set.
+- **Deleting an entry = data-plane revoke** in ~300 ms, closing the split-brain
+  where revoking only the control-plane token left the edge trusted until its cert
+  expired.
 
-Operators who prefer separation may instead keep the SAN list in a standalone
-`parapet-edge-trust` Secret (`allowed-sans` key); the default wiring reads the
-token registry. `ca.crt` always lives in the trust Secret (it can hold several
-concatenated CAs to support rotation overlap).
+The SAN in the minted cert and the core's allow-set entry are byte-identical **by
+construction**, because both derive from the one registry via **one shared function
+in one package, imported by BOTH `cmd/edge-controlplane` (the signer) and
+`cmd/parapet-ingress-controller` (the core allow-set)** — never two independent
+`identityFor()` implementations (a split-brain bug waiting to happen: e.g. one side
+lowercasing the id, the other not, as `authz.go:27` already lowercases domains).
+Canonical form: `spiffe://parapet.moonrhythm.io/edge/<id>` where `<id>` is
+**lowercased, trimmed, NFC-normalized, and validated as a SPIFFE path segment** (no
+`/`, no whitespace, bounded length) — **rejected fail-closed at load time on BOTH
+sides** if invalid. A conformance test asserts CP-stamped-SAN == core-allow-set
+entry for a fixed registry fixture.
+
+The identity is **never auto-derived** from the token's domains or its mere
+presence: a serve-all (`"*"`) token gets **no** data-plane identity by default
+(widest blast radius), and an existing registry **migrates to no identity** for
+every token — preserving "feature off ⇒ identical to today." The add/delete
+reload-skew between the two planes (~one debounce each) is **fail-closed in both
+directions**: a SAN in the allow-set with no live cert is harmless; a minted cert
+whose SAN isn't yet trusted just degrades to untrusted. Both planes expose the
+registry generation/hash they last applied as a metric, so an operator can confirm
+convergence before declaring an edge trusted.
+
+## Deployment models: k8s edge vs Docker edge
+
+There are two edge deployment shapes, and the data-plane client cert must work for
+**both** with the same onboarding gesture ("provision one token"). The mechanism
+that makes the cert *arrive* differs:
+
+**k8s edge.** The edge runs as a Deployment in some cluster (its own or the core's).
+cert-manager is available, so a per-edge `Certificate` (issuer `parapet-edge-ca`,
+`usages: [client auth]`, URI SAN `spiffe://parapet.moonrhythm.io/edge/<id>`) is
+minted into a `kubernetes.io/tls` Secret and mounted; `edge/forward.go` reads it
+**live**. This is the cert-manager path — now a **k8s-only alternative**, not the
+default.
+
+**Docker edge (the motivating case).** The edge is a bare `docker run` on a VM / box
+near clients (`deploy/edge/run-edge-docker.sh`). Its **only required input is
+`EDGE_CP_TOKEN`** — no cert-manager, no CRDs, no file mounts, no manual renewal. It
+already pulls its public cert+key (`GET /v1/certs`) and WAF rules (`GET /v1/waf`)
+from the control plane on `EDGE_REFRESH_INTERVAL`, fail-static, keys in memory only.
+A cert-manager-mounted client cert is **impossible** here (there is no cert-manager
+and no Secret to mount), and a hand-mounted PEM re-introduces manual file management
+and manual renewal — exactly what the token-pull model removed for the public cert.
+
+**So the data-plane identity rides the SAME channel and loop the public cert already
+rides.** The control plane **issues** the edge its data-plane client cert over the
+existing bearer-authenticated HTTPS channel: `POST /v1/edge-cert` (see
+[Control-plane wiring](#control-plane-wiring-cp-issues-the-client-cert)), CSR in,
+signed chain out, on `EDGE_REFRESH_INTERVAL`, fail-static, key in memory only. This
+is **the primary mechanism**; cert-manager is the alternative for operators who
+already run it and want the CA key out of the CP (`EDGE_CA_MODE=cert-manager`).
+
+| | k8s edge | Docker edge |
+|---|---|---|
+| Public cert+key | `GET /v1/certs` (token-pull) | `GET /v1/certs` (token-pull) |
+| WAF rules | `GET /v1/waf` (token-pull) | `GET /v1/waf` (token-pull) |
+| **Data-plane client cert** | cert-manager Secret **or** `POST /v1/edge-cert` | **`POST /v1/edge-cert`** (only option — no cert-manager) |
+| Required edge input | token (+ optional mounted cert Secret) | **`EDGE_CP_TOKEN`, and nothing else** |
+| Renewal | cert-manager `renewBefore` / CP loop | CP loop (`EDGE_REFRESH_INTERVAL`) |
+
+The payoff is uniformity: the Docker edge's onboarding stays "add one token to the
+registry," and the same token edit that authorizes its key/WAF fetch also makes the
+CP issue its data-plane identity **and** adds that identity to the core's allow-set.
 
 ## Core wiring
 
@@ -178,7 +246,9 @@ off ⇒ identical to today). Reuse the generic `watchResource[*v1.Secret]` for
 `x509.NewCertPool().AppendCertsFromPEM`; a **non-empty input that yields zero certs
 is rejected** (keep last-good, log, bump `parapet_trust_reload_rejected_total`); a
 *deliberately empty* `ca.crt` means "mTLS disabled." On success, atomically `Store`
-**both** `clientCAs` and `trustPol` together so they can never disagree.
+**both** `clientCAs` and `trustPol` together so they can never disagree. A rejected
+reload keeps last-good **and alerts loudly** — a stale allow-set silently degrades
+every edge onboarded after the rejection.
 
 **Header hardening (a real gap today, not just for mTLS):** mount a middleware
 **first** in `main.go`'s `m` chain (before `ctrl`) that **unconditionally deletes**
@@ -190,37 +260,188 @@ stay governed by parapet's trust/distrust.)
 
 ## Edge wiring
 
-In `edge/forward.go` `NewForwarder`, on the re-encrypt path (`useTLS == true`),
-wire a client cert into the transport's `tls.Config`:
+The default data-plane identity is **CP-issued** (see
+[Control-plane wiring](#control-plane-wiring-cp-issues-the-client-cert)). A new
+`EDGE_DATAPLANE_MTLS` (bool, default false — off ⇒ anonymous re-encrypt, identical
+to today) turns it on; `EDGE_UPSTREAM_TLS=true` is a prerequisite (loud startup
+error if mTLS is on with TLS off, mirroring the existing https-endpoint guard at
+`main.go:52-56`; warn if mTLS is off while the upstream is core `:443`).
 
-- New `EDGE_UPSTREAM_CLIENT_CERT` / `EDGE_UPSTREAM_CLIENT_KEY` (PEM paths). When
-  both are set, set `tls.Config.GetClientCertificate` to a callback that reads the
-  cert+key from disk **live** (mtime-cached), so a cert-manager renewal on the
-  mounted Secret is picked up with no restart. Both unset ⇒ no client cert
-  (anonymous re-encrypt — back-compat with today).
-- `tls.Config.InsecureSkipVerify` stays for now (the edge does not yet verify the
-  core's server cert — see [open questions](#open-questions)).
+- **`edge/clientcert.go` (new)** — an in-memory `ClientCertStore`
+  (`atomic.Pointer[tls.Certificate]`) with a `GetClientCertificate` callback
+  returning the live (complete key+chain) cert, and an **all-or-nothing**
+  `Update(chainPEM, heldKey)` that `tls.X509KeyPair`-validates the new pair and
+  atomically swaps — **if validation fails, the prior pair is kept** (never clears
+  the pointer, never swaps in a broken cert). `GetClientCertificate` returns
+  last-good non-empty whenever possible; a never-loaded empty return is loud
+  (metric + log) and gates readiness — never a silent half-rotated (new-key/old-chain)
+  state.
+- **`edge/refresh.go`** — `RefreshEdgeCertOnce(cp, ccStore)` mirroring
+  `RefreshCertOnce`: generate an ephemeral key **into a local var** (not the live
+  store), build the CSR, `cp.FetchEdgeCert(...)`, on success `ccStore.Update(chain,
+  localKey)` as **one atomic unit**, on error fail-static (keep the in-memory cert,
+  log a warning). `RunEdgeCertRefresh(ctx, cp, ccStore, ...)` mirrors
+  `RunCertRefresh` but **renews on remaining-life/renew-before, not bare interval
+  equality**, with **aggressive backoff retries** (faster than the 300 s tick) as
+  expiry nears, adds **per-edge jitter** (the current `RunCertRefresh` has none, so
+  a co-booted fleet stays phase-locked — a thundering-herd risk on a signing
+  endpoint), and **honors the CP's `Retry-After`**.
+- **`edge/forward.go` `NewForwarder`** gains a `*ClientCertStore` param (nil ⇒
+  anonymous re-encrypt, back-compat); on `useTLS` it sets
+  `tlsConfig.GetClientCertificate = ccStore.GetClientCertificate`.
+  `InsecureSkipVerify` stays for now (the edge still doesn't verify the core's
+  server cert — see [open questions](#open-questions)).
+- **Readiness is fail-closed.** When `EDGE_DATAPLANE_MTLS=true`, the readiness gate
+  (`cmd/edge-proxy/main.go:197`) becomes
+  `(serveAll || store.Loaded()) && clientCert.Loaded()` — a hard AND that
+  **serve-all does NOT bypass** (the headline Docker serve-all edge must not go
+  ready with no client cert and silently run untrusted). First-boot issuance
+  failure keeps the edge **not-ready** (503), not serving-while-untrusted, with a
+  bounded background retry that flips ready when the first cert lands.
 
-In `cmd/edge-proxy/main.go` startup, emit a **loud** error if
-`EDGE_UPSTREAM_CLIENT_CERT` is set with `EDGE_UPSTREAM_TLS=false` (a client cert
-needs TLS), and a warning if the upstream is core `:443` with no client cert
-configured (a silent untrusted downgrade). The edge remains the first hop and sets
-**no** `TrustProxy`, so it keeps overwriting incoming `X-Forwarded-*` with the true
-client peer before forwarding — the **transitive-trust invariant** the core relies
-on.
+The edge remains the first hop and sets **no** `TrustProxy`, so it keeps
+overwriting incoming `X-Forwarded-*` with the true client peer before forwarding —
+the **transitive-trust invariant** the core relies on.
+
+## Control-plane wiring: CP issues the client cert
+
+The default data-plane identity is **CP-issued over the existing bearer channel**,
+CSR-based, so the private key **never leaves the edge**.
+
+### The issuance endpoint (`POST /v1/edge-cert`)
+
+New endpoint on `edgecp.Server.Handler()` (alongside `GET /v1/certs` / `GET
+/v1/waf`), in the exact style of EDGE.md's REST table:
+
+```
+POST /v1/edge-cert    Authorization: Bearer <token>
+  request body (application/json): {"csr_pem": "<PKCS#10 CSR, PEM>"}
+  200 {"chain_pem":"<leaf+edge-CA-intermediates PEM>", "not_after":"<RFC3339>", "serial":"<hex>"}
+       chain_pem : leaf-first (edge leaf + edge-CA intermediates); NO key — the key never leaves the edge
+       not_after / serial : surfaced for edge renewal scheduling + logging (parapet_edge_clientcert_not_after)
+       Cache-Control: no-store, Pragma: no-cache (per-edge identity; NO ETag/304 — fresh key each renewal)
+  400 (missing/malformed/oversized CSR, bad PEM, CSR signature fails verify, unsupported/over-large key type)
+  401 (no/invalid token)  403 (token has no edge data-plane identity grant)  405 (not POST)
+  413 (CSR body over the 16 KiB cap)  429 (per-token rate limit OR global signer saturation — Retry-After set)
+```
+
+It is the **only mutating endpoint** (everything else is `GET`). The CP returns
+**`chain_pem` only** (no key on the wire — the edge holds it). `Cache-Control:
+no-store` **and** `Pragma: no-cache` are set. **No ETag / `If-None-Match` / 304**: a
+fresh ephemeral key each renewal means a new public key → new leaf → new chain, so a
+304 could never legitimately fire and an erroneous one would silently freeze a cert
+toward expiry — renewal is driven **solely** by `not_after`/renew-before. Body
+capped at 16 KiB via `io.LimitReader`. Absent signer / `EDGE_CA_*` unset ⇒ the
+endpoint **404s** (fully backward-compatible, mirroring `waf == nil` → 404).
+
+**CSR flow** (reusing `edge/refresh.go` + `edge/cp.go` `CpClient`):
+
+1. **Edge — ephemeral key in memory.** Generate `ecdsa.GenerateKey(elliptic.P256())`
+   (default; `EDGE_CLIENTCERT_KEY_TYPE`) **into a local variable**. Never written to
+   disk — same posture as `CertStore` keys (`edge/certstore.go:26-27`).
+2. **Edge — build CSR.** `x509.CreateCertificateRequest` with a minimal template;
+   any hint SAN/CN is **irrelevant** (the CP overrides it). PEM-encode.
+3. **Edge — POST over the bearer channel.** New `CpClient.FetchEdgeCert(csrPEM)`
+   mirroring `FetchCert`/`FetchWaf`: POSTs `{"csr_pem":…}`, sets `Authorization:
+   Bearer <token>`, body-capped read, returns chain+not_after+serial on 200 / error
+   otherwise (caller is fail-static). `do()` is generalized to take method+body
+   (today it is GET-only).
+4. **CP — verify + sign** (`handleEdgeCert`, new): `bearer(r)` + `authz.Known(token)`
+   → 401; `authz.Identity(token)` → 403 if no grant; decode CSR; **whitelist the key
+   type/curve BEFORE verifying** (ECDSA P-256/P-384 or Ed25519 only; reject RSA →
+   400) so a `CheckSignature` DoS on an oversized key is impossible;
+   `csr.CheckSignature()` (mandatory, unconditional — an unsupported sig alg is a
+   hard 400, never a silent pass) → 400 on failure; then `Signer.Sign(csr.PublicKey,
+   authorizedSAN)`.
+5. **CP — return chain only.** 200 with `chain_pem` + `not_after` + `serial`.
+6. **Edge — assemble + hold atomically.** Pair the returned chain with the in-memory
+   key into a `tls.Certificate` (`tls.X509KeyPair`) and atomically store the
+   **complete** keypair+chain in `ClientCertStore`.
+7. **Edge — present via `GetClientCertificate`** per handshake — no restart, no file.
+
+### Signing: template, custody, rate-limiting
+
+All in `edgecp/` + `cmd/edge-controlplane`, reusing existing primitives.
+
+**`edgecp/server.go`.** New `handleEdgeCert` + `mux.HandleFunc("POST /v1/edge-cert",
+…)`. New `signer *Signer` field (nil ⇒ 404), wired by a `WithSigner(*Signer)`
+chaining method like `WithWAF`. **Absent signer ⇒ backward-compatible.**
+
+**`edgecp/signer.go` (new).** `Signer` holds the parsed edge CA cert + key; `Sign`
+builds the `x509.Certificate` template **from a zero value — never from the parsed
+CSR** — setting ONLY:
+
+- `SerialNumber`: a fresh 128-bit CSPRNG serial (`crypto/rand`), surfaced as `serial`.
+- `NotBefore = now - EDGE_CLIENTCERT_SKEW` (default 10m), `NotAfter = now + EDGE_CLIENTCERT_TTL`.
+- `KeyUsage = DigitalSignature`; `ExtKeyUsage = [x509.ExtKeyUsageClientAuth]` ONLY.
+- `URIs = [authorizedSAN]` derived from the token (the shared-derivation package).
+  **No DNSNames, no IPAddresses, no Subject/CN of significance.**
+- `BasicConstraintsValid = true, IsCA = false`.
+
+The CSR contributes **exactly one thing: `csr.PublicKey`**. The template
+**explicitly never** assigns `Subject`/`DNSNames`/`IPAddresses`/`EmailAddresses`/
+`URIs`/`Extensions`/`ExtraExtensions` from the CSR — getting this exactly right is
+the single highest-value invariant (a verifier matching a smuggled CN, a copied
+rogue SAN, or a carried-over `basicConstraints CA:true` would defeat the model).
+**Post-sign self-check:** re-parse the issued leaf and assert `IsCA==false`,
+`KeyUsage==DigitalSignature`, `ExtKeyUsage==[ClientAuth]`, `URIs==[authorizedSAN]`,
+`len(DNSNames)==len(IPAddresses)==0`; **refuse to return** a cert that fails any
+check (mirrors the `GetConfigForClient` self-test discipline). A conformance test
+feeds a CSR carrying `CA:true`, a rogue URI/DNS SAN, and a malicious CN and asserts
+none appear in the leaf.
+
+**`edgecp/authz.go` — per-edge identity (explicit opt-in).** Extend `Authz` with
+`identities map[string]string` (token → id) populated alongside `tokens` in
+`NewAuthz`, plus `Identity(token) (string, bool)`. The grant is **explicit and
+separate**, NOT auto-derived from the token's presence or its domains; `Identity`
+returns `("",false)` (→ 403) unless the operator set it. A serve-all (`"*"`) token
+**MUST NOT** get a default identity. Migration defaults every token to NO identity.
+
+**CA custody — `EDGE_CA_MODE`:**
+
+- **`direct` (default — Docker-friendly).** In-process `x509.CreateCertificate` with
+  the edge CA key from `EDGE_CA_CERT`/`EDGE_CA_KEY`. **No cert-manager dependency** —
+  the whole point for a bare Docker edge. The CA key is the new crown jewel and
+  **now lives with the CP**: store it in its **own** Secret in `POD_NAMESPACE` (NOT
+  co-located with tenant TLS keys), tightest RBAC (only the CP ServiceAccount),
+  behind the CP's edge-sources-only `NetworkPolicy`. **Hot-reload** the key/cert
+  from the watched Secret (validate-then-swap, fail-closed) — NOT load-once — so CA
+  rotation needs no CP restart. Constrain the edge CA with **NameConstraints**
+  limiting URI SANs to `spiffe://parapet.moonrhythm.io/edge/*` (and EKU clientAuth),
+  so even a stolen CA key can mint less. Emit a **loud startup log** that the CP now
+  holds a fleet-minting key.
+- **`cert-manager` (k8s-only alternative).** The CP proxies a cert-manager
+  `CertificateRequest` to an `Issuer`/`ClusterIssuer` and polls. The CA key stays
+  inside cert-manager (smaller CP blast radius) but adds a hard CRD dependency and an
+  async round trip, and does **not** work without cert-manager. **Strongly preferred
+  wherever cert-manager is present.**
+
+**`cmd/edge-controlplane/main.go`.** Load `EDGE_CA_CERT`/`EDGE_CA_KEY` (or
+cert-manager mode), build `Signer`, `server.WithSigner(signer)`. Gated on the env
+being set (absent ⇒ no signer ⇒ 404 ⇒ back-compat).
+
+**Rate-limiting + DoS.** A **per-token** token-bucket (`EDGE_CLIENTCERT_RATE`,
+default 10/min → 429) blunts a single-token forged-CSR flood. It does **nothing**
+against a fleet-wide restart storm (N different tokens), so add a **global signing
+concurrency cap** (a bounded worker pool / semaphore around `Signer.Sign`) returning
+**429/503 + `Retry-After`** when saturated. The authz reject and the **key-type
+whitelist run before** any signing, so an unauthorized or oversized-key flood costs
+no CA work. Keep the endpoint behind the CP's existing edge-sources-only
+`NetworkPolicy`.
 
 ## Security model
 
-**Trust boundary.** Exactly the edges holding a private key whose cert chains to
-the dedicated edge CA **and** whose URI SAN is in the live allow-set. The CA signs
-nothing else, so chain-to-CA = sanctioned-edge credential. Trust is
-**operator-asserted**: only an operator editing the registry Secret moves the
-boundary — never an edge action, never a token-writable self-registration. mTLS
-trust is conferred **only on `:443`**.
+**Trust boundary.** Exactly the edges holding a private key whose cert chains to the
+dedicated edge CA **and** whose URI SAN is in the live allow-set. The CA signs
+nothing else. Trust is **operator-asserted**: only an operator editing the registry
+Secret moves the boundary — never an edge action, never a token-writable
+self-registration. mTLS trust is conferred **only on `:443`**.
 
 **Spoofing.** A non-edge reaching `:443` **cannot forge trust**:
-`VerifiedChains` is populated only after the Go stack cryptographically verifies
-the presented cert against `ClientCAs`; forging requires the in-cluster CA key.
+`VerifiedChains` is populated only after the Go stack cryptographically verifies the
+presented cert against `ClientCAs`; forging requires the in-cluster CA key. And a
+compromised edge **cannot request a SAN it isn't entitled to** — the CP stamps the
+SAN from the bearer token's registry identity and ignores the CSR's SAN entirely.
 
 > **Honest scoping (read this).** mTLS authenticates the **connection, not the
 > headers.** A trusted edge — or anything wielding a stolen edge key — can still
@@ -230,183 +451,225 @@ the presented cert against `ClientCAs`; forging requires the in-cluster CA key.
 > shipped `TRUST_PROXY: cloudflare` default, a non-edge from a Cloudflare CIDR
 > reaching `:443` is CIDR-trusted with no cert. So **never add edge egress CIDRs to
 > `TRUST_PROXY`** (mTLS is the edge path), and lock **both** core data-plane ports
-> with a `NetworkPolicy` to the edge/Cloudflare source set (today only the control
-> plane has one — `deploy/edge/controlplane.yaml`). Defense-in-depth so a stolen
-> edge key isn't usable from the open internet, and so "just add a CIDR" is never
-> the operational fix.
+> with a `NetworkPolicy` to the edge/Cloudflare source set.
 
-**Replay.** None on the data plane — the cert is proven inside a live mTLS
-handshake (ephemeral keys, transcript signing), not a replayable bearer credential.
-Residual risk is **key theft**, bounded by short cert lifetime + per-request SAN
-revocation.
+**Replay.** None on the data plane — the cert is proven inside a live mTLS handshake
+(ephemeral keys, transcript signing), not a replayable bearer credential.
+
+> **Token-minted certs outlive token revocation.** A leaked-but-not-yet-revoked
+> token POSTed to `/v1/edge-cert` mints a self-contained TLS credential the core
+> verifies cryptographically for its full TTL. Revoking the token stops *future*
+> issuance but does **not** revoke an already-minted cert — only **dropping the
+> registry entry** (which drops its SAN from the live allow-set, re-checked per
+> request) revokes it, within ~300 ms. Therefore: (1) the leaked-token runbook is
+> **"delete the registry entry,"** never "rotate only the token"; (2)
+> `EDGE_CLIENTCERT_TTL` is kept short to shrink the window; (3) **CP-issuance is
+> INCOMPATIBLE with `EDGE_TRUST_REQUIRE_SAN=false`** (CA-only mode) — the per-request
+> SAN check is the *only* bound on such a cert, so the CP MUST refuse to issue
+> and/or the core MUST refuse CA-only when the same edge CA backs issuance.
 
 **Blast radius.** A leaked edge client key lets the holder spoof XFF **as that one
-edge** until its SAN is dropped (~300 ms) or its cert expires. It leaks **no**
-server TLS private key (a separate control-plane credential). The **crown jewel is
-the edge CA key** (mints any edge) — kept in-cluster only, never shipped,
-single-purpose, rotated only on CA compromise.
+edge** until its SAN is dropped (~300 ms) or its cert expires. It leaks **no** server
+TLS private key. The **crown jewel is the edge CA key** (mints any edge). Under
+`EDGE_CA_MODE=direct` it **lives with the control plane** — a deliberate,
+design-acknowledged escalation from the CP's prior posture (it distributed tenant
+*leaf* keys; it now holds a *CA* that forges fleet-wide edge trust). Mitigated by: a
+**single-purpose** CA, **NameConstraints** capping URI SANs to
+`spiffe://parapet.moonrhythm.io/edge/*`, the key in its **own** tightly-RBAC'd
+in-cluster Secret (never the tenant-cert Secret, never shipped — only the chain
+leaves the cluster), **hot-reload** for restart-free rotation, short
+`EDGE_CLIENTCERT_TTL`, per-request SAN revocation, and the
+`EDGE_CA_MODE=cert-manager` alternative that keeps the CA key out of the CP. A
+future HSM/KMS signer interface can keep the raw key out of pod memory. CA-key
+compromise is handled by the overlap rotation runbook with a metric interlock.
 
 **Fail-default: fail-closed, degrading to the static CIDR branch.** A missing trust
 Secret ⇒ `trustPol` nil ⇒ mTLS branch always false ⇒ edges distrusted (degraded but
 safe — identical to the pre-mechanism world), Cloudflare CIDR unaffected, startup
 warning logged. An empty/garbage `ca.crt` on reload ⇒ validate-then-swap **rejects**
-and keeps last-good, so a fat-fingered edit can't silently distrust the whole fleet.
-**No path fails open.**
+and keeps last-good. First-boot issuance failure ⇒ edge **not-ready** (never
+serve-while-untrusted). **No path fails open.**
 
-**The explicit tradeoff.** This forces re-encrypt TLS (`EDGE_UPSTREAM_TLS=true`) and
-a PKI lifecycle (CA, per-edge certs, renewal) the plaintext `:80` default avoided,
-and an **expired edge cert hard-fails the handshake** (502s) rather than degrading.
-Accepted: a cryptographic, IP-independent, per-edge-revocable identity is worth the
-`renewBefore` discipline and the network backstop.
+**The explicit tradeoff.** This forces re-encrypt TLS (`EDGE_UPSTREAM_TLS=true`), a
+PKI lifecycle, and the CA key living with the CP (direct mode). An **expired edge
+cert hard-fails the handshake** (502s); the CP-outage budget (= `TTL` ×
+renew-before-fraction) must exceed the operator's CP recovery SLO. Accepted: a
+cryptographic, IP-independent, per-edge-revocable identity that makes a bare Docker
+edge work with nothing but a token is worth the discipline.
 
 ## Fail modes
 
 | Failure | Behavior |
 |---|---|
 | Trust Secret absent / never created | mTLS branch false for all (`trustPol` nil); edges distrusted (XFF overwritten → WAF/limits/GeoIP see edge IP); core serves; Cloudflare CIDR unaffected. **Fail-closed, degraded-not-down.** Startup warning + `parapet_trust_source{none}`. |
-| `ca.crt` edited to empty/garbage on reload | Validate-then-swap: non-empty input yielding zero certs **rejected**, last-good kept, `parapet_trust_reload_rejected_total++`, error logged. A *deliberately* empty `ca.crt` = "mTLS disabled." Never fails open. |
-| Edge client cert expired / not yet renewed | `VerifyClientCertIfGiven` **aborts the handshake** → edge `:443` connection fails (502s), harsher than a missing cert. Mitigated by generous `renewBefore`, live `GetClientCertificate` reload (no restart), NTP sync, alerting on edge 502s + cert `notAfter`. |
-| Edge on plaintext `:80` but operator expected trust | No client cert on `:80`; `r.TLS == nil`; edge distrusted (CIDR-only, and edges have no stable CIDR). Made loud: edge errors if `EDGE_UPSTREAM_CLIENT_CERT` set with TLS off; `parapet_trust_source{none}` alerts. |
-| Per-edge revocation (SAN-drop) | **Fast path.** SAN re-checked per request against the live atomic allow-set → distrusts within ~300 ms even on existing keep-alive/HTTP-2 connections. The routine revocation lever. |
-| CA-drop revocation latency | `VerifiedChains`/`ClientCAs` are consulted only at **handshake**. Dropping a CA takes effect on **new** handshakes only; existing connections keep their verified chain until they close. True bound = max connection lifetime, not 300 ms. Mitigate: prefer SAN-drop for routine revoke; cap `:443` connection age; reserve CA-drop for CA-key compromise. |
-| Split-brain: token revoked but trust lingers | Closed by single-sourcing the SAN allow-set from `edge-controlplane-tokens` — deleting a token removes its SAN. In *separation* mode (standalone `allowed-sans`), revoking only the CP token leaves the edge trusted until its cert expires (documented). |
-| Edge CA private key leaked | Attacker mints trusted edges until CA rotation. Highest severity. Mitigated by in-cluster-only key, single-purpose CA, and the overlap rotation runbook with a metric interlock (confirm every expected SAN is trusted under the new CA before dropping the old). |
-| `GetConfigForClient` returns nil / omits `ClientAuth`/`GetCertificate` | Guarded: base config built non-nil before `Serve()`; callback returns last-good on error, never nil; startup self-test asserts `GetCertificate` + `ClientCAs` + `ClientAuth==VerifyClientCertIfGiven`. Prevents a self-inflicted cert-serving break or silent mTLS disable. |
-| Forged-cert flood on `:443` | Each forged cert is rejected at the TLS handshake before reaching a handler; the per-request trust check is a cheap slice-len + map lookup behind an already-verified chain — no per-request crypto amplification. `NetworkPolicy` bounds who can attempt handshakes at all. |
+| `ca.crt` edited to empty/garbage on reload | Validate-then-swap: non-empty input yielding zero certs **rejected**, last-good kept, `parapet_trust_reload_rejected_total++`, **loud alert** (a stale allow-set silently degrades edges onboarded after). A *deliberately* empty `ca.crt` = "mTLS disabled." Never fails open. |
+| Edge client cert expired / not yet renewed | `VerifyClientCertIfGiven` **aborts the handshake** → edge `:443` connection 502s. Mitigated by short-TTL + generous renew-before, live `GetClientCertificate` reload, NTP sync, alerting on `parapet_edge_clientcert_not_after`. |
+| Edge on plaintext `:80` but operator expected trust | No client cert on `:80`; `r.TLS == nil`; edge distrusted (CIDR-only). Made loud: edge errors if `EDGE_DATAPLANE_MTLS` set with TLS off; `parapet_trust_source{none}` alerts. |
+| Per-edge revocation (registry-entry delete) | **Fast path.** SAN re-checked per request against the live atomic allow-set → distrusts within ~300 ms even on existing connections. The routine revocation lever. |
+| CA-drop revocation latency | `VerifiedChains`/`ClientCAs` are consulted only at **handshake**. Dropping a CA takes effect on **new** handshakes only; existing connections keep their verified chain until they close. Mitigate: prefer SAN-drop; cap `:443` connection age; reserve CA-drop for CA-key compromise. |
+| Edge CA private key leaked (direct mode) | Attacker mints trusted edges until CA rotation. **Highest severity.** Mitigated by the own-Secret + tightest-RBAC custody, NameConstraints, the cert-manager alternative (key out of CP), and the overlap rotation runbook with a metric interlock. |
+| `GetConfigForClient` returns nil / omits `ClientAuth`/`GetCertificate` | Guarded: base config built non-nil before `Serve()`; callback returns last-good, never nil; startup self-test asserts the three properties. |
+| CP-issuance endpoint unreachable / CP down | Edge keeps its last-good in-memory client cert (**fail static**); core `:443` handshakes keep succeeding. Renewal retries with aggressive backoff as expiry nears. Only if the CP stays down PAST `NotAfter` does the handshake hard-502. Outage budget = `TTL` × renew-before-fraction. |
+| Leaked-but-not-yet-revoked token replayed to `/v1/edge-cert` | Mints a cert for ITS OWN SAN, cryptographically valid for the full TTL. Token revocation does NOT revoke it — **only deleting the registry entry** drops its SAN (re-checked per request → distrusted ~300 ms). Runbook: delete the registry entry. Bounded by short `EDGE_CLIENTCERT_TTL`. |
+| CP-issuance enabled with `EDGE_TRUST_REQUIRE_SAN=false` (CA-only) | **Refused — fail-closed.** CA-only trusts any chain to the edge CA with no per-request SAN check, so a leaked-token-minted cert would stay trusted for the full TTL. The CP refuses to issue and/or the core refuses CA-only; startup error names the conflict. |
+| Malformed / oversized-key / unsupported-alg CSR (DoS probe) | 16 KiB body cap (413) bounds bytes; the **key-type/curve whitelist rejects (400) BEFORE `CheckSignature`** so an oversized-RSA verify-DoS is impossible. `CheckSignature` is mandatory; an unsupported sig alg is a hard 400. authz + reject precede any CA signing. |
+| Fleet-wide re-issue storm (rollout / node drain / CP recovery) | Per-token rate limit does NOT help (N tokens). A **global signing concurrency cap** returns 429/503 + `Retry-After`; the edge honors it with backoff; the edge refresh loop adds **jitter** (unlike the public-cert loop) so a co-booted fleet does not stay phase-locked. |
+| CP signs with a CA the core's `ClientCAs` does not yet trust (rotation skew) | Freshly-issued certs fail verification at the core → 502s. Prevented by the overlap invariant: the new CA must be in the core's `ClientCAs` bundle (concatenated CAs allowed) BEFORE the CP signs with it; the old CA stays until the metric interlock confirms every edge re-issued. CP hot-reloads the CA so rotation needs no restart. |
+| Clock skew: core clock behind the CP by > `EDGE_CLIENTCERT_SKEW` | A fresh cert is "not yet valid" at the core → handshake aborts → 502s, self-healing once skew elapses. The validator is the **core** clock. Mitigated by the configurable NotBefore backdating (default 10m), a hard NTP-sync prerequisite between CP and core pods, and a distinct notBefore/notAfter handshake-failure metric. |
+| First-boot issuance fails under `EDGE_DATAPLANE_MTLS=on` (CP down at startup) | **Fail-CLOSED on readiness:** edge stays not-ready (503), is NOT routed to, does not serve-while-untrusted. Bounded background retry flips ready when the first cert lands. Readiness `= (serveAll || store.Loaded()) && clientCert.Loaded()` — serve-all does NOT bypass. Availability tradeoff documented; CP HA recommended. |
+| `ClientCertStore.Update` gets an unparseable / mismatched chain | All-or-nothing: `tls.X509KeyPair(chain, heldKey)` failing keeps the PRIOR complete pair (never clears the pointer, never swaps in a broken cert), logs + bumps a rejection metric. Never a silent half-rotated state. |
 
 ## Configuration
 
 | Variable | Where | Default | Meaning |
 |---|---|---|---|
-| `TRUST_PROXY` | core | `cloudflare` (per `deploy/deployment.yaml`) | **Unchanged.** Static CIDR list / `cloudflare`/`true`/`false`. Becomes the `cidrTrust` OR-branch; coexists with mTLS trust. **Never add edge egress CIDRs here.** |
-| `EDGE_TRUST_SECRET` | core | `""` (feature **off**, fully backward-compatible) | Name of the Secret in `POD_NAMESPACE` carrying `ca.crt` (edge CA PEM bundle). `edge-controlplane-tokens` for single-source mode, or a dedicated `parapet-edge-trust` for separation mode. Unset ⇒ no trust watch, mTLS disabled, identical to today. |
-| `EDGE_TRUST_REQUIRE_SAN` | core | `true` | When true, trust requires the verified leaf's URI SAN to be in the live allow-set — enables per-edge revocation. When false, any cert chaining to the dedicated edge CA is trusted (CA-only mode, zero per-edge core edits, but single-edge revocation needs a CA rotation). |
-| `EDGE_UPSTREAM_TLS` | edge | `false` | **Unchanged.** Must be `true` for mTLS trust (a client cert needs TLS); selects `edge/forward.go`'s re-encrypt path. mTLS trust is opt-in per edge. |
-| `EDGE_UPSTREAM_CLIENT_CERT` / `EDGE_UPSTREAM_CLIENT_KEY` | edge | `""` / `""` | PEM paths to the edge's client cert+key, loaded **live** via `GetClientCertificate` (disk reload on renewal, no restart). Both unset ⇒ anonymous re-encrypt (back-compat). Set with `EDGE_UPSTREAM_TLS=false` ⇒ loud startup error. |
+| `TRUST_PROXY` | core | `cloudflare` | **Unchanged.** Static CIDR list / `cloudflare`/`true`/`false`. Becomes the `cidrTrust` OR-branch. **Never add edge egress CIDRs here.** |
+| `EDGE_TRUST_SECRET` | core | `""` (feature **off**) | Name of the Secret in `POD_NAMESPACE` carrying `ca.crt` (edge CA PEM bundle). `edge-controlplane-tokens` (single-source) or a dedicated `parapet-edge-trust` (separation). Unset ⇒ mTLS disabled, identical to today. |
+| `EDGE_TRUST_REQUIRE_SAN` | core | `true` | Trust requires the verified leaf's URI SAN ∈ the live allow-set (enables per-edge revocation). When false (CA-only), any chain to the edge CA is trusted. **Incompatible with CP-issuance: the per-request SAN check is the ONLY bound on a cert minted from a leaked bearer token (token revocation does not revoke a minted cert). When the same edge CA backs issuance, the CP MUST refuse to issue and/or the core MUST refuse CA-only — fail-closed.** |
+| `EDGE_DATAPLANE_MTLS` | edge | `false` | Enable the CP-issued data-plane client cert (CSR → `POST /v1/edge-cert`, presented via `GetClientCertificate`). Off ⇒ anonymous re-encrypt, identical to today. Requires `EDGE_UPSTREAM_TLS=true` (loud error otherwise). When on, readiness is gated on the client cert (fail-closed). |
+| `EDGE_CLIENTCERT_KEY_TYPE` | edge | `ecdsa-p256` | Key type for the in-memory ephemeral keypair (the key that never leaves the edge). `ecdsa-p256`/`p384`/`ed25519` — matches the CP's accepted-key whitelist. RSA is not offered (bounds the CP's CSR-verify DoS surface). |
+| `EDGE_CA_CERT` | CP | `""` | PEM path to the edge CA certificate (its OWN Secret, not the tenant-cert Secret). The same CA the core loads as `ClientCAs`. Hot-reloaded. Unset ⇒ no signer ⇒ `POST /v1/edge-cert` 404 (feature off). |
+| `EDGE_CA_KEY` | CP | `""` | PEM path to the edge CA **private** key (direct mode). The new crown jewel living with the CP — its OWN tightly-RBAC'd Secret, never shipped. Hot-reloaded. A loud startup log warns the CP holds a fleet-minting key. Ideally NameConstrained. |
+| `EDGE_CA_MODE` | CP | `direct` | `direct` = in-process `x509.CreateCertificate` (no cert-manager — the Docker-friendly default). `cert-manager` = proxy a `CertificateRequest` (k8s-only; CA key stays in cert-manager; CRD dependency + async). Prefer `cert-manager` where present. |
+| `EDGE_CLIENTCERT_TTL` | CP | `1h` | Issued cert lifetime. Short — renewal is free over the loop — to bound a leaked-token-minted cert. Outage budget = `TTL` × renew-before-fraction; raise (e.g. 24–72h) if outage tolerance matters more than mint-window shrinkage (call out the tension). |
+| `EDGE_CLIENTCERT_SKEW` | CP | `10m` | NotBefore backdating slack. The cert is minted on the CP clock but **validated on the core clock** at the handshake. NTP sync between CP and core pods is a hard prerequisite. A distinct core-side notBefore/notAfter failure metric surfaces a skew regression. |
+| `EDGE_CLIENTCERT_RATE` | CP | `10/min` | Per-token issuance rate limit (429 over cap). A **global** signing concurrency cap (worker pool around `Signer.Sign`, 429/503 + `Retry-After`) is separate and necessary — the per-token limit does nothing against a fleet-wide restart storm. |
+| `EDGE_UPSTREAM_CLIENT_CERT` / `EDGE_UPSTREAM_CLIENT_KEY` | edge | `""` / `""` | **cert-manager / mounted-Secret (k8s-only) path**, superseded as the default by `EDGE_DATAPLANE_MTLS` + CP-issuance. PEM paths to a mounted client cert+key, live-reloaded from disk. Use for the k8s-edge mount case. |
+| `EDGE_UPSTREAM_TLS` | edge | `false` | **Unchanged.** Must be `true` for mTLS trust. Selects the re-encrypt path. |
 | `EDGE_UPSTREAM_SNI` | edge | `""` | **Unchanged.** SNI/`ServerName` presented to the core on re-encrypt. |
 
-New metrics: `parapet_trust_source{mtls|cidr|none}` (per request, so an operator can
-confirm an edge is trusted via `mtls` and catch a silent CIDR/none fallback) and
-`parapet_trust_reload_rejected_total`.
+Metrics: `parapet_trust_source{mtls|cidr|none}` and `parapet_trust_reload_rejected_total`
+(core); `parapet_edge_clientcert_loaded` (0/1) and `parapet_edge_clientcert_not_after`
+(edge). Both planes also expose the registry generation/hash they last applied, so an
+operator can confirm convergence before declaring an edge trusted.
 
 ## Onboarding flow (the payoff)
 
-1. **One-time:** create the dedicated edge CA; put its PEM in the trust Secret
-   (`ca.crt`) in `POD_NAMESPACE`. Roll the core **once** to pick up the new code.
-   *This is the only restart, ever — never again per-edge.*
-2. **Per edge — mint identity:** a cert-manager `Certificate` (issuer
-   `parapet-edge-ca`, `usages: [client auth]`, URI SAN
-   `spiffe://parapet.moonrhythm.io/edge/<name>`) → a `kubernetes.io/tls` Secret in
-   the edge's namespace.
-3. **Per edge — register once:** add the edge's entry to
-   `edge-controlplane-tokens` (token → domains, plus its SPIFFE SAN). This single
-   edit makes the control plane authorize the edge **and** adds the SAN to the
-   core's allow-set — both planes converge, ~300 ms, no restart.
-4. **Configure the edge Deployment:** `EDGE_UPSTREAM_TLS=true`, `EDGE_UPSTREAM_ADDR`
-   → core `:443`, `EDGE_UPSTREAM_CLIENT_CERT`/`KEY` mounted from the cert Secret.
-5. **Deploy.** The edge re-encrypts to `:443` with its client cert; the core
-   verifies the chain + SAN and **immediately honors its `X-Forwarded-*`** — no
-   `TRUST_PROXY` edit, no core restart. Confirm via `parapet_trust_source{mtls}`.
-6. **Revoke (fast):** drop the edge's entry (and SAN) from the registry → distrusted
-   within ~300 ms, even on live connections. For a leaked **CA** key, use the
-   overlap rotation runbook.
+1. **One-time:** create the dedicated edge CA. Under `EDGE_CA_MODE=direct`, put its
+   cert + key in their **own** RBAC-locked Secret for the CP (`EDGE_CA_CERT` /
+   `EDGE_CA_KEY`) and its cert in the core's trust Secret (`ca.crt`); under
+   `cert-manager`, create the `Issuer`. Roll the core and CP **once** to pick up the
+   new code. *This is the only restart, ever — never again per-edge.*
+2. **Per edge — grant a data-plane identity (one registry edit, no cert-manager).**
+   Add the edge's entry to `edge-controlplane-tokens` with an explicit `id` (its
+   SPIFFE identity opt-in). This single edit (a) authorizes its cert/WAF fetch, (b)
+   makes the CP **issue** its data-plane client cert on `POST /v1/edge-cert` over the
+   existing bearer channel — key generated in the edge's memory, never mounted, never
+   renewed by hand — and (c) adds its SAN `spiffe://…/edge/<id>` to the core's live
+   allow-set. *(k8s-only alternative: mint a cert-manager `Certificate`, mount the
+   Secret, set `EDGE_CA_MODE=cert-manager` + `EDGE_UPSTREAM_CLIENT_CERT`.)*
+3. **Configure the edge:** `EDGE_DATAPLANE_MTLS=true`, `EDGE_UPSTREAM_TLS=true`,
+   `EDGE_UPSTREAM_ADDR` → core `:443`. For a Docker edge that's it — **no client-cert
+   file mounts**; its only input across all of this stays `EDGE_CP_TOKEN`.
+4. **Deploy.** The edge generates a keypair in memory, fetches its cert from the CP,
+   re-encrypts to `:443` presenting it; the core verifies the chain + SAN and
+   **immediately honors its `X-Forwarded-*`** — no `TRUST_PROXY` edit, no core
+   restart. Confirm via `parapet_trust_source{mtls}` and `parapet_edge_clientcert_loaded`.
+5. **Revoke:** **delete the edge's registry entry** → its SAN leaves the allow-set →
+   distrusted within ~300 ms, even on live connections (deleting only the token does
+   NOT revoke an already-minted cert). For a leaked **CA** key, use the overlap
+   rotation runbook.
 
 ## Phasing
 
-1. **Phase 1 — ship fast, reuse existing machinery.** cert-manager dedicated edge
-   CA + per-edge `Certificate`s mounted as Secrets. Core: the per-request closure,
-   `GetConfigForClient` hot-swapping `ClientCAs` over a **separate** atomic from the
-   SNI cert table, the `EDGE_TRUST_SECRET` watch (validate-then-swap, keep-last-good),
-   `EDGE_TRUST_REQUIRE_SAN=true` with SANs single-sourced from
-   `edge-controlplane-tokens`, the unconditional `X-Forwarded-Country/-ASN` strip,
-   and the new metrics. Edge: `EDGE_UPSTREAM_CLIENT_CERT/KEY` via live
-   `GetClientCertificate` + startup guards. `NetworkPolicy` locking core `:80`/`:443`
-   to edge/Cloudflare sources. **No parapet-framework changes, no control-plane
-   changes.**
-2. **Phase 2 — stronger, optional drop-in** (mirrors EDGE.md's bearer→mTLS framing):
-   the control plane **mints** the edge client cert and serves it over the existing
-   bearer channel (`GET /v1/edge-cert`, signed by the in-cluster edge CA, authorized
-   by the same token) so onboarding becomes "the CP issues the edge its identity"
-   with one fewer operator-managed Secret. Optionally make the hop **mutually**
-   authenticated (edge pins the core CA, drop `InsecureSkipVerify`). Optionally add
-   CRL/OCSP via `tls.Config.VerifyConnection` if revocation must beat
-   cert-lifetime + SAN-drop. Optionally migrate the SPIFFE-style SANs to real SPIRE
-   SVIDs (naming already aligns).
+1. **Phase 1 — the primary mechanism (makes a bare Docker edge work, no cert-manager).**
+   Core: the per-request closure, `GetConfigForClient` hot-swap over a **separate**
+   atomic from the SNI cert table, the `EDGE_TRUST_SECRET` watch
+   (validate-then-swap, keep-last-good, alert-on-reject), `EDGE_TRUST_REQUIRE_SAN=true`
+   single-sourced, the unconditional `X-Forwarded-Country/-ASN` strip, the metrics.
+   **Plus CP-issuance:** `POST /v1/edge-cert`, `edgecp/signer.go` (zero-value template
+   + post-sign self-check + key-type whitelist), `Authz.Identity`, the **shared SAN
+   derivation package** imported by both binaries, `EDGE_DATAPLANE_MTLS` edge wiring
+   with atomic key+chain swap, jitter, fail-closed readiness, the global signing
+   concurrency cap. The cert-manager mount path
+   (`EDGE_CA_MODE=cert-manager` / `EDGE_UPSTREAM_CLIENT_CERT`) ships **alongside** as
+   the k8s-only alternative. `NetworkPolicy` locking core `:80`/`:443` to
+   edge/Cloudflare sources.
+2. **Phase 2 — stronger hardening.** Mutual auth of the hop (edge pins the core CA,
+   drop `InsecureSkipVerify`); CRL/OCSP via `tls.Config.VerifyConnection` if
+   revocation must beat TTL + SAN-drop; an HSM/KMS `Signer` interface so the raw edge
+   CA key need not sit in CP pod memory; real SPIRE SVID migration (the SAN naming
+   already aligns).
 3. **Phase 3 — optional companion.** A `TRUST_PROXY_DYNAMIC=true` ConfigMap-of-CIDRs
    OR-branch for callers that genuinely cannot present a client cert (a known
-   in-cluster plaintext `:80` caller), covering the `EDGE_UPSTREAM_TLS=false` gap
-   with an operator-asserted CIDR — same atomic + validate-then-swap discipline,
+   in-cluster plaintext `:80` caller) — same atomic + validate-then-swap discipline,
    never panic on the watch path.
 
 ## Alternatives considered
 
-- **Token-gated `TrustProxy` (HMAC-over-timestamp header, single-sourced from the
-  token registry).** The judge panel's narrow co-leader, and the strongest on
-  operational single-source-of-truth — which is why we **grafted** that strength
-  (the SAN allow-set comes from the same `edge-controlplane-tokens` Secret).
-  Rejected as the *primary* mechanism on security: the credential is a request
-  **header** whose placement the attacker controls (vs a TLS-layer property they
-  cannot synthesize); on a sniffable private path a captured token is replayable for
-  the skew window; the **strip-before-upstream** middleware is order-fragile and
-  load-bearing; HMAC verification is an O(N) CPU-amplification vector under a forged
-  header flood; and it adds a **clock-skew** failure mode. mTLS has none of these.
-  *If the operator prefers the lower-PKI-overhead path, this is the fallback —
-  reopen the decision here.*
-- **Dynamic IP trust list (ConfigMap of CIDRs, hot-reloaded).** Lowest effort; we
-  graft its **operator-asserted-trust** principle, its rejection of token-writable
-  self-registration, its never-panic/keep-last-good discipline, and its
-  trust-source observability. Rejected as primary: it does **not raise the security
-  bar** — anything sharing a trusted CIDR can spoof XFF, and for NAT'd/dynamic edges
-  the natural pattern (trust the whole egress CIDR) *widens* the spoof surface. Kept
+- **CP mints key+cert and ships both (vs CSR-based).** Simpler on the edge (no
+  in-process keygen/CSR), and the only viable fallback if some edge runtime cannot do
+  x509 keygen. **Rejected as the default — strictly weaker:** it puts a *private key
+  on the wire*, re-introducing exactly the key-transits-the-channel exposure the cert
+  path otherwise avoids. The CSR form keeps the key edge-local (generated in memory;
+  only the public key + returned chain transit) for **no** added operator burden, and
+  the CP-decides-SAN property holds in both forms.
+- **Token-gated `TrustProxy` (HMAC-over-timestamp header).** A near-tie co-leader on
+  operational single-source-of-truth — which is why we **grafted** that strength (the
+  SAN allow-set comes from the same registry). Rejected as the *primary* mechanism on
+  security: the credential is a request **header** whose placement the attacker
+  controls; it is replayable for the skew window; the strip-before-upstream middleware
+  is order-fragile; HMAC verification is an O(N) CPU-amplification vector; and it adds
+  a clock-skew failure mode. mTLS has none of these.
+- **Dynamic IP trust list (ConfigMap of CIDRs).** Lowest effort; we graft its
+  operator-asserted-trust principle and keep-last-good discipline. Rejected as primary:
+  it does **not raise the security bar** — anything sharing a trusted CIDR can spoof
+  XFF — and for NAT'd/dynamic edges the natural pattern widens the spoof surface. Kept
   as the optional Phase 3 companion for the `:80` gap.
 - **SPIFFE/SPIRE workload identity (mTLS SVID).** Strongest in theory, operationally
-  disqualifying now: an out-of-cluster edge can't use in-cluster `k8s_psat`
-  attestation, so it needs SPIRE federation / nested SPIRE — a hard runtime
-  dependency, a concentrated CA-compromise target, and a *second* continuously
-  rotating CA bundle whose staleness breaks the data plane. Onboarding would touch
-  three systems. We graft only its **URI-SAN naming** (free, future-proof) and leave
-  a Phase 2 migration path.
-- **CA-only mTLS (no SAN check, `EDGE_TRUST_REQUIRE_SAN=false`).** The "gold
-  standard" for zero core-side edits — issuing the cert is the whole onboarding.
-  **Kept as a supported mode** but not the default: it makes single-edge revocation
-  impossible without a whole-CA rotation. Defaulting `require-SAN=true` restores
-  ~300 ms per-edge revocation for a one-line registry edit, which single-sourcing
-  makes free.
+  disqualifying now: an out-of-cluster edge can't use in-cluster attestation, so it
+  needs SPIRE federation — a hard runtime dependency and a second rotating CA bundle
+  whose staleness breaks the data plane. We graft only its **URI-SAN naming** and
+  leave a Phase 2 migration path.
+- **CA-only mTLS (`EDGE_TRUST_REQUIRE_SAN=false`).** Supported for **non-issuance**
+  deployments (issuing the cert is the whole onboarding) but **forbidden in
+  combination with CP-issuance**: CA-only trusts any chain to the edge CA, so a cert
+  minted from a leaked token before revocation would stay trusted for the full TTL
+  with no per-request revocation lever — resurrecting exactly the split-brain
+  single-sourcing closes.
 
 ## Open questions
 
-- **Registry shape:** single-source mode couples the data-plane trust schema to the
-  CP token-registry JSON (it must carry a per-token SPIFFE SAN). Store the SAN
-  explicitly, or derive it deterministically from the token/edge name?
-- **Phase 2 issuance:** CP-minted client certs (collapses onboarding, keeps the key
-  off persistent storage, but expands the CP's role and couples the two channels)
-  vs cert-manager-mounted Secrets — worth the coupling?
-- **Plaintext `:80` for edges:** forbid edge traffic on `:80` entirely (route edges
-  only to `:443`, eliminating the silent `EDGE_UPSTREAM_TLS=false` → untrusted
-  downgrade), or keep `:80` purely for known CIDR-trusted in-cluster callers via the
-  Phase 3 companion?
+- **`EDGE_CLIENTCERT_TTL` default — the mint-window vs CP-outage-budget tension:** a
+  short TTL (1h) shrinks a leaked-token-minted cert's life but cuts the outage budget
+  (= `TTL` × renew-before-fraction) before an expired cert hard-502s the edge. Pin a
+  default that exceeds the operator's CP recovery SLO, or expose `TTL` + renew-before
+  as paired knobs with a guard that renew-before < `TTL` by a safe margin?
+- **`EDGE_CA_MODE=cert-manager` async issuance:** the CP proxies a `CertificateRequest`
+  and polls — what poll timeout / failure handling keeps `POST /v1/edge-cert`
+  responsive (503 + `Retry-After` and let the edge fail-static, or block up to a
+  bound)? Does it also need the global signing concurrency cap, or does cert-manager's
+  own queue suffice?
+- **HSM/KMS signer interface for direct mode:** should `Signer.Sign` be an interface so
+  the raw edge CA key need not sit in CP pod memory (the highest-severity blast
+  radius), and is a KMS round-trip per issuance acceptable against the
+  fleet-restart-storm concurrency budget?
+- **Key reuse across a graceful restart:** should the edge re-use a surviving
+  in-memory key across a restart, or accept that every restart = one fresh
+  keygen+CSR+sign (given keys are never written to disk)? Is the per-restart signature
+  cost acceptable at fleet scale once the global cap + jitter are in place?
 - **Mutual auth of the hop:** should the edge verify the core's server cert (pin the
   core CA, drop `InsecureSkipVerify` in `forward.go`)? Today only edge→core is
   authenticated.
-- **Revocation target:** is SAN-drop (~300 ms) + short cert lifetimes enough, or does
-  the deployment need CRL/OCSP via `VerifyConnection`?
 - **Connection-age cap on `:443`:** what max lifetime balances draining stale-CA
   connections (for CA-drop revocation) against handshake churn? The default
-  `IdleTimeout` 320 s lets a busy connection outlive a CA drop indefinitely without
-  an explicit cap.
+  `IdleTimeout` 320 s lets a busy connection outlive a CA drop without an explicit cap.
 - **Multi-CA `ca.crt` parsing:** confirm `AppendCertsFromPEM` over a concatenated
-  bundle adds every valid block and that one malformed block doesn't silently drop
-  the good CAs — validate-then-swap must treat a partially-bad bundle as a **rejected**
-  reload, not a partial install.
+  bundle adds every valid block and that one malformed block doesn't silently drop the
+  good CAs — validate-then-swap must treat a partially-bad bundle as a **rejected**
+  reload.
 
 ## Conformance / contract
 
 On acceptance, fold into [`SPEC.md`](SPEC.md): the trust predicate
-(`cidrTrust OR (verified-edge-CA-chain AND SAN ∈ allow-set)`), the new env vars
-(`EDGE_TRUST_SECRET`, `EDGE_TRUST_REQUIRE_SAN`, `EDGE_UPSTREAM_CLIENT_CERT/KEY`),
-the `X-Forwarded-Country/-ASN` ingress strip, and the per-request order (trust
-evaluation precedes WAF/rate-limit, as today). The Rust implementation in
-[`rust/`](rust/) tracks the same contract or records a divergence.
+(`cidrTrust OR (verified-edge-CA-chain AND SAN ∈ allow-set)`), the new
+`POST /v1/edge-cert` endpoint (CSR in, chain out; CP-decided SAN; no key on the
+wire), the new env vars (`EDGE_TRUST_SECRET`, `EDGE_TRUST_REQUIRE_SAN`,
+`EDGE_DATAPLANE_MTLS`, `EDGE_CLIENTCERT_*`, `EDGE_CA_*`), the shared SAN-derivation
+package + its CP-SAN == core-allow-set conformance test, the `X-Forwarded-Country/-ASN`
+ingress strip, and the per-request order (trust evaluation precedes WAF/rate-limit,
+as today). The Rust implementation in [`rust/`](rust/) tracks the same contract or
+records a divergence.
 
 [TLS SNI fallback memory]: the proxy serves a self-signed fallback on an SNI miss
 when the live cert table loses `GetCertificate`; the `GetConfigForClient` self-test

--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -5,16 +5,18 @@
 > trust a newly-deployed **edge** proxy (`cmd/edge-proxy` + [`edge/`](edge/))
 > automatically — without an operator editing `TRUST_PROXY` and restarting the
 > core. It builds on the edge architecture in [`EDGE.md`](EDGE.md). Per
-> [`CLAUDE.md`](CLAUDE.md), the behavior contract changes in [`SPEC.md`](SPEC.md)
-> first; on acceptance, the contract bits (the trust predicate, the new env vars,
-> the `POST /v1/edge-cert` + tokenless `GET /v1/trust-bundle` endpoints, the
-> per-request order) fold into `SPEC.md` and the architecture into `EDGE.md`.
-> **No cert-manager dependency:** a run-once bootstrap Job self-manages the edge CA.
-> **The core no longer watches a k8s Secret for trust material; it pulls a CP-issued
-> trust bundle over verified server-TLS.** The CP is the single authority for the
-> SAN allow-set — there is no shared SAN-derivation package imported by both
-> binaries. **The serving control plane is stateless across N identical replicas
-> behind its Service (no leader election).**
+> [`CLAUDE.md`](CLAUDE.md), the contract changes in [`SPEC.md`](SPEC.md) first.
+> **Trust is CA-only:** the core trusts an edge iff `cidrTrust(r) OR a verified TLS
+> chain to the dedicated edge CA` — a pure cryptographic predicate, no SAN
+> allow-set, no per-request map read. Issuance stays token-gated; *trust* is
+> chain-to-CA. **No cert-manager** (a run-once bootstrap Job self-manages the edge
+> CA). The core pulls a tokenless trust bundle from the CP over verified server-TLS.
+> The serving CP is **stateless across N replicas** (no leader election).
+>
+> **Headline consequence:** *revocation is now CA rotation.* There is no per-edge
+> trust lever; revoking one edge re-keys the fleet's shared CA. Leaf TTL is **7
+> days**, so a compromised edge stays trusted until the rotation completes
+> (operator-driven minutes-to-low-hours) — **not seconds, and not 7 days**.
 
 ## The problem
 
@@ -22,932 +24,655 @@ The edge sits in front of the core and sets `X-Forwarded-For` / `X-Forwarded-Pro
 (and, with a GeoIP DB, `X-Forwarded-Country` / `X-Forwarded-ASN`) so the core's WAF,
 per-IP rate limits, GeoIP, and access logs see the **real client**, not the edge.
 For the core to honor those headers, the edge's source must be in the core's
-**trust list** — today the `TRUST_PROXY` env var (a CIDR list, or the literal
-`cloudflare`).
+**trust list** — today the `TRUST_PROXY` env var (a CIDR list, or `cloudflare`).
 
-`TRUST_PROXY` is read **once at startup**
-(`cmd/parapet-ingress-controller/main.go:214-237`), compiled into a
-`parapet.Conditional`, and frozen for the life of the process. So adding or
-replacing an edge means:
+`TRUST_PROXY` is read **once at startup** (`main.go:214-237`), compiled into a
+`parapet.Conditional`, and frozen. So adding/replacing an edge means editing that
+env **and restarting the core pod** — and the CIDR model is brittle for
+out-of-cluster, NAT'd, autoscaling edges.
 
-1. Edit `TRUST_PROXY` to add the new edge's source CIDR, **and**
-2. **restart the core pod** to pick it up.
-
-Two problems, not one. The restart is operationally painful (it's the cluster's
-ingress front door). And the CIDR model is brittle for the edge's actual topology:
-edges run *outside* the cluster, reaching it over a tunnel / peered VPC, often
-**NAT'd or autoscaling**, so the source IP the core sees is unstable and is not a
-good identity.
-
-> **Why trust is security-critical (not just plumbing).** parapet's inbound proxy
-> layer calls `TrustProxy(r)` **per request** (parapet `proxy.go`). Trusted →
-> honor the incoming `X-Forwarded-*`. Untrusted → overwrite them with the
-> immediate peer IP. So "trust everyone" is not an option: any source the core
-> trusts can **spoof `X-Forwarded-For`** to bypass IP-based WAF rules and per-IP
-> rate limits, and poison GeoIP/logs. Auto-trust must therefore mean *trust
-> exactly the sanctioned edges*, and that set must be **hot-reloadable**.
+> **Why trust is security-critical.** parapet calls `TrustProxy(r)` **per request**
+> (`proxy.go`). Trusted → honor the incoming `X-Forwarded-*`. Untrusted → overwrite
+> with the peer IP. Any source the core trusts can **spoof `X-Forwarded-For`** to
+> bypass IP WAF rules / per-IP rate limits and poison GeoIP/logs. Auto-trust must
+> mean *trust exactly the sanctioned edges*, hot-reloadably.
 
 ## The key enabler
 
-`parapet.Conditional` is `func(r *http.Request) bool`, evaluated **per request**
-(parapet `proxy.go` `ServeHTTP` → `m.Trust(r)` → `trust`/`distrust`). A closure
-installed **once** at startup can read an `atomic.Pointer` to a live trust policy
-that is **hot-swapped** from the trust bundle the core pulls from the control plane
+`parapet.Conditional` is `func(r *http.Request) bool`, evaluated **per request**.
+A closure installed **once** can read an `atomic.Pointer` to a live trust policy
+that is **hot-swapped** from the trust bundle the core pulls from the CP
 (`GET /v1/trust-bundle`), via the same validate-then-swap discipline the edge's
-`CpClient` fetch loop uses (`edge/cp.go`, `edge/refresh.go`) — fail-static,
-all-or-nothing, never rebuilding the route mux. **No restart.** The question is only
-*what credential the edge presents* and *how the core learns the live trust policy*
-— and the answer to the latter is now a tokenless CP pull, not a Secret watch.
+`CpClient` uses (`edge/cp.go`, `edge/refresh.go`) — fail-static, all-or-nothing,
+never rebuilding the route mux. **No restart.** The question is only *what
+credential the edge presents* and *how the core learns the live trust policy*.
 
-## Recommended design: edge mTLS (client-cert-as-trust)
+## Recommended design: edge mTLS (CA-only)
 
 Authenticate the **edge → core hop with mutual TLS**. Trust follows a private key,
 not a source IP.
 
-1. **A dedicated, single-purpose edge CA.** Created once and reused forever; it
-   signs **nothing else**, so "chains to this CA" means exactly "is a sanctioned-edge
-   credential." By default (**managed** mode) a **run-once bootstrap Job generates
-   the CA once and persists it**; the serving CP only **reads** it and signs — no
-   cert-manager, no out-of-band openssl. For orgs with an existing PKI, **provided**
-   mode lets the operator mount their own CA (`EDGE_CA_CERT`/`EDGE_CA_KEY`) and the
-   CP uses it without generating. Either way the key never reaches an edge — only
-   leaf certs do. See [Control-plane wiring](#control-plane-wiring-cp-issues-the-client-cert).
+1. **A dedicated, single-purpose edge CA.** Created once and reused; it signs
+   **nothing else**, so "chains to this CA" means exactly "is a sanctioned-edge
+   credential." By default (**managed** mode) a **run-once bootstrap Job** generates
+   it and persists it; the serving CP only **reads** it and signs. **provided** mode
+   lets an operator mount their own CA. The key never reaches an edge — only leaf
+   certs do. See [Control-plane wiring](#control-plane-wiring-cp-issues-the-client-cert).
 
-2. **Each edge gets a short-lived client cert with a stable URI SAN
-   `spiffe://parapet.moonrhythm.io/edge/<id>`.** The **control plane issues it** over
-   the edge's existing bearer-authenticated HTTPS channel — the edge sends a CSR to
-   `POST /v1/edge-cert`, the CP signs it with the edge CA and returns only the cert
-   chain; the **private key never leaves the edge**, and the **CP decides the SAN
-   from the token identity** (ignoring any SAN in the CSR), so a compromised edge
-   cannot request a SAN it isn't entitled to. Renewal is generous (renew at ~⅓
-   lifetime *remaining*) so it never races expiry — see [Edge wiring](#edge-wiring).
+2. **The CP issues each edge a leaf** over the bearer channel — the edge sends a CSR
+   to `POST /v1/edge-cert`, the CP signs it with the edge CA and returns only the
+   chain; the **private key never leaves the edge**. The CP stamps a URI SAN
+   (`spiffe://parapet.moonrhythm.io/edge/<id>`), **but the SAN is kept only for
+   non-trust uses** (`X-Forwarded` upstream identity, WAF zone, audit) and is
+   **never consulted for trust** — a mis-stamped, stale, or over-broad SAN can never
+   widen the trust boundary.
 
-3. **The edge presents it** on the re-encrypt hop. `edge/forward.go`'s
-   `EDGE_UPSTREAM_TLS=true` path gets the client cert via
-   `tls.Config.GetClientCertificate` — a **live callback** reading the in-memory
-   cert, so a renewal is picked up with **no edge restart**. A client cert can only
-   ride TLS, so edge trust is conferred **only on the core's `:443` listener**; the
-   plaintext `:80` listener can present none and is never mTLS-trusted.
+3. **The edge presents it** on the re-encrypt hop (`EDGE_UPSTREAM_TLS=true`) via a
+   live `GetClientCertificate` callback. A client cert can only ride TLS, so edge
+   trust is conferred **only on `:443`**; plaintext `:80` is never mTLS-trusted.
 
 4. **The core verifies it.** The `:443` `tls.Config` gets
-   `ClientAuth = tls.VerifyClientCertIfGiven` (the cert is **optional** —
-   Cloudflare-direct and browser traffic present none and complete the handshake
-   unchanged) and a `ClientCAs` pool sourced from the trust bundle the core pulls
-   from the CP's `GET /v1/trust-bundle` (no longer a watched Secret — see
-   [Core wiring](#core-wiring)). The standard library cryptographically verifies any
-   presented client cert (with `ExtKeyUsageClientAuth`) against `ClientCAs` during
-   the handshake and, on success, populates `r.TLS.VerifiedChains`. A
-   presented-but-unverifiable cert **aborts the handshake**.
+   `ClientAuth = tls.VerifyClientCertIfGiven` (the cert is optional — Cloudflare /
+   browsers present none) and a `ClientCAs` pool sourced from the trust-bundle
+   `ca_pem`. The stdlib populates `r.TLS.VerifiedChains` only after cryptographic
+   verification against `ClientCAs`; a presented-but-unverifiable cert aborts the
+   handshake.
 
 5. **The per-request trust predicate** (installed once; see [Core wiring](#core-wiring)):
 
    ```
-   trust(r) :=  cidrTrust(r)                                  // existing TRUST_PROXY (e.g. cloudflare)
-            OR ( len(r.TLS.VerifiedChains) > 0                // a chain verified to the edge CA, AND
-                 AND leafURISAN(r) ∈ liveAllowSet )           // its SAN is in the live allow-set
+   trust(r) := cidrTrust(r)                         // existing TRUST_PROXY (e.g. cloudflare)
+            OR len(r.TLS.VerifiedChains) > 0        // a chain cryptographically verified to the edge CA
    ```
 
-   The SAN check is re-evaluated **per request** against an `atomic.Pointer`-held
-   allow-set fed by the CP long-poll, so **dropping a registry entry distrusts that
-   edge within one debounce of the CP recompute** (sub-second normally; bounded by
-   `EDGE_TRUST_CP_POLL_INTERVAL` worst-case if a long-poll wake is missed — see
-   [Freshness](#freshness-long-poll-not-bare-poll)). The predicate itself is
-   unchanged; only the *feed* moves.
+   The edge CA signs nothing but edge leaves, so a verified chain **is** the trust
+   grant — a single non-empty check, no SAN lookup, no allow-set, no operator-asserted
+   string set in the per-request path.
 
-### Single source of truth (onboard in one place)
+### Single source of truth (onboard in one place); the SAN is not load-bearing
 
-Onboarding/offboarding touches one registry, `edge-controlplane-tokens`, whose shape
-becomes `{ "<token>": { "id": "<edge-id>", "domains": [...] } }`, where `id` is an
-**explicit, separate opt-in grant** of a data-plane identity. Adding an entry with an
-`id` → the CP issues that edge's cert (stamping its SAN) **and** publishes the same
-SAN in the allow-set; **deleting an entry = data-plane revoke** within the
-convergence bound below.
+Onboarding still touches one registry, `edge-controlplane-tokens`, shape
+`{ "<token>": { "id": ..., "domains": [...], "disabled": bool } }`. The `id` is
+still stamped into the leaf SAN — but **only for labeling/audit/WAF-zone
+attribution**. An over-broad or wrong `id` is now an *audit* issue, not a
+trust-widening. Removing the only operator-asserted string set from the per-request
+trust path **eliminates the silent fleet-wide trust-widening risk** of an over-broad
+allow-set — a strict safety improvement, at the cost of coarser (fleet-wide)
+revocation granularity (see [Revocation](#revocation--ca-rotation)).
 
-The SAN allow-set is now computed in **exactly one place — the control plane**, by
-the same `identityFor(id) -> spiffe://parapet.moonrhythm.io/edge/<id>` derivation
-`Signer.Sign` uses to stamp the URI SAN into every issued leaf. The core no longer
-derives anything: it *receives* the live `allowed_sans` already computed, over `GET
-/v1/trust-bundle`. So CP-stamped-SAN == broadcast-allow-set-entry holds **by
-construction within one process**, not across a cross-binary boundary — the prior
-shared-package-imported-by-both-binaries hack and its split-brain risk are **gone**,
-not papered over with a conformance test. Canonical form is unchanged: `<id>`
-**lowercased, trimmed, NFC-normalized, validated as a SPIFFE path segment** (no `/`,
-no whitespace, bounded length), **rejected fail-closed at load time** if invalid. A
-serve-all (`"*"`) token gets **no** identity by default; an existing registry
-migrates to no identity for every token (feature off ⇒ identical to today).
-
-**This single-sourcing also removes the only independent cross-check**, so the CP's
-allow-set correctness is now wholly load-bearing for the trust boundary: an
-over-broad allow-set is a silent fleet-wide trust-widening with no second opinion.
-Two guards replace the deleted cross-binary check (see [Conformance](#conformance--contract)):
-(a) an **intra-process** test asserting `identityFor()` output == the SAN
-`Signer.Sign` stamps for a fixed fixture; (b) a **revocation** test asserting a
-known-dropped id is **absent** from a freshly-computed `allowed_sans`. `allowed_sans`
-MUST be recomputed from the **same registry snapshot** that authorizes
-`/v1/edge-cert` at that generation, and the generation is bumped only **after** the
-new allow-set is computed. The core logs/metrics the **size + hash** of every
-accepted allow-set (`parapet_trust_allowed_sans_count`, `parapet_trust_bundle_hash`)
-so an unexpected widening is alertable.
+The CP no longer derives or broadcasts an allow-set; the core no longer derives
+anything. The cross-binary `identityFor` derivation, the "sole uncross-checked
+authority" risk, and the SAN cross-check conformance test all disappear because the
+only thing the core verifies is a cryptographic chain.
 
 ## Deployment models: k8s edge vs Docker edge
 
-There are two edge deployment shapes, and the data-plane client cert must work for
-**both** with the same onboarding gesture ("provision one token"). The cert always
-arrives the same way — the CP issues it via `POST /v1/edge-cert`; only how the edge
-is packaged differs:
+The data-plane client cert works for **both** shapes with the same gesture
+("provision one token"); it always arrives via `POST /v1/edge-cert`.
 
-**k8s edge.** The edge runs as a Deployment in some cluster (its own or the core's).
-The data-plane client cert rides `POST /v1/edge-cert` exactly as for Docker. An
-operator who already runs cert-manager and wants to *mount* a client cert can still
-do so via the legacy `EDGE_UPSTREAM_CLIENT_CERT`/`_KEY` file path — a mount detail on
-the edge, **not a CA mode on the CP**. cert-manager is no longer part of this design.
+**k8s edge.** Runs as a Deployment. cert-manager is no longer part of this design;
+an operator who already runs it can still *mount* a client cert via the legacy
+`EDGE_UPSTREAM_CLIENT_CERT`/`_KEY` path — a mount detail, not a CA mode.
 
-**Docker edge (the motivating case).** The edge is a bare `docker run` on a VM / box
-near clients (`deploy/edge/run-edge-docker.sh`). Its **only required input is
-`EDGE_CP_TOKEN`** — no cert-manager, no CRDs, no file mounts, no manual renewal. It
-already pulls its public cert+key (`GET /v1/certs`) and WAF rules (`GET /v1/waf`)
-from the control plane on `EDGE_REFRESH_INTERVAL`, fail-static, keys in memory only.
-The data-plane identity rides the **same channel and loop**: `POST /v1/edge-cert`,
-CSR in, signed chain out, key in memory only.
+**Docker edge (the motivating case).** A bare `docker run`; its **only required
+input is `EDGE_CP_TOKEN`**. It already pulls its public cert+key (`GET /v1/certs`)
+and WAF rules (`GET /v1/waf`) from the CP, fail-static, keys in memory only. The
+data-plane identity rides the same loop: `POST /v1/edge-cert`, key in memory only.
 
 | | k8s edge | Docker edge |
 |---|---|---|
-| Public cert+key | `GET /v1/certs` (token-pull) | `GET /v1/certs` (token-pull) |
-| WAF rules | `GET /v1/waf` (token-pull) | `GET /v1/waf` (token-pull) |
-| **Data-plane client cert** | `POST /v1/edge-cert` (mounted-cert file path optional) | **`POST /v1/edge-cert`** |
-| Required edge input | token (+ optional mounted cert Secret) | **`EDGE_CP_TOKEN`, and nothing else** |
-| Renewal | CP loop (`EDGE_REFRESH_INTERVAL`) | CP loop (`EDGE_REFRESH_INTERVAL`) |
+| Public cert+key / WAF | `GET /v1/certs` / `GET /v1/waf` | same |
+| **Data-plane client cert** | `POST /v1/edge-cert` (mounted-cert optional) | **`POST /v1/edge-cert`** |
+| Required edge input | token (+ optional mounted cert) | **`EDGE_CP_TOKEN`, and nothing else** |
 
 ## Core wiring
 
-In `cmd/parapet-ingress-controller/main.go`, replace the one-shot `trustProxy`
-block (`:214-237`) — but keep the existing static parse **verbatim** into a fixed
-local `cidrTrust` (`"true"` → `parapet.Trusted()`; `"false"`/`""` → nil; else
-`parapet.TrustCIDRs(list)` with the `predefinedCIDRs["cloudflare"]` expansion). Add a
-trust-policy holder owned by the controller:
+In `main.go`, replace the one-shot `trustProxy` block (`:214-237`). Keep the static
+parse **verbatim** into a fixed local `cidrTrust`. Add a single atomic:
 
 ```go
-type trustPolicy struct{ allowedSANs map[string]struct{} }
-var trustPol   atomic.Pointer[trustPolicy]
-var clientCAs  atomic.Pointer[x509.CertPool]
+var clientCAs atomic.Pointer[x509.CertPool]   // the only trust state in the core
 ```
 
-Install **one** closure, assigned to **both** servers' `TrustProxy` field:
+(There is **no** `trustPolicy`/`trustPol`/`allowedSANs` — those are deleted.)
+Install **one** closure, assigned to **both** servers' `TrustProxy`:
 
 ```go
 trustProxy = func(r *http.Request) bool {
-    if cidrTrust != nil && cidrTrust(r) { return true }       // metric: cidr
-    if r.TLS == nil || len(r.TLS.VerifiedChains) == 0 { return false } // metric: none
-    p := trustPol.Load(); if p == nil { return false }
-    if requireSAN { return sanAllowed(r.TLS.PeerCertificates[0], p.allowedSANs) }
-    return true // CA-only mode (EDGE_TRUST_REQUIRE_SAN=false) — forbidden with CP-issuance
+    if cidrTrust != nil && cidrTrust(r) { return true }               // metric: cidr
+    if r.TLS == nil || len(r.TLS.VerifiedChains) == 0 { return false } // metric: none / not-:443
+    return true                                                        // verified chain to the edge CA == trust
 }
 ```
 
-`sanAllowed` matches the leaf's URI SANs *exactly* against the allow-set. The `:80`
-server's `r.TLS == nil` short-circuits the mTLS branch, leaving CIDR-only.
-**Only the *feed* into `trustPol`/`clientCAs` changes — from a k8s Secret watch to a
-CP long-poll (next section). The per-request closure, the two atomics, `sanAllowed`,
-and the `GetConfigForClient` hot-swap + self-test below are all identical to the
-Secret-watch design.**
-
-**Hot-swap `:443` `ClientCAs` without clobbering the SNI cert table** (unchanged).
-Set, once, before `Serve()`:
-
-```go
-base.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
-    c := base.Clone()
-    c.ClientCAs = clientCAs.Load()   // fresh per handshake; never nil
-    return c, nil                    // carries GetCertificate = ctrl.GetCertificate (live), ClientAuth, fallback
-}
-```
-
-`GetConfigForClient` must be non-nil before `Serve()` and never return nil (last-good
-on error). A startup **self-test** asserts the served config carries `GetCertificate`
-+ `ClientCAs` + `ClientAuth == VerifyClientCertIfGiven`. The bytes into `clientCAs`
-just arrive from the CP now.
+`sanAllowed`, the `requireSAN` branch, and `trustPol.Load()` are gone. Keep the `:80`
+`r.TLS == nil` short-circuit (CIDR-only on plaintext) and the `GetConfigForClient`
+hot-swap (`c.ClientCAs = clientCAs.Load()`, fresh per handshake, never nil) +
+startup self-test (asserts `GetCertificate` + `ClientCAs` +
+`ClientAuth == VerifyClientCertIfGiven`) **verbatim**. Only the *feed* into
+`clientCAs` changes; trust no longer reads any per-request map.
 
 ### The trust pull (tokenless CP client)
 
 Gated by `EDGE_TRUST_CP_ENDPOINT != ""` (default off ⇒ identical to today). There is
-**no 6th k8s watcher** — `controller_trust.go` and the `watchResource[*v1.Secret]`
-trust invocation are gone. Instead a new tokenless `TrustCpClient` (a new small file,
-e.g. `trust/client.go`) mirrors `edge/cp.go`'s `CpClient` minus the `Authorization`
-header: `http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}` whose
-`tlsConfig.RootCAs` is built from `EDGE_TRUST_CP_CA` via
-`x509.NewCertPool().AppendCertsFromPEM`. `FetchTrustBundle(sinceGen, etag)` builds
-`base + "/v1/trust-bundle?watch=1&since=<sinceGen>"`, sets `If-None-Match`,
-body-capped `json.Decode` into `{generation, ca_pem, allowed_sans}`, returns
-`Unchanged` on 304 and an error on any non-200/304 (caller fail-statics).
+**no k8s watcher** for trust. A tokenless `TrustCpClient` (new file, e.g.
+`trust/client.go`) mirrors `edge/cp.go`'s `CpClient` minus the `Authorization`
+header. `FetchTrustBundle(sinceGen, etag)` builds
+`base + "/v1/trust-bundle?watch=1&since=<sinceGen>"`, decodes
+`{generation, ca_pem, ca_id}` (no `allowed_sans`), returns `Unchanged` on 304.
 
-**Deliberate inversion of `edge/cp.go`:** that client silently ignores an unparseable
-CA and falls back to system roots (`edge/cp.go:42-47`); for the trust channel that is
-**forbidden**. A missing / empty / unreadable / unparseable `EDGE_TRUST_CP_CA`, or an
-`AppendCertsFromPEM` that adds **zero** certs, is a **FATAL startup error** when
-`EDGE_TRUST_CP_ENDPOINT` is set. `InsecureSkipVerify` is **never** set; a startup
-self-test asserts `tlsConfig.RootCAs != nil && !tlsConfig.InsecureSkipVerify` (carry a
-code comment naming this inversion so a future client-unification refactor cannot
-re-introduce the fallback). A non-`https://` endpoint is rejected fatally — **no
-plaintext analog, ever** (contrast the edge data plane's `EDGE_CP_ALLOW_PLAINTEXT`).
-Server-cert **identity**, not merely chain-to-CA, is the boundary: `EDGE_TRUST_CP_CA`
-SHOULD be a **dedicated single-purpose CA that signs only the CP server cert**; the
-client verifies the CP cert hostname against the endpoint host (Go's default
-`ServerName`-from-dial-host, never loosened); a shared org CA is loud-warned.
+A single long-poll goroutine, on a good 200: **strict all-or-nothing parse** of
+`ca_pem` into an `x509.CertPool` — reject a non-empty input that yields *fewer*
+certs than blocks present (never a partial `AppendCertsFromPEM`, never a system-roots
+fallback; keep last-good, bump `parapet_trust_reload_rejected_total`); **reject any
+bundle whose `generation <=` held** (forward-only, `parapet_trust_rollback_rejected_total`);
+then atomically `Store` `clientCAs`. **The strict parse now applies during rotation
+too** — a truncated/garbled NEW block in the `OLD ++ NEW` overlap bundle must be
+rejected (keep last-good), never half-applied, so a bad NEW block blocks the rotation
+loudly rather than silently dropping NEW (which would 502 just-re-minted edges).
 
-A single **long-poll refresh goroutine** (mirroring `RunCertRefresh` but blocking, not
-ticking) calls `FetchTrustBundle`. On a good 200 it does the **same validate-then-swap,
-all-or-nothing** the old Secret watch did: parse `ca_pem` into an `x509.CertPool`
-(**reject a non-empty-input-that-yields-zero-certs bundle**, keep last-good, bump
-`parapet_trust_reload_rejected_total`), build the `allowedSANs` set, **reject any
-bundle whose `generation` <= the one currently held** (forward-only, bump
-`parapet_trust_rollback_rejected_total`), then atomically `Store` **both** `clientCAs`
-and `trustPol` together. On 304/timeout it re-issues with the unchanged `since`; on
-connection drop/error it fail-statics (keep last-good), short jittered backoff,
-re-issues. **NEVER nil the live pool from a bad/empty/forged fetched bundle** — only
-feature-off does. An empty `allowed_sans` with a valid `ca_pem` is accepted as an
-operator-driven shrink **only when the generation strictly advances**, so a
-truncated/forged body cannot masquerade as an empty set.
+**Deliberate inversion of `edge/cp.go`:** a missing/empty/unparseable
+`EDGE_TRUST_CP_CA`, or an `AppendCertsFromPEM` that adds **zero** certs, is a **FATAL
+startup error**; `InsecureSkipVerify` is never set; a non-`https://` endpoint is
+rejected fatally — **no plaintext analog ever**. `EDGE_TRUST_CP_CA` SHOULD be a
+dedicated single-purpose CA signing only the CP server cert; the client verifies the
+CP cert hostname against the endpoint host.
 
 ### Freshness: long-poll, not bare poll
 
-A bare poll would make revocation as slow as the poll interval; the old k8s watch gave
-~300 ms. To keep that, `GET /v1/trust-bundle` supports a **long-poll**:
-`?watch=1&since=<generation>` **blocks** server-side until the generation advances past
-`<since>` (a registry edit → recompute → bump → broadcast, or a CA rotation step) or a
-server-side ceiling (`EDGE_TRUST_CP_WATCH_TIMEOUT`, default ~30 s) elapses → `304`. CP
-side: a `generation` (see [Generation](#generation-content-derived-replica-identical--monotonic))
-bumped on every **observed content change**, with a `sync.Cond` broadcast to wake
-blocked waiters. The SAN set is serialized **deterministically** (sorted,
-NFC-normalized) before the gen/etag hash, so non-deterministic map iteration cannot
-compute a spuriously-unchanged etag and stall the bump (the `WafStore.recompute`
-early-return on equal etag is correct only because its `fingerprint` is sorted —
-`wafstore.go:86-94`; the trust bundle MUST do the same).
-
-The core: on **200** → validate-then-swap, advance `since` to the returned (strictly
-greater) generation, re-issue `watch=1&since=<new>`; on **304/timeout** → re-issue
-unchanged; on error → fail-static + jittered backoff + re-issue. **Liveness:** the
-watch call MUST NOT use a whole-request `http.Client.Timeout` (it would guillotine a
-legitimately-blocking long-poll); use Transport-level `ResponseHeaderTimeout`/
-`IdleConnTimeout` + a per-attempt context deadline of `watch-timeout + slack` (~45 s
-for a 30 s block) + TCP keep-alive, so a half-open connection is detected and the
-single watch goroutine never wedges. The CP `http.Server` `WriteTimeout`/`IdleTimeout`
-MUST be **>= the watch ceiling** (today only `ReadHeaderTimeout` is set,
-`cmd/edge-controlplane/main.go:103`). **The safety-net plain-GET poll
-(`EDGE_TRUST_CP_POLL_INTERVAL`, default 5 m) runs unconditionally alongside the
-long-poll** as a correctness backstop. Honest SLA: **sub-second normally, ≤ one poll
-interval worst-case** — never present sub-second as guaranteed.
+With per-request SAN revocation gone, the generation/long-poll no longer carries
+per-edge revocation; it now matters **only for CA rotation** — the core must trust
+NEW before edges re-mint and drop OLD promptly after convergence, which is exactly
+when freshness matters. **Keep the long-poll** (`?watch=1&since=<generation>` blocks
+until the generation advances or `EDGE_TRUST_CP_WATCH_TIMEOUT` ~30 s → 304); steady-
+state freshness can relax, so `EDGE_TRUST_CP_POLL_INTERVAL` may lengthen. The
+etag/generation is derived over `generation || ca_pem || ca_id`, where **`ca_id` is
+a stable sorted-SHA256 fingerprint over the CA certs in `ca_pem`** (so map-iteration
+nondeterminism cannot stall the bump). The unconditional safety-net plain-GET poll
+runs alongside as a correctness backstop; the watch call avoids a whole-request
+`http.Client.Timeout` (Transport timeouts + per-attempt ctx deadline + TCP
+keep-alive). The CP `http.Server` `WriteTimeout`/`IdleTimeout` MUST be ≥ the ceiling.
 
 ### Generation (content-derived, replica-identical + monotonic)
 
-The revocation guarantee rests on the generation being **strictly monotonic and
-tamper-evident over the verified TLS channel**, *and* (for a stateless multi-replica
-CP) **identical on every replica**. Both are satisfied by deriving generation from the
-**apiserver `resourceVersion`** of the source objects — `generation = max(resourceVersion)`
-across the source Secrets/ConfigMaps (the `edge-controlplane-tokens` registry and the
-`parapet-edge-ca` Secret). resourceVersion is the etcd revision at last write; etcd is a
-**single global monotonic counter**, so this value is server-assigned (identical on
-every replica reading the same objects), monotonic, and **persisted across CP restarts
-by construction** — it lives in etcd, not a CP process. This **dissolves the apparent
-conflict** between "content-derived/stateless" and "monotonic/persisted": one source
-satisfies both. Do **not** use a per-process `atomic.Uint64` counter (replica-divergent)
-nor leading bytes of a content hash (non-monotonic; truncation collisions).
+`generation = max(resourceVersion)` across the source objects (the registry Secret +
+the `parapet-edge-ca` Secret). etcd is a single global monotonic revision counter, so
+this is server-assigned (identical on every CP replica), monotonic, and persisted
+across CP restarts **by construction** — no process counter. **Forward-only is now
+LOAD-BEARING for CA-rotation-as-revocation:** a replayed OLDER bundle over any TLS gap
+could re-add a just-dropped OLD CA (**re-trusting a compromised edge** whose leaf
+chains to OLD) or remove a just-added NEW CA (un-trusting a just-re-minted fleet →
+mass 502). The core swaps only on a strictly-advancing generation. (Also fixes the
+pre-existing `wafstore.go` per-process-counter flap under `replicas: 2`.)
 
-Three rules: (1) **Forward-only swap** — the core rejects any bundle whose
-`generation <=` the one it holds (`parapet_trust_rollback_rejected_total`), so a MITM
-on any TLS gap can't replay a captured **older** 200 to un-revoke a dropped SAN. (2)
-**No reset** — because generation is an etcd revision, a CP restart never lowers it, so
-a core holding `since=N` is never stranded. (3) **Equality/identity token** — anti-rollback
-rests on server-TLS + forward-only, not on the value being a dense counter.
+### Warm-start cache (fail-closed)
 
-> **Pre-existing bug fixed here:** `edgecp/wafstore.go:32` `gen atomic.Uint64`, bumped
-> at `:80`, returned at `:124` into `wafResponse.Generation` — under `replicas: 2` two
-> replicas ingesting identical ConfigMaps return *different* generation integers, so an
-> edge round-robining the Service sees the counter flap (e.g. 7,4,8,4). The fix applies
-> the **same** resourceVersion-derived generation to `/v1/waf`; the sha256 fingerprint
-> at `wafstore.go:86` stays for the ETag (already content-derived + replica-safe).
-
-### Warm-start cache (fail-closed for revocation)
-
-A core restart during a CP outage loses its in-memory `clientCAs`/`trustPol` and would
-otherwise degrade to CIDR-only until the CP returns. To shrink that window the core
-**persists the last-good bundle to `EDGE_TRUST_CP_CACHE_FILE`** (write-on-successful-swap;
-the bundle is public — `ca_pem` + opaque SAN ids — so **no new secret-at-rest concern**).
-**But the disk copy confers NO trust until revalidated against the live CP.** A restarted
-core with the CP down reads the file as a **warm-start hint only**, stays **CIDR-only**,
-and flips to mTLS-trust **only after the first successful live fetch supersedes it**.
-This is deliberate and fail-closed: persisting-**and-trusting** the file would resurrect
-a revoked SAN (revoke X → CP down → core restarts → reads a disk bundle still containing
-X → X trusted across the whole outage). `EDGE_TRUST_CP_MAX_STALE` (default ~1 h) caps the
-hint's age; an older file is ignored. Emit `parapet_trust_source{file}` (vs
-`{mtls}`/`{cidr}`/`{none}`) and `parapet_trust_bundle_age_seconds` so a stale/pre-bundle
-core is alertable. **No-trust-until-revalidated is the default and is non-negotiable.**
-
-**Header hardening (a real gap today):** mount a middleware **first** in `main.go`'s `m`
-chain that **unconditionally deletes** client-supplied `X-Forwarded-Country` /
-`X-Forwarded-ASN` at ingress (`forwardGeoHeaders`, `main.go:329`, only *overwrites* them
-when a DB is loaded → a no-DB core passes a client-forged value upstream). Treat both as
-edge-set-only.
+The core persists the last-good bundle (`ca_pem` + `ca_id`, public — no secret-at-rest
+concern) to `EDGE_TRUST_CP_CACHE_FILE`, **but it confers NO trust until revalidated**.
+A restarted core with the CP down reads it as a warm-start hint, stays **CIDR-only**,
+and flips to mTLS only after the first live fetch supersedes it — because persisting-
+and-trusting could **resurrect an OLD CA the operator just rotated out**
+(re-trusting a compromised edge) across a restart-during-outage. `EDGE_TRUST_CP_MAX_STALE`
+caps the hint's age. `parapet_trust_source{file|mtls|cidr|none}` makes the state
+alertable. (Header hardening unchanged: the core unconditionally strips client-supplied
+`X-Forwarded-Country/-ASN` at ingress.)
 
 ## Edge wiring
 
-The default data-plane identity is **CP-issued**. `EDGE_DATAPLANE_MTLS` (bool, default
-false — off ⇒ anonymous re-encrypt, identical to today) turns it on; `EDGE_UPSTREAM_TLS=true`
-is a prerequisite (loud startup error otherwise).
+The default data-plane identity is CP-issued (`EDGE_DATAPLANE_MTLS=true`; requires
+`EDGE_UPSTREAM_TLS=true`). `edge/clientcert.go` holds the leaf in an in-memory
+`ClientCertStore` (`atomic.Pointer[tls.Certificate]`); `Update` is **all-or-nothing**
+(keep the prior pair on failure). `RunEdgeCertRefresh` renews on remaining-life
+(re-mint at ≤ ⅓ of the now-7d TTL, ~the 56 h mark) with backoff + jitter +
+`Retry-After`.
 
-- **`edge/clientcert.go` (new)** — an in-memory `ClientCertStore`
-  (`atomic.Pointer[tls.Certificate]`), `GetClientCertificate` returns the live
-  (complete key+chain) cert, and an **all-or-nothing** `Update(chainPEM, heldKey)`
-  that `tls.X509KeyPair`-validates and atomically swaps — **if validation fails, the
-  prior pair is kept** (never a half-rotated state). A never-loaded empty return is
-  loud and gates readiness.
-- **`edge/refresh.go`** — `RefreshEdgeCertOnce`: generate an ephemeral key **into a
-  local var**, build the CSR, `cp.FetchEdgeCert(...)`, on success `Update` as one
-  atomic unit, on error fail-static. `RunEdgeCertRefresh` renews on
-  remaining-life/renew-before with backoff + **jitter**, honoring `Retry-After`.
-- **`edge/forward.go` `NewForwarder`** gains a `*ClientCertStore` param (nil ⇒
-  anonymous re-encrypt); on `useTLS` it sets
-  `tlsConfig.GetClientCertificate = ccStore.GetClientCertificate`. `InsecureSkipVerify`
-  stays for now (the edge doesn't yet verify the core's server cert — see open
-  questions). **This is the deliberate mirror image of the trust channel:** the edge
-  data-plane hop is authenticated by the edge's *client* cert and still skip-verifies
-  the server; the core→CP trust channel is authenticated by the CP's *server* cert with
-  no client cert and **never** skip-verifies. Same binary pair, opposite posture, by
-  design.
-- **Readiness is fail-closed.** When `EDGE_DATAPLANE_MTLS=true`, readiness
-  (`cmd/edge-proxy/main.go:197`) becomes `(serveAll || store.Loaded()) && clientCert.Loaded()`
-  — serve-all does NOT bypass it. First-boot issuance failure keeps the edge not-ready
-  (503). **But CP-readiness ≠ system-readiness:** the edge can't self-detect "the core
-  doesn't trust my CA," so it can go ready and still 502 in the convergence window — see
-  the system-readiness fail mode.
+### Force-re-mint trigger: proactive overlap (primary) + reactive (floor)
 
-The edge remains the first hop and sets **no** `TrustProxy`, so it overwrites incoming
-`X-Forwarded-*` with the true client peer before forwarding — the **transitive-trust
-invariant** the core relies on.
+With a 7-day TTL good edges will **not** naturally renew during a rotation, so
+dropping OLD without a trigger would 502 the fleet until natural renewal (days). So:
+
+- **Proactive (primary).** The trust-bundle gains `ca_id`; the edge observes it via a
+  **`ca_id` field added to the token-gated `GET /v1/waf` 200 body** — the edge has
+  **no** trust-bundle call (it only does `FetchCert`/`FetchWaf`; the trust-bundle is a
+  core-only, tokenless endpoint), so `ca_id` rides the edge's existing ETag-revalidated
+  refresh loop, its bearer token, and its `EDGE_REFRESH_INTERVAL` poll — no new
+  endpoint/auth/goroutine. On a `ca_id` change the edge immediately re-runs the CSR →
+  `POST /v1/edge-cert` flow to get a NEW-CA leaf **before** OLD is dropped. This is why
+  the revoke flow is ADD-new → edges-re-mint → confirm-converged → DROP-old, and why
+  the drop is convergence-gated: the proactive path is the **mass path**, so the drop
+  is a no-op for good edges.
+- **Reactive (floor).** If an edge missed the signal, its upstream handshake fails at
+  the drop with a `bad_certificate`/`certificate_unknown`/`unknown_ca` alert. The
+  ErrorHandler (`edge/forward.go`, today a generic 502 for *all* upstream errors) MUST
+  **classify narrowly**: re-mint **only** on those TLS cert-verify alerts, **never** on
+  a generic 502, dial error, timeout, or healthy-core HTTP status — otherwise an
+  unrelated core outage triggers a fleet-wide re-mint storm and a tight loop. Add a
+  per-edge single-flight + backoff and a **circuit-breaker** (stop after K consecutive
+  re-mints that did NOT change `ca_id` — the failure isn't a trust problem). The brief
+  per-edge 502 blip self-heals once the new leaf lands (`retryMiddleware`).
+
+**Anti-thundering-herd on both triggers:** a rotation flips `ca_id` for the whole
+fleet at once, so spread re-mints by full jitter in `[0, EDGE_CLIENTCERT_REMINT_JITTER]`
+(default ≥ 60 s, sized to exceed signer drain) + exponential backoff + `Retry-After`
+honoring (the signer is per-replica-rate-limited; one token per edge means the per-token
+bucket does NOT bound the aggregate) + per-edge single-flight.
+
+**Fail-static two-hop separation.** Re-minting touches the **data-plane** (edge→core)
+client cert **only**. The edge keeps serving its **public** leaf to clients throughout
+(client TLS is independent) and keeps presenting its current (OLD-CA) client cert during
+the overlap — **safe because the core trusts `OLD ++ NEW`**. `ClientCertStore.Update`
+all-or-nothing means a failed re-mint keeps the prior pair; the edge degrades but never
+fails open and never drops public TLS.
 
 ## Control-plane wiring: CP issues the client cert
 
 ### Stateless serving control plane (HA via replicas + Service)
 
-The serving CP holds **no control-plane-owned state**: every input (the edge-CA keypair
-from `parapet-edge-ca`, the `edge-controlplane-tokens` registry, tenant TLS via the
-`Reloader`, WAF via `WafReloader`/`IngressReloader`) is read from the apiserver into a
-derived, reconstructible cache, so replicas are **byte-identical and interchangeable**.
-HA is the existing ClusterIP Service over N pods with the `/healthz?ready=1` gate; the CP
-is **off the request path** (edges/core pull on timers/long-poll, fail-static), so losing
-a replica only delays a pull, never drops live traffic. **No leader election, no lease, no
-in-serving CAS, no write RBAC.** Signing is deterministic and stateless per request:
-zero-value leaf template + fresh 128-bit CSPRNG serial + clock-derived validity +
-registry-derived SAN, so two replicas signing the same CSR produce equally-valid,
-differently-serialed certs. Multiple concurrently-valid serials per SAN (one per replica
-that served a renewal) are **expected**, because revocation is SAN-drop in the core, not
-serial/CRL. This subsection replaces the in-serving create-once/CAS/anti-regen machinery
-that previously lived here — that machinery moves into the bootstrap Job below.
+The serving CP holds **no control-plane-owned state**: every input (the edge-CA keypair,
+the registry, tenant TLS, WAF) is read from the apiserver into a reconstructible cache,
+so replicas are byte-identical. HA is the ClusterIP Service over N pods with the
+`/healthz?ready=1` gate; the CP is off the request path (pull on timers/long-poll,
+fail-static). **No leader election, no in-serving CAS, no write RBAC.** Signing is
+deterministic per request. Multiple concurrently-valid serials per edge (one per replica
+that served a renewal) are expected; revocation is CA rotation, not serial/CRL.
 
 ### `GET /v1/trust-bundle` — the tokenless trust endpoint
 
-New handler on `edgecp.Server.Handler()` (`edgecp/server.go:30-36`), mounted **alongside**
-the token-gated `GET /v1/certs`/`GET /v1/waf` but a sibling of the **no-auth**
-`GET /healthz` — it **never inspects `Authorization`**:
-
 ```
-GET /v1/trust-bundle    (NO Authorization header)   [If-None-Match: "<etag>"]   [?watch=1&since=<generation>]
-  200 {"generation": N, "ca_pem": "<edge-CA PUBLIC cert bundle, PEM>", "allowed_sans": ["spiffe://parapet.moonrhythm.io/edge/<id>", …]}
-       generation   : resourceVersion-derived, replica-identical + monotonic; bumped whenever ca_pem OR allowed_sans changes
-       ca_pem       : the edge CA PUBLIC cert(s) ONLY (overlap bundle old++new during rotation). NEVER a private key.
-       allowed_sans : the live allow-set, CP-computed from edge-controlplane-tokens via the single canonical identityFor derivation
-       ETag: "<strong validator over generation || ca_pem || sorted(allowed_sans)>"   Content-Type: application/json   Cache-Control: no-cache
-  304 (If-None-Match matched OR a ?watch long-poll elapsed with no generation change)
-  503 (signer/CA not yet initialized — bootstrap Job hasn't populated the CA; core fail-statics and retries)
+GET /v1/trust-bundle    (NO Authorization header)   [If-None-Match]   [?watch=1&since=<generation>]
+  200 {"generation": N, "ca_pem": "<edge-CA PUBLIC cert bundle; OLD++NEW during rotation>", "ca_id": "<sorted-SHA256 of the CA certs in ca_pem>"}
+       NEVER a private key. ca_id changes whenever a CA is added to or dropped from ca_pem.
+       ETag over generation || ca_pem || ca_id.   Cache-Control: no-cache
+  304 (If-None-Match matched OR a ?watch elapsed with no change)
+  503 (CA not yet initialized — bootstrap Job hasn't populated it; core fail-statics and retries)
 ```
 
-New `edgecp/trust.go` + `mux.HandleFunc("GET /v1/trust-bundle", s.handleTrustBundle)`. The
-handler: (1) **no `bearer(r)` call**; (2) computes `allowed_sans` from the **same
-`edge-controlplane-tokens` registry** the CP authorizes against, via the canonical
-`identityFor` (the **same** code path `Signer.Sign` stamps with — byte-identical by
-construction); (3) assembles `ca_pem` as the **public** cert(s) only from the live
-`Signer`; (4) reads the resourceVersion-derived generation + a `sync.Cond` for the
-long-poll, `ETag = etagOfString(...)` (`server.go:130`). Wired like `WithWAF`: a
-`WithTrust(...)`, so **absent signer ⇒ 503** (the endpoint *exists* but is not-yet-ready
-— 503, not 404, so the core retries rather than treating it as permanent). No new CP
-watch — the trust bundle is a new **view** over state the CP already maintains. There is
-**no 401/403 path**.
+A sibling of the no-auth `GET /healthz` — it **never inspects `Authorization`**. The
+handler assembles `ca_pem` as the **public** cert(s) only from the live `Signer`;
+the core uses `ca_id` only for observability/convergence (the trust input is `ca_pem`).
+There is **no `allowed_sans`** and **no 401/403 path**. **No-token is safe only because
+server-TLS is the integrity boundary** (a token authenticates the client, not the
+response; `ca_pem` is public, `ca_id` is a fingerprint) — so the CP MUST refuse to start
+in plaintext when it is a trust source (`CP_TLS_CERT`/`CP_TLS_KEY` required; fatal
+otherwise), with no plaintext analog on either end. The secret/scoped endpoints
+(`/v1/certs`, `/v1/waf`, `/v1/edge-cert`) **keep** their token.
 
-### Bounding the unauthenticated long-poll
-
-Because `/v1/trust-bundle?watch=1` is **unauthenticated** and **blocks a goroutine +
-connection** for up to the watch ceiling, the CP **cannot bound concurrency by caller**.
-Any NetworkPolicy-permitted source could otherwise open thousands of concurrent watches
-and exhaust the goroutine/FD budget, **starving the token-gated `/v1/certs`/`/v1/waf`/
-`/v1/edge-cert` the data plane needs**. So the CP MUST add **auth-independent** limits: a
-**bounded semaphore** on concurrent in-flight watch handlers (over-limit ⇒ `503` +
-`Retry-After`, or short-block then `304`); a **hard server-side deadline** via `context`
-(≤ the watch ceiling); a **per-source-IP concurrent-connection cap**; a response **body
-cap**; and a cheap reject of `?watch` with an absurd/missing `since`. **The
-edge-sources-only NetworkPolicy is now availability-load-bearing** (the only caller bound
-on this endpoint) — a hard prerequisite — and the CP `http.Server` MUST set
-`WriteTimeout`/`IdleTimeout` ≥ the watch ceiling.
-
-### CP-side TLS guard (no plaintext trust channel, either end)
-
-The no-token decision is safe **only because server-TLS is the integrity boundary** — so
-it MUST be non-optional on the CP **server** side too. The CP today serves plaintext when
-`CP_TLS_CERT`/`CP_TLS_KEY` are both empty (`cmd/edge-controlplane/main.go:40-51`). **When
-the CP is a trust source (the trust bundle is wired), `CP_TLS_CERT`/`CP_TLS_KEY` MUST be
-set — plaintext + trust-bundle is a FATAL CP startup error**, mirroring the existing
-`CP_TLS` pairing guard. The edge **data-plane** plaintext exception (`EDGE_CP_ALLOW_PLAINTEXT`)
-does **NOT** extend to the trust channel on **either** end: an on-path attacker on a
-"trusted" private network who injects a forged `ca_pem` over plaintext mints leaves the
-core trusts = fleet-wide XFF-spoof = trust-boundary takeover.
+**Bounding the unauthenticated long-poll:** a bounded semaphore on concurrent watch
+handlers (over-limit ⇒ 503 + `Retry-After`), a context deadline ≤ the ceiling, a
+per-source-IP cap, and a body cap — the edge-sources-only NetworkPolicy is now
+**availability-load-bearing**, a hard prerequisite.
 
 ### The issuance endpoint (`POST /v1/edge-cert`)
 
-CSR-based, so the private key **never leaves the edge**:
-
-```
-POST /v1/edge-cert    Authorization: Bearer <token>
-  request body: {"csr_pem": "<PKCS#10 CSR, PEM>"}
-  200 {"chain_pem":"…", "not_after":"<RFC3339>", "serial":"<hex>"}   (NO key on the wire; Cache-Control: no-store, Pragma: no-cache; no ETag/304)
-  400 (malformed/oversized CSR, bad PEM, sig fails verify, unsupported/over-large key type)
-  401 (no/invalid token)  403 (token has no edge identity grant)  405 (not POST)  413 (CSR > 16 KiB)  429 (rate limit / signer saturation — Retry-After)
-```
-
-The edge generates an ephemeral key in memory, sends the CSR; the CP **whitelists the key
-type/curve BEFORE `CheckSignature`** (ECDSA P-256/P-384 or Ed25519 only; reject RSA → 400),
-verifies proof-of-possession, then `Signer.Sign(csr.PublicKey, authorizedSAN)`. Absent
-signer ⇒ 404 (back-compat).
+CSR-based; the private key never leaves the edge. A token whose registry entry has
+`disabled:true` (or is absent) is treated as **UNKNOWN → 401**, so a blacklisted token
+cannot mint. The CP whitelists the key type/curve **before** `CheckSignature` (ECDSA
+P-256/P-384 or Ed25519; reject RSA → 400), then `Signer.Sign(csr.PublicKey, authorizedSAN)`.
 
 ### Signing: template, custody, rate-limiting
 
-**`edgecp/signer.go` (new).** `Signer` holds the parsed edge CA cert + key (behind an
-interface — the **HSM/KMS seam**); `Sign` builds the leaf template **from a zero value —
-never from the parsed CSR** — setting ONLY `SerialNumber` (128-bit CSPRNG), `NotBefore =
-now - EDGE_CLIENTCERT_SKEW`, `NotAfter = now + EDGE_CLIENTCERT_TTL`, `KeyUsage =
-DigitalSignature`, `ExtKeyUsage = [ClientAuth]`, `URIs = [authorizedSAN]`,
-`BasicConstraintsValid = true, IsCA = false`. The CSR contributes **only `csr.PublicKey`**.
-**Post-sign self-check (mandatory in BOTH modes):** re-parse the leaf and assert
-`IsCA==false`, `KeyUsage`, `ExtKeyUsage==[ClientAuth]`, `URIs==[authorizedSAN]`, no
-DNS/IP; refuse to return otherwise.
+`Signer.Sign` builds the leaf template **from a zero value** — only `SerialNumber`
+(CSPRNG), `NotBefore = now - skew`, `NotAfter = now + EDGE_CLIENTCERT_TTL`, `KeyUsage =
+DigitalSignature`, `ExtKeyUsage = [ClientAuth]`, `URIs = [authorizedSAN]` (audit-only),
+`IsCA = false`. Post-sign self-check re-parses and asserts the shape; refuse otherwise.
 
-**`edgecp/authz.go` — per-edge identity (explicit opt-in).** `Identity(token) (string,
-bool)`; returns `("",false)` (→ 403) unless the operator set an `id`. Serve-all gets none.
+**`edgecp/authz.go` — the `disabled` tombstone.** The registry shape becomes
+`{"<token>":{"id":...,"domains":[...],"disabled":bool}}`. A **single chokepoint**:
+`Known`, `Identity`, **and** `Allowed` all treat `disabled:true` (and a deleted entry)
+as **ABSENT** — a **full lockout**: a disabled token cannot mint (`/v1/edge-cert`),
+fetch **private keys** (`/v1/certs`), or fetch WAF (`/v1/waf`). Prefer the tombstone
+over deletion (audit trail; blocks an accidental GitOps re-add silently re-enabling a
+revoked edge; survives a registry restore); deletion is equally honored. **Residual,
+stated loudly:** `disabled`/deletion stops only **future** minting — the already-minted
+leaf chains to the live CA and stays trusted until expiry or CA rotation (see
+[Revocation](#revocation--ca-rotation)).
 
-**CA custody — managed (default) vs provided.** Two modes, decided at boot by the
-**presence** of `EDGE_CA_CERT`/`EDGE_CA_KEY` (no `EDGE_CA_MODE` knob):
+**CA custody — managed (Job) vs provided.** Managed (default): the run-once bootstrap
+Job generates a single-purpose, NameConstrained ECDSA-P384 CA (`KeyUsage =
+CertSign|CRLSign`, EKU `clientAuth`, `MaxPathLenZero`) and persists it; serving reads +
+hot-reloads, never writes. Provided: mounted `EDGE_CA_CERT`/`EDGE_CA_KEY` (validated:
+`IsCA`, EKU `clientAuth`, warn/refuse if no `PermittedURIDomains`). `cmd/edge-controlplane/main.go`
+branches FIRST on `EDGE_CA_BOOTSTRAP`/`--bootstrap-ca` (run `EnsureCA`, then exit);
+`POD_NAMESPACE` is fatal-if-empty in bootstrap and serving-managed mode.
 
-- **`managed` (default — zero PKI, zero cert-manager).** A **run-once bootstrap Job**
-  generates the CA once and persists it to `parapet-edge-ca`; the serving CP **reads** it
-  and hot-reloads it, **never generates or writes**. The generated CA template (from a
-  zero value): key **ECDSA P-384** (`EDGE_CA_KEY_TYPE=ed25519` alt), PKCS#8; `SerialNumber`
-  128-bit CSPRNG; `Subject` CN `parapet-edge-ca`; `NotBefore = now-10m`, `NotAfter = now +
-  EDGE_CA_TTL`; `KeyUsage = CertSign | CRLSign` ONLY; `ExtKeyUsage = [ClientAuth]` ONLY;
-  `BasicConstraintsValid=true, IsCA=true, MaxPathLenZero=true`;
-  `NameConstraints.PermittedURIDomains = ["parapet.moonrhythm.io"]`. **Honest scope:** this
-  pins the SAN **host** only — path scoping to `/edge/*` is *not* expressible as a URI
-  NameConstraint (the issuance template's `URIs=[authorizedSAN]` + post-sign self-check pin
-  the path); the constraint stops cross-domain/serverAuth abuse, NOT edge-fleet
-  impersonation. A conformance test must prove `x509.Verify` rejects
-  `spiffe://evil.example/edge/x` and accepts the legit form. The **Job** logs it
-  GENERATED/ADOPTED a fleet-minting CA; the **serving** CP logs it HOLDS a loaded signer
-  (read-only).
-- **`provided` (escape hatch — operator's own PKI).** Both `EDGE_CA_CERT`/`EDGE_CA_KEY`
-  point at mounted PEM files; the CP **uses** them, never generates/writes, needs no
-  get/update RBAC; hot-reload the files. **Validation (mandatory):** `IsCA` + EKU
-  `clientAuth` (reject pure serverAuth/anyEKU); **warn loudly (or refuse) if no
-  `NameConstraints.PermittedURIDomains`**. Dedicated single-purpose CA, never a shared org
-  intermediate. cert-manager may *populate* the mounted Secret, but the CP sees opaque
-  files — no CRD, no `CertificateRequest`.
-
-**`cmd/edge-controlplane/main.go`.** Branch **FIRST** on `EDGE_CA_BOOTSTRAP` /
-`--bootstrap-ca`: if set, run `EnsureCA` against `parapet-edge-ca` in `POD_NAMESPACE` then
-`os.Exit(0 success / non-zero failure)` — **never start the server**. Else serving mode:
-managed = `GetSecret`+parse to a `*Signer` and start the CA-Secret **read-watch**; provided
-= mounted files; neither = nil signer = 404. Both-or-neither `EDGE_CA_CERT`/`EDGE_CA_KEY`
-guard. Empty `POD_NAMESPACE` is **fatal** in bootstrap mode and serving-managed mode.
-**Serving no longer calls `EnsureCA`/`UpdateSecret`.**
-
-**Rate-limiting + DoS.** The per-token bucket (`EDGE_CLIENTCERT_RATE`) and the global
-signing concurrency cap are **PER-REPLICA** — with N replicas behind the Service the
-effective fleet ceiling is **N× nominal**, and it scales **silently** as replicas rise for
-HA. Document this; a truly hard global cap needs externalized rate-limit state (out of
-scope, same exception class as the purge journal). authz-reject + the key-type whitelist
-run **before** any signing, so unauthorized/oversized floods cost zero CA work; keep
-per-edge refresh jitter.
+**Rate-limiting + the rotation thundering herd.** The per-token bucket and global
+signing cap are **per-replica** (effective ceiling N×). A rotation flips `ca_id`
+fleet-wide at once, so without spreading, every edge re-mints simultaneously against the
+CPU-bound ECDSA-P384 signer — a self-inflicted DoS that, because drop-OLD is
+convergence-gated, would **extend** the window the compromised edge stays trusted.
+Require jitter + backoff + `Retry-After` on both triggers; **proactive overlap is the
+mass path** (good edges already hold NEW-CA leaves before the drop), reactive is the
+per-edge floor only.
 
 ### CA generation: the run-once bootstrap Job (single intentional writer)
 
-CA generation runs in the same `edge-controlplane` binary in one-shot mode
-(`--bootstrap-ca` / `EDGE_CA_BOOTSTRAP=true`) running `edgecp.EnsureCA`, then exit 0
-(success/adopt) or non-zero (Job retries). Pure-Go x509, no cert-manager. Operator
-pre-creates an **empty** `parapet-edge-ca` stub (RBAC `resourceNames` scopes get/update but
-not create). `EnsureCA` on a strongly-consistent typed `GetSecret` (never an informer
-cache):
+`edgecp.EnsureCA` runs in the `--bootstrap-ca` one-shot binary, then exits. On a
+strongly-consistent typed `GetSecret`: (a) valid keypair → ADOPT (re-run is a no-op);
+(b) guard annotation present but blanked → **HARD ANOMALY**, never regenerate, exit
+non-zero + `parapet_edge_ca_unexpected_empty_total`; (c) virgin stub → generate, write
+keypair + guard annotation. **A k8s Job is not a guaranteed single writer**
+(node-loss double-run, Helm/Argo delete-recreate, manual re-apply), so **RETAIN the
+`resourceVersion`-CAS** + a re-read-before-Update no-op; on `IsConflict` re-read and
+ADOPT. Re-GET after Update and assert the CA parses before exit 0. The same machinery
+serves rotation (below).
 
-- **(a)** `tls.crt`+`tls.key` parse to a valid CA keypair → **ADOPT**, exit 0 (re-run is a
-  pure no-op).
-- **(b)** guard annotation `parapet.moonrhythm.io/edge-ca-generation` present but
-  `tls.crt`/`tls.key` empty-or-unparseable → **HARD ANOMALY** (a populated CA was
-  re-blanked by a GitOps prune, an apply of the empty stub, a Velero restore, or an
-  operator recreate) → **NEVER regenerate**, exit non-zero with a distinct message, bump
-  `parapet_edge_ca_unexpected_empty_total`.
-- **(c)** virgin stub (no annotation **and** empty) → generate the CA in memory and write
-  keypair + guard annotation + populated-at timestamp together.
+### Bootstrap-Job vs serving ordering (the cold-start window)
 
-> **Override of the brief (both red-team rounds, unanimous):** a k8s Job is **not** a
-> guaranteed single writer — node-loss double-run, delete-recreate on redeploy/Helm/Argo,
-> and manual re-apply all produce transient concurrent Job pods. So **RETAIN the
-> `resourceVersion`-CAS** on the write plus a **re-read-immediately-before-Update
-> no-op-if-now-populated** check: without the CAS two pods both observing the empty stub
-> both `UpdateSecret` last-write-wins → two different CAs → the second silently distrusts
-> everything signed against the first. On `apierrors.IsConflict` re-read and **ADOPT** the
-> winner. The Secret-is-the-lock property (the CAS, not statelessness) linearizes the
-> inevitable double-run. The **anti-regeneration guard** is the load-bearing safety
-> property and now lives in the Job.
-
-`NotFound` on the stub is a **fatal config error** (no fallback to a broad create grant).
-Empty `POD_NAMESPACE` is fatal. **Failure semantics:** exit non-zero on any failure to
-reach a known-good terminal state; **re-GET after `UpdateSecret` and assert the CA parses
-before exit 0** (no swallowed write error, no silent no-op Complete). The create-once is
-tested against `k8s.io/client-go/kubernetes/fake` (honors CAS) with a two-goroutine
-concurrent-generate test asserting exactly one CA survives and the loser adopts.
-
-### Bootstrap-Job vs serving-Deployment ordering (the cold-start window)
-
-Job-before-serving is a **HARD ordering requirement**, not a should. Preferred: ship the
-Job as a **Helm pre-install/pre-upgrade hook** (hook-weight before the Deployment) AND/OR
-an **Argo PreSync hook**, preferred over an initContainer (which re-runs on every pod
-restart/scale-up and would need write RBAC on the serving SA, defeating read-only-serving).
-Belt-and-suspenders: serving readiness stays gated on a loaded CA, so even if ordering
-slips no replica serves a CA-less 404. **Cold-start no-signer window:** until the Job
-populates the CA, all serving replicas read no CA, all stay **not-ready (503)**, the
-Service has zero endpoints, `POST /v1/edge-cert` is connection-refused, the trust-bundle
-has no `ca_pem`. Edges **fail-static on their last-good leaf** (degraded, never fail-open);
-brand-new edges get no-endpoints. Bounded by Job completion; unbounded only if the Job is
-slow/failing (hence the Job-Failed alert + the absence-of-populated-CA-after-deadline
-alert). On the core side: a trust-bundle returning no `ca_pem` MUST be treated as
-**not-yet-bootstrapped** (keep retrying, never cache empty as last-good, never permanently
-latch CIDR-only; self-heal on the first non-empty pull).
+Job-before-serving is a HARD requirement (Helm pre-install / Argo PreSync hook,
+preferred over an initContainer). Belt-and-suspenders: serving readiness is gated on a
+loaded CA. Until the Job populates the CA, serving replicas are not-ready (503), the
+Service has zero endpoints, the trust-bundle has no `ca_pem`; edges fail-static on their
+last-good leaf (degraded, never fail-open). The core treats a no-`ca_pem` trust-bundle as
+not-yet-bootstrapped (keep retrying, never cache empty).
 
 ### Where the core gets the CA (the CP serves it; the core never reads the Secret)
 
-The core **no longer reads the `parapet-edge-ca` Secret at all** — not the public cert, not
-(incidentally) the private key. It pulls the edge CA's **public** cert(s) as `ca_pem` from
-`GET /v1/trust-bundle`, alongside the `allowed_sans` the CP computes. `EDGE_TRUST_SECRET`
-is **removed**; the core needs **zero** k8s access for trust (the fetch is an outbound
-HTTPS call). Because the core never touches the CA Secret, **`parapet-edge-ca` can live in
-a CP-only namespace with the CP as its only reader** — the prior namespace co-tenancy that
-let the core SA read the CA *private* key is **eliminated, not deferred** (see
-[Security model](#security-model)). The cert the CP signs **with** and the cert the core
-**trusts** are still the same bytes from the same authority — the CP assembles `ca_pem`
-directly from its live `Signer` (the overlap bundle old++new during rotation) — so they
-cannot drift, with **no publish step and no second write target**. The old namespace
-invariant tying the core's trust to `POD_NAMESPACE` is **dropped**.
+The core **never reads `parapet-edge-ca`** — it pulls the public `ca_pem` from
+`GET /v1/trust-bundle`. `EDGE_TRUST_SECRET` is removed; the core needs **zero** k8s
+access for trust. Because the core never touches the CA Secret, **`parapet-edge-ca`
+lives in a CP-only namespace** with the CP as its only reader — the core-SA-can-read-the-CA-key
+concern is **eliminated**. The CP assembles `ca_pem` from its live `Signer`, so the
+signing CA and the trusted CA cannot drift, with no publish step.
 
-### CA hot-reload + rotation (Job-driven, bundle-based, no cert-manager)
+### Revocation = CA rotation
 
-**The serving signer is hot-reloadable, not boot-once.** Every serving replica runs the
-**CA-Secret read-watch** (`atomic.Pointer[*Signer]`, validate-then-swap; active key derived
-solely from Secret content `tls-active: old|new`, converge within one debounce), so a
-Job-driven rotation is picked up without restart. A boot-once read would leave a replica
-signing with a stale in-memory key — strictly worse across N replicas with no leader. On a
-runtime CA-Secret **DELETE/blank**, the replica **keeps its last-good in-memory signer**,
-alerts, and **never drops to no-signer** (mirrors the core trust-watch keep-last-good) —
-with the in-serving anti-regen guard now removed, this read-watch keep-last-good is the only
-in-process safety net against a blanked Secret.
+> ⚠️ **BLACKLISTING A TOKEN DOES NOT REVOKE TRUST.** Removing or disabling a token in
+> `edge-controlplane-tokens` only stops the edge minting a **new** leaf. Its
+> already-minted leaf chains to the still-live edge CA and stays **fully trusted** (can
+> spoof `X-Forwarded-For`, bypass per-IP WAF/rate-limits, poison GeoIP/logs) until that
+> leaf **expires (up to 7 days)** OR the CA is **rotated out**. For any real compromise
+> (stolen leaf key, owned edge box), **CA ROTATION IS MANDATORY, not optional.** The
+> effective revocation SLA = time-to-rotate + fleet-converge + drop-OLD (operator-driven
+> minutes-to-low-hours) — **not seconds, and not the 7-day TTL**.
 
-**Rotation is a run-once Job** (the `--bootstrap-ca` binary / a rotate subcommand), **NOT**
-leader-elected serving. **Rotation invariant:** the NEW CA's public cert must be in
-`ca_pem` (which the core trusts) BEFORE the CP signs any leaf with the new key — else fresh
-leaves 502. Bundle support (`AppendCertsFromPEM` appends every block) lets `tls.crt`/`ca_pem`
-hold an overlap bundle. The 4-stage promote/trim machine: (1) generate NEW; (2) write
-`tls.crt = OLD ++ NEW`, stage NEW key, keep OLD active → core trusts both; (3) keep signing
-OLD while leaves renew; (4) flip `tls-active: new`, keep both certs ≥ one full leaf-TTL,
-then trim OLD — gated on the per-serving-replica `parapet_edge_ca_signer_fingerprint`
-convergence interlock. **Stolen-CA-key emergency:** skip overlap, write only the new CA,
-accept the brief gap — this is the stolen-CA-key runbook (SAN-drop can't revoke a forged
-leaf riding a real SAN).
+**CA rotation is now the revocation primitive** — a routine, on-demand, safety-critical
+operation, not the rare 10-year event. It is driven by the same `--bootstrap-ca`/rotate
+Job (never leader-elected serving) and is modeled as an **idempotent-per-phase state
+machine** with a persisted annotation on the CA Secret
+(`parapet.moonrhythm.io/edge-ca-rotation-phase: overlap|converged|trimmed`) + an
+intent/deadline annotation naming *why* (revoke of id X). The overlap flow:
+
+1. Generate a NEW CA in memory; `resourceVersion`-CAS-write `tls.crt = OLD ++ NEW`,
+   NEW key staged, `tls-active: old`.
+2. Serving replicas converge (read-watch, `atomic.Pointer[*Signer]`, active key chosen
+   solely from `tls-active`); the trust-bundle `ca_pem` broadcasts `OLD ++ NEW` and
+   `ca_id` flips.
+3. The core's long-poll picks up `OLD ++ NEW`, rebuilds `ClientCAs`, trusts **both** —
+   **rotation invariant: NEW's public cert is in the `ca_pem` the core trusts BEFORE any
+   leaf is signed under NEW.**
+4. Flip `tls-active: new`; good edges re-mint onto NEW (proactive, jittered).
+5. **The convergence interlock** (below) gates the OLD drop; then CAS-write
+   `tls.crt = NEW` only — the moment OLD is dropped, the revoked edge's OLD-CA leaf stops
+   verifying and it is distrusted.
+
+The trim is re-runnable (an interrupted rotation is resumed by re-invoking the tool,
+never regenerating a third CA). `parapet_edge_ca_rotation_stuck` **pages** while the
+Secret sits in `overlap` past its deadline — a half-applied rotation means the
+compromised edge is still trusted. The stolen-CA-key emergency (skip overlap, accept the
+gap) is unchanged.
+
+#### The convergence interlock (drop-OLD is metric-gated, never timer-gated)
+
+Dropping OLD is the **only** step that actually distrusts the revoked edge, and dropping
+it before the fleet re-mints 502s every not-yet-converged edge — so it MUST be gated on
+**positively observed** convergence across **both planes**, never on elapsed time. The
+Job/tool MUST NOT write `tls.crt = NEW` until pod-/edge-labeled metrics confirm: (1)
+every serving CP replica reports the NEW `parapet_edge_ca_signer_fingerprint` AND has
+`OLD ++ NEW` in its trust-bundle output; (2) the core(s) report `ca_id == new-set`; (3)
+every **good** edge reports `parapet_edge_clientcert_ca_id == new`; (4) the revoked id
+has **no leaf under NEW** (verify absence). A missing/unreporting/partitioned replica or
+edge **blocks** the drop (fail-closed) — holding the overlap open is cheap and safe;
+dropping early is the only unsafe move. The only bypass is a loud, logged operator
+override. Size the deadline to ≥ one `EDGE_REFRESH_INTERVAL` (proactive detection lag) +
+`EDGE_CLIENTCERT_REMINT_JITTER` + signer drain. A convergence stall extends the
+compromised-trusted window, so the stuck alert is a page.
+
+**Pre-rotation barrier (close the re-mint race).** The blacklist must **converge on
+every CP replica** (each replica's authz-snapshot generation ≥ the disabling generation,
+via a pod-labeled metric) **before** flipping `ca_id` — a precondition, not a parallel
+step — else the compromised edge mints a fresh NEW-CA leaf off a lagging replica during
+the overlap and survives the drop. Residual: a leaf minted in the sub-second
+pre-convergence window (if the barrier was skipped) survives to the next rotation.
 
 ### k8s client: the first write path (Job-only)
 
-The `k8s` client is read-only today (`Get*`/`Watch*`). Managed mode adds `GetSecret` +
-`UpdateSecret` to the interface and both backends — but **`UpdateSecret` is invoked SOLELY
-by the bootstrap/rotation Job, never by serving, never by the core**. Serving managed uses
-`GetSecret` read-only at boot then the read-watch. Import `apierrors` for
-`IsConflict`/`IsNotFound`. No `CreateSecret` (the stub is pre-created; `NotFound` is
-fatal-config). `EnsureCA` is **idempotent** (re-run after a CA exists is a pure adopt).
+`GetSecret` + `UpdateSecret` are added but **`UpdateSecret` is invoked SOLELY by the
+bootstrap/rotation Job**, never by serving, never by the core. Serving managed uses
+`GetSecret` read-only at boot then the read-watch.
 
 ## Deployment & RBAC (self-managed CA, two ServiceAccounts)
 
-1. **Two SAs.** `edge-controlplane` (serving, **read-only**) and
-   `edge-controlplane-bootstrap` (the Job, scoped write). The serving CP **stops** reusing
-   the controller's SA.
-2. **`controlplane.yaml`:** `serviceAccountName: edge-controlplane` (read-only); add
-   `POD_NAMESPACE` via downward API `metadata.namespace`; hardened `securityContext`
-   (`readOnlyRootFilesystem`, `runAsNonRoot`, `allowPrivilegeEscalation: false`); the
-   `readinessProbe` comment updated to "503 until the cert store **and** (when issuance
-   enabled) the CA signer have loaded"; `replicas` now safe to raise freely.
-3. **`role-ca.yaml`** — namespaced Role with secrets `get, update` scoped to
-   `resourceNames: [parapet-edge-ca]` in `POD_NAMESPACE`, bound to the **Job SA only**
-   (never namespace-wide, never create, never delete). The serving SA does **not** get it.
-4. **Cluster-wide read rebind:** because the serving CP runs `WATCH_NAMESPACE=""`
-   (cluster-wide tenant-cert Reloader), the **serving** SA keeps a ClusterRoleBinding to the
-   existing read ClusterRole — a namespaced RoleBinding alone silently breaks cert
-   distribution. The Job SA needs no cluster-wide read.
-5. **`ca-secret.yaml`** — the pre-created **empty** `parapet-edge-ca` stub in a **CP-only
-   namespace** (the Secret, the Role, the RoleBinding all live there; no core workload
-   occupies it → full CA-key-read isolation as the **default**). MUST carry GitOps
-   drift-exclusion (`argocd.argoproj.io/sync-options: Prune=false` + `ignoreDifferences` on
-   `/data` and `/metadata/annotations`; Flux field-manager note).
-6. **The core keeps** its namespace-wide secrets list/watch (for SNI) but reads **nothing**
-   from `parapet-edge-ca` — trust arrives over `GET /v1/trust-bundle`. **Zero new core
-   RBAC**, and `EDGE_TRUST_SECRET` is gone. The core's only new config is
-   `EDGE_TRUST_CP_ENDPOINT` + the mandatory `EDGE_TRUST_CP_CA` (the CP **server** CA,
-   distinct from the edge CA in `ca_pem`).
-7. **`bootstrap-job.yaml`** — `completions: 1`, `parallelism: 1`, `restartPolicy: OnFailure`,
-   finite-but-generous `backoffLimit`, `ttlSecondsAfterFinished` (reap a Completed Job
-   before the next sync recreates it), `POD_NAMESPACE` via downward API, sequenced before
-   serving via the pre-install/PreSync hook.
-8. **RBAC self-probes:** the serving CP probe-Lists secrets in `WATCH_NAMESPACE`; the Job
-   probe-Gets the CA Secret; on 403 each fatal-logs the exact missing binding.
-9. **etcd encryption-at-rest** is a managed-mode prerequisite (the CA key now lives in a
-   Secret written by the Job and read by every serving replica); a Secret loss = forced CA
-   rotation (overlap runbook).
+Two SAs: `edge-controlplane` (serving, **read-only** — namespace-wide secrets
+list/watch + a ClusterRoleBinding to the existing read ClusterRole, needed because
+`WATCH_NAMESPACE=""` drives cluster-wide tenant-cert distribution) and
+`edge-controlplane-bootstrap` (the Job, **scoped write** — `get,update` on
+`resourceNames: [parapet-edge-ca]` in a CP-only namespace). The empty `parapet-edge-ca`
+stub is pre-created with GitOps drift-exclusion (`Prune=false`, `ignoreDifferences` on
+`/data` and `/metadata/annotations`). `controlplane.yaml` sets `serviceAccountName:
+edge-controlplane`, `POD_NAMESPACE` via downward API, a hardened `securityContext`, and
+a `readinessProbe` that is 503 until the cert store **and** (when issuance enabled) the
+CA signer have loaded. `bootstrap-job.yaml`: `completions:1, parallelism:1,
+restartPolicy:OnFailure`, finite `backoffLimit`, `ttlSecondsAfterFinished`, sequenced
+before serving via the pre-install/PreSync hook — **and re-used as the rotation Job**.
+The core keeps its existing RBAC and reads nothing from `parapet-edge-ca`. RBAC
+self-probes fatal-log the exact missing binding on 403. etcd encryption-at-rest is a
+prerequisite (the CA key lives in a Secret).
 
 ## Security model
 
 **Trust boundary.** Exactly the edges holding a private key whose cert chains to the
-dedicated edge CA **and** whose URI SAN is in the live allow-set. Trust is
-**operator-asserted**. mTLS trust is conferred **only on `:443`**.
+dedicated edge CA. (No allow-set clause.)
 
-**Spoofing.** A non-edge reaching `:443` cannot forge trust (`VerifiedChains` is populated
-only after cryptographic verification against `ClientCAs`). A compromised edge cannot
-request a SAN it isn't entitled to (the CP stamps it from the token identity).
+**Spoofing.** A non-edge reaching `:443` cannot forge trust (`VerifiedChains` is
+populated only after cryptographic verification against `ClientCAs`). The stamped SAN is
+**audit-only and never load-bearing for trust**. The trust bundle is public; the defense
+against a forged CA is **verified server-TLS, not a token** (which is why
+`/v1/trust-bundle` safely drops the token while the secret/scoped endpoints keep theirs).
 
-### Why the trust endpoint drops the token (and the others keep it)
+**Blast radius.** A leaked edge **leaf** key lets the holder spoof XFF **as the fleet**
+(CA-only cannot scope a leaf to an IP or an id) until the CA is rotated out. The crown
+jewel is still the edge CA key (the bootstrap Job GENERATES it once; serving replicas
+read/HOLD it), forging the **entire fleet** if stolen, bounded **only by CA rotation**.
+The CA Secret lives in a CP-only namespace (full key-read isolation). `allowed_sans` no
+longer exists, so there is no broadcast roster.
 
-A bearer token authenticates the **client to the server** ("who is calling"); it does
-**not** protect **response integrity** ("is what I got back genuine"). The trust bundle is
-read-only and **non-secret by nature**: `ca_pem` is a *public* CA cert, and `allowed_sans`
-is at worst mild fleet-recon (opaque ids), already bounded by the CP's ClusterIP +
-edge-sources-only NetworkPolicy. What the core needs protection against is a **forged**
-CA/allow-set — a trust-boundary takeover. The defense against forgery is **server-side TLS
-the core verifies**, *not* a token the core *sends*. So the token on `/v1/trust-bundle` was
-pure ceremony; dropping it removes one credential the core would hold/rotate/leak, with
-**zero security loss, provided server-TLS verification stays mandatory and non-skippable**.
-**The other endpoints KEEP their token, deliberately:** `GET /v1/certs` ships **private
-keys**, `GET /v1/waf` ships **per-edge-scoped** rules (the scoping *is* the bound), `POST
-/v1/edge-cert` **mints identity** — all serve secret or caller-scoped material and need to
-authenticate *which* edge is calling. Only `/v1/trust-bundle` — broadcast-public, same
-bytes for everyone — can safely drop it.
+> **Stolen leaf key / cloned edge box (an accepted CA-only consequence).** CA-only is
+> pure chain-to-CA — no per-leaf pin, no IP binding. A leaf key exfiltrated from one edge
+> and replayed from a **different IP** is cryptographically identical to the legitimate
+> edge and **fully trusted**, indistinguishable from it; there is **no per-edge lever to
+> kill just the clone** (blacklisting the token does not invalidate the already-stolen
+> leaf). The only remedy is **CA rotation**. Because the leaf key is now long-lived (7 d,
+> 168× the old 1 h), require the edge to hold the leaf key **in memory only** (never on
+> disk), **recommend an optional non-exportable-key path** (TPM/PKCS#11 via
+> `GetClientCertificate`) for high-value edges, and keep the SAN stamped so audit logs can
+> **attribute** which edge identity a connection used — clone detection is an out-of-band
+> log/anomaly concern, never a trust mechanism.
 
-**Blast radius.** A leaked edge **leaf** key lets the holder spoof XFF **as that one edge**
-until its SAN is dropped or its cert expires. The **crown jewel is the edge CA key**. The
-bootstrap Job **GENERATES** it (once ever); serving replicas only **read/HOLD** it.
-**CA-key isolation is now the default, not a wart:** the core never reads the
-`parapet-edge-ca` Secret — it pulls only the public `ca_pem` — so the CA Secret lives in a
-**CP-only namespace** with the dedicated CP SA as its sole reader; the prior concession
-that the core SA could read the CA *private* key via namespace co-tenancy is **eliminated**.
-The CP still concentrates risk (cluster-wide read of all tenant TLS keys via
-`WATCH_NAMESPACE=""` **and** the fleet-minting CA key — pin `WATCH_NAMESPACE` to shrink
-this), and **a stolen CA key still forges the entire fleet** (NameConstraints + EKU stop
-only cross-purpose abuse, NOT impersonation — a forged leaf rides a real SAN, so per-request
-SAN-drop can't revoke it), bounded **only by CA rotation**. Statelessness pushes all CA
-durability onto etcd, so the read-watch keep-last-good in every serving replica is the only
-in-process safety net against a re-blank. The new wrinkle: `allowed_sans` is broadcast
-unauthenticated — **not** a security property; the ids are opaque, confer no capability
-without a CA-chained key, are at worst mild recon; **operators MUST NOT encode secrets in
-edge ids**, and the NetworkPolicy keeps the surface bounded.
+> **Honest consequences of the CA-only + 7-day + revoke-by-rotation model.** (1) Per-edge
+> revoke = fleet-level CA rotation; no per-edge lever. (2) A compromised edge stays
+> trusted until rotation completes (blacklist only stops re-minting). (3) CA rotation is
+> now routine and safety-critical — a botched rotation (drop OLD before convergence) 502s
+> the entire fleet. (4) We take **both** proactive overlap (no-blip steady path) and
+> reactive (self-heals a missed poll), accepting the extra overlap complexity as the price
+> of not 502-ing the fleet on every revoke. (5) Net safety improvement: trust is a pure
+> cryptographic predicate with no operator-asserted string set in the per-request path —
+> at the cost of coarser (fleet-wide) revocation granularity. The operator has accepted
+> this tradeoff.
 
-**Fail-default: fail-closed.** A CP **unreachable at first boot** ⇒ `trustPol` nil ⇒ mTLS
-branch false ⇒ edges distrusted (degraded-but-safe), CIDR/Cloudflare branch unaffected. A
-bad/forged/empty/zero-cert `ca_pem` ⇒ validate-then-swap **rejects** and keeps last-good
-(never nils the live pool). A **steady-state CP outage never drops existing trust** (fail-
-static); only trust *changes* stall. A **persistently-unreachable CP MUST surface as a
-loud, alerting condition** (`parapet_trust_source{none}` stuck pre-bundle), never a quiet
-permanent degrade. **No path fails open.**
-
-**The explicit tradeoff.** This forces re-encrypt TLS, a PKI lifecycle, and the CA key
-living in-cluster. An expired edge cert hard-fails the handshake (502s); the CP-outage
-budget (= `EDGE_CLIENTCERT_TTL` × renew-before-fraction) must exceed the CP recovery SLO.
-It also adds a steady-state runtime dependency **for trust *changes* only** (core→CP to
-onboard or revoke); steady-state trust of already-known edges is fail-static and
-CP-independent. The trust feed must be **at least as available as the apiserver/watch-cache
-it replaced** — so **CP HA (≥2 replicas behind the ClusterIP) is REQUIRED**, and the core
-persists a warm-start cache (no-trust-until-revalidated) so a restart during a CP outage
-does not distrust the fleet. There is **no leader to fast-recover** — N stateless replicas
-+ the Service is the recovery story.
+**Fail-closed.** A CP unreachable at first boot ⇒ `clientCAs` nil ⇒ mTLS branch false ⇒
+edges distrusted (degraded-but-safe), CIDR branch unaffected. A bad/forged/empty/zero-cert
+`ca_pem` ⇒ reject + keep last-good. A steady-state CP outage never drops existing trust;
+a persistently-unreachable CP is a loud alert. **No path fails open.** The CP-outage budget
+= `EDGE_CLIENTCERT_TTL` × renew-before-fraction (~4.6 days at 7 d), which must exceed the
+CP recovery SLO. **CP HA (≥2 replicas) is REQUIRED.**
 
 ## Fail modes
 
 | Failure | Behavior |
 |---|---|
-| Bootstrap Job not yet run / still running (cold start) | `parapet-edge-ca` empty/absent → all serving replicas read no CA, all not-ready (503), the Service has zero endpoints, `POST /v1/edge-cert` connection-refused, trust-bundle has no `ca_pem`. Edges fail-static on last-good leaf; new edges stay not-ready. **Degraded, never fail-open.** Bounded by Job completion; self-heals on populate. Core treats no-`ca_pem` as not-yet-bootstrapped (keep retrying, never cache empty). |
-| Bootstrap Job re-runs after the CA is populated (redeploy / Helm / Argo / `kubectl apply`) | (a) parse → ADOPT, exit 0 (no-op). (b) guard annotation present but blanked → HARD ANOMALY, **never regenerate**, exit non-zero + `parapet_edge_ca_unexpected_empty_total++` + alert. The stub carries GitOps drift-exclusion. |
-| Two bootstrap Job pods run concurrently (node-loss double-run, delete-recreate, re-apply) | The `resourceVersion`-CAS linearizes them: exactly one `UpdateSecret` wins, the other gets `IsConflict`, re-reads, ADOPTS. The re-read-before-Update no-op closes the common race earlier. Single-writer is **not** relied on as a k8s guarantee; the CAS is the lock. |
-| Bootstrap Job fails silently (exhausts backoffLimit, or exits 0 without writing) | Forbidden: exit non-zero on any failure; re-GET after `UpdateSecret` and assert the CA parses before exit 0. Alerts on `kube_job_failed` AND absence-of-populated-CA-after-deadline AND `parapet_edge_ca_generated_total` exceeding 1 across the fleet lifetime. |
-| A serving replica caches the CA, then a rotation/re-populate writes a new CA | The CA-Secret read-watch (`atomic.Pointer[*Signer]`, validate-then-swap; active key from Secret content) converges within one debounce; the per-replica `parapet_edge_ca_signer_fingerprint` interlock gates trimming the old CA. |
-| Runtime CA-Secret DELETE/blank on a serving replica (GitOps prune, restored empty stub) | The replica **keeps its last-good in-memory signer**, alerts, never drops to no-signer. With the in-serving anti-regen guard removed, this is the only in-process safety net. |
-| CP unreachable at first boot (no cached bundle, or warm-start hint > `EDGE_TRUST_CP_MAX_STALE`) | `trustPol` nil ⇒ edges distrusted (XFF overwritten); core serves; CIDR branch unaffected. **Fail-closed.** `parapet_trust_source{none}`; background retry flips to mTLS on the first valid bundle. A persistently-unreachable CP is a loud alert. |
-| Core restart during a CP outage (in-memory bundle lost) | Reads `EDGE_TRUST_CP_CACHE_FILE` as a **warm-start hint only** — confers NO trust until revalidated. Degrades to CIDR-only until the CP returns. `parapet_trust_source{file}` then `{mtls}`. Persisting-and-trusting is forbidden (would resurrect a revoked SAN). CP HA makes this rare. |
-| Forged / replayed OLDER bundle over any TLS gap | Rejected by **forward-only**: the core swaps only when `generation` strictly advances; a replayed older body bumps `parapet_trust_rollback_rejected_total` and is dropped. The integrity precondition is mandatory non-skippable server-TLS. |
-| Bad / forged / empty / zero-cert `ca_pem` on a fetch | Validate-then-swap **rejects** (non-empty-input-yields-zero-certs is rejected), keeps last-good, bumps `parapet_trust_reload_rejected_total`, alerts. NEVER nils the live pool. An empty `allowed_sans` is accepted only when `generation` strictly advances. |
-| Missing/unparseable `EDGE_TRUST_CP_CA`, or non-https `EDGE_TRUST_CP_ENDPOINT`, when on | **FATAL** startup error — never a warning, never a system-roots fallback, never plaintext. A self-test asserts `RootCAs != nil && !InsecureSkipVerify`. No `EDGE_CP_ALLOW_PLAINTEXT` analog on either end. |
-| CP is a trust source but `CP_TLS_CERT`/`CP_TLS_KEY` empty (plaintext) | **FATAL CP startup error** (mirrors the `CP_TLS` pairing guard). The trust channel has no plaintext mode on either end. |
-| Unauthenticated long-poll flood (connection/goroutine/FD exhaustion) | Bounded: a semaphore caps concurrent watch handlers (over-limit ⇒ 503 + Retry-After), a context deadline frees blocked handlers, a per-source-IP cap + body cap apply, absurd `since` rejected cheaply. The edge-sources-only NetworkPolicy is availability-load-bearing; the CP sets `WriteTimeout`/`IdleTimeout` ≥ the watch ceiling. |
-| `/v1/waf` or trust-bundle generation seen flapping by a load-balanced client | Fixed: generation is resourceVersion-derived (replica-identical + monotonic), not a per-process counter. Two replicas reading identical source emit equal generation. The ETag stays the take/304 driver. |
-| CP restart resets an in-memory generation below a core's held `since` | Cannot happen: generation is an etcd resourceVersion, not a CP process counter, so a CP restart never lowers it. (If a content-hash were ever used instead, the CP would have to re-floor above the core's `since` and return current truth — but resourceVersion makes this moot.) |
-| Revocation across N stateless CP replicas + N core pods | Eventually-consistent, self-healing. Total exposure = max-CP-replica-watch-lag (a revoked token can mint one last full-TTL leaf off a lagging CP replica) + max-CORE-replica-watch-lag (a dropped SAN still honored on a lagging core pod), each = watch/relist lag + 300 ms debounce. Runbook confirms convergence on **all** replicas of **both** planes via the pod-labeled generation metric before declaring trusted/revoked. Short `EDGE_CLIENTCERT_TTL` bounds the last-mint window. |
-| CP-side allow-set derivation bug widens trust (single uncross-checked authority) | Pinned by intra-process tests (`identityFor()` == the SAN `Signer.Sign` stamps; a known-revoked id absent from a fresh `allowed_sans`), recomputed from the same registry snapshot that authorizes `/v1/edge-cert`. The core logs/metrics `parapet_trust_allowed_sans_count` + `parapet_trust_bundle_hash` so an unexpected widening is alertable. |
-| Allow-set change does not propagate (gen fails to bump / long-poll wedges) | Three mitigations: deterministic (sorted, NFC) SAN serialization before the gen/etag hash; the core watch client avoids a whole-request timeout (Transport idle/header timeouts + per-attempt ctx deadline + TCP keep-alive); the unconditional `EDGE_TRUST_CP_POLL_INTERVAL` safety poll. SLA: sub-second normally, ≤ one poll interval worst-case. |
-| Fleet-wide re-issue storm under N stateless replicas | The per-token rate limit and global signing cap are **PER-REPLICA** (effective ceiling N×, scales silently as replicas rise). authz-reject + key-type whitelist before any signing; the cap returns 429/503 + Retry-After; per-edge jitter prevents phase-lock. A hard global cap needs externalized state (deferred). |
-| CP readiness ("can sign") mistaken for system readiness ("core trusts the CA") | The edge can't self-detect the core-doesn't-trust-me state and WILL go ready and serve 502s in the convergence window. The onboarding gate **REQUIRES** confirming `parapet_trust_source{mtls}` / the trust-bundle hash includes the new CA before routing prod traffic. |
-| `EDGE_TRUST_SECRET` set on upgrade but `EDGE_TRUST_CP_ENDPOINT` unset (knob rename) | The core emits a **loud startup error** naming the rename, rather than silently ignoring the old knob and dropping every edge to CIDR-only. Back-compat is stated against a named shipped baseline, not "today." |
+| **Operator blacklists the token (`disabled:true`) but never rotates the CA** | The compromised edge's already-minted leaf chains to the live OLD CA and stays **fully trusted** until expiry (≤7 d). Mitigated by the boxed top-of-section WARNING, the single `revoke --edge` tool that does both steps atomically, and `parapet_edge_token_disabled_without_rotation` firing until the CA generation that distrusts the leaf advances. The default-dangerous path — made impossible to miss. |
+| **Blacklisted edge re-mints a NEW-CA leaf during the overlap (race across N stateless replicas)** | The blacklist must converge on **every** CP replica (pod-labeled authz-snapshot generation ≥ the disabling generation) **before** flipping `ca_id` — a barrier, not a parallel step. The pre-drop gate additionally asserts the revoked id has **no leaf under NEW** (verify absence). Residual: a leaf minted in the sub-second pre-convergence window (if the barrier was skipped) survives to the next rotation. |
+| **Half-applied rotation (NEW added, OLD never dropped)** | Silent indefinite trust of the revoked edge — the worst outcome. Mitigated by the idempotent-per-phase state machine (`overlap\|converged\|trimmed` annotation + intent/deadline), `parapet_edge_ca_rotation_stuck` paging while stuck in `overlap` past deadline, and a re-runnable trim that never regenerates a third CA. |
+| **Drop-OLD gated on a timer instead of measured convergence** | Forbidden. A hard convergence interlock across both planes (every CP replica reports NEW fingerprint + `OLD++NEW`; core reports `ca_id==new`; every good edge reports `parapet_edge_clientcert_ca_id==new`; revoked id absent under NEW); any unreporting/partitioned replica/edge blocks the drop (fail-closed); a loud logged override is the only bypass. |
+| **Stolen leaf key replayed from a cloned box (different IP)** | Undetectable under CA-only (no per-leaf pin, no IP binding); fully trusted and indistinguishable from the real edge. Accepted consequence; the only remedy is CA rotation. Require memory-only key, recommend TPM/PKCS#11, keep the SAN for out-of-band audit attribution. |
+| **`disabled:true` honored at only some authz call sites** | A disabled token could still mint via `/v1/edge-cert` or pull tenant **private keys** via `/v1/certs`. Required: a single chokepoint where `Known`/`Identity`/`Allowed` treat `disabled` (or deleted) as ABSENT — a full lockout. Residual: stops only future minting (rotation still mandatory for the live leaf). |
+| **Reactive re-mint misclassifies a non-trust upstream error** | `forward.go`'s ErrorHandler today collapses all errors to a generic 502. Required: re-mint **only** on a `bad_certificate`/`certificate_unknown`/`unknown_ca` handshake alert, never on dial/timeout/HTTP-status; per-edge single-flight + backoff + a circuit-breaker after K no-`ca_id`-change attempts — so an unrelated core outage can't cause a fleet-wide re-mint storm / tight loop. |
+| **Reactive-drop thundering herd → self-inflicted DoS on `POST /v1/edge-cert`** | Dropping OLD without confirming proactive convergence fails every good edge's handshake at once; all M edges re-mint against the per-replica-rate-limited, CPU-bound signer, which 429/503s and stalls convergence (extending the compromised-trusted window). Mitigated: proactive overlap is the mass path (convergence-gated drop is a no-op for good edges); reactive is the per-edge floor; jitter + backoff + `Retry-After` + single-flight. |
+| **Replayed older trust-bundle un-trusts a re-minted fleet or re-trusts a dropped CA** | Forward-only/anti-rollback is load-bearing: the core swaps only on a strictly-advancing `generation` (resourceVersion-derived), rejects `generation<=held` (`parapet_trust_rollback_rejected_total`), over mandatory non-skippable verified server-TLS. |
+| **Malformed/partial NEW CA PEM in the `OLD++NEW` overlap bundle** | Strict all-or-nothing parse on both core and edge (reject non-empty-yields-fewer-certs; never partial-append; keep last-good; bump the reject metric). The convergence gate asserts the core's pool actually contains the NEW fingerprint before any leaf is signed under NEW — a bad NEW block blocks the rotation loudly rather than half-applying it. |
+| **CP unreachable at first boot / core restart during a CP outage** | First boot: `clientCAs` nil ⇒ CIDR-only (fail-closed); background retry flips to mTLS on the first valid bundle. Restart-during-outage: the warm-start file is a hint only (no trust until revalidated); `parapet_trust_source{file}` then `{mtls}`. A persistently-unreachable CP is a loud alert. CP HA required. |
+| **Renewal failure inside the renew-before margin lets a leaf expire** | An expired client cert hard-fails the upstream handshake (502, same symptom as a CA drop). Guard: renew-before-fraction strictly in (0,1) with renew-instant leaving ≥ several `EDGE_REFRESH_INTERVAL` of slack, plus backoff+jitter retries; CP-outage budget = `TTL` × renew-before-fraction must exceed the CP recovery SLO. |
+| **Bootstrap Job race / re-run / silent fail** | The `resourceVersion`-CAS linearizes concurrent Job pods (loser adopts); the anti-regeneration guard makes a re-blank a HARD ANOMALY (never regenerate); exit non-zero + re-GET-verify before exit 0; alerts on `kube_job_failed`, absence-of-populated-CA-after-deadline, and `parapet_edge_ca_generated_total > 1`. |
 
 ## Configuration
 
 | Variable | Where | Default | Meaning |
 |---|---|---|---|
-| `TRUST_PROXY` | core | `cloudflare` | **Unchanged.** Static CIDR / `cloudflare`/`true`/`false` → the `cidrTrust` OR-branch. **Never add edge egress CIDRs here.** |
-| `EDGE_TRUST_CP_ENDPOINT` | core | `""` (feature off) | HTTPS base URL of the control plane. Set ⇒ the core pulls its trust bundle from `GET /v1/trust-bundle` instead of watching a Secret; unset ⇒ identical to today (CIDR-only). **MUST be `https://`** — non-https is a fatal startup error, no plaintext analog ever. |
-| `EDGE_TRUST_CP_CA` | core | `""` | PEM (path/inline) of the CA that signs the **CP server** cert → the trust client's `RootCAs`. **MANDATORY + FATAL** if missing/empty/unreadable/unparseable (or zero certs) when the endpoint is set — the only thing protecting the core from a forged trust anchor. No system-roots fallback, no skip-verify. SHOULD be a dedicated single-purpose CA; distinct from the edge CA in `ca_pem`. |
-| `EDGE_TRUST_CP_WATCH_TIMEOUT` | core/CP | `30s` | Server-side long-poll block ceiling. The CP `http.Server` `WriteTimeout`/`IdleTimeout` MUST be ≥ this; the core uses a per-attempt context deadline of this + slack, **not** a whole-request `http.Client.Timeout`. |
-| `EDGE_TRUST_CP_POLL_INTERVAL` | core | `5m` | Safety-net plain-GET poll, run **unconditionally** alongside the long-poll. Bounds worst-case revocation latency if a broadcast is missed or the watch goroutine wedges. |
-| `EDGE_TRUST_CP_CACHE_FILE` | core | `""` (recommended: set) | Path to persist the last-good bundle (public `ca_pem` + opaque SANs — no secret-at-rest concern). Written on every successful swap; read on boot as a **warm-start hint that confers NO trust until revalidated**. Never authoritative. |
-| `EDGE_TRUST_CP_MAX_STALE` | core | `1h` | Max age of the warm-start hint; an older file is ignored. Secondary bound (the primary is no-trust-until-revalidated). |
-| `EDGE_TRUST_REQUIRE_SAN` | core | `true` | Trust requires the verified leaf's URI SAN ∈ the live allow-set; the allow-set now comes from `/v1/trust-bundle`'s `allowed_sans` (no longer re-derived in the core). Still **incompatible with CP-issuance when CA-only** (fail-closed). |
-| `EDGE_DATAPLANE_MTLS` | edge | `false` | Enable the CP-issued data-plane client cert (CSR → `POST /v1/edge-cert`). Off ⇒ anonymous re-encrypt. Requires `EDGE_UPSTREAM_TLS=true`. Readiness gated on a loaded cert (fail-closed). |
-| `EDGE_CLIENTCERT_KEY_TYPE` | edge | `ecdsa-p256` | In-memory ephemeral keypair type (`p256`/`p384`/`ed25519`). RSA not offered (bounds the CP CSR-verify DoS surface). |
-| `EDGE_CLIENTCERT_TTL` | CP | `1h` | Issued **leaf** lifetime. Short — renewal is free — to bound a leaked-token-minted cert. Raise (24–72h) if outage tolerance dominates. |
-| `EDGE_CLIENTCERT_SKEW` | CP | `10m` | NotBefore backdating slack. The cert is minted on the CP clock, **validated on the core clock**. NTP sync between CP and core is a prerequisite. |
-| `EDGE_CLIENTCERT_RATE` + global signing cap | CP | `10/min` per token; cap unsized | **PER-REPLICA** behind the Service ⇒ effective fleet ceiling **N×**, scaling silently as replicas rise for HA. authz-reject + key-type whitelist run before any signing. A hard global cap needs externalized state (deferred). |
-| `EDGE_CA_BOOTSTRAP` / `--bootstrap-ca` | CP (Job) | false (serving mode) | Runs the same binary in one-shot CA-bootstrap mode (`EnsureCA`: adopt-if-present, generate-if-absent, never-regenerate, **CAS-guarded**, re-read-verify-before-exit), then exit. **The only process that writes the CA Secret.** |
-| `EDGE_CA_CERT` / `EDGE_CA_KEY` | CP | `""` (⇒ managed) | **Provided mode:** PEM paths to a mounted edge CA cert+key. Set ⇒ the CP uses them, never generates/writes; hot-reloaded. Both-or-neither (hard error if only one). Absent ⇒ managed (the Job generates). |
-| `EDGE_CA_SECRET` | CP | `parapet-edge-ca` | Name of the CA Secret in `POD_NAMESPACE`. The **Job** writes it (scoped get/update); **serving** reads it (read-only get + read-watch). Pre-created empty with GitOps drift-exclusion. Lives in a CP-only namespace. |
-| `EDGE_CA_TTL` | CP | `87600h` (10y) | Lifetime of a CP-generated edge CA cert. Long-lived (the leaf TTL is the short knob). Ignored in provided mode. Rotation is Job-driven. *(Open: shorten to 1–2y unless convergence-gated rotation has shipped.)* |
-| `EDGE_CA_KEY_TYPE` | CP | `ecdsa-p384` | Key type for a CP-generated CA (`p384`/`ed25519`). Ignored in provided mode. |
-| `POD_NAMESPACE` | CP | downward API `metadata.namespace` (**required**) | The CP's own namespace; the CA Secret is **read** here (serving-managed) and **written** here (the Job). NOT `WATCH_NAMESPACE`. Empty in bootstrap or serving-managed mode ⇒ fatal. |
-| `WATCH_NAMESPACE` | CP | `""` (all namespaces) | Cluster-wide tenant-TLS read = highest blast radius. **Recommend pinning** to the tenant-secret namespace(s). Distinct from `POD_NAMESPACE`; the CA read/write never uses it. |
-| `EDGE_UPSTREAM_CLIENT_CERT` / `_KEY` | edge | `""` | **Legacy mounted-cert (k8s-only) edge-side path**, superseded by `EDGE_DATAPLANE_MTLS` + CP-issuance. A mount detail, not a CA mode. |
-| `EDGE_UPSTREAM_TLS` / `EDGE_UPSTREAM_SNI` | edge | `false` / `""` | **Unchanged.** `EDGE_UPSTREAM_TLS=true` is required for mTLS trust; SNI presented on re-encrypt. |
+| `TRUST_PROXY` | core | `cloudflare` | **Unchanged** — the `cidrTrust` OR-branch. Never add edge egress CIDRs here. |
+| `EDGE_TRUST_CP_ENDPOINT` | core | `""` (off) | HTTPS base URL of the CP. Set ⇒ the core pulls `GET /v1/trust-bundle`. **MUST be `https://`** — non-https is fatal, no plaintext analog ever. |
+| `EDGE_TRUST_CP_CA` | core | `""` | PEM of the CA that signs the **CP server** cert → `RootCAs`. **Mandatory + fatal** if missing/empty/unparseable; no system-roots fallback, no skip-verify. Dedicated single-purpose CA; distinct from the edge CA in `ca_pem`. |
+| `EDGE_TRUST_CP_WATCH_TIMEOUT` / `_POLL_INTERVAL` | core/CP | `30s` / `5m` | Long-poll ceiling; safety-net poll. The poll now bounds **CA-rotation** propagation only (not per-request revocation), so it may lengthen; keep the long-poll for fast rotation convergence. |
+| `EDGE_TRUST_CP_CACHE_FILE` / `_MAX_STALE` | core | `""` / `1h` | Warm-start hint (no trust until revalidated; bounded by max-stale). |
+| `EDGE_TRUST_REQUIRE_SAN` | core | **forced false, deprecated** | CA-only is the only model; the per-request SAN check is removed. Setting `true` with CP-issuance is a **fatal config error**. Slated for removal. |
+| `EDGE_DATAPLANE_MTLS` | edge | `false` | Enable the CP-issued client cert. Requires `EDGE_UPSTREAM_TLS=true`. Readiness gated on a loaded cert. |
+| `EDGE_CLIENTCERT_TTL` | CP | **`168h` (7 d)** | Issued **leaf** lifetime (was 1 h). Buys a ~multi-day CP-outage budget (= `TTL` × renew-before-fraction ≈ 4.6 d). Renewal stays remaining-life (≤⅓, ~56 h mark). The paired-knob guard: renew-before-fraction in (0,1) with ≥ several `EDGE_REFRESH_INTERVAL` of slack before expiry. |
+| `EDGE_CLIENTCERT_REMINT_JITTER` | edge | `60s` (≥ signer drain) | Max random delay before a force-re-mint (proactive or reactive), to prevent a re-mint thundering herd when `ca_id` flips fleet-wide. With exponential backoff + `Retry-After` + per-edge single-flight + a no-`ca_id`-change circuit-breaker. |
+| `EDGE_CLIENTCERT_KEY_TYPE` / `_SKEW` / `_RATE` | edge/CP | `ecdsa-p256` / `10m` / `10/min` | Ephemeral key type; NotBefore backdate (negligible vs 7 d, but NTP between CP and core stays a prerequisite); per-token issuance limit (**per-replica**, effective N×). |
+| `EDGE_CA_BOOTSTRAP` / `--bootstrap-ca` | CP (Job) | false | One-shot CA bootstrap **and rotation** mode (`EnsureCA`: adopt/generate/never-regenerate, CAS-guarded). The only writer of the CA Secret. |
+| `EDGE_CA_CERT` / `_KEY` | CP | `""` (⇒ managed) | Provided mode (mounted CA). Both-or-neither. Absent ⇒ managed (the Job generates). |
+| `EDGE_CA_SECRET` | CP | `parapet-edge-ca` | The CA Secret in a CP-only namespace; Job writes (scoped), serving reads (read-only + read-watch). Pre-created empty, GitOps drift-exclusion. |
+| `EDGE_CA_TTL` | CP | `8760h–17520h` (1–2 y) | Edge CA cert lifetime. **Shortened** from 10 y now that rotation is a routine on-demand primitive — but kept comfortably longer than the expected revoke-driven rotation interval so a scheduled CA expiry doesn't collide with on-demand rotations. |
+| `POD_NAMESPACE` / `WATCH_NAMESPACE` | CP | downward API (**required**) / `""` | CA Secret namespace (read serving-managed, write Job); pin `WATCH_NAMESPACE` to shrink the cluster-wide tenant-TLS read blast radius. |
 
-Metrics: `parapet_trust_source{mtls|cidr|none|file}`, `parapet_trust_reload_rejected_total`,
-`parapet_trust_rollback_rejected_total`, `parapet_trust_bundle_age_seconds`,
-`parapet_trust_allowed_sans_count`, `parapet_trust_bundle_hash` (core);
-`parapet_edge_clientcert_loaded`, `parapet_edge_clientcert_not_after` (edge);
-`parapet_edge_ca_generated_total` (Job; alert if > 1 fleet-lifetime),
-`parapet_edge_ca_unexpected_empty_total`, `parapet_edge_ca_signer_fingerprint`
-(per-serving-replica, pod-labeled). Both planes expose the registry/trust-bundle
-generation they last applied (pod-labeled) for convergence gating.
+Registry shape: `{"<token>":{"id":...,"domains":[...],"disabled":bool}}`. New trust-bundle
+field `ca_id`. Metrics: `parapet_trust_source{mtls|cidr|none|file}`,
+`parapet_trust_reload_rejected_total`, `parapet_trust_rollback_rejected_total`,
+`parapet_trust_bundle_age_seconds` (core); `parapet_edge_clientcert_loaded`,
+`parapet_edge_clientcert_not_after`, **`parapet_edge_clientcert_ca_id`** (edge);
+**`parapet_edge_token_disabled_without_rotation`**, **`parapet_edge_ca_rotation_stuck`**,
+`parapet_edge_ca_generated_total`, `parapet_edge_ca_unexpected_empty_total`,
+`parapet_edge_ca_signer_fingerprint` (CP, pod-labeled). **Removed:**
+`parapet_trust_allowed_sans_count` and the deterministic-SAN-serialization-before-etag
+requirement.
 
 ## Onboarding flow (the payoff)
 
-1. **One-time, code-only:** deploy the two SAs (read-only serving + scoped-write Job) and
-   their RBAC, pre-create the **empty** `parapet-edge-ca` stub (CP-only namespace, GitOps
-   drift-exclusion), set `POD_NAMESPACE` on both the serving Deployment and the Job, and
-   ship the **bootstrap Job as a pre-install/PreSync hook ordered before serving**. On
-   first install the Job **generates and persists** the edge CA once (managed mode) — **no
-   openssl, no cert-manager**; serving becomes ready only once a CA is loaded. The core
-   points `EDGE_TRUST_CP_ENDPOINT` at the CP and `EDGE_TRUST_CP_CA` at the CP **server** CA,
-   then pulls the edge CA's public cert + the live allow-set over `GET /v1/trust-bundle`.
-   *Only restart, ever — never again per-edge.*
-2. **Per edge — grant a data-plane identity (one registry edit).** Add the edge's entry to
-   `edge-controlplane-tokens` with an explicit `id`. This single edit authorizes its
-   cert/WAF fetch, makes the CP **issue** its data-plane cert on `POST /v1/edge-cert`, and
-   publishes its SAN in `allowed_sans`.
+1. **One-time, code-only:** deploy the two SAs + RBAC, pre-create the empty
+   `parapet-edge-ca` stub (CP-only namespace, GitOps drift-exclusion), set
+   `POD_NAMESPACE`, and ship the **bootstrap Job as a pre-install/PreSync hook before
+   serving**. On first install the Job generates+persists the edge CA (managed) — no
+   openssl, no cert-manager. The core points `EDGE_TRUST_CP_ENDPOINT` + `EDGE_TRUST_CP_CA`
+   and pulls the public CA + `ca_id` over `GET /v1/trust-bundle`.
+2. **Per edge — grant identity (one registry edit).** Add the edge's entry with an `id`
+   (now labeling/audit, **not** a trust grant). This authorizes its cert/WAF fetch and
+   makes the CP issue its leaf via `POST /v1/edge-cert`.
 3. **Configure the edge:** `EDGE_DATAPLANE_MTLS=true`, `EDGE_UPSTREAM_TLS=true`,
-   `EDGE_UPSTREAM_ADDR` → core `:443`. For a Docker edge that's it — its only input stays
-   `EDGE_CP_TOKEN`.
-4. **Deploy + verify.** Confirm `parapet_trust_source{mtls}` **and** that
-   `parapet_trust_bundle_hash` / `parapet_trust_allowed_sans_count` reflect the new id **as
-   observed by the core** before routing prod traffic (worst-case convergence one
-   `EDGE_TRUST_CP_POLL_INTERVAL`).
-5. **Revoke:** **delete the edge's registry entry** → its SAN leaves `allowed_sans` →
-   distrusted, with latency = max-CP-replica-watch-lag + max-CORE-replica-watch-lag (each
-   watch/relist lag + 300 ms debounce); confirm convergence on **all** replicas of **both**
-   planes via the pod-labeled generation metric. Deleting only the token does NOT revoke an
-   already-minted cert. For a **leaked CA key**, SAN-drop does NOT help — the only fix is
-   **CA rotation** (the Job-driven overlap runbook), gated on the convergence metric.
+   `EDGE_UPSTREAM_ADDR` → core `:443`. Docker edge: only input stays `EDGE_CP_TOKEN`.
+4. **Deploy + verify.** Confirm `parapet_trust_source{mtls}` and that the core's active
+   CA set / `ca_id` reflects the CA (worst-case convergence one `EDGE_TRUST_CP_POLL_INTERVAL`).
+5. **Revoke — see the boxed warning and the runbook below.**
+
+### Revoke an edge
+
+> ⚠️ **Blacklisting a token does NOT revoke trust** — see [Revocation](#revocation--ca-rotation).
+> For a real compromise, CA rotation is mandatory.
+
+Ship a single tool, **`edge-controlplane revoke --edge <id>`**, that performs **both**
+steps as one atomic, idempotent, resumable gesture (resumable via the rotation-phase
+annotation): (1) **blacklist** — set `disabled:true` (preferred over delete; a full
+lockout); (2) **wait** until the blacklist has converged on **every** CP replica
+(pod-labeled metric) — a barrier, not a parallel step; (3) **add** the NEW CA to the
+overlap bundle; (4) good edges re-mint under NEW (proactive, jittered); (5) **confirm**
+convergence via the interlock (every good edge on NEW; the revoked id absent under NEW);
+(6) **drop** OLD — the revoked edge's OLD-CA leaf stops verifying and it is distrusted.
+Never expose a bare `blacklist` verb that does only step (1) without loudly printing
+"TRUST NOT YET REVOKED — run rotate"; `parapet_edge_token_disabled_without_rotation`
+fires until the rotation completes.
 
 ## Phasing
 
-1. **Phase 1 — the primary mechanism (a bare Docker edge works, no cert-manager, HA CP).**
-   Core: the per-request closure + `GetConfigForClient` hot-swap (unchanged); the tokenless
-   `TrustCpClient` long-poll (mandatory-server-TLS, fatal-on-missing-CA, forward-only
-   resourceVersion-derived generation, validate-then-swap, fail-static, warm-start disk
-   cache that confers no trust until revalidated); `EDGE_TRUST_REQUIRE_SAN=true`; the
-   `X-Forwarded-Country/-ASN` strip; the metrics. CP-issuance: `POST /v1/edge-cert`,
-   `edgecp/signer.go` (zero-value template + post-sign self-check + key-type whitelist +
-   HSM/KMS seam), `Authz.Identity`, the **single in-CP `identityFor`** derivation (no shared
-   cross-binary package). **Managed-CA via a run-once bootstrap Job** (`--bootstrap-ca`)
-   running `EnsureCA` (adopt-or-generate-never-regenerate, ECDSA-P384, single-purpose,
-   NameConstrained), **keeping the `resourceVersion`-CAS and the anti-regeneration guard
-   INSIDE the Job** plus a re-read-before-write no-op; the k8s write path scoped to the Job
-   SA; serving replicas read-only with the CA-Secret read-watch keeping the signer
-   hot-reloadable. **Stateless-HA serving** (no leader election; Service +
-   readiness-gated-on-loaded-CA), the **content-derived generation fix** for **both**
-   `/v1/waf` and the trust-bundle, the Job-ordering hook, the `GET /v1/trust-bundle`
-   endpoint (tokenless, `?watch` long-poll, bounded concurrency), and the CP-side fatal
-   guard that trust-distribution requires `CP_TLS`. `NetworkPolicy` locking core `:80`/`:443`
-   and the CP (now availability-load-bearing).
-2. **Phase 2 — stronger hardening.** Mutual auth of the edge hop (edge pins the core CA,
-   drop `InsecureSkipVerify`); **CA auto-rotation** (Job triggered at `NotAfter` × fraction)
-   gated on the cross-replica convergence metric; an **HSM/KMS `Signer`** so the raw CA key
-   never sits in pod memory; CRL/OCSP via `VerifyConnection`; real SPIRE SVID migration.
-   *(The CP-only-namespace CA-key-read isolation is now the Phase-1 default, not a Phase-2
-   item.)*
-3. **Phase 3 — optional companion.** A `TRUST_PROXY_DYNAMIC=true` ConfigMap-of-CIDRs
-   OR-branch for callers that genuinely cannot present a client cert — same atomic +
-   validate-then-swap discipline.
+1. **Phase 1 — the primary mechanism.** Core: the CA-only closure (`cidrTrust OR
+   verified-chain`), `GetConfigForClient` hot-swap, the tokenless `TrustCpClient`
+   long-poll (mandatory server-TLS, forward-only resourceVersion-derived generation,
+   strict all-or-nothing parse, warm-start hint), the `X-Forwarded` strip, the metrics.
+   CP-issuance: `POST /v1/edge-cert`, the signer, the **`disabled` tombstone full
+   lockout**. Trust-bundle `{generation, ca_pem, ca_id}`. **Managed-CA via the run-once
+   bootstrap Job** (CAS + anti-regen guard inside the Job). **Stateless-HA serving**.
+   The **force-re-mint trigger** (`ca_id` on `/v1/waf` + proactive re-mint + the narrow
+   reactive classifier + jitter/backoff/circuit-breaker). The **convergence-gated overlap
+   CA rotation** (now the revocation primitive — moved from Phase 2) and the **`revoke
+   --edge` tool**. `NetworkPolicy` locking core `:80`/`:443` and the CP.
+2. **Phase 2 — stronger hardening.** Edge pins the core CA (drop `InsecureSkipVerify`);
+   an **HSM/KMS `Signer`** so the raw CA key never sits in pod memory; the **non-exportable
+   leaf key path** (TPM/PKCS#11) for high-value edges; CRL/OCSP; real SPIRE SVID
+   migration.
+3. **Phase 3 — optional `TRUST_PROXY_DYNAMIC` CIDR companion** for callers that cannot
+   present a client cert.
 
 ## Alternatives considered
 
-- **Core keeps watching the CA Secret + a shared SAN-derivation package (the prior design).**
-  Rejected: it forced the core to hold k8s read on a namespace co-tenant with the CA
-  *private* key, required a cross-binary derivation package with a split-brain risk (papered
-  over by a conformance test), and made revocation latency depend on a 6th Secret watch. The
-  tokenless CP pull is strictly better — one fewer credential, an unforgeable trust anchor
-  (mandatory server-TLS), single-sourced allow-set, full CA-key isolation — at the honest
-  cost of a steady-state core→CP dependency for trust *changes* (mitigated by fail-static +
-  a warm-start cache + required CP HA).
-- **In-serving CA generation with a `resourceVersion`-CAS create-once (the prior managed
-  mode).** Rejected for HA: it kept write RBAC on every serving replica and made the serving
-  process stateful-ish. The CAS + anti-regen guard are **retained but relocated into a
-  run-once Job**; serving becomes read-only and trivially replicable. (A naive "a Job is a
-  single writer so drop the CAS" was itself rejected — a Job is not a guaranteed single
-  pod.)
-- **CP mints key+cert and ships both (vs CSR-based).** Rejected as default — strictly weaker
-  (puts a private key on the wire). The CSR form keeps the key edge-local.
-- **Token-gated `TrustProxy` (HMAC header).** A near-tie co-leader on operational
-  single-source-of-truth (grafted). Rejected as primary on security: replayable header,
-  order-fragile strip, O(N) HMAC amplification, clock-skew.
-- **Dynamic IP trust list (ConfigMap of CIDRs).** Lowest effort; grafted its
-  operator-asserted-trust + keep-last-good discipline. Rejected as primary (no security-bar
-  raise; widens the spoof surface for NAT'd edges). Kept as the optional Phase 3 companion.
-- **SPIFFE/SPIRE workload identity.** Operationally disqualifying now (out-of-cluster
-  attestation needs SPIRE federation + a second rotating CA bundle). Grafted only the
-  URI-SAN naming.
-- **CA-only mTLS (`EDGE_TRUST_REQUIRE_SAN=false`).** Supported for non-issuance deployments
-  but **forbidden with CP-issuance** (no per-request revocation lever).
-- **cert-manager-issued CA / cert-manager-proxy issuance (removed).** Added a hard CRD
-  dependency + async round-trip + an out-of-band CA-creation step that defeats the zero-PKI
-  goal. The CP now self-manages the CA via the Job; provided mode covers existing PKIs.
+- **SAN allow-set per-request trust (the prior design, removed by decision).** It gave
+  per-edge revocation in seconds (drop the registry entry → SAN leaves the allow-set), at
+  the cost of a per-request operator-asserted string set the CP was the sole uncross-checked
+  authority for, a cross-binary derivation, and a single-fleet-widening-bug surface. Removed
+  in favor of CA-only: a pure cryptographic trust predicate with no silent trust-widening —
+  **trading per-edge instant revocation for coarser, fleet-wide revoke-by-CA-rotation.** The
+  operator accepted this; `EDGE_CLIENTCERT_TTL=7d` + the `revoke --edge` tool make the
+  rotation the explicit, tooled revocation path.
+- **CP mints key+cert and ships both.** Rejected (puts a private key on the wire); CSR-based
+  keeps the key edge-local.
+- **Token-gated `TrustProxy` (HMAC header) / dynamic IP list / SPIFFE-SPIRE.** Rejected as
+  primary (replayable header / no security-bar raise / out-of-cluster attestation infra);
+  the SAN naming is grafted from SPIFFE.
+- **cert-manager-issued CA.** Removed (CRD dependency + out-of-band CA creation defeats the
+  zero-PKI goal). The bootstrap Job self-manages the CA; provided mode covers existing PKIs.
 
 ## Open questions
 
-- **Generation source:** confirm `max(resourceVersion)` across the source ConfigMaps/Secrets
-  as the generation (the only option both replica-identical AND monotonic). resourceVersion
-  is officially opaque (treat as monotonic-per-object; handle a delete+recreate that resets
-  it by also keying on object UID so a recreate triggers a re-sync, not a permanent reject).
-  If a hash is ever preferred, **rename** the field to an opaque equality-only fingerprint
-  with ordering/since/rollback semantics forbidden.
-- **Purge journal (Phase 5, design-only):** the lone genuinely-stateful feature,
-  **known-broken under `replicas>1`** with a per-process in-memory monotonic `seq` (an admin
-  `POST` lands on one replica only; per-replica `seq`/`min_seq` fire `flush_required`
-  spuriously). MUST be externalized (a ConfigMap/CRD journal every replica observes via its
-  existing watch; `POST` becomes a write-to-k8s) before shipping multi-replica. Do not
-  enable `/v1/purges` with `replicas>1` until then.
-- **Hard global signing cap:** a true fleet-wide ceiling vs the per-replica N× loosening
-  needs externalized rate-limit state (a shared token bucket). Accept N× (simplest), set
-  per-replica = `ceil(target/N)` (imperfect under uneven LB), or defer? `N` is not directly
-  available inside a pod (would come from an env/Deployment field).
-- **Long-poll concurrency cap default:** what semaphore size balances "never starve the
-  token-gated endpoints" against "a small legit core fleet + its safety poll is never 503'd"?
-  Tie to the expected core replica count behind the NetworkPolicy.
-- **CP HA enforcement:** ≥2 replicas is now REQUIRED — should the core warn if it can detect
-  a single-replica CP, or is this left to deployment review?
-- **First-boot ordering on a fresh cluster:** the core's first bundle needs the Job's
-  `EnsureCA` to have populated the CA (503 until then) AND the CP server cert present — pin
-  the deploy ordering / readiness-gating so a cold cluster converges without a manual
-  restart, and decide whether the core blocks startup on the first bundle or starts
-  CIDR-only and converges.
-- **`EDGE_CLIENTCERT_TTL` vs CP-outage budget:** pin a default that exceeds the CP recovery
-  SLO, or expose `TTL` + renew-before as paired knobs with a guard that renew-before < `TTL`
-  by a safe margin?
-- **Empty-stub feasibility:** do target k8s versions reject a zero-length `tls.crt` on a
-  `kubernetes.io/tls` CREATE? If so, ship the stub as type `Opaque` (type is advisory to our
-  code and can't change on `Update`).
-- **Mutual auth of the edge hop:** should the edge verify the core's server cert (pin the
-  core CA, drop `InsecureSkipVerify` in `forward.go`)? Today only edge→core (data plane) and
-  core→CP (trust) directions are asymmetric by design.
+- **`revoke --edge` tooling form** (subcommand vs CLI vs Job) and the metric-read channel
+  it uses to gate the OLD-drop (Prometheus query / a CP convergence-status endpoint).
+- **`ca_id` channel:** confirm `ca_id` on `GET /v1/waf` (cheapest) — but `/v1/waf` is only
+  fetched on `EDGE_REFRESH_INTERVAL` and a serve-no-WAF edge still needs the signal; verify
+  every edge polls it even with WAF distribution off, or attach `ca_id` to `/v1/certs` too.
+- **Convergence gate vs a permanently-dead edge:** the interlock blocks the drop on any
+  non-reporting good edge (fail-closed) — but a dead edge would block every revoke forever.
+  Define the operator-override and how a decommissioned (vs partitioned) edge is excluded
+  without re-introducing a per-edge allow-set.
+- **`EDGE_CLIENTCERT_REMINT_JITTER` vs signer capacity:** the jitter window must exceed the
+  fleet's signer drain (M edges / (N replicas × rate × sign-cost)); does a rotation need a
+  temporary signing-capacity bump or a fleet-size-aware jitter default?
+- **Circuit-breaker K** default and its coupling to `EDGE_REFRESH_INTERVAL`.
+- **`EDGE_CA_TTL` shortening (1–2 y):** confirm the shorter CA TTL doesn't itself trigger a
+  forced rotation (and a fleet re-mint) on an inconvenient cadence — keep it comfortably
+  longer than the expected revoke-driven rotation interval.
+- **Non-exportable leaf key (TPM/PKCS#11):** Phase 2, or required now given the 7-day (168×)
+  leaf-key exposure window for compromise-sensitive deployments?
+- **Generation source** (resourceVersion opacity / UID-reset handling), **purge journal**
+  externalization before `replicas>1`, **hard global signing cap**, **long-poll concurrency
+  cap default**, **CP HA enforcement**, **first-boot cluster ordering**, **empty-stub
+  feasibility** (Opaque vs `kubernetes.io/tls`) — unchanged from prior rounds.
 
 ## Conformance / contract
 
-On acceptance, fold into [`SPEC.md`](SPEC.md): the trust predicate
-(`cidrTrust OR (verified-edge-CA-chain AND SAN ∈ allow-set)`); the `POST /v1/edge-cert`
-(CSR in, chain out, CP-decided SAN, no key on the wire) and the **tokenless** `GET
-/v1/trust-bundle` (with the `?watch` long-poll and the forbidden-401/403 property)
-endpoints; the managed (bootstrap-Job) / provided CA model and the **stateless-serving +
-run-once-Job** posture; the **content-derived generation contract** (replica-identical AND
-monotonic; resourceVersion-derived) for **both** `/v1/waf` and the trust-bundle; the new env
-vars (`EDGE_TRUST_CP_*`, `EDGE_DATAPLANE_MTLS`, `EDGE_CLIENTCERT_*`, `EDGE_CA_*`, CP
-`POD_NAMESPACE`/`WATCH_NAMESPACE`); the `X-Forwarded-Country/-ASN` ingress strip; and the
-per-request order (trust evaluation precedes WAF/rate-limit). Conformance tests: the
-intra-process `identityFor()` == `Signer.Sign` SAN; a known-revoked id absent from a fresh
-`allowed_sans`; the two-goroutine concurrent-generate CAS test against client-go fake
-(exactly one CA survives, the loser adopts), exercised against the Job `EnsureCA`; two
-`WafStore`/serving replicas fed identical source report **equal** generation; the
-NameConstraints `x509.Verify` accept/reject pair. The Rust implementation in [`rust/`](rust/)
-tracks the same contract or records a divergence.
+On acceptance, fold into [`SPEC.md`](SPEC.md): the predicate (`cidrTrust OR
+verified-edge-CA-chain` — no SAN clause); `POST /v1/edge-cert` and the **tokenless**
+`GET /v1/trust-bundle` (`{generation, ca_pem, ca_id}`, `?watch` long-poll, no 401/403);
+the managed (bootstrap-Job) / provided CA model, the **stateless-serving + run-once-Job**
+posture, and **CA rotation as the revocation primitive** (overlap bundle + convergence
+interlock); the **`disabled` tombstone** full-lockout; the content-derived generation
+contract; the force-re-mint trigger; the new env vars; the `X-Forwarded` strip. Conformance
+tests: (1) **DELETE** "a known-revoked id absent from a fresh `allowed_sans`" (the mechanism
+no longer exists); (2) **KEEP** "`identityFor()` == the SAN `Signer.Sign` stamps" but
+**re-scoped as a labeling/audit check, explicitly NOT a trust check**; (3) **ADD** the
+load-bearing trust test: `x509.Verify` of an edge leaf against the trust-bundle `ca_pem`
+pool returns a non-empty chain, plus the NameConstraints accept/reject pair; (4) **ADD** a
+rotation test: an `OLD++NEW` overlap `ca_pem` verifies leaves under **both**; after trim, an
+OLD-CA leaf fails; the strict all-or-nothing parse rejects a truncated NEW block (keep
+last-good); (5) **ADD** a disabled-token test: a `disabled` entry is treated as UNKNOWN at
+`Known`/`Identity`/`Allowed` (no mint, no `/v1/certs`, no `/v1/waf`); (6) the two-goroutine
+concurrent-generate CAS test against client-go fake. The Rust implementation in
+[`rust/`](rust/) tracks the same contract or records a divergence.
 
 [TLS SNI fallback memory]: the proxy serves a self-signed fallback on an SNI miss when the
-live cert table loses `GetCertificate`; the `GetConfigForClient` self-test exists to prevent
+live cert table loses `GetCertificate`; the `GetConfigForClient` self-test prevents
 re-introducing that class of bug during a trust reload.

--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -7,9 +7,14 @@
 > core. It builds on the edge architecture in [`EDGE.md`](EDGE.md). Per
 > [`CLAUDE.md`](CLAUDE.md), the behavior contract changes in [`SPEC.md`](SPEC.md)
 > first; on acceptance, the contract bits (the trust predicate, the new env vars,
-> the new `POST /v1/edge-cert` endpoint, the per-request order) fold into `SPEC.md`
-> and the architecture into `EDGE.md`. **No cert-manager dependency:** the control
-> plane self-manages the edge CA.
+> the `POST /v1/edge-cert` + tokenless `GET /v1/trust-bundle` endpoints, the
+> per-request order) fold into `SPEC.md` and the architecture into `EDGE.md`.
+> **No cert-manager dependency:** a run-once bootstrap Job self-manages the edge CA.
+> **The core no longer watches a k8s Secret for trust material; it pulls a CP-issued
+> trust bundle over verified server-TLS.** The CP is the single authority for the
+> SAN allow-set — there is no shared SAN-derivation package imported by both
+> binaries. **The serving control plane is stateless across N identical replicas
+> behind its Service (no leader election).**
 
 ## The problem
 
@@ -47,11 +52,12 @@ good identity.
 `parapet.Conditional` is `func(r *http.Request) bool`, evaluated **per request**
 (parapet `proxy.go` `ServeHTTP` → `m.Trust(r)` → `trust`/`distrust`). A closure
 installed **once** at startup can read an `atomic.Pointer` to a live trust policy
-that is **hot-swapped** from a watched Kubernetes Secret — exactly the
-`debounce` + validate-then-swap idiom the WAF reload already uses
-(`controller_waf.go`), which never rebuilds the route mux. **No restart.** The
-question is only *what credential the edge presents* and *where the trust policy
-comes from*.
+that is **hot-swapped** from the trust bundle the core pulls from the control plane
+(`GET /v1/trust-bundle`), via the same validate-then-swap discipline the edge's
+`CpClient` fetch loop uses (`edge/cp.go`, `edge/refresh.go`) — fail-static,
+all-or-nothing, never rebuilding the route mux. **No restart.** The question is only
+*what credential the edge presents* and *how the core learns the live trust policy*
+— and the answer to the latter is now a tokenless CP pull, not a Secret watch.
 
 ## Recommended design: edge mTLS (client-cert-as-trust)
 
@@ -60,22 +66,21 @@ not a source IP.
 
 1. **A dedicated, single-purpose edge CA.** Created once and reused forever; it
    signs **nothing else**, so "chains to this CA" means exactly "is a sanctioned-edge
-   credential." By default (**managed** mode) the **control plane generates the CA on
-   first boot and persists it** to its own RBAC-locked `parapet-edge-ca` Secret — no
+   credential." By default (**managed** mode) a **run-once bootstrap Job generates
+   the CA once and persists it**; the serving CP only **reads** it and signs — no
    cert-manager, no out-of-band openssl. For orgs with an existing PKI, **provided**
-   mode lets the operator mount their own CA (`EDGE_CA_CERT`/`EDGE_CA_KEY`) and the CP
-   uses it without generating. Either way the key never reaches an edge — only leaf
-   certs do. See [Control-plane wiring](#control-plane-wiring-cp-issues-the-client-cert).
+   mode lets the operator mount their own CA (`EDGE_CA_CERT`/`EDGE_CA_KEY`) and the
+   CP uses it without generating. Either way the key never reaches an edge — only
+   leaf certs do. See [Control-plane wiring](#control-plane-wiring-cp-issues-the-client-cert).
 
 2. **Each edge gets a short-lived client cert with a stable URI SAN
-   `spiffe://parapet.moonrhythm.io/edge/<id>`.** By default the **control plane
-   issues it** over the edge's existing bearer-authenticated HTTPS channel — the
-   edge sends a CSR to `POST /v1/edge-cert`, the CP signs it with the edge CA and
-   returns only the cert chain; the **private key never leaves the edge**, and the
-   **CP decides the SAN from the token identity** (ignoring any SAN in the CSR), so a
-   compromised edge cannot request a SAN it isn't entitled to. Renewal is generous
-   (renew at ~⅓ lifetime *remaining*) so it never races expiry — see
-   [Edge wiring](#edge-wiring).
+   `spiffe://parapet.moonrhythm.io/edge/<id>`.** The **control plane issues it** over
+   the edge's existing bearer-authenticated HTTPS channel — the edge sends a CSR to
+   `POST /v1/edge-cert`, the CP signs it with the edge CA and returns only the cert
+   chain; the **private key never leaves the edge**, and the **CP decides the SAN
+   from the token identity** (ignoring any SAN in the CSR), so a compromised edge
+   cannot request a SAN it isn't entitled to. Renewal is generous (renew at ~⅓
+   lifetime *remaining*) so it never races expiry — see [Edge wiring](#edge-wiring).
 
 3. **The edge presents it** on the re-encrypt hop. `edge/forward.go`'s
    `EDGE_UPSTREAM_TLS=true` path gets the client cert via
@@ -87,11 +92,12 @@ not a source IP.
 4. **The core verifies it.** The `:443` `tls.Config` gets
    `ClientAuth = tls.VerifyClientCertIfGiven` (the cert is **optional** —
    Cloudflare-direct and browser traffic present none and complete the handshake
-   unchanged) and a `ClientCAs` pool sourced from the watched trust Secret. The
-   standard library cryptographically verifies any presented client cert (with
-   `ExtKeyUsageClientAuth`) against `ClientCAs` during the handshake and, on
-   success, populates `r.TLS.VerifiedChains`. A presented-but-unverifiable cert
-   **aborts the handshake**.
+   unchanged) and a `ClientCAs` pool sourced from the trust bundle the core pulls
+   from the CP's `GET /v1/trust-bundle` (no longer a watched Secret — see
+   [Core wiring](#core-wiring)). The standard library cryptographically verifies any
+   presented client cert (with `ExtKeyUsageClientAuth`) against `ClientCAs` during
+   the handshake and, on success, populates `r.TLS.VerifiedChains`. A
+   presented-but-unverifiable cert **aborts the handshake**.
 
 5. **The per-request trust predicate** (installed once; see [Core wiring](#core-wiring)):
 
@@ -102,46 +108,46 @@ not a source IP.
    ```
 
    The SAN check is re-evaluated **per request** against an `atomic.Pointer`-held
-   allow-set, so **dropping a SAN distrusts that edge within ~300 ms** — even on
-   existing keep-alive / HTTP-2 connections. That is the fast per-edge revocation
-   lever (but **not** a defense against a stolen *CA* key — see the Security model).
+   allow-set fed by the CP long-poll, so **dropping a registry entry distrusts that
+   edge within one debounce of the CP recompute** (sub-second normally; bounded by
+   `EDGE_TRUST_CP_POLL_INTERVAL` worst-case if a long-poll wake is missed — see
+   [Freshness](#freshness-long-poll-not-bare-poll)). The predicate itself is
+   unchanged; only the *feed* moves.
 
 ### Single source of truth (onboard in one place)
 
-The SAN allow-set is derived from the **same `edge-controlplane-tokens` Secret the
-control plane already authorizes against** (`edgecp.Authz`, `edgecp/authz.go`).
-The registry shape becomes `{ "<token>": { "id": "<edge-id>", "domains": [...] } }`,
-where `id` is an **explicit, separate opt-in grant** of a data-plane identity.
+Onboarding/offboarding touches one registry, `edge-controlplane-tokens`, whose shape
+becomes `{ "<token>": { "id": "<edge-id>", "domains": [...] } }`, where `id` is an
+**explicit, separate opt-in grant** of a data-plane identity. Adding an entry with an
+`id` → the CP issues that edge's cert (stamping its SAN) **and** publishes the same
+SAN in the allow-set; **deleting an entry = data-plane revoke** within the
+convergence bound below.
 
-**Onboarding/offboarding touches one registry:**
+The SAN allow-set is now computed in **exactly one place — the control plane**, by
+the same `identityFor(id) -> spiffe://parapet.moonrhythm.io/edge/<id>` derivation
+`Signer.Sign` uses to stamp the URI SAN into every issued leaf. The core no longer
+derives anything: it *receives* the live `allowed_sans` already computed, over `GET
+/v1/trust-bundle`. So CP-stamped-SAN == broadcast-allow-set-entry holds **by
+construction within one process**, not across a cross-binary boundary — the prior
+shared-package-imported-by-both-binaries hack and its split-brain risk are **gone**,
+not papered over with a conformance test. Canonical form is unchanged: `<id>`
+**lowercased, trimmed, NFC-normalized, validated as a SPIFFE path segment** (no `/`,
+no whitespace, bounded length), **rejected fail-closed at load time** if invalid. A
+serve-all (`"*"`) token gets **no** identity by default; an existing registry
+migrates to no identity for every token (feature off ⇒ identical to today).
 
-- Adding an entry with an `id` → the control plane issues that edge's data-plane
-  cert (stamping its SAN) **and** the core adds the same SAN to its allow-set.
-- **Deleting an entry = data-plane revoke** in ~300 ms, closing the split-brain
-  where revoking only the control-plane token left the edge trusted until its cert
-  expired.
-
-The SAN in the minted cert and the core's allow-set entry are byte-identical **by
-construction**, because both derive from the one registry via **one shared function
-in one package, imported by BOTH `cmd/edge-controlplane` (the signer) and
-`cmd/parapet-ingress-controller` (the core allow-set)** — never two independent
-`identityFor()` implementations (a split-brain bug waiting to happen: e.g. one side
-lowercasing the id, the other not, as `authz.go:27` already lowercases domains).
-Canonical form: `spiffe://parapet.moonrhythm.io/edge/<id>` where `<id>` is
-**lowercased, trimmed, NFC-normalized, and validated as a SPIFFE path segment** (no
-`/`, no whitespace, bounded length) — **rejected fail-closed at load time on BOTH
-sides** if invalid. A conformance test asserts CP-stamped-SAN == core-allow-set
-entry for a fixed registry fixture.
-
-The identity is **never auto-derived** from the token's domains or its mere
-presence: a serve-all (`"*"`) token gets **no** data-plane identity by default
-(widest blast radius), and an existing registry **migrates to no identity** for
-every token — preserving "feature off ⇒ identical to today." The add/delete
-reload-skew between the two planes (~one debounce each) is **fail-closed in both
-directions**: a SAN in the allow-set with no live cert is harmless; a minted cert
-whose SAN isn't yet trusted just degrades to untrusted. Both planes expose the
-registry generation/hash they last applied as a metric, so an operator can confirm
-convergence before declaring an edge trusted.
+**This single-sourcing also removes the only independent cross-check**, so the CP's
+allow-set correctness is now wholly load-bearing for the trust boundary: an
+over-broad allow-set is a silent fleet-wide trust-widening with no second opinion.
+Two guards replace the deleted cross-binary check (see [Conformance](#conformance--contract)):
+(a) an **intra-process** test asserting `identityFor()` output == the SAN
+`Signer.Sign` stamps for a fixed fixture; (b) a **revocation** test asserting a
+known-dropped id is **absent** from a freshly-computed `allowed_sans`. `allowed_sans`
+MUST be recomputed from the **same registry snapshot** that authorizes
+`/v1/edge-cert` at that generation, and the generation is bumped only **after** the
+new allow-set is computed. The core logs/metrics the **size + hash** of every
+accepted allow-set (`parapet_trust_allowed_sans_count`, `parapet_trust_bundle_hash`)
+so an unexpected widening is alertable.
 
 ## Deployment models: k8s edge vs Docker edge
 
@@ -153,9 +159,8 @@ is packaged differs:
 **k8s edge.** The edge runs as a Deployment in some cluster (its own or the core's).
 The data-plane client cert rides `POST /v1/edge-cert` exactly as for Docker. An
 operator who already runs cert-manager and wants to *mount* a client cert can still
-do so via the legacy `EDGE_UPSTREAM_CLIENT_CERT`/`_KEY` file path — but that is a
-mount detail on the edge, **not a CA mode on the CP**. cert-manager is no longer part
-of this design.
+do so via the legacy `EDGE_UPSTREAM_CLIENT_CERT`/`_KEY` file path — a mount detail on
+the edge, **not a CA mode on the CP**. cert-manager is no longer part of this design.
 
 **Docker edge (the motivating case).** The edge is a bare `docker run` on a VM / box
 near clients (`deploy/edge/run-edge-docker.sh`). Its **only required input is
@@ -173,26 +178,21 @@ CSR in, signed chain out, key in memory only.
 | Required edge input | token (+ optional mounted cert Secret) | **`EDGE_CP_TOKEN`, and nothing else** |
 | Renewal | CP loop (`EDGE_REFRESH_INTERVAL`) | CP loop (`EDGE_REFRESH_INTERVAL`) |
 
-The payoff is uniformity: the Docker edge's onboarding stays "add one token to the
-registry," and the same token edit that authorizes its key/WAF fetch also makes the
-CP issue its data-plane identity **and** adds that identity to the core's allow-set.
-
 ## Core wiring
 
 In `cmd/parapet-ingress-controller/main.go`, replace the one-shot `trustProxy`
 block (`:214-237`) — but keep the existing static parse **verbatim** into a fixed
 local `cidrTrust` (`"true"` → `parapet.Trusted()`; `"false"`/`""` → nil; else
-`parapet.TrustCIDRs(list)` with the `predefinedCIDRs["cloudflare"]` expansion from
-`config.go`). Add a trust-policy holder owned by the controller:
+`parapet.TrustCIDRs(list)` with the `predefinedCIDRs["cloudflare"]` expansion). Add a
+trust-policy holder owned by the controller:
 
 ```go
 type trustPolicy struct{ allowedSANs map[string]struct{} }
 var trustPol   atomic.Pointer[trustPolicy]
-var clientCAs  atomic.Pointer[x509.CertPool]   // SEPARATE atomic from the SNI cert table
+var clientCAs  atomic.Pointer[x509.CertPool]
 ```
 
-Install **one** closure, assigned to **both** servers' `TrustProxy` field (as
-today):
+Install **one** closure, assigned to **both** servers' `TrustProxy` field:
 
 ```go
 trustProxy = func(r *http.Request) bool {
@@ -200,19 +200,19 @@ trustProxy = func(r *http.Request) bool {
     if r.TLS == nil || len(r.TLS.VerifiedChains) == 0 { return false } // metric: none
     p := trustPol.Load(); if p == nil { return false }
     if requireSAN { return sanAllowed(r.TLS.PeerCertificates[0], p.allowedSANs) }
-    return true // CA-only mode (EDGE_TRUST_REQUIRE_SAN=false): any chain to the dedicated edge CA
+    return true // CA-only mode (EDGE_TRUST_REQUIRE_SAN=false) — forbidden with CP-issuance
 }
 ```
 
-`sanAllowed` matches the leaf's **URI** SANs (`r.TLS.PeerCertificates[0].URIs`)
-*exactly* against the allow-set — URI-typed, never substring. The `:80` server's
-`r.TLS == nil` short-circuits the mTLS branch, leaving CIDR-only — byte-for-byte
-today's plaintext behavior.
+`sanAllowed` matches the leaf's URI SANs *exactly* against the allow-set. The `:80`
+server's `r.TLS == nil` short-circuits the mTLS branch, leaving CIDR-only.
+**Only the *feed* into `trustPol`/`clientCAs` changes — from a k8s Secret watch to a
+CP long-poll (next section). The per-request closure, the two atomics, `sanAllowed`,
+and the `GetConfigForClient` hot-swap + self-test below are all identical to the
+Secret-watch design.**
 
-**Hot-swap `:443` `ClientCAs` without clobbering the SNI cert table.** Do **not**
-clone and replace the whole `tls.Config` on a trust reload (that path risks
-dropping `GetCertificate` and regressing into the self-signed-fallback gotcha — see
-the [TLS SNI fallback memory]). Instead set, once, before `Serve()`:
+**Hot-swap `:443` `ClientCAs` without clobbering the SNI cert table** (unchanged).
+Set, once, before `Serve()`:
 
 ```go
 base.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
@@ -222,655 +222,732 @@ base.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
 }
 ```
 
-`GetConfigForClient` must be non-nil before `Serve()` and must **never** return nil
-(return last-good on any error). A startup **self-test** asserts the served config
-carries `GetCertificate` **and** `ClientCAs` **and**
-`ClientAuth == VerifyClientCertIfGiven`.
+`GetConfigForClient` must be non-nil before `Serve()` and never return nil (last-good
+on error). A startup **self-test** asserts the served config carries `GetCertificate`
++ `ClientCAs` + `ClientAuth == VerifyClientCertIfGiven`. The bytes into `clientCAs`
+just arrive from the CP now.
 
-### The trust watch
+### The trust pull (tokenless CP client)
 
-`controller.go` + a new `controller_trust.go` mirroring `controller_waf.go`: a 6th
-watcher, gated by `EDGE_TRUST_SECRET != ""` (default off ⇒ identical to today).
-Reuse the generic `watchResource[*v1.Secret]` for `POD_NAMESPACE`; on change call
-`reloadTrustDebounced` (a 300 ms `debounce`). It **never rebuilds `ctrl.mux`** (trust
-is orthogonal to routes) and is **validate-then-swap, all-or-nothing** like WAF
-`SetRules`. Parse the CA bundle: read key **`tls.crt`** first (the managed
-`kubernetes.io/tls` `parapet-edge-ca` Secret), falling back to `ca.crt` (a
-hand-rolled bundle / provided-mode convention); whichever is non-empty is fed to
-`x509.NewCertPool().AppendCertsFromPEM`. A **non-empty input that yields zero certs
-is rejected** (keep last-good, log, bump `parapet_trust_reload_rejected_total`). On
-success, atomically `Store` **both** `clientCAs` and `trustPol` so they can never
-disagree. A rejected reload keeps last-good **and alerts loudly** — a stale allow-set
-silently degrades every edge onboarded after the rejection.
+Gated by `EDGE_TRUST_CP_ENDPOINT != ""` (default off ⇒ identical to today). There is
+**no 6th k8s watcher** — `controller_trust.go` and the `watchResource[*v1.Secret]`
+trust invocation are gone. Instead a new tokenless `TrustCpClient` (a new small file,
+e.g. `trust/client.go`) mirrors `edge/cp.go`'s `CpClient` minus the `Authorization`
+header: `http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}` whose
+`tlsConfig.RootCAs` is built from `EDGE_TRUST_CP_CA` via
+`x509.NewCertPool().AppendCertsFromPEM`. `FetchTrustBundle(sinceGen, etag)` builds
+`base + "/v1/trust-bundle?watch=1&since=<sinceGen>"`, sets `If-None-Match`,
+body-capped `json.Decode` into `{generation, ca_pem, allowed_sans}`, returns
+`Unchanged` on 304 and an error on any non-200/304 (caller fail-statics).
 
-**Runtime keep-last-good on disappearance.** Distinguish **startup absence**
-(`EDGE_TRUST_SECRET` set but the Secret/key never loaded ⇒ degrade to CIDR-only,
-safe, warn) from **runtime disappearance** (the watched Secret is DELETED, or its
-`tls.crt`/`ca.crt` goes empty, *after* a good bundle was applied). A runtime
-DELETE/empty event MUST **keep last-good `clientCAs`** and bump
-`parapet_trust_reload_rejected_total` + alert — it MUST NEVER nil the live pool,
-because nilling it instantly distrusts the whole fleet (every edge's XFF
-overwritten). Only a deliberately-empty bundle *at startup* means "mTLS disabled."
+**Deliberate inversion of `edge/cp.go`:** that client silently ignores an unparseable
+CA and falls back to system roots (`edge/cp.go:42-47`); for the trust channel that is
+**forbidden**. A missing / empty / unreadable / unparseable `EDGE_TRUST_CP_CA`, or an
+`AppendCertsFromPEM` that adds **zero** certs, is a **FATAL startup error** when
+`EDGE_TRUST_CP_ENDPOINT` is set. `InsecureSkipVerify` is **never** set; a startup
+self-test asserts `tlsConfig.RootCAs != nil && !tlsConfig.InsecureSkipVerify` (carry a
+code comment naming this inversion so a future client-unification refactor cannot
+re-introduce the fallback). A non-`https://` endpoint is rejected fatally — **no
+plaintext analog, ever** (contrast the edge data plane's `EDGE_CP_ALLOW_PLAINTEXT`).
+Server-cert **identity**, not merely chain-to-CA, is the boundary: `EDGE_TRUST_CP_CA`
+SHOULD be a **dedicated single-purpose CA that signs only the CP server cert**; the
+client verifies the CP cert hostname against the endpoint host (Go's default
+`ServerName`-from-dial-host, never loosened); a shared org CA is loud-warned.
 
-**Header hardening (a real gap today, not just for mTLS):** mount a middleware
-**first** in `main.go`'s `m` chain (before `ctrl`) that **unconditionally deletes**
-client-supplied `X-Forwarded-Country` / `X-Forwarded-ASN` at ingress.
-`forwardGeoHeaders` (`main.go:329`) only *overwrites* them when a DB is loaded — so
-a core with no GeoIP DB currently passes a **client-forged** `X-Forwarded-Country`
-straight upstream. Treat both as edge-set-only. (`X-Real-Ip` / `X-Forwarded-For`
-stay governed by parapet's trust/distrust.)
+A single **long-poll refresh goroutine** (mirroring `RunCertRefresh` but blocking, not
+ticking) calls `FetchTrustBundle`. On a good 200 it does the **same validate-then-swap,
+all-or-nothing** the old Secret watch did: parse `ca_pem` into an `x509.CertPool`
+(**reject a non-empty-input-that-yields-zero-certs bundle**, keep last-good, bump
+`parapet_trust_reload_rejected_total`), build the `allowedSANs` set, **reject any
+bundle whose `generation` <= the one currently held** (forward-only, bump
+`parapet_trust_rollback_rejected_total`), then atomically `Store` **both** `clientCAs`
+and `trustPol` together. On 304/timeout it re-issues with the unchanged `since`; on
+connection drop/error it fail-statics (keep last-good), short jittered backoff,
+re-issues. **NEVER nil the live pool from a bad/empty/forged fetched bundle** — only
+feature-off does. An empty `allowed_sans` with a valid `ca_pem` is accepted as an
+operator-driven shrink **only when the generation strictly advances**, so a
+truncated/forged body cannot masquerade as an empty set.
+
+### Freshness: long-poll, not bare poll
+
+A bare poll would make revocation as slow as the poll interval; the old k8s watch gave
+~300 ms. To keep that, `GET /v1/trust-bundle` supports a **long-poll**:
+`?watch=1&since=<generation>` **blocks** server-side until the generation advances past
+`<since>` (a registry edit → recompute → bump → broadcast, or a CA rotation step) or a
+server-side ceiling (`EDGE_TRUST_CP_WATCH_TIMEOUT`, default ~30 s) elapses → `304`. CP
+side: a `generation` (see [Generation](#generation-content-derived-replica-identical--monotonic))
+bumped on every **observed content change**, with a `sync.Cond` broadcast to wake
+blocked waiters. The SAN set is serialized **deterministically** (sorted,
+NFC-normalized) before the gen/etag hash, so non-deterministic map iteration cannot
+compute a spuriously-unchanged etag and stall the bump (the `WafStore.recompute`
+early-return on equal etag is correct only because its `fingerprint` is sorted —
+`wafstore.go:86-94`; the trust bundle MUST do the same).
+
+The core: on **200** → validate-then-swap, advance `since` to the returned (strictly
+greater) generation, re-issue `watch=1&since=<new>`; on **304/timeout** → re-issue
+unchanged; on error → fail-static + jittered backoff + re-issue. **Liveness:** the
+watch call MUST NOT use a whole-request `http.Client.Timeout` (it would guillotine a
+legitimately-blocking long-poll); use Transport-level `ResponseHeaderTimeout`/
+`IdleConnTimeout` + a per-attempt context deadline of `watch-timeout + slack` (~45 s
+for a 30 s block) + TCP keep-alive, so a half-open connection is detected and the
+single watch goroutine never wedges. The CP `http.Server` `WriteTimeout`/`IdleTimeout`
+MUST be **>= the watch ceiling** (today only `ReadHeaderTimeout` is set,
+`cmd/edge-controlplane/main.go:103`). **The safety-net plain-GET poll
+(`EDGE_TRUST_CP_POLL_INTERVAL`, default 5 m) runs unconditionally alongside the
+long-poll** as a correctness backstop. Honest SLA: **sub-second normally, ≤ one poll
+interval worst-case** — never present sub-second as guaranteed.
+
+### Generation (content-derived, replica-identical + monotonic)
+
+The revocation guarantee rests on the generation being **strictly monotonic and
+tamper-evident over the verified TLS channel**, *and* (for a stateless multi-replica
+CP) **identical on every replica**. Both are satisfied by deriving generation from the
+**apiserver `resourceVersion`** of the source objects — `generation = max(resourceVersion)`
+across the source Secrets/ConfigMaps (the `edge-controlplane-tokens` registry and the
+`parapet-edge-ca` Secret). resourceVersion is the etcd revision at last write; etcd is a
+**single global monotonic counter**, so this value is server-assigned (identical on
+every replica reading the same objects), monotonic, and **persisted across CP restarts
+by construction** — it lives in etcd, not a CP process. This **dissolves the apparent
+conflict** between "content-derived/stateless" and "monotonic/persisted": one source
+satisfies both. Do **not** use a per-process `atomic.Uint64` counter (replica-divergent)
+nor leading bytes of a content hash (non-monotonic; truncation collisions).
+
+Three rules: (1) **Forward-only swap** — the core rejects any bundle whose
+`generation <=` the one it holds (`parapet_trust_rollback_rejected_total`), so a MITM
+on any TLS gap can't replay a captured **older** 200 to un-revoke a dropped SAN. (2)
+**No reset** — because generation is an etcd revision, a CP restart never lowers it, so
+a core holding `since=N` is never stranded. (3) **Equality/identity token** — anti-rollback
+rests on server-TLS + forward-only, not on the value being a dense counter.
+
+> **Pre-existing bug fixed here:** `edgecp/wafstore.go:32` `gen atomic.Uint64`, bumped
+> at `:80`, returned at `:124` into `wafResponse.Generation` — under `replicas: 2` two
+> replicas ingesting identical ConfigMaps return *different* generation integers, so an
+> edge round-robining the Service sees the counter flap (e.g. 7,4,8,4). The fix applies
+> the **same** resourceVersion-derived generation to `/v1/waf`; the sha256 fingerprint
+> at `wafstore.go:86` stays for the ETag (already content-derived + replica-safe).
+
+### Warm-start cache (fail-closed for revocation)
+
+A core restart during a CP outage loses its in-memory `clientCAs`/`trustPol` and would
+otherwise degrade to CIDR-only until the CP returns. To shrink that window the core
+**persists the last-good bundle to `EDGE_TRUST_CP_CACHE_FILE`** (write-on-successful-swap;
+the bundle is public — `ca_pem` + opaque SAN ids — so **no new secret-at-rest concern**).
+**But the disk copy confers NO trust until revalidated against the live CP.** A restarted
+core with the CP down reads the file as a **warm-start hint only**, stays **CIDR-only**,
+and flips to mTLS-trust **only after the first successful live fetch supersedes it**.
+This is deliberate and fail-closed: persisting-**and-trusting** the file would resurrect
+a revoked SAN (revoke X → CP down → core restarts → reads a disk bundle still containing
+X → X trusted across the whole outage). `EDGE_TRUST_CP_MAX_STALE` (default ~1 h) caps the
+hint's age; an older file is ignored. Emit `parapet_trust_source{file}` (vs
+`{mtls}`/`{cidr}`/`{none}`) and `parapet_trust_bundle_age_seconds` so a stale/pre-bundle
+core is alertable. **No-trust-until-revalidated is the default and is non-negotiable.**
+
+**Header hardening (a real gap today):** mount a middleware **first** in `main.go`'s `m`
+chain that **unconditionally deletes** client-supplied `X-Forwarded-Country` /
+`X-Forwarded-ASN` at ingress (`forwardGeoHeaders`, `main.go:329`, only *overwrites* them
+when a DB is loaded → a no-DB core passes a client-forged value upstream). Treat both as
+edge-set-only.
 
 ## Edge wiring
 
-The default data-plane identity is **CP-issued** (see
-[Control-plane wiring](#control-plane-wiring-cp-issues-the-client-cert)). A new
-`EDGE_DATAPLANE_MTLS` (bool, default false — off ⇒ anonymous re-encrypt, identical
-to today) turns it on; `EDGE_UPSTREAM_TLS=true` is a prerequisite (loud startup
-error if mTLS is on with TLS off, mirroring the existing https-endpoint guard at
-`main.go:52-56`; warn if mTLS is off while the upstream is core `:443`).
+The default data-plane identity is **CP-issued**. `EDGE_DATAPLANE_MTLS` (bool, default
+false — off ⇒ anonymous re-encrypt, identical to today) turns it on; `EDGE_UPSTREAM_TLS=true`
+is a prerequisite (loud startup error otherwise).
 
 - **`edge/clientcert.go` (new)** — an in-memory `ClientCertStore`
-  (`atomic.Pointer[tls.Certificate]`) with a `GetClientCertificate` callback
-  returning the live (complete key+chain) cert, and an **all-or-nothing**
-  `Update(chainPEM, heldKey)` that `tls.X509KeyPair`-validates the new pair and
-  atomically swaps — **if validation fails, the prior pair is kept** (never clears
-  the pointer, never swaps in a broken cert). `GetClientCertificate` returns
-  last-good non-empty whenever possible; a never-loaded empty return is loud
-  (metric + log) and gates readiness — never a silent half-rotated state.
-- **`edge/refresh.go`** — `RefreshEdgeCertOnce(cp, ccStore)`: generate an ephemeral
-  key **into a local var** (not the live store), build the CSR, `cp.FetchEdgeCert(...)`,
-  on success `ccStore.Update(chain, localKey)` as **one atomic unit**, on error
-  fail-static (keep the in-memory cert, log a warning). `RunEdgeCertRefresh` mirrors
-  `RunCertRefresh` but **renews on remaining-life/renew-before, not bare interval
-  equality**, with **aggressive backoff retries** as expiry nears, adds **per-edge
-  jitter** (the current `RunCertRefresh` has none → a co-booted fleet stays
-  phase-locked, a thundering-herd risk on a signing endpoint), and **honors the CP's
-  `Retry-After`**.
+  (`atomic.Pointer[tls.Certificate]`), `GetClientCertificate` returns the live
+  (complete key+chain) cert, and an **all-or-nothing** `Update(chainPEM, heldKey)`
+  that `tls.X509KeyPair`-validates and atomically swaps — **if validation fails, the
+  prior pair is kept** (never a half-rotated state). A never-loaded empty return is
+  loud and gates readiness.
+- **`edge/refresh.go`** — `RefreshEdgeCertOnce`: generate an ephemeral key **into a
+  local var**, build the CSR, `cp.FetchEdgeCert(...)`, on success `Update` as one
+  atomic unit, on error fail-static. `RunEdgeCertRefresh` renews on
+  remaining-life/renew-before with backoff + **jitter**, honoring `Retry-After`.
 - **`edge/forward.go` `NewForwarder`** gains a `*ClientCertStore` param (nil ⇒
-  anonymous re-encrypt, back-compat); on `useTLS` it sets
-  `tlsConfig.GetClientCertificate = ccStore.GetClientCertificate`.
-  `InsecureSkipVerify` stays for now (the edge still doesn't verify the core's
-  server cert — see [open questions](#open-questions)).
-- **Readiness is fail-closed.** When `EDGE_DATAPLANE_MTLS=true`, the readiness gate
-  (`cmd/edge-proxy/main.go:197`) becomes
-  `(serveAll || store.Loaded()) && clientCert.Loaded()` — a hard AND that
-  **serve-all does NOT bypass**. First-boot issuance failure keeps the edge
-  **not-ready** (503), not serving-while-untrusted, with a bounded background retry.
-  **But CP-readiness ≠ system-readiness:** the edge cannot self-detect "the core does
-  not yet trust my CA" (trust convergence happens in another process), so it can go
-  ready and still 502 in the convergence window — see the system-readiness fail mode.
+  anonymous re-encrypt); on `useTLS` it sets
+  `tlsConfig.GetClientCertificate = ccStore.GetClientCertificate`. `InsecureSkipVerify`
+  stays for now (the edge doesn't yet verify the core's server cert — see open
+  questions). **This is the deliberate mirror image of the trust channel:** the edge
+  data-plane hop is authenticated by the edge's *client* cert and still skip-verifies
+  the server; the core→CP trust channel is authenticated by the CP's *server* cert with
+  no client cert and **never** skip-verifies. Same binary pair, opposite posture, by
+  design.
+- **Readiness is fail-closed.** When `EDGE_DATAPLANE_MTLS=true`, readiness
+  (`cmd/edge-proxy/main.go:197`) becomes `(serveAll || store.Loaded()) && clientCert.Loaded()`
+  — serve-all does NOT bypass it. First-boot issuance failure keeps the edge not-ready
+  (503). **But CP-readiness ≠ system-readiness:** the edge can't self-detect "the core
+  doesn't trust my CA," so it can go ready and still 502 in the convergence window — see
+  the system-readiness fail mode.
 
-The edge remains the first hop and sets **no** `TrustProxy`, so it keeps
-overwriting incoming `X-Forwarded-*` with the true client peer before forwarding —
-the **transitive-trust invariant** the core relies on.
+The edge remains the first hop and sets **no** `TrustProxy`, so it overwrites incoming
+`X-Forwarded-*` with the true client peer before forwarding — the **transitive-trust
+invariant** the core relies on.
 
 ## Control-plane wiring: CP issues the client cert
 
-The default data-plane identity is **CP-issued over the existing bearer channel**,
-CSR-based, so the private key **never leaves the edge**.
+### Stateless serving control plane (HA via replicas + Service)
+
+The serving CP holds **no control-plane-owned state**: every input (the edge-CA keypair
+from `parapet-edge-ca`, the `edge-controlplane-tokens` registry, tenant TLS via the
+`Reloader`, WAF via `WafReloader`/`IngressReloader`) is read from the apiserver into a
+derived, reconstructible cache, so replicas are **byte-identical and interchangeable**.
+HA is the existing ClusterIP Service over N pods with the `/healthz?ready=1` gate; the CP
+is **off the request path** (edges/core pull on timers/long-poll, fail-static), so losing
+a replica only delays a pull, never drops live traffic. **No leader election, no lease, no
+in-serving CAS, no write RBAC.** Signing is deterministic and stateless per request:
+zero-value leaf template + fresh 128-bit CSPRNG serial + clock-derived validity +
+registry-derived SAN, so two replicas signing the same CSR produce equally-valid,
+differently-serialed certs. Multiple concurrently-valid serials per SAN (one per replica
+that served a renewal) are **expected**, because revocation is SAN-drop in the core, not
+serial/CRL. This subsection replaces the in-serving create-once/CAS/anti-regen machinery
+that previously lived here — that machinery moves into the bootstrap Job below.
+
+### `GET /v1/trust-bundle` — the tokenless trust endpoint
+
+New handler on `edgecp.Server.Handler()` (`edgecp/server.go:30-36`), mounted **alongside**
+the token-gated `GET /v1/certs`/`GET /v1/waf` but a sibling of the **no-auth**
+`GET /healthz` — it **never inspects `Authorization`**:
+
+```
+GET /v1/trust-bundle    (NO Authorization header)   [If-None-Match: "<etag>"]   [?watch=1&since=<generation>]
+  200 {"generation": N, "ca_pem": "<edge-CA PUBLIC cert bundle, PEM>", "allowed_sans": ["spiffe://parapet.moonrhythm.io/edge/<id>", …]}
+       generation   : resourceVersion-derived, replica-identical + monotonic; bumped whenever ca_pem OR allowed_sans changes
+       ca_pem       : the edge CA PUBLIC cert(s) ONLY (overlap bundle old++new during rotation). NEVER a private key.
+       allowed_sans : the live allow-set, CP-computed from edge-controlplane-tokens via the single canonical identityFor derivation
+       ETag: "<strong validator over generation || ca_pem || sorted(allowed_sans)>"   Content-Type: application/json   Cache-Control: no-cache
+  304 (If-None-Match matched OR a ?watch long-poll elapsed with no generation change)
+  503 (signer/CA not yet initialized — bootstrap Job hasn't populated the CA; core fail-statics and retries)
+```
+
+New `edgecp/trust.go` + `mux.HandleFunc("GET /v1/trust-bundle", s.handleTrustBundle)`. The
+handler: (1) **no `bearer(r)` call**; (2) computes `allowed_sans` from the **same
+`edge-controlplane-tokens` registry** the CP authorizes against, via the canonical
+`identityFor` (the **same** code path `Signer.Sign` stamps with — byte-identical by
+construction); (3) assembles `ca_pem` as the **public** cert(s) only from the live
+`Signer`; (4) reads the resourceVersion-derived generation + a `sync.Cond` for the
+long-poll, `ETag = etagOfString(...)` (`server.go:130`). Wired like `WithWAF`: a
+`WithTrust(...)`, so **absent signer ⇒ 503** (the endpoint *exists* but is not-yet-ready
+— 503, not 404, so the core retries rather than treating it as permanent). No new CP
+watch — the trust bundle is a new **view** over state the CP already maintains. There is
+**no 401/403 path**.
+
+### Bounding the unauthenticated long-poll
+
+Because `/v1/trust-bundle?watch=1` is **unauthenticated** and **blocks a goroutine +
+connection** for up to the watch ceiling, the CP **cannot bound concurrency by caller**.
+Any NetworkPolicy-permitted source could otherwise open thousands of concurrent watches
+and exhaust the goroutine/FD budget, **starving the token-gated `/v1/certs`/`/v1/waf`/
+`/v1/edge-cert` the data plane needs**. So the CP MUST add **auth-independent** limits: a
+**bounded semaphore** on concurrent in-flight watch handlers (over-limit ⇒ `503` +
+`Retry-After`, or short-block then `304`); a **hard server-side deadline** via `context`
+(≤ the watch ceiling); a **per-source-IP concurrent-connection cap**; a response **body
+cap**; and a cheap reject of `?watch` with an absurd/missing `since`. **The
+edge-sources-only NetworkPolicy is now availability-load-bearing** (the only caller bound
+on this endpoint) — a hard prerequisite — and the CP `http.Server` MUST set
+`WriteTimeout`/`IdleTimeout` ≥ the watch ceiling.
+
+### CP-side TLS guard (no plaintext trust channel, either end)
+
+The no-token decision is safe **only because server-TLS is the integrity boundary** — so
+it MUST be non-optional on the CP **server** side too. The CP today serves plaintext when
+`CP_TLS_CERT`/`CP_TLS_KEY` are both empty (`cmd/edge-controlplane/main.go:40-51`). **When
+the CP is a trust source (the trust bundle is wired), `CP_TLS_CERT`/`CP_TLS_KEY` MUST be
+set — plaintext + trust-bundle is a FATAL CP startup error**, mirroring the existing
+`CP_TLS` pairing guard. The edge **data-plane** plaintext exception (`EDGE_CP_ALLOW_PLAINTEXT`)
+does **NOT** extend to the trust channel on **either** end: an on-path attacker on a
+"trusted" private network who injects a forged `ca_pem` over plaintext mints leaves the
+core trusts = fleet-wide XFF-spoof = trust-boundary takeover.
 
 ### The issuance endpoint (`POST /v1/edge-cert`)
 
-New endpoint on `edgecp.Server.Handler()` (alongside `GET /v1/certs` / `GET
-/v1/waf`), in the exact style of EDGE.md's REST table:
+CSR-based, so the private key **never leaves the edge**:
 
 ```
 POST /v1/edge-cert    Authorization: Bearer <token>
-  request body (application/json): {"csr_pem": "<PKCS#10 CSR, PEM>"}
-  200 {"chain_pem":"<leaf+edge-CA-intermediates PEM>", "not_after":"<RFC3339>", "serial":"<hex>"}
-       chain_pem : leaf-first (edge leaf + edge-CA intermediates); NO key — the key never leaves the edge
-       not_after / serial : surfaced for edge renewal scheduling + logging (parapet_edge_clientcert_not_after)
-       Cache-Control: no-store, Pragma: no-cache (per-edge identity; NO ETag/304 — fresh key each renewal)
-  400 (missing/malformed/oversized CSR, bad PEM, CSR signature fails verify, unsupported/over-large key type)
-  401 (no/invalid token)  403 (token has no edge data-plane identity grant)  405 (not POST)
-  413 (CSR body over the 16 KiB cap)  429 (per-token rate limit OR global signer saturation — Retry-After set)
+  request body: {"csr_pem": "<PKCS#10 CSR, PEM>"}
+  200 {"chain_pem":"…", "not_after":"<RFC3339>", "serial":"<hex>"}   (NO key on the wire; Cache-Control: no-store, Pragma: no-cache; no ETag/304)
+  400 (malformed/oversized CSR, bad PEM, sig fails verify, unsupported/over-large key type)
+  401 (no/invalid token)  403 (token has no edge identity grant)  405 (not POST)  413 (CSR > 16 KiB)  429 (rate limit / signer saturation — Retry-After)
 ```
 
-It is the **only mutating endpoint** (everything else is `GET`). The CP returns
-**`chain_pem` only** (no key on the wire — the edge holds it). `Cache-Control:
-no-store` **and** `Pragma: no-cache` are set. **No ETag / `If-None-Match` / 304**: a
-fresh ephemeral key each renewal means a new public key → new leaf → new chain.
-Body capped at 16 KiB via `io.LimitReader`. Absent signer ⇒ the endpoint **404s**
-(fully backward-compatible).
-
-**CSR flow** (reusing `edge/refresh.go` + `edge/cp.go` `CpClient`):
-
-1. **Edge — ephemeral key in memory.** Generate `ecdsa.GenerateKey(elliptic.P256())`
-   (default; `EDGE_CLIENTCERT_KEY_TYPE`) **into a local variable**. Never written to
-   disk — same posture as `CertStore` keys (`edge/certstore.go:26-27`).
-2. **Edge — build CSR.** `x509.CreateCertificateRequest` with a minimal template;
-   any hint SAN/CN is **irrelevant** (the CP overrides it). PEM-encode.
-3. **Edge — POST over the bearer channel.** New `CpClient.FetchEdgeCert(csrPEM)`
-   mirroring `FetchCert`/`FetchWaf`: POSTs `{"csr_pem":…}`, sets `Authorization:
-   Bearer <token>`, body-capped read, returns chain+not_after+serial on 200 / error
-   otherwise (caller fail-static). `do()` is generalized to take method+body
-   (today GET-only).
-4. **CP — verify + sign** (`handleEdgeCert`, new): `bearer(r)` + `authz.Known(token)`
-   → 401; `authz.Identity(token)` → 403 if no grant; decode CSR; **whitelist the key
-   type/curve BEFORE verifying** (ECDSA P-256/P-384 or Ed25519 only; reject RSA →
-   400) so a `CheckSignature` DoS on an oversized key is impossible;
-   `csr.CheckSignature()` (mandatory — an unsupported sig alg is a hard 400, never a
-   silent pass) → 400 on failure; then `Signer.Sign(csr.PublicKey, authorizedSAN)`.
-5. **CP — return chain only.** 200 with `chain_pem` + `not_after` + `serial`.
-6. **Edge — assemble + hold atomically.** Pair the chain with the in-memory key into
-   a `tls.Certificate` and atomically store the **complete** keypair+chain.
-7. **Edge — present via `GetClientCertificate`** per handshake — no restart, no file.
+The edge generates an ephemeral key in memory, sends the CSR; the CP **whitelists the key
+type/curve BEFORE `CheckSignature`** (ECDSA P-256/P-384 or Ed25519 only; reject RSA → 400),
+verifies proof-of-possession, then `Signer.Sign(csr.PublicKey, authorizedSAN)`. Absent
+signer ⇒ 404 (back-compat).
 
 ### Signing: template, custody, rate-limiting
 
-All in `edgecp/` + `cmd/edge-controlplane`, reusing existing primitives.
-
-**`edgecp/server.go`.** New `handleEdgeCert` + `mux.HandleFunc("POST /v1/edge-cert",
-…)`. New `signer atomic.Pointer[*Signer]` (nil ⇒ 404), wired by `WithSigner` like
-`WithWAF`. **Absent signer ⇒ backward-compatible.**
-
 **`edgecp/signer.go` (new).** `Signer` holds the parsed edge CA cert + key (behind an
-interface — the **HSM/KMS seam**); `Sign` builds the leaf `x509.Certificate` template
-**from a zero value — never from the parsed CSR** — setting ONLY: `SerialNumber`
-(128-bit CSPRNG); `NotBefore = now - EDGE_CLIENTCERT_SKEW`, `NotAfter = now +
-EDGE_CLIENTCERT_TTL`; `KeyUsage = DigitalSignature`; `ExtKeyUsage =
-[ExtKeyUsageClientAuth]` ONLY; `URIs = [authorizedSAN]` from the token (the shared
-derivation package); `BasicConstraintsValid = true, IsCA = false`. The CSR
-contributes **exactly one thing: `csr.PublicKey`**. The template **explicitly never**
-assigns `Subject`/`DNSNames`/`IPAddresses`/`EmailAddresses`/`URIs`/`Extensions`/
-`ExtraExtensions` from the CSR. **Post-sign self-check (mandatory in BOTH CA modes):**
-re-parse the issued leaf and assert `IsCA==false`, `KeyUsage==DigitalSignature`,
-`ExtKeyUsage==[ClientAuth]`, `URIs==[authorizedSAN]`,
-`len(DNSNames)==len(IPAddresses)==0`; **refuse to return** a cert that fails any
-check. A conformance test feeds a CSR carrying `CA:true`, a rogue URI/DNS SAN, and a
-malicious CN and asserts none appear in the leaf.
+interface — the **HSM/KMS seam**); `Sign` builds the leaf template **from a zero value —
+never from the parsed CSR** — setting ONLY `SerialNumber` (128-bit CSPRNG), `NotBefore =
+now - EDGE_CLIENTCERT_SKEW`, `NotAfter = now + EDGE_CLIENTCERT_TTL`, `KeyUsage =
+DigitalSignature`, `ExtKeyUsage = [ClientAuth]`, `URIs = [authorizedSAN]`,
+`BasicConstraintsValid = true, IsCA = false`. The CSR contributes **only `csr.PublicKey`**.
+**Post-sign self-check (mandatory in BOTH modes):** re-parse the leaf and assert
+`IsCA==false`, `KeyUsage`, `ExtKeyUsage==[ClientAuth]`, `URIs==[authorizedSAN]`, no
+DNS/IP; refuse to return otherwise.
 
-**`edgecp/authz.go` — per-edge identity (explicit opt-in).** Extend `Authz` with
-`identities map[string]string` (token → id) populated alongside `tokens` in
-`NewAuthz`, plus `Identity(token) (string, bool)`. The grant is **explicit and
-separate**, NOT auto-derived from the token's presence or its domains; `Identity`
-returns `("",false)` (→ 403) unless the operator set it. A serve-all (`"*"`) token
-**MUST NOT** get a default identity. Migration defaults every token to NO identity.
+**`edgecp/authz.go` — per-edge identity (explicit opt-in).** `Identity(token) (string,
+bool)`; returns `("",false)` (→ 403) unless the operator set an `id`. Serve-all gets none.
 
-**CA custody — managed (default) vs provided.** The edge CA is the new crown jewel
-and **lives with the CP**. Two modes, decided at boot by the **presence** of
-`EDGE_CA_CERT`/`EDGE_CA_KEY` (no `EDGE_CA_MODE` knob):
+**CA custody — managed (default) vs provided.** Two modes, decided at boot by the
+**presence** of `EDGE_CA_CERT`/`EDGE_CA_KEY` (no `EDGE_CA_MODE` knob):
 
-- **`managed` (default — zero PKI, zero openssl, zero cert-manager).** On first boot
-  the CP **generates** a single-purpose edge CA and **persists** it to its own
-  `parapet-edge-ca` Secret (`kubernetes.io/tls`, in `POD_NAMESPACE`), reuses it
-  across restarts/replicas, and **hot-reloads** it on change. The generated CA
-  template (from a zero value): key **ECDSA P-384** (`EDGE_CA_KEY_TYPE=ed25519`
-  alt), PKCS#8; `SerialNumber` 128-bit CSPRNG; `Subject` CN `parapet-edge-ca`
-  (cosmetic); `NotBefore = now-10m`, `NotAfter = now + EDGE_CA_TTL` (default 10y —
-  the **leaf** TTL is the short knob); `KeyUsage = CertSign | CRLSign` ONLY;
-  `ExtKeyUsage = [ClientAuth]` ONLY; `BasicConstraintsValid=true, IsCA=true,
-  MaxPathLenZero=true`; `NameConstraints.PermittedURIDomains = ["parapet.moonrhythm.io"]`.
-  **Honest scope:** this pins the SAN **host** only — SPIFFE path-segment scoping to
-  `/edge/*` is *not* expressible as a URI NameConstraint (the issuance template's
-  `URIs=[authorizedSAN]` + post-sign self-check pin the path). So the constraint stops
-  cross-domain/serverAuth abuse of a stolen key, **NOT** edge-fleet impersonation. **A
-  conformance test must prove** `x509.Verify` rejects `spiffe://evil.example/edge/x`
-  and accepts `spiffe://parapet.moonrhythm.io/edge/x` under this constraint before it
-  is counted as a control. Managed mode emits a **loud startup log** that the CP now
-  HOLDS (and on first boot GENERATED) a fleet-minting CA key, and requires the new
-  `k8s` write path, the dedicated CP ServiceAccount, and `POD_NAMESPACE`.
+- **`managed` (default — zero PKI, zero cert-manager).** A **run-once bootstrap Job**
+  generates the CA once and persists it to `parapet-edge-ca`; the serving CP **reads** it
+  and hot-reloads it, **never generates or writes**. The generated CA template (from a
+  zero value): key **ECDSA P-384** (`EDGE_CA_KEY_TYPE=ed25519` alt), PKCS#8; `SerialNumber`
+  128-bit CSPRNG; `Subject` CN `parapet-edge-ca`; `NotBefore = now-10m`, `NotAfter = now +
+  EDGE_CA_TTL`; `KeyUsage = CertSign | CRLSign` ONLY; `ExtKeyUsage = [ClientAuth]` ONLY;
+  `BasicConstraintsValid=true, IsCA=true, MaxPathLenZero=true`;
+  `NameConstraints.PermittedURIDomains = ["parapet.moonrhythm.io"]`. **Honest scope:** this
+  pins the SAN **host** only — path scoping to `/edge/*` is *not* expressible as a URI
+  NameConstraint (the issuance template's `URIs=[authorizedSAN]` + post-sign self-check pin
+  the path); the constraint stops cross-domain/serverAuth abuse, NOT edge-fleet
+  impersonation. A conformance test must prove `x509.Verify` rejects
+  `spiffe://evil.example/edge/x` and accepts the legit form. The **Job** logs it
+  GENERATED/ADOPTED a fleet-minting CA; the **serving** CP logs it HOLDS a loaded signer
+  (read-only).
 - **`provided` (escape hatch — operator's own PKI).** Both `EDGE_CA_CERT`/`EDGE_CA_KEY`
-  point at mounted PEM files; the CP **uses** them, **never generates**, **never
-  writes** the Secret, and **needs no `get`/`update` RBAC**. Hot-reload the mounted
-  files (validate-then-swap). **Validation (mandatory):** the CA MUST be `IsCA` and
-  carry EKU `clientAuth` (reject pure serverAuth / hard-reject `anyExtendedKeyUsage`);
-  **warn loudly (or refuse behind a flag) if it lacks
-  `NameConstraints.PermittedURIDomains`** — the leak-containment guarantee is void
-  without it. It SHOULD be a **dedicated single-purpose** CA, never a shared org
-  intermediate. Not cert-manager-specific: cert-manager may *populate* the mounted
-  Secret, but the CP sees opaque files — no CRD, no `CertificateRequest`, no polling.
+  point at mounted PEM files; the CP **uses** them, never generates/writes, needs no
+  get/update RBAC; hot-reload the files. **Validation (mandatory):** `IsCA` + EKU
+  `clientAuth` (reject pure serverAuth/anyEKU); **warn loudly (or refuse) if no
+  `NameConstraints.PermittedURIDomains`**. Dedicated single-purpose CA, never a shared org
+  intermediate. cert-manager may *populate* the mounted Secret, but the CP sees opaque
+  files — no CRD, no `CertificateRequest`.
 
-**`cmd/edge-controlplane/main.go`.** Branch on `EDGE_CA_CERT`/`EDGE_CA_KEY`: both set
-⇒ provided (read, validate, build `Signer`); both empty ⇒ managed (`edgecp.EnsureCA`
-adopt-or-generate + persist, synchronous, before serving); exactly one set ⇒ hard
-config error (mirrors the `CP_TLS_CERT`/`CP_TLS_KEY` pairing guard at `main.go:41-44`).
-In managed mode, `POD_NAMESPACE` MUST be non-empty (downward-API `metadata.namespace`)
-— a missing `POD_NAMESPACE` is a **fatal** startup error, never a silent
-wrong-namespace write. Either branch yields one `*Signer` wired via
-`server.WithSigner(signer)`; neither ⇒ nil signer ⇒ `POST /v1/edge-cert` 404
-(back-compat).
+**`cmd/edge-controlplane/main.go`.** Branch **FIRST** on `EDGE_CA_BOOTSTRAP` /
+`--bootstrap-ca`: if set, run `EnsureCA` against `parapet-edge-ca` in `POD_NAMESPACE` then
+`os.Exit(0 success / non-zero failure)` — **never start the server**. Else serving mode:
+managed = `GetSecret`+parse to a `*Signer` and start the CA-Secret **read-watch**; provided
+= mounted files; neither = nil signer = 404. Both-or-neither `EDGE_CA_CERT`/`EDGE_CA_KEY`
+guard. Empty `POD_NAMESPACE` is **fatal** in bootstrap mode and serving-managed mode.
+**Serving no longer calls `EnsureCA`/`UpdateSecret`.**
 
-**Rate-limiting + DoS.** A **per-token** token-bucket (`EDGE_CLIENTCERT_RATE`,
-default 10/min → 429) blunts a single-token forged-CSR flood. It does **nothing**
-against a fleet-wide restart storm (N tokens), so add a **global signing concurrency
-cap** (a bounded worker pool / semaphore around `Signer.Sign`) returning **429/503 +
-`Retry-After`** when saturated. The authz reject and the **key-type whitelist run
-before** any signing, so an unauthorized or oversized-key flood costs no CA work.
-Keep the endpoint behind the CP's edge-sources-only `NetworkPolicy`.
+**Rate-limiting + DoS.** The per-token bucket (`EDGE_CLIENTCERT_RATE`) and the global
+signing concurrency cap are **PER-REPLICA** — with N replicas behind the Service the
+effective fleet ceiling is **N× nominal**, and it scales **silently** as replicas rise for
+HA. Document this; a truly hard global cap needs externalized rate-limit state (out of
+scope, same exception class as the purge journal). authz-reject + the key-type whitelist
+run **before** any signing, so unauthorized/oversized floods cost zero CA work; keep
+per-edge refresh jitter.
 
-### Managed-CA bootstrap: replica-safe create-once + anti-regeneration guard
+### CA generation: the run-once bootstrap Job (single intentional writer)
 
-`edgecp.EnsureCA(ctx, k8sClient, podNamespace, secretName)` runs **synchronously
-before serving** (mirroring `wafReloader.LoadOnce` at `main.go:88-93`); only after it
-returns a valid `Signer` is `WithSigner` wired. Until then `POST /v1/edge-cert` 404s
-— never sign with a half-initialized/unpersisted CA.
+CA generation runs in the same `edge-controlplane` binary in one-shot mode
+(`--bootstrap-ca` / `EDGE_CA_BOOTSTRAP=true`) running `edgecp.EnsureCA`, then exit 0
+(success/adopt) or non-zero (Job retries). Pure-Go x509, no cert-manager. Operator
+pre-creates an **empty** `parapet-edge-ca` stub (RBAC `resourceNames` scopes get/update but
+not create). `EnsureCA` on a strongly-consistent typed `GetSecret` (never an informer
+cache):
 
-**Precondition (manifest):** the operator pre-creates an **empty** `parapet-edge-ca`
-Secret. RBAC `resourceNames` can scope `get`/`update` but **cannot** scope `create`;
-the stub lets us grant scoped `update` instead of broad namespace `create`.
+- **(a)** `tls.crt`+`tls.key` parse to a valid CA keypair → **ADOPT**, exit 0 (re-run is a
+  pure no-op).
+- **(b)** guard annotation `parapet.moonrhythm.io/edge-ca-generation` present but
+  `tls.crt`/`tls.key` empty-or-unparseable → **HARD ANOMALY** (a populated CA was
+  re-blanked by a GitOps prune, an apply of the empty stub, a Velero restore, or an
+  operator recreate) → **NEVER regenerate**, exit non-zero with a distinct message, bump
+  `parapet_edge_ca_unexpected_empty_total`.
+- **(c)** virgin stub (no annotation **and** empty) → generate the CA in memory and write
+  keypair + guard annotation + populated-at timestamp together.
 
-**The CAS read MUST be a strongly-consistent typed `Secrets(ns).Get`** (the new
-`k8s.GetSecret`), never an informer/lister cache (a stale-empty cache read can
-livelock the loser into regenerating). Algorithm `ensureCA(ctx)`:
+> **Override of the brief (both red-team rounds, unanimous):** a k8s Job is **not** a
+> guaranteed single writer — node-loss double-run, delete-recreate on redeploy/Helm/Argo,
+> and manual re-apply all produce transient concurrent Job pods. So **RETAIN the
+> `resourceVersion`-CAS** on the write plus a **re-read-immediately-before-Update
+> no-op-if-now-populated** check: without the CAS two pods both observing the empty stub
+> both `UpdateSecret` last-write-wins → two different CAs → the second silently distrusts
+> everything signed against the first. On `apierrors.IsConflict` re-read and **ADOPT** the
+> winner. The Secret-is-the-lock property (the CAS, not statelessness) linearizes the
+> inevitable double-run. The **anti-regeneration guard** is the load-bearing safety
+> property and now lives in the Job.
 
-1. `GetSecret(podNamespace, parapet-edge-ca)`. Cases:
-   - **(a) populated** (`tls.crt`+`tls.key` parse into a valid CA keypair) → **ADOPT**,
-     build `Signer`, log "adopted existing edge CA", return. *(Steady state, replica
-     scale-up, and the CAS-loser all land here.)*
-   - **(b) guard annotation present but `tls.crt` empty** → **HARD ANOMALY** (a
-     populated CA was re-blanked). **NEVER regenerate** (a regenerate is
-     indistinguishable from the catastrophic re-blank and would distrust the whole
-     fleet). Keep any in-memory CA, bump `parapet_edge_ca_unexpected_empty_total`,
-     alert, fail readiness. CA replacement is the **overlap rotation**, never
-     delete+regenerate.
-   - **(c) virgin empty stub** (no guard annotation, never populated) → go to 2.
-   - **(d) `NotFound`** → **fatal config error** ("operator must pre-create the empty
-     parapet-edge-ca Secret"). Do NOT fall back to a broad `create` grant.
-2. Generate keypair + self-signed CA **in memory** (local vars).
-3. On the **observed** Secret object (carrying its `resourceVersion`), set
-   `Data["tls.crt"]`/`Data["tls.key"]` **and a guard annotation**
-   `parapet.moonrhythm.io/edge-ca-generation` + populated-at timestamp, and call
-   `k8s.UpdateSecret(...)`. `Update` is a compare-and-swap on `resourceVersion`:
-   succeeds only if the stored version is unchanged.
-4. **Success** → I am the winner; use my keypair; bump `parapet_edge_ca_generated_total`.
-5. **Conflict** (`apierrors.IsConflict`, the loser path) → RE-READ and **ADOPT** the
-   winner's keypair (case a), discard mine. Still-empty re-read (transient, never
-   possible once the guard annotation is set) → jittered bounded backoff;
-   **exhaustion is a hard non-zero exit** (kubelet restarts) — never a silent
-   no-signer 404.
+`NotFound` on the stub is a **fatal config error** (no fallback to a broad create grant).
+Empty `POD_NAMESPACE` is fatal. **Failure semantics:** exit non-zero on any failure to
+reach a known-good terminal state; **re-GET after `UpdateSecret` and assert the CA parses
+before exit 0** (no swallowed write error, no silent no-op Complete). The create-once is
+tested against `k8s.io/client-go/kubernetes/fake` (honors CAS) with a two-goroutine
+concurrent-generate test asserting exactly one CA survives and the loser adopts.
 
-The API server's `resourceVersion` CAS **linearizes** the replicas: exactly one
-`Update` on the empty stub wins; the other gets `Conflict` and adopts. **The Secret
-IS the lock — no leader election, no leases.**
+### Bootstrap-Job vs serving-Deployment ordering (the cold-start window)
 
-**Anti-regeneration is the load-bearing safety property.** The guard annotation
-(case b) closes the GitOps/operator re-blank hazard: a Flux/Argo sync or `kubectl
-apply` that resets the stub to empty does NOT trigger a regenerate-and-distrust. The
-pre-created stub in `deploy/` MUST carry GitOps drift-exclusion
-(`argocd.argoproj.io/sync-options: Prune=false`, an `ignoreDifferences` on `/data`,
-a Flux server-side-apply field-manager note). Alert if `parapet_edge_ca_generated_total`
-ever increments more than once across the fleet's lifetime.
+Job-before-serving is a **HARD ordering requirement**, not a should. Preferred: ship the
+Job as a **Helm pre-install/pre-upgrade hook** (hook-weight before the Deployment) AND/OR
+an **Argo PreSync hook**, preferred over an initContainer (which re-runs on every pod
+restart/scale-up and would need write RBAC on the serving SA, defeating read-only-serving).
+Belt-and-suspenders: serving readiness stays gated on a loaded CA, so even if ordering
+slips no replica serves a CA-less 404. **Cold-start no-signer window:** until the Job
+populates the CA, all serving replicas read no CA, all stay **not-ready (503)**, the
+Service has zero endpoints, `POST /v1/edge-cert` is connection-refused, the trust-bundle
+has no `ca_pem`. Edges **fail-static on their last-good leaf** (degraded, never fail-open);
+brand-new edges get no-endpoints. Bounded by Job completion; unbounded only if the Job is
+slow/failing (hence the Job-Failed alert + the absence-of-populated-CA-after-deadline
+alert). On the core side: a trust-bundle returning no `ca_pem` MUST be treated as
+**not-yet-bootstrapped** (keep retrying, never cache empty as last-good, never permanently
+latch CIDR-only; self-heal on the first non-empty pull).
 
-**Testability:** the create-once MUST be tested against
-`k8s.io/client-go/kubernetes/fake` (or envtest), which honors `resourceVersion` CAS
-and returns `IsConflict`, with a two-goroutine concurrent-generate test asserting
-exactly one CA survives and the loser adopts. The **fs backend's `UpdateSecret` is
-non-CAS** (best-effort in-memory) so managed mode against fs **regenerates per boot**
-— fine for local dev, **never** prod, and cannot validate the linearization.
+### Where the core gets the CA (the CP serves it; the core never reads the Secret)
 
-### Where the core gets the CA (one Secret, no publish step)
+The core **no longer reads the `parapet-edge-ca` Secret at all** — not the public cert, not
+(incidentally) the private key. It pulls the edge CA's **public** cert(s) as `ca_pem` from
+`GET /v1/trust-bundle`, alongside the `allowed_sans` the CP computes. `EDGE_TRUST_SECRET`
+is **removed**; the core needs **zero** k8s access for trust (the fetch is an outbound
+HTTPS call). Because the core never touches the CA Secret, **`parapet-edge-ca` can live in
+a CP-only namespace with the CP as its only reader** — the prior namespace co-tenancy that
+let the core SA read the CA *private* key is **eliminated, not deferred** (see
+[Security model](#security-model)). The cert the CP signs **with** and the cert the core
+**trusts** are still the same bytes from the same authority — the CP assembles `ca_pem`
+directly from its live `Signer` (the overlap bundle old++new during rotation) — so they
+cannot drift, with **no publish step and no second write target**. The old namespace
+invariant tying the core's trust to `POD_NAMESPACE` is **dropped**.
 
-The **core reads the public CA cert directly from the same `parapet-edge-ca` Secret**
-via its existing trust watch — no separate publish step, no extra CP write, no skew.
-Point the core at it: `EDGE_TRUST_SECRET=parapet-edge-ca`, reading key **`tls.crt`**
-(fallback `ca.crt`). The cert the CP signs **with** and the cert the core **trusts**
-are the **same bytes in the same Secret**, so they cannot drift; the core needs **zero
-new RBAC** (it already list/watches secrets in the namespace). (Rejected: a separate
-`parapet-edge-trust` Secret holding only `ca.crt` — a second write target and a
-re-introduced publish/skew window for nothing the namespace co-tenancy doesn't already
-concede.)
+### CA hot-reload + rotation (Job-driven, bundle-based, no cert-manager)
 
-**Namespace invariant:** the CP's CA Secret and the core's `EDGE_TRUST_SECRET` watch
-MUST be in the **same** namespace, and that namespace is `POD_NAMESPACE` for **both**.
-The CP's CA read/write targets `POD_NAMESPACE` (the pod's own namespace), **NOT**
-`WATCH_NAMESPACE` (which defaults to `""` = all-namespaces and cannot be a write
-target). The core already injects `POD_NAMESPACE` via the downward API
-(`deploy/deployment.yaml:38-41`); the CP manifest does not today and MUST be amended.
+**The serving signer is hot-reloadable, not boot-once.** Every serving replica runs the
+**CA-Secret read-watch** (`atomic.Pointer[*Signer]`, validate-then-swap; active key derived
+solely from Secret content `tls-active: old|new`, converge within one debounce), so a
+Job-driven rotation is picked up without restart. A boot-once read would leave a replica
+signing with a stale in-memory key — strictly worse across N replicas with no leader. On a
+runtime CA-Secret **DELETE/blank**, the replica **keeps its last-good in-memory signer**,
+alerts, and **never drops to no-signer** (mirrors the core trust-watch keep-last-good) —
+with the in-serving anti-regen guard now removed, this read-watch keep-last-good is the only
+in-process safety net against a blanked Secret.
 
-### CA hot-reload + rotation (CP-driven, bundle-based, no cert-manager)
+**Rotation is a run-once Job** (the `--bootstrap-ca` binary / a rotate subcommand), **NOT**
+leader-elected serving. **Rotation invariant:** the NEW CA's public cert must be in
+`ca_pem` (which the core trusts) BEFORE the CP signs any leaf with the new key — else fresh
+leaves 502. Bundle support (`AppendCertsFromPEM` appends every block) lets `tls.crt`/`ca_pem`
+hold an overlap bundle. The 4-stage promote/trim machine: (1) generate NEW; (2) write
+`tls.crt = OLD ++ NEW`, stage NEW key, keep OLD active → core trusts both; (3) keep signing
+OLD while leaves renew; (4) flip `tls-active: new`, keep both certs ≥ one full leaf-TTL,
+then trim OLD — gated on the per-serving-replica `parapet_edge_ca_signer_fingerprint`
+convergence interlock. **Stolen-CA-key emergency:** skip overlap, write only the new CA,
+accept the brief gap — this is the stolen-CA-key runbook (SAN-drop can't revoke a forged
+leaf riding a real SAN).
 
-**The signer is hot-reloadable, not boot-once.** `EnsureCA` does the create-once; a
-**CA-Secret watch** (a 2nd CP watcher, mirroring the cert `Reloader`) then keeps the
-signer live: validate-then-swap into `atomic.Pointer[*Signer]`. A boot-time-only
-signer would let a replica that booted **before** a rotation keep signing with a stale
-in-memory key — intermittent 502s during the bundle-trim step. Every replica exposes
-`parapet_edge_ca_signer_fingerprint`; the rotation interlock confirms **all** replicas
-converged before trimming.
+### k8s client: the first write path (Job-only)
 
-**Rotation invariant:** the NEW CA's public cert must be in the core's `ClientCAs`
-BEFORE the CP signs any leaf with the new key — else fresh leaves 502. The enabler is
-**bundle support**: `AppendCertsFromPEM` appends every CERTIFICATE block, so `tls.crt`
-can hold an **overlap bundle** (old ++ new CA concatenated), and validate-then-swap
-treats a partially-bad bundle as a rejected reload (keep last-good).
+The `k8s` client is read-only today (`Get*`/`Watch*`). Managed mode adds `GetSecret` +
+`UpdateSecret` to the interface and both backends — but **`UpdateSecret` is invoked SOLELY
+by the bootstrap/rotation Job, never by serving, never by the core**. Serving managed uses
+`GetSecret` read-only at boot then the read-watch. Import `apierrors` for
+`IsConflict`/`IsNotFound`. No `CreateSecret` (the stub is pre-created; `NotFound` is
+fatal-config). `EnsureCA` is **idempotent** (re-run after a CA exists is a pure adopt).
 
-**Rotation is single-writer** (Phase 1: a one-shot Job / subcommand, or
-leader-elected — NOT the steady-state `replicas: 2`). The Secret-as-lock CAS
-linearizes only create-once, not a 4-stage promote/trim state machine. So the **active
-signer is derived SOLELY from Secret content** (e.g. a `tls-active: old|new` field),
-never per-replica state, and every stage is gated on a **core-observed**
-trust-bundle-hash metric:
+## Deployment & RBAC (self-managed CA, two ServiceAccounts)
 
-1. Generate NEW CA in memory.
-2. Write `tls.crt = OLD ++ NEW`, stage NEW key as `tls-next.key`, keep OLD active.
-   Core's watch fires → trusts BOTH. (Invariant satisfied.)
-3. Keep signing with OLD while every short-TTL leaf renews; watch
-   `parapet_edge_clientcert_not_after` / registry-generation convergence.
-4. **Promote:** set `tls-active: new` (all replicas swap within one debounce), keep
-   BOTH certs in the bundle for ≥ one full leaf-TTL, then trim the OLD cert — only
-   after the convergence metric shows zero leaves on the old CA.
-
-**CA-key-compromise emergency:** skip overlap, write ONLY the new CA, accept the brief
-gap (existing edges 502 until they re-fetch a new-CA leaf). **This is the stolen-CA-key
-runbook** — SAN-drop cannot revoke a forged leaf riding a real SAN. Auto-rotation is
-Phase 2.
-
-### k8s client: the first write path
-
-The `k8s` client is **read-only** today (`k8s/k8s.go` exposes only `Get*`/`Watch*`;
-`cluster.go` wraps List/Watch; `fs.go` is the local fixture backend). Managed mode
-needs the **first** write path, added to the interface and **both** backends with
-package-level forwarders:
-
-- `GetSecret(ctx, ns, name) (*v1.Secret, error)` — single-object read preserving
-  `resourceVersion` for the CAS. cluster: `Secrets(ns).Get`. fs: matching secret or
-  `apierrors.NewNotFound`.
-- `UpdateSecret(ctx, ns, *v1.Secret) (*v1.Secret, error)` — the CAS write; sends
-  `s.ResourceVersion`; apiserver rejects a stale version with `Conflict`. cluster:
-  `Secrets(ns).Update`. fs: best-effort in-memory (**non-CAS**, dev-only).
-
-Import `k8s.io/apimachinery/pkg/api/errors` for `IsConflict`/`IsNotFound`. No
-`CreateSecret` in the recommended posture (the stub is pre-created; `NotFound` is
-fatal-config). The **core never uses these writes** — they live solely in the CP
-boot/rotation path. `ensureCA` is **idempotent**: re-running after a CA exists is a
-pure adopt (no write).
-
-## Deployment & RBAC (self-managed CA)
-
-The CP **stops reusing** the controller's ServiceAccount — splitting the SA is the
-prerequisite for isolating the mint/write capability from the core. Concrete manifest
-changes:
-
-1. **New `deploy/edge/serviceaccount.yaml`** — ServiceAccount `edge-controlplane`.
-2. **`controlplane.yaml`:** `serviceAccountName: edge-controlplane` (was
-   `parapet-ingress-controller`); add `POD_NAMESPACE` via downward API `fieldRef:
-   metadata.namespace` (**required** in managed mode); add a hardened `securityContext`
-   (`readOnlyRootFilesystem`, `runAsNonRoot`, `allowPrivilegeEscalation: false`) and an
-   egress `NetworkPolicy`; add `EDGE_CA_SECRET` (and optionally `EDGE_CA_TTL`,
-   `EDGE_CA_KEY_TYPE`).
-3. **New `deploy/edge/role-ca.yaml`** — namespaced Role `edge-controlplane` in
-   `POD_NAMESPACE` with secrets `get, update` scoped to
-   `resourceNames: [parapet-edge-ca]` (resourceNames scopes get/update/patch/delete
-   but **cannot** scope create — exactly why the stub is pre-created), + RoleBinding to
-   the new SA.
-4. **Cluster-wide read rebind (the migration footgun):** because the CP runs
-   `WATCH_NAMESPACE=""` (cluster-wide tenant-cert Reloader), the new SA needs a
-   **ClusterRoleBinding** to the existing `parapet-ingress-controller` read ClusterRole.
-   A namespaced RoleBinding alone **silently breaks cert distribution**. If
-   `WATCH_NAMESPACE` is pinned, a namespaced RoleBinding to the read Role suffices —
-   the binding scope MUST match `WATCH_NAMESPACE`. Ship `deploy/edge/role-binding-read.yaml`.
-5. **New `deploy/edge/ca-secret.yaml`** — the pre-created **empty** `parapet-edge-ca`
-   Secret in `POD_NAMESPACE`. (Confirm whether target k8s rejects a zero-length
-   `tls.crt` on a `kubernetes.io/tls` CREATE; if so ship it as type `Opaque` — type is
-   advisory to our code and cannot change on `Update`.) MUST carry GitOps
-   drift-exclusion so a reconciler never prunes or blanks the CP-populated Secret.
-6. **The core keeps** its namespace-wide secrets list/watch (it needs all tenant TLS
-   for SNI) and reads ONLY the public `tls.crt` from `parapet-edge-ca` via
-   `EDGE_TRUST_SECRET` — **zero new core RBAC**.
-7. **CP startup RBAC self-probe:** after `k8s.Init`, probe-List secrets in
-   `WATCH_NAMESPACE` and probe-Get the CA Secret; on 403, fatal-log naming the exact
-   missing binding.
-8. **etcd encryption-at-rest** is a managed-mode prerequisite (loud startup warning if
-   undetectable): the long-lived CA key now lives in a Secret, exposed in etcd backups
-   and to anyone with namespace secret-get without it.
+1. **Two SAs.** `edge-controlplane` (serving, **read-only**) and
+   `edge-controlplane-bootstrap` (the Job, scoped write). The serving CP **stops** reusing
+   the controller's SA.
+2. **`controlplane.yaml`:** `serviceAccountName: edge-controlplane` (read-only); add
+   `POD_NAMESPACE` via downward API `metadata.namespace`; hardened `securityContext`
+   (`readOnlyRootFilesystem`, `runAsNonRoot`, `allowPrivilegeEscalation: false`); the
+   `readinessProbe` comment updated to "503 until the cert store **and** (when issuance
+   enabled) the CA signer have loaded"; `replicas` now safe to raise freely.
+3. **`role-ca.yaml`** — namespaced Role with secrets `get, update` scoped to
+   `resourceNames: [parapet-edge-ca]` in `POD_NAMESPACE`, bound to the **Job SA only**
+   (never namespace-wide, never create, never delete). The serving SA does **not** get it.
+4. **Cluster-wide read rebind:** because the serving CP runs `WATCH_NAMESPACE=""`
+   (cluster-wide tenant-cert Reloader), the **serving** SA keeps a ClusterRoleBinding to the
+   existing read ClusterRole — a namespaced RoleBinding alone silently breaks cert
+   distribution. The Job SA needs no cluster-wide read.
+5. **`ca-secret.yaml`** — the pre-created **empty** `parapet-edge-ca` stub in a **CP-only
+   namespace** (the Secret, the Role, the RoleBinding all live there; no core workload
+   occupies it → full CA-key-read isolation as the **default**). MUST carry GitOps
+   drift-exclusion (`argocd.argoproj.io/sync-options: Prune=false` + `ignoreDifferences` on
+   `/data` and `/metadata/annotations`; Flux field-manager note).
+6. **The core keeps** its namespace-wide secrets list/watch (for SNI) but reads **nothing**
+   from `parapet-edge-ca` — trust arrives over `GET /v1/trust-bundle`. **Zero new core
+   RBAC**, and `EDGE_TRUST_SECRET` is gone. The core's only new config is
+   `EDGE_TRUST_CP_ENDPOINT` + the mandatory `EDGE_TRUST_CP_CA` (the CP **server** CA,
+   distinct from the edge CA in `ca_pem`).
+7. **`bootstrap-job.yaml`** — `completions: 1`, `parallelism: 1`, `restartPolicy: OnFailure`,
+   finite-but-generous `backoffLimit`, `ttlSecondsAfterFinished` (reap a Completed Job
+   before the next sync recreates it), `POD_NAMESPACE` via downward API, sequenced before
+   serving via the pre-install/PreSync hook.
+8. **RBAC self-probes:** the serving CP probe-Lists secrets in `WATCH_NAMESPACE`; the Job
+   probe-Gets the CA Secret; on 403 each fatal-logs the exact missing binding.
+9. **etcd encryption-at-rest** is a managed-mode prerequisite (the CA key now lives in a
+   Secret written by the Job and read by every serving replica); a Secret loss = forced CA
+   rotation (overlap runbook).
 
 ## Security model
 
 **Trust boundary.** Exactly the edges holding a private key whose cert chains to the
 dedicated edge CA **and** whose URI SAN is in the live allow-set. Trust is
-**operator-asserted**: only an operator editing the registry Secret moves the boundary.
-mTLS trust is conferred **only on `:443`**.
+**operator-asserted**. mTLS trust is conferred **only on `:443`**.
 
-**Spoofing.** A non-edge reaching `:443` **cannot forge trust**: `VerifiedChains` is
-populated only after the Go stack cryptographically verifies the presented cert against
-`ClientCAs`; forging requires the edge CA key. A compromised edge **cannot request a SAN
-it isn't entitled to** — the CP stamps the SAN from the bearer token's registry
-identity and ignores the CSR's SAN.
+**Spoofing.** A non-edge reaching `:443` cannot forge trust (`VerifiedChains` is populated
+only after cryptographic verification against `ClientCAs`). A compromised edge cannot
+request a SAN it isn't entitled to (the CP stamps it from the token identity).
 
-> **Honest scoping.** mTLS authenticates the **connection, not the headers.** A trusted
-> edge — or anything wielding a stolen edge *leaf* key — can still set
-> `X-Forwarded-For` for its own requests; the claim is **"an unauthenticated peer is
-> never trusted,"** not "XFF can never be spoofed." Second caveat: with the shipped
-> `TRUST_PROXY: cloudflare` default, a non-edge from a Cloudflare CIDR is CIDR-trusted
-> with no cert. **Never add edge egress CIDRs to `TRUST_PROXY`**, and lock both
-> data-plane ports with a `NetworkPolicy`.
+### Why the trust endpoint drops the token (and the others keep it)
 
-**Replay.** None on the data plane — the cert is proven inside a live mTLS handshake.
+A bearer token authenticates the **client to the server** ("who is calling"); it does
+**not** protect **response integrity** ("is what I got back genuine"). The trust bundle is
+read-only and **non-secret by nature**: `ca_pem` is a *public* CA cert, and `allowed_sans`
+is at worst mild fleet-recon (opaque ids), already bounded by the CP's ClusterIP +
+edge-sources-only NetworkPolicy. What the core needs protection against is a **forged**
+CA/allow-set — a trust-boundary takeover. The defense against forgery is **server-side TLS
+the core verifies**, *not* a token the core *sends*. So the token on `/v1/trust-bundle` was
+pure ceremony; dropping it removes one credential the core would hold/rotate/leak, with
+**zero security loss, provided server-TLS verification stays mandatory and non-skippable**.
+**The other endpoints KEEP their token, deliberately:** `GET /v1/certs` ships **private
+keys**, `GET /v1/waf` ships **per-edge-scoped** rules (the scoping *is* the bound), `POST
+/v1/edge-cert` **mints identity** — all serve secret or caller-scoped material and need to
+authenticate *which* edge is calling. Only `/v1/trust-bundle` — broadcast-public, same
+bytes for everyone — can safely drop it.
 
-> **Token-minted leaf certs outlive token revocation.** A leaked-but-not-yet-revoked
-> token POSTed to `/v1/edge-cert` mints a self-contained cert the core verifies for its
-> full TTL. Revoking the token stops *future* issuance but does **not** revoke a minted
-> cert — only **dropping the registry entry** (which drops its SAN from the live
-> allow-set, re-checked per request) revokes it, in ~300 ms. Runbook for a leaked
-> **token**: delete the registry entry. `EDGE_CLIENTCERT_TTL` is kept short to shrink
-> the window; **CP-issuance is INCOMPATIBLE with `EDGE_TRUST_REQUIRE_SAN=false`** (the
-> per-request SAN check is the only bound on such a cert).
+**Blast radius.** A leaked edge **leaf** key lets the holder spoof XFF **as that one edge**
+until its SAN is dropped or its cert expires. The **crown jewel is the edge CA key**. The
+bootstrap Job **GENERATES** it (once ever); serving replicas only **read/HOLD** it.
+**CA-key isolation is now the default, not a wart:** the core never reads the
+`parapet-edge-ca` Secret — it pulls only the public `ca_pem` — so the CA Secret lives in a
+**CP-only namespace** with the dedicated CP SA as its sole reader; the prior concession
+that the core SA could read the CA *private* key via namespace co-tenancy is **eliminated**.
+The CP still concentrates risk (cluster-wide read of all tenant TLS keys via
+`WATCH_NAMESPACE=""` **and** the fleet-minting CA key — pin `WATCH_NAMESPACE` to shrink
+this), and **a stolen CA key still forges the entire fleet** (NameConstraints + EKU stop
+only cross-purpose abuse, NOT impersonation — a forged leaf rides a real SAN, so per-request
+SAN-drop can't revoke it), bounded **only by CA rotation**. Statelessness pushes all CA
+durability onto etcd, so the read-watch keep-last-good in every serving replica is the only
+in-process safety net against a re-blank. The new wrinkle: `allowed_sans` is broadcast
+unauthenticated — **not** a security property; the ids are opaque, confer no capability
+without a CA-chained key, are at worst mild recon; **operators MUST NOT encode secrets in
+edge ids**, and the NetworkPolicy keeps the surface bounded.
 
-**Blast radius.** A leaked edge **leaf** key lets the holder spoof XFF **as that one
-edge** until its SAN is dropped (~300 ms) or its cert expires. The **crown jewel is the
-edge CA key** (mints any edge). In **managed** mode the CP both **GENERATES and HOLDS**
-it — a deliberate escalation from the CP's prior posture (it distributed tenant *leaf*
-keys; it now holds, and mints, a *CA* that forges fleet-wide edge trust). **State this
-plainly:** a stolen edge-CA key forges the **entire** fleet's identities. NameConstraints
-(`PermittedURIDomains`) and EKU `clientAuth` only stop **cross-purpose** abuse (other URI
-domains, serverAuth leaves) — they do **not** bound edge-fleet impersonation, because a
-forged leaf carries a SAN already in the allow-set, so **per-request SAN-drop does NOT
-revoke a forged leaf without also distrusting the legitimate edge.** The **only** real
-bound on a stolen CA key is **CA rotation** (the overlap/emergency runbook); that, not
-SAN-drop, is the stolen-CA-key runbook. Mitigations that genuinely shrink the
-window/surface: a **single-purpose** CA (`KeyUsage=CertSign|CRLSign`, `MaxPathLen=0`,
-EKU `clientAuth`), its **own** tightly-RBAC'd Secret read only by the **dedicated CP
-ServiceAccount**, the CP's edge-sources-only `NetworkPolicy` + hardened pod, **provided**
-mode (key never in an in-cluster Secret) for high-assurance, and a future **HSM/KMS
-`Signer`** so the raw key never sits in pod memory. **Phase-1 honesty:** because the
-**core** SA needs namespace-wide secret read for SNI certs, the core CAN read the CA
-private key from `parapet-edge-ca` in the shared namespace — the dedicated CP SA isolates
-the **mint/write** capability, NOT key-read. Full key-read isolation requires moving
-`parapet-edge-ca` to a CP-only namespace (Phase-1 *option*, applyable manifest) or
-provided mode. The CP also concentrates risk: the same process holds cluster-wide read of
-**all** tenant TLS keys (`WATCH_NAMESPACE=""`) **and** the fleet-minting CA key — pin
-`WATCH_NAMESPACE` to specific tenant-secret namespaces to shrink this.
-
-**Fail-default: fail-closed, degrading to the static CIDR branch.** A missing trust
-Secret ⇒ `trustPol` nil ⇒ mTLS branch false ⇒ edges distrusted (degraded but safe),
-Cloudflare CIDR unaffected. An empty/garbage `ca.crt` on reload ⇒ validate-then-swap
-**rejects** and keeps last-good. First-boot issuance failure ⇒ edge **not-ready**. A
-trust Secret that **vanishes at runtime** keeps **last-good** `clientCAs` and alerts — it
-never nils the live pool; only a *never-loaded* startup absence degrades to the CIDR
-branch. **No path fails open.**
+**Fail-default: fail-closed.** A CP **unreachable at first boot** ⇒ `trustPol` nil ⇒ mTLS
+branch false ⇒ edges distrusted (degraded-but-safe), CIDR/Cloudflare branch unaffected. A
+bad/forged/empty/zero-cert `ca_pem` ⇒ validate-then-swap **rejects** and keeps last-good
+(never nils the live pool). A **steady-state CP outage never drops existing trust** (fail-
+static); only trust *changes* stall. A **persistently-unreachable CP MUST surface as a
+loud, alerting condition** (`parapet_trust_source{none}` stuck pre-bundle), never a quiet
+permanent degrade. **No path fails open.**
 
 **The explicit tradeoff.** This forces re-encrypt TLS, a PKI lifecycle, and the CA key
-living with the CP (managed mode). An **expired edge cert hard-fails the handshake**
-(502s); the CP-outage budget (= `EDGE_CLIENTCERT_TTL` × renew-before-fraction) must
-exceed the operator's CP recovery SLO. Accepted: a cryptographic, IP-independent,
-per-edge-revocable identity that makes a bare Docker edge work with nothing but a token.
+living in-cluster. An expired edge cert hard-fails the handshake (502s); the CP-outage
+budget (= `EDGE_CLIENTCERT_TTL` × renew-before-fraction) must exceed the CP recovery SLO.
+It also adds a steady-state runtime dependency **for trust *changes* only** (core→CP to
+onboard or revoke); steady-state trust of already-known edges is fail-static and
+CP-independent. The trust feed must be **at least as available as the apiserver/watch-cache
+it replaced** — so **CP HA (≥2 replicas behind the ClusterIP) is REQUIRED**, and the core
+persists a warm-start cache (no-trust-until-revalidated) so a restart during a CP outage
+does not distrust the fleet. There is **no leader to fast-recover** — N stateless replicas
++ the Service is the recovery story.
 
 ## Fail modes
 
 | Failure | Behavior |
 |---|---|
-| Trust Secret absent / never created (startup) | mTLS branch false (`trustPol` nil); edges distrusted (XFF overwritten); core serves; Cloudflare CIDR unaffected. **Fail-closed, degraded-not-down.** Startup warning + `parapet_trust_source{none}`. |
-| `ca.crt`/`tls.crt` empty/garbage on reload | Validate-then-swap **rejects**, last-good kept, `parapet_trust_reload_rejected_total++`, **loud alert**. Never fails open. |
-| Managed CA Secret deleted / blanked at RUNTIME (operator, GitOps prune, restore of the empty stub) | CP: the guard annotation makes a re-blanked-but-previously-populated stub a HARD ANOMALY — the CP **NEVER regenerates** (would mint a new CA and distrust the fleet), keeps its in-memory CA, bumps `parapet_edge_ca_unexpected_empty_total`, alerts, fails readiness. Core: a runtime DELETE/empty of `EDGE_TRUST_SECRET` keeps **LAST-GOOD** `ClientCAs` + alerts — never nils the live pool. Replacement is the overlap rotation, never delete+regenerate. The `deploy/` stub carries GitOps drift-exclusion. |
-| Two CP replicas both observe an empty stub and both generate (split-CA race) | `resourceVersion` CAS linearizes them: exactly one `Update` wins (rv advances), the other gets `Conflict`, re-reads, **ADOPTS** the winner's keypair. The Secret IS the lock — no leader election. The CAS read MUST be a strongly-consistent typed `Get` (never an informer cache, which can serve a stale-empty stub and livelock the loser); retry exhaustion is a hard non-zero exit. |
-| CP started managed with empty `POD_NAMESPACE` (downward API not wired) | **FATAL** startup error before any write — the CA Secret has no known namespace and a wrong-namespace write would land where the core never sees it. Mirrors the `CP_TLS` pairing guard. |
-| CP switched to the dedicated SA without the cluster-wide read rebind (`WATCH_NAMESPACE=""`) | The cluster-wide tenant-cert Reloader 403s → stale/empty cert store → edges fail to fetch certs → data-plane outage. MUST bind a ClusterRoleBinding to the existing read ClusterRole. The CP startup RBAC self-probe fails loud, naming the missing binding. |
-| A CP replica booted before a CA rotation keeps signing with the stale key | Prevented by the CA-Secret watch: signer is `atomic.Pointer[*Signer]`, hot-reloaded on change; the active key derives solely from Secret content (`tls-active`) so all replicas converge within one debounce. The interlock confirms all `parapet_edge_ca_signer_fingerprint` match before trimming. |
-| Edge client cert expired / CP down past `NotAfter` | `VerifyClientCertIfGiven` aborts the handshake → 502s. Until expiry, the edge keeps its last-good in-memory cert (**fail static**) and retries with backoff. Outage budget = `TTL` × renew-before-fraction; size `TTL` above the CP recovery SLO. |
-| Leaked-but-not-yet-revoked token replayed to `/v1/edge-cert` | Mints a cert for ITS OWN SAN, valid for the full TTL. Token revocation does NOT revoke it — **only deleting the registry entry** drops its SAN (per-request → distrusted ~300 ms). Bounded by short `EDGE_CLIENTCERT_TTL`. |
-| Stolen edge-CA key (managed mode) | Attacker forges the **ENTIRE fleet's** identities. NameConstraints + EKU stop only cross-purpose abuse, NOT impersonation (a forged leaf rides a real SAN, so SAN-drop can't revoke it without distrusting the legit edge). The ONLY bound is **CA ROTATION**. Phase-1 honesty: the CA key is readable by the core SA (namespace co-tenancy); the dedicated CP SA isolates mint/write, not key-read. |
-| CP signs with a CA the core's `ClientCAs` doesn't yet trust (rotation skew) | Fresh certs fail verification → 502s. Prevented by the overlap invariant (new CA in the bundle BEFORE signing with it) + the convergence interlock. CP hot-reloads the CA so rotation needs no restart. |
-| Clock skew: core clock behind the CP by > `EDGE_CLIENTCERT_SKEW` | A fresh cert is "not yet valid" at the core → handshake aborts → 502s, self-healing once skew elapses. The validator is the **core** clock. Mitigated by the NotBefore backdating (default 10m), an NTP-sync prerequisite, and a distinct notBefore/notAfter failure metric. |
-| First-boot issuance fails under `EDGE_DATAPLANE_MTLS=on` (CP down at startup) | **Fail-CLOSED on readiness:** edge stays not-ready (503), not routed to. Bounded background retry flips ready when the first cert lands. Readiness `= (serveAll || store.Loaded()) && clientCert.Loaded()` — serve-all does NOT bypass. CP HA recommended. |
-| CP readiness ("can sign") mistaken for system readiness ("core trusts the CA") | The edge cannot self-detect the core-doesn't-trust-me state and WILL go ready and serve 502s in the convergence window (core debounce + watch + etcd lag, worst-case seconds). The onboarding gate **REQUIRES** confirming `parapet_trust_source{mtls}` / the trust-bundle-hash includes the new CA before routing prod traffic; optionally an edge-side post-issuance re-encrypt probe before flipping ready. |
-| Provided-mode CA mounted without NameConstraints / clientAuth EKU | The CP validates: `IsCA` required; EKU must contain `clientAuth` (reject pure serverAuth / anyEKU); **warn loudly (or refuse behind a flag)** if `NameConstraints.PermittedURIDomains` is absent. The post-sign self-check still bounds the emitted leaf in both modes. |
-| Malformed / oversized-key / unsupported-alg CSR (DoS probe) | 16 KiB body cap (413); the **key-type/curve whitelist rejects (400) BEFORE `CheckSignature`** so an oversized-RSA verify-DoS is impossible. authz + reject precede any CA signing. |
-| Fleet-wide re-issue storm (rollout / drain / CP recovery) | Per-token rate limit does NOT help (N tokens). A **global signing concurrency cap** returns 429/503 + `Retry-After`; the edge honors it with backoff; the edge refresh loop adds **jitter** so a co-booted fleet doesn't stay phase-locked. |
-| `ClientCertStore.Update` gets an unparseable / mismatched chain | All-or-nothing: `tls.X509KeyPair(chain, heldKey)` failing keeps the PRIOR pair (never clears the pointer, never swaps a broken cert), logs + bumps a rejection metric. Never a silent half-rotated state. |
-| `GetConfigForClient` returns nil / omits `ClientAuth`/`GetCertificate` | Guarded: base config built non-nil before `Serve()`; callback returns last-good, never nil; startup self-test asserts the three properties. |
+| Bootstrap Job not yet run / still running (cold start) | `parapet-edge-ca` empty/absent → all serving replicas read no CA, all not-ready (503), the Service has zero endpoints, `POST /v1/edge-cert` connection-refused, trust-bundle has no `ca_pem`. Edges fail-static on last-good leaf; new edges stay not-ready. **Degraded, never fail-open.** Bounded by Job completion; self-heals on populate. Core treats no-`ca_pem` as not-yet-bootstrapped (keep retrying, never cache empty). |
+| Bootstrap Job re-runs after the CA is populated (redeploy / Helm / Argo / `kubectl apply`) | (a) parse → ADOPT, exit 0 (no-op). (b) guard annotation present but blanked → HARD ANOMALY, **never regenerate**, exit non-zero + `parapet_edge_ca_unexpected_empty_total++` + alert. The stub carries GitOps drift-exclusion. |
+| Two bootstrap Job pods run concurrently (node-loss double-run, delete-recreate, re-apply) | The `resourceVersion`-CAS linearizes them: exactly one `UpdateSecret` wins, the other gets `IsConflict`, re-reads, ADOPTS. The re-read-before-Update no-op closes the common race earlier. Single-writer is **not** relied on as a k8s guarantee; the CAS is the lock. |
+| Bootstrap Job fails silently (exhausts backoffLimit, or exits 0 without writing) | Forbidden: exit non-zero on any failure; re-GET after `UpdateSecret` and assert the CA parses before exit 0. Alerts on `kube_job_failed` AND absence-of-populated-CA-after-deadline AND `parapet_edge_ca_generated_total` exceeding 1 across the fleet lifetime. |
+| A serving replica caches the CA, then a rotation/re-populate writes a new CA | The CA-Secret read-watch (`atomic.Pointer[*Signer]`, validate-then-swap; active key from Secret content) converges within one debounce; the per-replica `parapet_edge_ca_signer_fingerprint` interlock gates trimming the old CA. |
+| Runtime CA-Secret DELETE/blank on a serving replica (GitOps prune, restored empty stub) | The replica **keeps its last-good in-memory signer**, alerts, never drops to no-signer. With the in-serving anti-regen guard removed, this is the only in-process safety net. |
+| CP unreachable at first boot (no cached bundle, or warm-start hint > `EDGE_TRUST_CP_MAX_STALE`) | `trustPol` nil ⇒ edges distrusted (XFF overwritten); core serves; CIDR branch unaffected. **Fail-closed.** `parapet_trust_source{none}`; background retry flips to mTLS on the first valid bundle. A persistently-unreachable CP is a loud alert. |
+| Core restart during a CP outage (in-memory bundle lost) | Reads `EDGE_TRUST_CP_CACHE_FILE` as a **warm-start hint only** — confers NO trust until revalidated. Degrades to CIDR-only until the CP returns. `parapet_trust_source{file}` then `{mtls}`. Persisting-and-trusting is forbidden (would resurrect a revoked SAN). CP HA makes this rare. |
+| Forged / replayed OLDER bundle over any TLS gap | Rejected by **forward-only**: the core swaps only when `generation` strictly advances; a replayed older body bumps `parapet_trust_rollback_rejected_total` and is dropped. The integrity precondition is mandatory non-skippable server-TLS. |
+| Bad / forged / empty / zero-cert `ca_pem` on a fetch | Validate-then-swap **rejects** (non-empty-input-yields-zero-certs is rejected), keeps last-good, bumps `parapet_trust_reload_rejected_total`, alerts. NEVER nils the live pool. An empty `allowed_sans` is accepted only when `generation` strictly advances. |
+| Missing/unparseable `EDGE_TRUST_CP_CA`, or non-https `EDGE_TRUST_CP_ENDPOINT`, when on | **FATAL** startup error — never a warning, never a system-roots fallback, never plaintext. A self-test asserts `RootCAs != nil && !InsecureSkipVerify`. No `EDGE_CP_ALLOW_PLAINTEXT` analog on either end. |
+| CP is a trust source but `CP_TLS_CERT`/`CP_TLS_KEY` empty (plaintext) | **FATAL CP startup error** (mirrors the `CP_TLS` pairing guard). The trust channel has no plaintext mode on either end. |
+| Unauthenticated long-poll flood (connection/goroutine/FD exhaustion) | Bounded: a semaphore caps concurrent watch handlers (over-limit ⇒ 503 + Retry-After), a context deadline frees blocked handlers, a per-source-IP cap + body cap apply, absurd `since` rejected cheaply. The edge-sources-only NetworkPolicy is availability-load-bearing; the CP sets `WriteTimeout`/`IdleTimeout` ≥ the watch ceiling. |
+| `/v1/waf` or trust-bundle generation seen flapping by a load-balanced client | Fixed: generation is resourceVersion-derived (replica-identical + monotonic), not a per-process counter. Two replicas reading identical source emit equal generation. The ETag stays the take/304 driver. |
+| CP restart resets an in-memory generation below a core's held `since` | Cannot happen: generation is an etcd resourceVersion, not a CP process counter, so a CP restart never lowers it. (If a content-hash were ever used instead, the CP would have to re-floor above the core's `since` and return current truth — but resourceVersion makes this moot.) |
+| Revocation across N stateless CP replicas + N core pods | Eventually-consistent, self-healing. Total exposure = max-CP-replica-watch-lag (a revoked token can mint one last full-TTL leaf off a lagging CP replica) + max-CORE-replica-watch-lag (a dropped SAN still honored on a lagging core pod), each = watch/relist lag + 300 ms debounce. Runbook confirms convergence on **all** replicas of **both** planes via the pod-labeled generation metric before declaring trusted/revoked. Short `EDGE_CLIENTCERT_TTL` bounds the last-mint window. |
+| CP-side allow-set derivation bug widens trust (single uncross-checked authority) | Pinned by intra-process tests (`identityFor()` == the SAN `Signer.Sign` stamps; a known-revoked id absent from a fresh `allowed_sans`), recomputed from the same registry snapshot that authorizes `/v1/edge-cert`. The core logs/metrics `parapet_trust_allowed_sans_count` + `parapet_trust_bundle_hash` so an unexpected widening is alertable. |
+| Allow-set change does not propagate (gen fails to bump / long-poll wedges) | Three mitigations: deterministic (sorted, NFC) SAN serialization before the gen/etag hash; the core watch client avoids a whole-request timeout (Transport idle/header timeouts + per-attempt ctx deadline + TCP keep-alive); the unconditional `EDGE_TRUST_CP_POLL_INTERVAL` safety poll. SLA: sub-second normally, ≤ one poll interval worst-case. |
+| Fleet-wide re-issue storm under N stateless replicas | The per-token rate limit and global signing cap are **PER-REPLICA** (effective ceiling N×, scales silently as replicas rise). authz-reject + key-type whitelist before any signing; the cap returns 429/503 + Retry-After; per-edge jitter prevents phase-lock. A hard global cap needs externalized state (deferred). |
+| CP readiness ("can sign") mistaken for system readiness ("core trusts the CA") | The edge can't self-detect the core-doesn't-trust-me state and WILL go ready and serve 502s in the convergence window. The onboarding gate **REQUIRES** confirming `parapet_trust_source{mtls}` / the trust-bundle hash includes the new CA before routing prod traffic. |
+| `EDGE_TRUST_SECRET` set on upgrade but `EDGE_TRUST_CP_ENDPOINT` unset (knob rename) | The core emits a **loud startup error** naming the rename, rather than silently ignoring the old knob and dropping every edge to CIDR-only. Back-compat is stated against a named shipped baseline, not "today." |
 
 ## Configuration
 
 | Variable | Where | Default | Meaning |
 |---|---|---|---|
-| `TRUST_PROXY` | core | `cloudflare` | **Unchanged.** Static CIDR list / `cloudflare`/`true`/`false` → the `cidrTrust` OR-branch. **Never add edge egress CIDRs here.** |
-| `EDGE_TRUST_SECRET` | core | `""` (feature **off**) | Name of the Secret in `POD_NAMESPACE` carrying the edge CA **public** cert into `ClientCAs`. Set to `parapet-edge-ca` to single-source from the managed CA Secret. Reads key **`tls.crt`** first, `ca.crt` as fallback. MUST be the same namespace as the CP's CA Secret (= `POD_NAMESPACE` for both). Unset ⇒ mTLS disabled, identical to today. |
-| `EDGE_TRUST_REQUIRE_SAN` | core | `true` | Trust requires the verified leaf's URI SAN ∈ the live allow-set (enables per-edge revocation). **Incompatible with CP-issuance: the per-request SAN check is the ONLY bound on a cert minted from a leaked token. When the same edge CA backs issuance, the CP MUST refuse to issue and/or the core MUST refuse CA-only — fail-closed.** |
-| `EDGE_DATAPLANE_MTLS` | edge | `false` | Enable the CP-issued data-plane client cert (CSR → `POST /v1/edge-cert`, presented via `GetClientCertificate`). Off ⇒ anonymous re-encrypt, identical to today. Requires `EDGE_UPSTREAM_TLS=true` (loud error otherwise). When on, readiness is gated on the client cert (fail-closed). |
-| `EDGE_CLIENTCERT_KEY_TYPE` | edge | `ecdsa-p256` | Key type for the in-memory ephemeral keypair (never leaves the edge). `ecdsa-p256`/`p384`/`ed25519` — matches the CP's accepted-key whitelist. RSA not offered (bounds the CP's CSR-verify DoS surface). |
-| `EDGE_CLIENTCERT_TTL` | CP | `1h` | Issued **leaf** cert lifetime. Short — renewal is free over the loop — to bound a leaked-token-minted cert. Outage budget = `TTL` × renew-before-fraction; raise (24–72h) if outage tolerance dominates (call out the tension). |
-| `EDGE_CLIENTCERT_SKEW` | CP | `10m` | NotBefore backdating slack. The cert is minted on the CP clock but **validated on the core clock**. NTP sync between CP and core is a hard prerequisite. |
-| `EDGE_CLIENTCERT_RATE` | CP | `10/min` | Per-token issuance rate limit (429). A **global** signing concurrency cap (429/503 + `Retry-After`) is separate and necessary — per-token does nothing against a fleet-wide restart storm. |
-| `EDGE_CA_CERT` / `EDGE_CA_KEY` | CP | `""` / `""` (⇒ managed mode) | **Provided mode:** PEM paths to a MOUNTED edge CA cert+key. Set ⇒ the CP uses them and does NOT generate/write the Secret; hot-reloaded from disk. Both-or-neither (hard config error if only one). Absent ⇒ **managed** mode (CP self-generates). Not cert-manager-specific. |
-| `EDGE_CA_SECRET` | CP | `parapet-edge-ca` | Name of the Secret in `POD_NAMESPACE` the CP adopts-or-generates the CA into (managed). Operator pre-creates it **empty** (with GitOps drift-exclusion). Keys `tls.crt`/`tls.key`; carries the `parapet.moonrhythm.io/edge-ca-generation` guard once populated. Read/written in `POD_NAMESPACE`, never `WATCH_NAMESPACE`. |
-| `EDGE_CA_TTL` | CP | `87600h` (10y) | Lifetime of a CP-**generated** edge CA cert (managed/generate path). Long-lived (the CA is the anchor; the short knob is the leaf TTL). Ignored in provided mode. *(Open: shorten to 1–2y unless convergence-gated rotation has shipped.)* |
-| `EDGE_CA_KEY_TYPE` | CP | `ecdsa-p384` | Key type for a CP-generated CA: `ecdsa-p384` (default) or `ed25519`. Ignored in provided mode. |
-| `POD_NAMESPACE` | CP | downward API `metadata.namespace` (**required in managed mode**) | The CP's own namespace; the CA Secret is read/written here (NOT `WATCH_NAMESPACE`). Empty in managed mode ⇒ fatal startup error. Must be added to `deploy/edge/controlplane.yaml` (the core already wires it). |
-| `WATCH_NAMESPACE` | CP | `""` (all namespaces) | Existing knob; documented here for its security weight. `""` = cluster-wide tenant-TLS read = highest blast radius. **Recommend pinning** to the namespace(s) holding tenant TLS Secrets. Distinct from `POD_NAMESPACE`; the CA read/write never uses it. |
-| `EDGE_UPSTREAM_CLIENT_CERT` / `_KEY` | edge | `""` / `""` | **Legacy mounted-cert (k8s-only) edge-side path**, superseded as the default by `EDGE_DATAPLANE_MTLS` + CP-issuance. PEM paths to a mounted client cert+key, live-reloaded from disk. An edge mount detail, not a CA mode. |
-| `EDGE_UPSTREAM_TLS` | edge | `false` | **Unchanged.** Must be `true` for mTLS trust. Selects the re-encrypt path. |
-| `EDGE_UPSTREAM_SNI` | edge | `""` | **Unchanged.** SNI/`ServerName` presented to the core on re-encrypt. |
+| `TRUST_PROXY` | core | `cloudflare` | **Unchanged.** Static CIDR / `cloudflare`/`true`/`false` → the `cidrTrust` OR-branch. **Never add edge egress CIDRs here.** |
+| `EDGE_TRUST_CP_ENDPOINT` | core | `""` (feature off) | HTTPS base URL of the control plane. Set ⇒ the core pulls its trust bundle from `GET /v1/trust-bundle` instead of watching a Secret; unset ⇒ identical to today (CIDR-only). **MUST be `https://`** — non-https is a fatal startup error, no plaintext analog ever. |
+| `EDGE_TRUST_CP_CA` | core | `""` | PEM (path/inline) of the CA that signs the **CP server** cert → the trust client's `RootCAs`. **MANDATORY + FATAL** if missing/empty/unreadable/unparseable (or zero certs) when the endpoint is set — the only thing protecting the core from a forged trust anchor. No system-roots fallback, no skip-verify. SHOULD be a dedicated single-purpose CA; distinct from the edge CA in `ca_pem`. |
+| `EDGE_TRUST_CP_WATCH_TIMEOUT` | core/CP | `30s` | Server-side long-poll block ceiling. The CP `http.Server` `WriteTimeout`/`IdleTimeout` MUST be ≥ this; the core uses a per-attempt context deadline of this + slack, **not** a whole-request `http.Client.Timeout`. |
+| `EDGE_TRUST_CP_POLL_INTERVAL` | core | `5m` | Safety-net plain-GET poll, run **unconditionally** alongside the long-poll. Bounds worst-case revocation latency if a broadcast is missed or the watch goroutine wedges. |
+| `EDGE_TRUST_CP_CACHE_FILE` | core | `""` (recommended: set) | Path to persist the last-good bundle (public `ca_pem` + opaque SANs — no secret-at-rest concern). Written on every successful swap; read on boot as a **warm-start hint that confers NO trust until revalidated**. Never authoritative. |
+| `EDGE_TRUST_CP_MAX_STALE` | core | `1h` | Max age of the warm-start hint; an older file is ignored. Secondary bound (the primary is no-trust-until-revalidated). |
+| `EDGE_TRUST_REQUIRE_SAN` | core | `true` | Trust requires the verified leaf's URI SAN ∈ the live allow-set; the allow-set now comes from `/v1/trust-bundle`'s `allowed_sans` (no longer re-derived in the core). Still **incompatible with CP-issuance when CA-only** (fail-closed). |
+| `EDGE_DATAPLANE_MTLS` | edge | `false` | Enable the CP-issued data-plane client cert (CSR → `POST /v1/edge-cert`). Off ⇒ anonymous re-encrypt. Requires `EDGE_UPSTREAM_TLS=true`. Readiness gated on a loaded cert (fail-closed). |
+| `EDGE_CLIENTCERT_KEY_TYPE` | edge | `ecdsa-p256` | In-memory ephemeral keypair type (`p256`/`p384`/`ed25519`). RSA not offered (bounds the CP CSR-verify DoS surface). |
+| `EDGE_CLIENTCERT_TTL` | CP | `1h` | Issued **leaf** lifetime. Short — renewal is free — to bound a leaked-token-minted cert. Raise (24–72h) if outage tolerance dominates. |
+| `EDGE_CLIENTCERT_SKEW` | CP | `10m` | NotBefore backdating slack. The cert is minted on the CP clock, **validated on the core clock**. NTP sync between CP and core is a prerequisite. |
+| `EDGE_CLIENTCERT_RATE` + global signing cap | CP | `10/min` per token; cap unsized | **PER-REPLICA** behind the Service ⇒ effective fleet ceiling **N×**, scaling silently as replicas rise for HA. authz-reject + key-type whitelist run before any signing. A hard global cap needs externalized state (deferred). |
+| `EDGE_CA_BOOTSTRAP` / `--bootstrap-ca` | CP (Job) | false (serving mode) | Runs the same binary in one-shot CA-bootstrap mode (`EnsureCA`: adopt-if-present, generate-if-absent, never-regenerate, **CAS-guarded**, re-read-verify-before-exit), then exit. **The only process that writes the CA Secret.** |
+| `EDGE_CA_CERT` / `EDGE_CA_KEY` | CP | `""` (⇒ managed) | **Provided mode:** PEM paths to a mounted edge CA cert+key. Set ⇒ the CP uses them, never generates/writes; hot-reloaded. Both-or-neither (hard error if only one). Absent ⇒ managed (the Job generates). |
+| `EDGE_CA_SECRET` | CP | `parapet-edge-ca` | Name of the CA Secret in `POD_NAMESPACE`. The **Job** writes it (scoped get/update); **serving** reads it (read-only get + read-watch). Pre-created empty with GitOps drift-exclusion. Lives in a CP-only namespace. |
+| `EDGE_CA_TTL` | CP | `87600h` (10y) | Lifetime of a CP-generated edge CA cert. Long-lived (the leaf TTL is the short knob). Ignored in provided mode. Rotation is Job-driven. *(Open: shorten to 1–2y unless convergence-gated rotation has shipped.)* |
+| `EDGE_CA_KEY_TYPE` | CP | `ecdsa-p384` | Key type for a CP-generated CA (`p384`/`ed25519`). Ignored in provided mode. |
+| `POD_NAMESPACE` | CP | downward API `metadata.namespace` (**required**) | The CP's own namespace; the CA Secret is **read** here (serving-managed) and **written** here (the Job). NOT `WATCH_NAMESPACE`. Empty in bootstrap or serving-managed mode ⇒ fatal. |
+| `WATCH_NAMESPACE` | CP | `""` (all namespaces) | Cluster-wide tenant-TLS read = highest blast radius. **Recommend pinning** to the tenant-secret namespace(s). Distinct from `POD_NAMESPACE`; the CA read/write never uses it. |
+| `EDGE_UPSTREAM_CLIENT_CERT` / `_KEY` | edge | `""` | **Legacy mounted-cert (k8s-only) edge-side path**, superseded by `EDGE_DATAPLANE_MTLS` + CP-issuance. A mount detail, not a CA mode. |
+| `EDGE_UPSTREAM_TLS` / `EDGE_UPSTREAM_SNI` | edge | `false` / `""` | **Unchanged.** `EDGE_UPSTREAM_TLS=true` is required for mTLS trust; SNI presented on re-encrypt. |
 
-Metrics: `parapet_trust_source{mtls|cidr|none}`, `parapet_trust_reload_rejected_total`
-(core); `parapet_edge_clientcert_loaded` (0/1), `parapet_edge_clientcert_not_after`
-(edge); `parapet_edge_ca_generated_total`, `parapet_edge_ca_signer_fingerprint`,
-`parapet_edge_ca_unexpected_empty_total` (CP). Both planes also expose the registry
-generation/hash they last applied, so an operator can confirm convergence before
-declaring an edge trusted.
+Metrics: `parapet_trust_source{mtls|cidr|none|file}`, `parapet_trust_reload_rejected_total`,
+`parapet_trust_rollback_rejected_total`, `parapet_trust_bundle_age_seconds`,
+`parapet_trust_allowed_sans_count`, `parapet_trust_bundle_hash` (core);
+`parapet_edge_clientcert_loaded`, `parapet_edge_clientcert_not_after` (edge);
+`parapet_edge_ca_generated_total` (Job; alert if > 1 fleet-lifetime),
+`parapet_edge_ca_unexpected_empty_total`, `parapet_edge_ca_signer_fingerprint`
+(per-serving-replica, pod-labeled). Both planes expose the registry/trust-bundle
+generation they last applied (pod-labeled) for convergence gating.
 
 ## Onboarding flow (the payoff)
 
-1. **One-time, code-only:** deploy the dedicated `edge-controlplane` ServiceAccount +
-   its scoped Role/RoleBinding (`get,update` on `resourceNames: [parapet-edge-ca]`) +
-   the cluster-wide read rebind (when `WATCH_NAMESPACE=""`), pre-create the **empty**
-   `parapet-edge-ca` Secret (with GitOps drift-exclusion annotations), set
-   `POD_NAMESPACE` on the CP via the downward API, and roll the core + CP **once** to
-   pick up the new code. On first boot the CP **generates and persists** the edge CA
-   itself (managed mode) — **no openssl, no cert-manager, no out-of-band CA**. The core
-   points `EDGE_TRUST_SECRET=parapet-edge-ca` and reads the public cert from the same
-   Secret. *This is the only restart, ever — never again per-edge.* (Provided mode: skip
-   the generate — mount `EDGE_CA_CERT`/`EDGE_CA_KEY`; the CP needs no `get`/`update`.)
-2. **Per edge — grant a data-plane identity (one registry edit).** Add the edge's entry
-   to `edge-controlplane-tokens` with an explicit `id`. This single edit (a) authorizes
-   its cert/WAF fetch, (b) makes the CP **issue** its data-plane client cert on `POST
-   /v1/edge-cert` — key generated in the edge's memory, never mounted, never renewed by
-   hand — and (c) adds its SAN `spiffe://…/edge/<id>` to the core's live allow-set.
+1. **One-time, code-only:** deploy the two SAs (read-only serving + scoped-write Job) and
+   their RBAC, pre-create the **empty** `parapet-edge-ca` stub (CP-only namespace, GitOps
+   drift-exclusion), set `POD_NAMESPACE` on both the serving Deployment and the Job, and
+   ship the **bootstrap Job as a pre-install/PreSync hook ordered before serving**. On
+   first install the Job **generates and persists** the edge CA once (managed mode) — **no
+   openssl, no cert-manager**; serving becomes ready only once a CA is loaded. The core
+   points `EDGE_TRUST_CP_ENDPOINT` at the CP and `EDGE_TRUST_CP_CA` at the CP **server** CA,
+   then pulls the edge CA's public cert + the live allow-set over `GET /v1/trust-bundle`.
+   *Only restart, ever — never again per-edge.*
+2. **Per edge — grant a data-plane identity (one registry edit).** Add the edge's entry to
+   `edge-controlplane-tokens` with an explicit `id`. This single edit authorizes its
+   cert/WAF fetch, makes the CP **issue** its data-plane cert on `POST /v1/edge-cert`, and
+   publishes its SAN in `allowed_sans`.
 3. **Configure the edge:** `EDGE_DATAPLANE_MTLS=true`, `EDGE_UPSTREAM_TLS=true`,
-   `EDGE_UPSTREAM_ADDR` → core `:443`. For a Docker edge that's it — **no client-cert
-   file mounts**; its only input stays `EDGE_CP_TOKEN`.
-4. **Deploy + verify.** The edge generates a keypair in memory, fetches its cert, and
-   re-encrypts to `:443` presenting it. **Confirm `parapet_trust_source{mtls}` / the
-   trust-bundle-hash includes the CA before routing prod traffic** (the edge can't
-   self-detect the core-doesn't-trust-me window). No `TRUST_PROXY` edit, no core restart.
-5. **Revoke:** **delete the edge's registry entry** → its SAN leaves the allow-set →
-   distrusted within ~300 ms (deleting only the token does NOT revoke an already-minted
-   cert). For a **leaked CA key**, SAN-drop does NOT help (a forged leaf rides a real
-   SAN) — the only fix is **CA rotation** (overlap runbook), gated on the convergence
-   metric.
+   `EDGE_UPSTREAM_ADDR` → core `:443`. For a Docker edge that's it — its only input stays
+   `EDGE_CP_TOKEN`.
+4. **Deploy + verify.** Confirm `parapet_trust_source{mtls}` **and** that
+   `parapet_trust_bundle_hash` / `parapet_trust_allowed_sans_count` reflect the new id **as
+   observed by the core** before routing prod traffic (worst-case convergence one
+   `EDGE_TRUST_CP_POLL_INTERVAL`).
+5. **Revoke:** **delete the edge's registry entry** → its SAN leaves `allowed_sans` →
+   distrusted, with latency = max-CP-replica-watch-lag + max-CORE-replica-watch-lag (each
+   watch/relist lag + 300 ms debounce); confirm convergence on **all** replicas of **both**
+   planes via the pod-labeled generation metric. Deleting only the token does NOT revoke an
+   already-minted cert. For a **leaked CA key**, SAN-drop does NOT help — the only fix is
+   **CA rotation** (the Job-driven overlap runbook), gated on the convergence metric.
 
 ## Phasing
 
-1. **Phase 1 — the primary mechanism (a bare Docker edge works, no cert-manager).** Core:
-   the per-request closure, `GetConfigForClient` hot-swap over a **separate** atomic from
-   the SNI cert table, the `EDGE_TRUST_SECRET` watch (validate-then-swap, keep-last-good,
-   runtime-keep-last-good-on-delete, alert-on-reject), `EDGE_TRUST_REQUIRE_SAN=true`
-   single-sourced, the `X-Forwarded-Country/-ASN` strip, the metrics. CP-issuance: `POST
-   /v1/edge-cert`, `edgecp/signer.go` (zero-value template + post-sign self-check +
-   key-type whitelist + HSM/KMS seam interface), `Authz.Identity`, the **shared SAN
-   derivation package**, the global signing concurrency cap. **Managed-CA bootstrap:**
-   `edgecp.EnsureCA` (adopt-or-generate, ECDSA-P384, single-purpose, NameConstrained)
-   under the `resourceVersion`-CAS create-once over the pre-created empty Secret, the
-   **anti-regeneration guard**, the new `k8s.GetSecret`/`UpdateSecret` write path, the
-   CA-Secret **watch** keeping the signer hot-reloadable (`atomic.Pointer[*Signer]`), the
-   dedicated CP ServiceAccount + scoped Role + cluster-wide read rebind, `POD_NAMESPACE`
-   on the CP, the CP startup RBAC self-probe, and the CA metrics. **Provided** mode ships
-   alongside as the escape hatch. Edge: `EDGE_DATAPLANE_MTLS` wiring with atomic key+chain
-   swap, jitter, fail-closed readiness. `NetworkPolicy` locking core `:80`/`:443`.
-2. **Phase 2 — stronger hardening.** Mutual auth of the hop (edge pins the core CA, drop
-   `InsecureSkipVerify`); the CP-only-namespace CA-key-read isolation as a turnkey
-   manifest; **CA auto-rotation** (CP rotates at `NotAfter` × fraction) gated on the
-   cross-replica convergence metric; an **HSM/KMS `Signer`** so the raw CA key never sits
-   in pod memory; CRL/OCSP via `tls.Config.VerifyConnection` if revocation must beat TTL +
-   SAN-drop; real SPIRE SVID migration (the SAN naming already aligns).
+1. **Phase 1 — the primary mechanism (a bare Docker edge works, no cert-manager, HA CP).**
+   Core: the per-request closure + `GetConfigForClient` hot-swap (unchanged); the tokenless
+   `TrustCpClient` long-poll (mandatory-server-TLS, fatal-on-missing-CA, forward-only
+   resourceVersion-derived generation, validate-then-swap, fail-static, warm-start disk
+   cache that confers no trust until revalidated); `EDGE_TRUST_REQUIRE_SAN=true`; the
+   `X-Forwarded-Country/-ASN` strip; the metrics. CP-issuance: `POST /v1/edge-cert`,
+   `edgecp/signer.go` (zero-value template + post-sign self-check + key-type whitelist +
+   HSM/KMS seam), `Authz.Identity`, the **single in-CP `identityFor`** derivation (no shared
+   cross-binary package). **Managed-CA via a run-once bootstrap Job** (`--bootstrap-ca`)
+   running `EnsureCA` (adopt-or-generate-never-regenerate, ECDSA-P384, single-purpose,
+   NameConstrained), **keeping the `resourceVersion`-CAS and the anti-regeneration guard
+   INSIDE the Job** plus a re-read-before-write no-op; the k8s write path scoped to the Job
+   SA; serving replicas read-only with the CA-Secret read-watch keeping the signer
+   hot-reloadable. **Stateless-HA serving** (no leader election; Service +
+   readiness-gated-on-loaded-CA), the **content-derived generation fix** for **both**
+   `/v1/waf` and the trust-bundle, the Job-ordering hook, the `GET /v1/trust-bundle`
+   endpoint (tokenless, `?watch` long-poll, bounded concurrency), and the CP-side fatal
+   guard that trust-distribution requires `CP_TLS`. `NetworkPolicy` locking core `:80`/`:443`
+   and the CP (now availability-load-bearing).
+2. **Phase 2 — stronger hardening.** Mutual auth of the edge hop (edge pins the core CA,
+   drop `InsecureSkipVerify`); **CA auto-rotation** (Job triggered at `NotAfter` × fraction)
+   gated on the cross-replica convergence metric; an **HSM/KMS `Signer`** so the raw CA key
+   never sits in pod memory; CRL/OCSP via `VerifyConnection`; real SPIRE SVID migration.
+   *(The CP-only-namespace CA-key-read isolation is now the Phase-1 default, not a Phase-2
+   item.)*
 3. **Phase 3 — optional companion.** A `TRUST_PROXY_DYNAMIC=true` ConfigMap-of-CIDRs
    OR-branch for callers that genuinely cannot present a client cert — same atomic +
-   validate-then-swap discipline, never panic on the watch path.
+   validate-then-swap discipline.
 
 ## Alternatives considered
 
-- **CP mints key+cert and ships both (vs CSR-based).** Simpler on the edge, the only
-  viable fallback if an edge runtime cannot do x509 keygen. **Rejected as default —
-  strictly weaker:** it puts a *private key on the wire*. The CSR form keeps the key
-  edge-local for no added operator burden.
+- **Core keeps watching the CA Secret + a shared SAN-derivation package (the prior design).**
+  Rejected: it forced the core to hold k8s read on a namespace co-tenant with the CA
+  *private* key, required a cross-binary derivation package with a split-brain risk (papered
+  over by a conformance test), and made revocation latency depend on a 6th Secret watch. The
+  tokenless CP pull is strictly better — one fewer credential, an unforgeable trust anchor
+  (mandatory server-TLS), single-sourced allow-set, full CA-key isolation — at the honest
+  cost of a steady-state core→CP dependency for trust *changes* (mitigated by fail-static +
+  a warm-start cache + required CP HA).
+- **In-serving CA generation with a `resourceVersion`-CAS create-once (the prior managed
+  mode).** Rejected for HA: it kept write RBAC on every serving replica and made the serving
+  process stateful-ish. The CAS + anti-regen guard are **retained but relocated into a
+  run-once Job**; serving becomes read-only and trivially replicable. (A naive "a Job is a
+  single writer so drop the CAS" was itself rejected — a Job is not a guaranteed single
+  pod.)
+- **CP mints key+cert and ships both (vs CSR-based).** Rejected as default — strictly weaker
+  (puts a private key on the wire). The CSR form keeps the key edge-local.
 - **Token-gated `TrustProxy` (HMAC header).** A near-tie co-leader on operational
-  single-source-of-truth — we **grafted** that strength (the SAN allow-set from the same
-  registry). Rejected as primary on security: a replayable header credential,
-  order-fragile strip middleware, an O(N) HMAC CPU-amplification vector, and a clock-skew
-  failure mode. mTLS has none of these.
-- **Dynamic IP trust list (ConfigMap of CIDRs).** Lowest effort; we graft its
-  operator-asserted-trust principle and keep-last-good discipline. Rejected as primary: it
-  does **not raise the security bar** and widens the spoof surface for NAT'd edges. Kept as
-  the optional Phase 3 companion.
-- **SPIFFE/SPIRE workload identity.** Strongest in theory, operationally disqualifying now
-  (out-of-cluster attestation needs SPIRE federation + a second rotating CA bundle whose
-  staleness breaks the data plane). We graft only its **URI-SAN naming** and leave a Phase
-  2 migration path.
-- **CA-only mTLS (`EDGE_TRUST_REQUIRE_SAN=false`).** Supported for **non-issuance**
-  deployments but **forbidden with CP-issuance**: CA-only trusts any chain to the edge CA
-  with no per-request SAN check, so a cert minted from a leaked token would stay trusted
-  for the full TTL — resurrecting exactly the split-brain single-sourcing closes.
-- **cert-manager-issued CA / cert-manager-proxy issuance (removed).** An earlier draft
-  offered `EDGE_CA_MODE=cert-manager` (the CP proxies a `CertificateRequest`) and an
-  out-of-band cert-manager self-signed Issuer for the CA. **Removed:** it added a hard CRD
-  dependency, an async issuance round-trip, and an out-of-band CA-creation step that
-  defeats the zero-PKI goal for a bare Docker edge. The CP now self-manages the CA
-  (managed mode); operators with an existing PKI use **provided** mode (mounted CA, no
-  CRDs). cert-manager can still *populate* the mounted Secret, but the CP treats it as
-  opaque files — no `CertificateRequest`, no polling, no CRD.
+  single-source-of-truth (grafted). Rejected as primary on security: replayable header,
+  order-fragile strip, O(N) HMAC amplification, clock-skew.
+- **Dynamic IP trust list (ConfigMap of CIDRs).** Lowest effort; grafted its
+  operator-asserted-trust + keep-last-good discipline. Rejected as primary (no security-bar
+  raise; widens the spoof surface for NAT'd edges). Kept as the optional Phase 3 companion.
+- **SPIFFE/SPIRE workload identity.** Operationally disqualifying now (out-of-cluster
+  attestation needs SPIRE federation + a second rotating CA bundle). Grafted only the
+  URI-SAN naming.
+- **CA-only mTLS (`EDGE_TRUST_REQUIRE_SAN=false`).** Supported for non-issuance deployments
+  but **forbidden with CP-issuance** (no per-request revocation lever).
+- **cert-manager-issued CA / cert-manager-proxy issuance (removed).** Added a hard CRD
+  dependency + async round-trip + an out-of-band CA-creation step that defeats the zero-PKI
+  goal. The CP now self-manages the CA via the Job; provided mode covers existing PKIs.
 
 ## Open questions
 
-- **Empty-stub feasibility:** do the target k8s versions reject a zero-length `tls.crt`
-  on a `kubernetes.io/tls` Secret CREATE? If yes, the pre-created stub must be type
-  `Opaque`. Confirm and pin one stub type.
-- **NameConstraints enforcement:** does `x509.Verify` actually enforce
-  `PermittedURIDomains` for a `spiffe://` leaf URI against `parapet.moonrhythm.io`? Add a
-  conformance test (reject `spiffe://evil.example/edge/x`, accept the legit form) **before**
-  counting NameConstraints as a security control — the stdlib's URI-SAN NameConstraint
-  support is underspecified.
-- **`EDGE_CA_TTL` default:** 10y maximizes single-theft value of a plaintext-Secret key.
-  Pin shorter (1–2y) until convergence-gated rotation ships, or keep 10y only contingent
-  on rotation being implementable? Tie the decision to whether etcd encryption-at-rest is
-  a hard prerequisite.
-- **CP-only namespace for the CA Secret:** ship the key-read-isolation manifest (core SA
-  cannot read `parapet-edge-ca`) as a Phase-1 option now, or defer? The core's SNI read is
-  namespace-wide by necessity, so co-tenancy concedes core-reads-the-key unless the CA
-  Secret moves namespaces.
-- **HSM/KMS `Signer`:** the interface lands in Phase 1; does the in-memory impl suffice
-  for first ship, and is a KMS round-trip per issuance acceptable against the
-  fleet-restart-storm concurrency budget?
-- **System-readiness gap:** add an edge-side post-issuance probe (test re-encrypt
-  handshake to the core before flipping ready), or accept the gap with the core-side
-  `parapet_trust_source{mtls}` / bundle-hash as a REQUIRED onboarding gate?
-- **Rotation single-writer mechanism:** ship Phase-1 rotation as a one-shot Job/subcommand,
-  or add leader election to the steady-state `replicas: 2`? The Secret-as-lock CAS
-  linearizes only create-once, not the 4-stage promote/trim.
-- **`EDGE_CLIENTCERT_TTL` vs CP-outage budget:** pin a default that exceeds the operator's
-  CP recovery SLO, or expose `TTL` + renew-before as paired knobs with a guard that
-  renew-before < `TTL` by a safe margin?
+- **Generation source:** confirm `max(resourceVersion)` across the source ConfigMaps/Secrets
+  as the generation (the only option both replica-identical AND monotonic). resourceVersion
+  is officially opaque (treat as monotonic-per-object; handle a delete+recreate that resets
+  it by also keying on object UID so a recreate triggers a re-sync, not a permanent reject).
+  If a hash is ever preferred, **rename** the field to an opaque equality-only fingerprint
+  with ordering/since/rollback semantics forbidden.
+- **Purge journal (Phase 5, design-only):** the lone genuinely-stateful feature,
+  **known-broken under `replicas>1`** with a per-process in-memory monotonic `seq` (an admin
+  `POST` lands on one replica only; per-replica `seq`/`min_seq` fire `flush_required`
+  spuriously). MUST be externalized (a ConfigMap/CRD journal every replica observes via its
+  existing watch; `POST` becomes a write-to-k8s) before shipping multi-replica. Do not
+  enable `/v1/purges` with `replicas>1` until then.
+- **Hard global signing cap:** a true fleet-wide ceiling vs the per-replica N× loosening
+  needs externalized rate-limit state (a shared token bucket). Accept N× (simplest), set
+  per-replica = `ceil(target/N)` (imperfect under uneven LB), or defer? `N` is not directly
+  available inside a pod (would come from an env/Deployment field).
+- **Long-poll concurrency cap default:** what semaphore size balances "never starve the
+  token-gated endpoints" against "a small legit core fleet + its safety poll is never 503'd"?
+  Tie to the expected core replica count behind the NetworkPolicy.
+- **CP HA enforcement:** ≥2 replicas is now REQUIRED — should the core warn if it can detect
+  a single-replica CP, or is this left to deployment review?
+- **First-boot ordering on a fresh cluster:** the core's first bundle needs the Job's
+  `EnsureCA` to have populated the CA (503 until then) AND the CP server cert present — pin
+  the deploy ordering / readiness-gating so a cold cluster converges without a manual
+  restart, and decide whether the core blocks startup on the first bundle or starts
+  CIDR-only and converges.
+- **`EDGE_CLIENTCERT_TTL` vs CP-outage budget:** pin a default that exceeds the CP recovery
+  SLO, or expose `TTL` + renew-before as paired knobs with a guard that renew-before < `TTL`
+  by a safe margin?
+- **Empty-stub feasibility:** do target k8s versions reject a zero-length `tls.crt` on a
+  `kubernetes.io/tls` CREATE? If so, ship the stub as type `Opaque` (type is advisory to our
+  code and can't change on `Update`).
+- **Mutual auth of the edge hop:** should the edge verify the core's server cert (pin the
+  core CA, drop `InsecureSkipVerify` in `forward.go`)? Today only edge→core (data plane) and
+  core→CP (trust) directions are asymmetric by design.
 
 ## Conformance / contract
 
 On acceptance, fold into [`SPEC.md`](SPEC.md): the trust predicate
-(`cidrTrust OR (verified-edge-CA-chain AND SAN ∈ allow-set)`), the new
-`POST /v1/edge-cert` endpoint (CSR in, chain out; CP-decided SAN; no key on the wire),
-the managed/provided CA model, the new env vars (`EDGE_TRUST_*`, `EDGE_DATAPLANE_MTLS`,
-`EDGE_CLIENTCERT_*`, `EDGE_CA_*`, CP `POD_NAMESPACE`/`WATCH_NAMESPACE`), the shared
-SAN-derivation package + its CP-SAN == core-allow-set conformance test, the
-NameConstraints-enforcement test, the `X-Forwarded-Country/-ASN` ingress strip, and the
-per-request order (trust evaluation precedes WAF/rate-limit). The Rust implementation in
-[`rust/`](rust/) tracks the same contract or records a divergence.
+(`cidrTrust OR (verified-edge-CA-chain AND SAN ∈ allow-set)`); the `POST /v1/edge-cert`
+(CSR in, chain out, CP-decided SAN, no key on the wire) and the **tokenless** `GET
+/v1/trust-bundle` (with the `?watch` long-poll and the forbidden-401/403 property)
+endpoints; the managed (bootstrap-Job) / provided CA model and the **stateless-serving +
+run-once-Job** posture; the **content-derived generation contract** (replica-identical AND
+monotonic; resourceVersion-derived) for **both** `/v1/waf` and the trust-bundle; the new env
+vars (`EDGE_TRUST_CP_*`, `EDGE_DATAPLANE_MTLS`, `EDGE_CLIENTCERT_*`, `EDGE_CA_*`, CP
+`POD_NAMESPACE`/`WATCH_NAMESPACE`); the `X-Forwarded-Country/-ASN` ingress strip; and the
+per-request order (trust evaluation precedes WAF/rate-limit). Conformance tests: the
+intra-process `identityFor()` == `Signer.Sign` SAN; a known-revoked id absent from a fresh
+`allowed_sans`; the two-goroutine concurrent-generate CAS test against client-go fake
+(exactly one CA survives, the loser adopts), exercised against the Job `EnsureCA`; two
+`WafStore`/serving replicas fed identical source report **equal** generation; the
+NameConstraints `x509.Verify` accept/reject pair. The Rust implementation in [`rust/`](rust/)
+tracks the same contract or records a divergence.
 
-[TLS SNI fallback memory]: the proxy serves a self-signed fallback on an SNI miss
-when the live cert table loses `GetCertificate`; the `GetConfigForClient` self-test
-above exists to prevent re-introducing that class of bug during a trust reload.
+[TLS SNI fallback memory]: the proxy serves a self-signed fallback on an SNI miss when the
+live cert table loses `GetCertificate`; the `GetConfigForClient` self-test exists to prevent
+re-introducing that class of bug during a trust reload.

--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -1,0 +1,413 @@
+# Auto-trust edge proxy (data-plane trust without a restart)
+
+> **Status: DRAFT / design-only — not implemented.** This proposes how the
+> in-cluster **core** proxy (`cmd/parapet-ingress-controller`, "parapet") comes to
+> trust a newly-deployed **edge** proxy (`cmd/edge-proxy` + [`edge/`](edge/))
+> automatically — without an operator editing `TRUST_PROXY` and restarting the
+> core. It builds on the edge architecture in [`EDGE.md`](EDGE.md). Per
+> [`CLAUDE.md`](CLAUDE.md), the behavior contract changes in [`SPEC.md`](SPEC.md)
+> first; on acceptance, the contract bits (the trust predicate, the new env vars,
+> the per-request order) fold into `SPEC.md` and the architecture into `EDGE.md`.
+
+## The problem
+
+The edge sits in front of the core and sets `X-Forwarded-For` / `X-Forwarded-Proto`
+(and, with a GeoIP DB, `X-Forwarded-Country` / `X-Forwarded-ASN`) so the core's WAF,
+per-IP rate limits, GeoIP, and access logs see the **real client**, not the edge.
+For the core to honor those headers, the edge's source must be in the core's
+**trust list** — today the `TRUST_PROXY` env var (a CIDR list, or the literal
+`cloudflare`).
+
+`TRUST_PROXY` is read **once at startup**
+(`cmd/parapet-ingress-controller/main.go:214-237`), compiled into a
+`parapet.Conditional`, and frozen for the life of the process. So adding or
+replacing an edge means:
+
+1. Edit `TRUST_PROXY` to add the new edge's source CIDR, **and**
+2. **restart the core pod** to pick it up.
+
+Two problems, not one. The restart is operationally painful (it's the cluster's
+ingress front door). And the CIDR model is brittle for the edge's actual topology:
+edges run *outside* the cluster, reaching it over a tunnel / peered VPC, often
+**NAT'd or autoscaling**, so the source IP the core sees is unstable and is not a
+good identity.
+
+> **Why trust is security-critical (not just plumbing).** parapet's inbound proxy
+> layer calls `TrustProxy(r)` **per request** (parapet `proxy.go`). Trusted →
+> honor the incoming `X-Forwarded-*`. Untrusted → overwrite them with the
+> immediate peer IP. So "trust everyone" is not an option: any source the core
+> trusts can **spoof `X-Forwarded-For`** to bypass IP-based WAF rules and per-IP
+> rate limits, and poison GeoIP/logs. Auto-trust must therefore mean *trust
+> exactly the sanctioned edges*, and that set must be **hot-reloadable**.
+
+## The key enabler
+
+`parapet.Conditional` is `func(r *http.Request) bool`, evaluated **per request**
+(parapet `proxy.go` `ServeHTTP` → `m.Trust(r)` → `trust`/`distrust`). A closure
+installed **once** at startup can read an `atomic.Pointer` to a live trust policy
+that is **hot-swapped** from a watched Kubernetes Secret — exactly the
+`debounce` + validate-then-swap idiom the WAF reload already uses
+(`controller_waf.go`), which never rebuilds the route mux. **No restart.** The
+question is only *what credential the edge presents* and *where the trust policy
+comes from*.
+
+## Recommended design: edge mTLS (client-cert-as-trust)
+
+Authenticate the **edge → core hop with mutual TLS**. Trust follows a private key,
+not a source IP.
+
+1. **A dedicated, single-purpose edge CA.** Created once (cert-manager self-signed
+   `Issuer` + CA `Certificate` `parapet-edge-ca`, or an operator-managed
+   self-signed CA). It signs **nothing else**, so "chains to this CA" means exactly
+   "is a sanctioned-edge credential." Its private key stays in-cluster; only leaf
+   cert+key ever reach an edge.
+
+2. **Each edge gets a short-lived client cert** from that CA (cert-manager
+   `Certificate`, `usages: [client auth]`, with a stable SPIFFE-style URI SAN
+   `spiffe://parapet.moonrhythm.io/edge/<name>` — a free, greppable per-edge
+   identity and a clean future SPIRE migration path). `renewBefore` is generous
+   (renew at ~⅓ lifetime) so renewal never races expiry.
+
+3. **The edge presents it** on the re-encrypt hop. `edge/forward.go`'s
+   `EDGE_UPSTREAM_TLS=true` path gets a client cert via
+   `tls.Config.GetClientCertificate` — a **live disk-reading callback** (mtime
+   cached), *not* a one-shot `tls.X509KeyPair` at startup — so a cert-manager
+   renewal is picked up with **no edge restart**. A client cert can only ride TLS,
+   so edge trust is conferred **only on the core's `:443` listener**; the plaintext
+   `:80` listener can present none and is never mTLS-trusted.
+
+4. **The core verifies it.** The `:443` `tls.Config` gets
+   `ClientAuth = tls.VerifyClientCertIfGiven` (the cert is **optional** —
+   Cloudflare-direct and browser traffic present none and complete the handshake
+   unchanged) and a `ClientCAs` pool sourced from the watched trust Secret. The
+   standard library cryptographically verifies any presented client cert (with
+   `ExtKeyUsageClientAuth`) against `ClientCAs` during the handshake and, on
+   success, populates `r.TLS.VerifiedChains`. A presented-but-unverifiable cert
+   **aborts the handshake**.
+
+5. **The per-request trust predicate** (installed once; see [Core wiring](#core-wiring)):
+
+   ```
+   trust(r) :=  cidrTrust(r)                                  // existing TRUST_PROXY (e.g. cloudflare)
+            OR ( len(r.TLS.VerifiedChains) > 0                // a chain verified to the edge CA, AND
+                 AND leafURISAN(r) ∈ liveAllowSet )           // its SAN is in the live allow-set
+   ```
+
+   The SAN check is re-evaluated **per request** against an `atomic.Pointer`-held
+   allow-set, so **dropping a SAN distrusts that edge within ~300 ms** — even on
+   existing keep-alive / HTTP-2 connections. That is the fast revocation lever.
+
+### Single source of truth (onboard in one place)
+
+The SAN allow-set is derived from the **same `edge-controlplane-tokens` Secret the
+control plane already authorizes against** (`edgecp.Authz`, `edgecp/authz.go`).
+Each edge's token entry carries (or deterministically derives) its SPIFFE SAN.
+**Onboarding/offboarding touches one registry:**
+
+- Adding a token → the control plane issues that edge its certs/WAF **and** the
+  core adds its SAN to the data-plane allow-set. Both planes converge from one
+  object, in ~300 ms, with no restart of either.
+- **Deleting a token = data-plane revoke**, closing the split-brain where revoking
+  only the control-plane token left the edge trusted on the data plane until its
+  cert expired.
+
+Operators who prefer separation may instead keep the SAN list in a standalone
+`parapet-edge-trust` Secret (`allowed-sans` key); the default wiring reads the
+token registry. `ca.crt` always lives in the trust Secret (it can hold several
+concatenated CAs to support rotation overlap).
+
+## Core wiring
+
+In `cmd/parapet-ingress-controller/main.go`, replace the one-shot `trustProxy`
+block (`:214-237`) — but keep the existing static parse **verbatim** into a fixed
+local `cidrTrust` (`"true"` → `parapet.Trusted()`; `"false"`/`""` → nil; else
+`parapet.TrustCIDRs(list)` with the `predefinedCIDRs["cloudflare"]` expansion from
+`config.go`). Add a trust-policy holder owned by the controller:
+
+```go
+type trustPolicy struct{ allowedSANs map[string]struct{} }
+var trustPol   atomic.Pointer[trustPolicy]
+var clientCAs  atomic.Pointer[x509.CertPool]   // SEPARATE atomic from the SNI cert table
+```
+
+Install **one** closure, assigned to **both** servers' `TrustProxy` field (as
+today):
+
+```go
+trustProxy = func(r *http.Request) bool {
+    if cidrTrust != nil && cidrTrust(r) { return true }       // metric: cidr
+    if r.TLS == nil || len(r.TLS.VerifiedChains) == 0 { return false } // metric: none
+    p := trustPol.Load(); if p == nil { return false }
+    if requireSAN { return sanAllowed(r.TLS.PeerCertificates[0], p.allowedSANs) }
+    return true // CA-only mode (EDGE_TRUST_REQUIRE_SAN=false): any chain to the dedicated edge CA
+}
+```
+
+`sanAllowed` matches the leaf's **URI** SANs (`r.TLS.PeerCertificates[0].URIs`)
+*exactly* against the allow-set — URI-typed, never substring. The `:80` server's
+`r.TLS == nil` short-circuits the mTLS branch, leaving CIDR-only — byte-for-byte
+today's plaintext behavior.
+
+**Hot-swap `:443` `ClientCAs` without clobbering the SNI cert table.** Do **not**
+clone and replace the whole `tls.Config` on a trust reload (that path risks
+dropping `GetCertificate` and regressing into the self-signed-fallback gotcha — see
+the [TLS SNI fallback memory]). Instead set, once, before `Serve()`:
+
+```go
+base.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+    c := base.Clone()
+    c.ClientCAs = clientCAs.Load()   // fresh per handshake; never nil
+    return c, nil                    // carries GetCertificate = ctrl.GetCertificate (live), ClientAuth, fallback
+}
+```
+
+`GetConfigForClient` must be non-nil before `Serve()` and must **never** return nil
+(return last-good on any error). A startup **self-test** asserts the served config
+carries `GetCertificate` **and** `ClientCAs` **and**
+`ClientAuth == VerifyClientCertIfGiven` (not `RequireAndVerify`, which would abort
+Cloudflare/browser handshakes; not `NoClientCert`, which silently disables mTLS).
+The SNI-cert reload loop and the trust reload loop write **separate** atomics and
+never share a config object.
+
+**The trust watch** (`controller.go` + a new `controller_trust.go` mirroring
+`controller_waf.go`): a 6th watcher, gated by `EDGE_TRUST_SECRET != ""` (default
+off ⇒ identical to today). Reuse the generic `watchResource[*v1.Secret]` for
+`POD_NAMESPACE`; on change call `reloadTrustDebounced` (a 300 ms `debounce`). It
+**never rebuilds `ctrl.mux`** (trust is orthogonal to routes) and is
+**validate-then-swap, all-or-nothing** like WAF `SetRules`: parse `ca.crt` with
+`x509.NewCertPool().AppendCertsFromPEM`; a **non-empty input that yields zero certs
+is rejected** (keep last-good, log, bump `parapet_trust_reload_rejected_total`); a
+*deliberately empty* `ca.crt` means "mTLS disabled." On success, atomically `Store`
+**both** `clientCAs` and `trustPol` together so they can never disagree.
+
+**Header hardening (a real gap today, not just for mTLS):** mount a middleware
+**first** in `main.go`'s `m` chain (before `ctrl`) that **unconditionally deletes**
+client-supplied `X-Forwarded-Country` / `X-Forwarded-ASN` at ingress.
+`forwardGeoHeaders` (`main.go:329`) only *overwrites* them when a DB is loaded — so
+a core with no GeoIP DB currently passes a **client-forged** `X-Forwarded-Country`
+straight upstream. Treat both as edge-set-only. (`X-Real-Ip` / `X-Forwarded-For`
+stay governed by parapet's trust/distrust.)
+
+## Edge wiring
+
+In `edge/forward.go` `NewForwarder`, on the re-encrypt path (`useTLS == true`),
+wire a client cert into the transport's `tls.Config`:
+
+- New `EDGE_UPSTREAM_CLIENT_CERT` / `EDGE_UPSTREAM_CLIENT_KEY` (PEM paths). When
+  both are set, set `tls.Config.GetClientCertificate` to a callback that reads the
+  cert+key from disk **live** (mtime-cached), so a cert-manager renewal on the
+  mounted Secret is picked up with no restart. Both unset ⇒ no client cert
+  (anonymous re-encrypt — back-compat with today).
+- `tls.Config.InsecureSkipVerify` stays for now (the edge does not yet verify the
+  core's server cert — see [open questions](#open-questions)).
+
+In `cmd/edge-proxy/main.go` startup, emit a **loud** error if
+`EDGE_UPSTREAM_CLIENT_CERT` is set with `EDGE_UPSTREAM_TLS=false` (a client cert
+needs TLS), and a warning if the upstream is core `:443` with no client cert
+configured (a silent untrusted downgrade). The edge remains the first hop and sets
+**no** `TrustProxy`, so it keeps overwriting incoming `X-Forwarded-*` with the true
+client peer before forwarding — the **transitive-trust invariant** the core relies
+on.
+
+## Security model
+
+**Trust boundary.** Exactly the edges holding a private key whose cert chains to
+the dedicated edge CA **and** whose URI SAN is in the live allow-set. The CA signs
+nothing else, so chain-to-CA = sanctioned-edge credential. Trust is
+**operator-asserted**: only an operator editing the registry Secret moves the
+boundary — never an edge action, never a token-writable self-registration. mTLS
+trust is conferred **only on `:443`**.
+
+**Spoofing.** A non-edge reaching `:443` **cannot forge trust**:
+`VerifiedChains` is populated only after the Go stack cryptographically verifies
+the presented cert against `ClientCAs`; forging requires the in-cluster CA key.
+
+> **Honest scoping (read this).** mTLS authenticates the **connection, not the
+> headers.** A trusted edge — or anything wielding a stolen edge key — can still
+> set `X-Forwarded-For` to whatever it likes *for its own requests*, because
+> parapet honors a trusted hop's XFF verbatim. The claim is **"an unauthenticated
+> peer is never trusted,"** not "XFF can never be spoofed." Second caveat: with the
+> shipped `TRUST_PROXY: cloudflare` default, a non-edge from a Cloudflare CIDR
+> reaching `:443` is CIDR-trusted with no cert. So **never add edge egress CIDRs to
+> `TRUST_PROXY`** (mTLS is the edge path), and lock **both** core data-plane ports
+> with a `NetworkPolicy` to the edge/Cloudflare source set (today only the control
+> plane has one — `deploy/edge/controlplane.yaml`). Defense-in-depth so a stolen
+> edge key isn't usable from the open internet, and so "just add a CIDR" is never
+> the operational fix.
+
+**Replay.** None on the data plane — the cert is proven inside a live mTLS
+handshake (ephemeral keys, transcript signing), not a replayable bearer credential.
+Residual risk is **key theft**, bounded by short cert lifetime + per-request SAN
+revocation.
+
+**Blast radius.** A leaked edge client key lets the holder spoof XFF **as that one
+edge** until its SAN is dropped (~300 ms) or its cert expires. It leaks **no**
+server TLS private key (a separate control-plane credential). The **crown jewel is
+the edge CA key** (mints any edge) — kept in-cluster only, never shipped,
+single-purpose, rotated only on CA compromise.
+
+**Fail-default: fail-closed, degrading to the static CIDR branch.** A missing trust
+Secret ⇒ `trustPol` nil ⇒ mTLS branch always false ⇒ edges distrusted (degraded but
+safe — identical to the pre-mechanism world), Cloudflare CIDR unaffected, startup
+warning logged. An empty/garbage `ca.crt` on reload ⇒ validate-then-swap **rejects**
+and keeps last-good, so a fat-fingered edit can't silently distrust the whole fleet.
+**No path fails open.**
+
+**The explicit tradeoff.** This forces re-encrypt TLS (`EDGE_UPSTREAM_TLS=true`) and
+a PKI lifecycle (CA, per-edge certs, renewal) the plaintext `:80` default avoided,
+and an **expired edge cert hard-fails the handshake** (502s) rather than degrading.
+Accepted: a cryptographic, IP-independent, per-edge-revocable identity is worth the
+`renewBefore` discipline and the network backstop.
+
+## Fail modes
+
+| Failure | Behavior |
+|---|---|
+| Trust Secret absent / never created | mTLS branch false for all (`trustPol` nil); edges distrusted (XFF overwritten → WAF/limits/GeoIP see edge IP); core serves; Cloudflare CIDR unaffected. **Fail-closed, degraded-not-down.** Startup warning + `parapet_trust_source{none}`. |
+| `ca.crt` edited to empty/garbage on reload | Validate-then-swap: non-empty input yielding zero certs **rejected**, last-good kept, `parapet_trust_reload_rejected_total++`, error logged. A *deliberately* empty `ca.crt` = "mTLS disabled." Never fails open. |
+| Edge client cert expired / not yet renewed | `VerifyClientCertIfGiven` **aborts the handshake** → edge `:443` connection fails (502s), harsher than a missing cert. Mitigated by generous `renewBefore`, live `GetClientCertificate` reload (no restart), NTP sync, alerting on edge 502s + cert `notAfter`. |
+| Edge on plaintext `:80` but operator expected trust | No client cert on `:80`; `r.TLS == nil`; edge distrusted (CIDR-only, and edges have no stable CIDR). Made loud: edge errors if `EDGE_UPSTREAM_CLIENT_CERT` set with TLS off; `parapet_trust_source{none}` alerts. |
+| Per-edge revocation (SAN-drop) | **Fast path.** SAN re-checked per request against the live atomic allow-set → distrusts within ~300 ms even on existing keep-alive/HTTP-2 connections. The routine revocation lever. |
+| CA-drop revocation latency | `VerifiedChains`/`ClientCAs` are consulted only at **handshake**. Dropping a CA takes effect on **new** handshakes only; existing connections keep their verified chain until they close. True bound = max connection lifetime, not 300 ms. Mitigate: prefer SAN-drop for routine revoke; cap `:443` connection age; reserve CA-drop for CA-key compromise. |
+| Split-brain: token revoked but trust lingers | Closed by single-sourcing the SAN allow-set from `edge-controlplane-tokens` — deleting a token removes its SAN. In *separation* mode (standalone `allowed-sans`), revoking only the CP token leaves the edge trusted until its cert expires (documented). |
+| Edge CA private key leaked | Attacker mints trusted edges until CA rotation. Highest severity. Mitigated by in-cluster-only key, single-purpose CA, and the overlap rotation runbook with a metric interlock (confirm every expected SAN is trusted under the new CA before dropping the old). |
+| `GetConfigForClient` returns nil / omits `ClientAuth`/`GetCertificate` | Guarded: base config built non-nil before `Serve()`; callback returns last-good on error, never nil; startup self-test asserts `GetCertificate` + `ClientCAs` + `ClientAuth==VerifyClientCertIfGiven`. Prevents a self-inflicted cert-serving break or silent mTLS disable. |
+| Forged-cert flood on `:443` | Each forged cert is rejected at the TLS handshake before reaching a handler; the per-request trust check is a cheap slice-len + map lookup behind an already-verified chain — no per-request crypto amplification. `NetworkPolicy` bounds who can attempt handshakes at all. |
+
+## Configuration
+
+| Variable | Where | Default | Meaning |
+|---|---|---|---|
+| `TRUST_PROXY` | core | `cloudflare` (per `deploy/deployment.yaml`) | **Unchanged.** Static CIDR list / `cloudflare`/`true`/`false`. Becomes the `cidrTrust` OR-branch; coexists with mTLS trust. **Never add edge egress CIDRs here.** |
+| `EDGE_TRUST_SECRET` | core | `""` (feature **off**, fully backward-compatible) | Name of the Secret in `POD_NAMESPACE` carrying `ca.crt` (edge CA PEM bundle). `edge-controlplane-tokens` for single-source mode, or a dedicated `parapet-edge-trust` for separation mode. Unset ⇒ no trust watch, mTLS disabled, identical to today. |
+| `EDGE_TRUST_REQUIRE_SAN` | core | `true` | When true, trust requires the verified leaf's URI SAN to be in the live allow-set — enables per-edge revocation. When false, any cert chaining to the dedicated edge CA is trusted (CA-only mode, zero per-edge core edits, but single-edge revocation needs a CA rotation). |
+| `EDGE_UPSTREAM_TLS` | edge | `false` | **Unchanged.** Must be `true` for mTLS trust (a client cert needs TLS); selects `edge/forward.go`'s re-encrypt path. mTLS trust is opt-in per edge. |
+| `EDGE_UPSTREAM_CLIENT_CERT` / `EDGE_UPSTREAM_CLIENT_KEY` | edge | `""` / `""` | PEM paths to the edge's client cert+key, loaded **live** via `GetClientCertificate` (disk reload on renewal, no restart). Both unset ⇒ anonymous re-encrypt (back-compat). Set with `EDGE_UPSTREAM_TLS=false` ⇒ loud startup error. |
+| `EDGE_UPSTREAM_SNI` | edge | `""` | **Unchanged.** SNI/`ServerName` presented to the core on re-encrypt. |
+
+New metrics: `parapet_trust_source{mtls|cidr|none}` (per request, so an operator can
+confirm an edge is trusted via `mtls` and catch a silent CIDR/none fallback) and
+`parapet_trust_reload_rejected_total`.
+
+## Onboarding flow (the payoff)
+
+1. **One-time:** create the dedicated edge CA; put its PEM in the trust Secret
+   (`ca.crt`) in `POD_NAMESPACE`. Roll the core **once** to pick up the new code.
+   *This is the only restart, ever — never again per-edge.*
+2. **Per edge — mint identity:** a cert-manager `Certificate` (issuer
+   `parapet-edge-ca`, `usages: [client auth]`, URI SAN
+   `spiffe://parapet.moonrhythm.io/edge/<name>`) → a `kubernetes.io/tls` Secret in
+   the edge's namespace.
+3. **Per edge — register once:** add the edge's entry to
+   `edge-controlplane-tokens` (token → domains, plus its SPIFFE SAN). This single
+   edit makes the control plane authorize the edge **and** adds the SAN to the
+   core's allow-set — both planes converge, ~300 ms, no restart.
+4. **Configure the edge Deployment:** `EDGE_UPSTREAM_TLS=true`, `EDGE_UPSTREAM_ADDR`
+   → core `:443`, `EDGE_UPSTREAM_CLIENT_CERT`/`KEY` mounted from the cert Secret.
+5. **Deploy.** The edge re-encrypts to `:443` with its client cert; the core
+   verifies the chain + SAN and **immediately honors its `X-Forwarded-*`** — no
+   `TRUST_PROXY` edit, no core restart. Confirm via `parapet_trust_source{mtls}`.
+6. **Revoke (fast):** drop the edge's entry (and SAN) from the registry → distrusted
+   within ~300 ms, even on live connections. For a leaked **CA** key, use the
+   overlap rotation runbook.
+
+## Phasing
+
+1. **Phase 1 — ship fast, reuse existing machinery.** cert-manager dedicated edge
+   CA + per-edge `Certificate`s mounted as Secrets. Core: the per-request closure,
+   `GetConfigForClient` hot-swapping `ClientCAs` over a **separate** atomic from the
+   SNI cert table, the `EDGE_TRUST_SECRET` watch (validate-then-swap, keep-last-good),
+   `EDGE_TRUST_REQUIRE_SAN=true` with SANs single-sourced from
+   `edge-controlplane-tokens`, the unconditional `X-Forwarded-Country/-ASN` strip,
+   and the new metrics. Edge: `EDGE_UPSTREAM_CLIENT_CERT/KEY` via live
+   `GetClientCertificate` + startup guards. `NetworkPolicy` locking core `:80`/`:443`
+   to edge/Cloudflare sources. **No parapet-framework changes, no control-plane
+   changes.**
+2. **Phase 2 — stronger, optional drop-in** (mirrors EDGE.md's bearer→mTLS framing):
+   the control plane **mints** the edge client cert and serves it over the existing
+   bearer channel (`GET /v1/edge-cert`, signed by the in-cluster edge CA, authorized
+   by the same token) so onboarding becomes "the CP issues the edge its identity"
+   with one fewer operator-managed Secret. Optionally make the hop **mutually**
+   authenticated (edge pins the core CA, drop `InsecureSkipVerify`). Optionally add
+   CRL/OCSP via `tls.Config.VerifyConnection` if revocation must beat
+   cert-lifetime + SAN-drop. Optionally migrate the SPIFFE-style SANs to real SPIRE
+   SVIDs (naming already aligns).
+3. **Phase 3 — optional companion.** A `TRUST_PROXY_DYNAMIC=true` ConfigMap-of-CIDRs
+   OR-branch for callers that genuinely cannot present a client cert (a known
+   in-cluster plaintext `:80` caller), covering the `EDGE_UPSTREAM_TLS=false` gap
+   with an operator-asserted CIDR — same atomic + validate-then-swap discipline,
+   never panic on the watch path.
+
+## Alternatives considered
+
+- **Token-gated `TrustProxy` (HMAC-over-timestamp header, single-sourced from the
+  token registry).** The judge panel's narrow co-leader, and the strongest on
+  operational single-source-of-truth — which is why we **grafted** that strength
+  (the SAN allow-set comes from the same `edge-controlplane-tokens` Secret).
+  Rejected as the *primary* mechanism on security: the credential is a request
+  **header** whose placement the attacker controls (vs a TLS-layer property they
+  cannot synthesize); on a sniffable private path a captured token is replayable for
+  the skew window; the **strip-before-upstream** middleware is order-fragile and
+  load-bearing; HMAC verification is an O(N) CPU-amplification vector under a forged
+  header flood; and it adds a **clock-skew** failure mode. mTLS has none of these.
+  *If the operator prefers the lower-PKI-overhead path, this is the fallback —
+  reopen the decision here.*
+- **Dynamic IP trust list (ConfigMap of CIDRs, hot-reloaded).** Lowest effort; we
+  graft its **operator-asserted-trust** principle, its rejection of token-writable
+  self-registration, its never-panic/keep-last-good discipline, and its
+  trust-source observability. Rejected as primary: it does **not raise the security
+  bar** — anything sharing a trusted CIDR can spoof XFF, and for NAT'd/dynamic edges
+  the natural pattern (trust the whole egress CIDR) *widens* the spoof surface. Kept
+  as the optional Phase 3 companion for the `:80` gap.
+- **SPIFFE/SPIRE workload identity (mTLS SVID).** Strongest in theory, operationally
+  disqualifying now: an out-of-cluster edge can't use in-cluster `k8s_psat`
+  attestation, so it needs SPIRE federation / nested SPIRE — a hard runtime
+  dependency, a concentrated CA-compromise target, and a *second* continuously
+  rotating CA bundle whose staleness breaks the data plane. Onboarding would touch
+  three systems. We graft only its **URI-SAN naming** (free, future-proof) and leave
+  a Phase 2 migration path.
+- **CA-only mTLS (no SAN check, `EDGE_TRUST_REQUIRE_SAN=false`).** The "gold
+  standard" for zero core-side edits — issuing the cert is the whole onboarding.
+  **Kept as a supported mode** but not the default: it makes single-edge revocation
+  impossible without a whole-CA rotation. Defaulting `require-SAN=true` restores
+  ~300 ms per-edge revocation for a one-line registry edit, which single-sourcing
+  makes free.
+
+## Open questions
+
+- **Registry shape:** single-source mode couples the data-plane trust schema to the
+  CP token-registry JSON (it must carry a per-token SPIFFE SAN). Store the SAN
+  explicitly, or derive it deterministically from the token/edge name?
+- **Phase 2 issuance:** CP-minted client certs (collapses onboarding, keeps the key
+  off persistent storage, but expands the CP's role and couples the two channels)
+  vs cert-manager-mounted Secrets — worth the coupling?
+- **Plaintext `:80` for edges:** forbid edge traffic on `:80` entirely (route edges
+  only to `:443`, eliminating the silent `EDGE_UPSTREAM_TLS=false` → untrusted
+  downgrade), or keep `:80` purely for known CIDR-trusted in-cluster callers via the
+  Phase 3 companion?
+- **Mutual auth of the hop:** should the edge verify the core's server cert (pin the
+  core CA, drop `InsecureSkipVerify` in `forward.go`)? Today only edge→core is
+  authenticated.
+- **Revocation target:** is SAN-drop (~300 ms) + short cert lifetimes enough, or does
+  the deployment need CRL/OCSP via `VerifyConnection`?
+- **Connection-age cap on `:443`:** what max lifetime balances draining stale-CA
+  connections (for CA-drop revocation) against handshake churn? The default
+  `IdleTimeout` 320 s lets a busy connection outlive a CA drop indefinitely without
+  an explicit cap.
+- **Multi-CA `ca.crt` parsing:** confirm `AppendCertsFromPEM` over a concatenated
+  bundle adds every valid block and that one malformed block doesn't silently drop
+  the good CAs — validate-then-swap must treat a partially-bad bundle as a **rejected**
+  reload, not a partial install.
+
+## Conformance / contract
+
+On acceptance, fold into [`SPEC.md`](SPEC.md): the trust predicate
+(`cidrTrust OR (verified-edge-CA-chain AND SAN ∈ allow-set)`), the new env vars
+(`EDGE_TRUST_SECRET`, `EDGE_TRUST_REQUIRE_SAN`, `EDGE_UPSTREAM_CLIENT_CERT/KEY`),
+the `X-Forwarded-Country/-ASN` ingress strip, and the per-request order (trust
+evaluation precedes WAF/rate-limit, as today). The Rust implementation in
+[`rust/`](rust/) tracks the same contract or records a divergence.
+
+[TLS SNI fallback memory]: the proxy serves a self-signed fallback on an SNI miss
+when the live cert table loses `GetCertificate`; the `GetConfigForClient` self-test
+above exists to prevent re-introducing that class of bug during a trust reload.

--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -8,7 +8,8 @@
 > [`CLAUDE.md`](CLAUDE.md), the behavior contract changes in [`SPEC.md`](SPEC.md)
 > first; on acceptance, the contract bits (the trust predicate, the new env vars,
 > the new `POST /v1/edge-cert` endpoint, the per-request order) fold into `SPEC.md`
-> and the architecture into `EDGE.md`.
+> and the architecture into `EDGE.md`. **No cert-manager dependency:** the control
+> plane self-manages the edge CA.
 
 ## The problem
 
@@ -57,22 +58,22 @@ comes from*.
 Authenticate the **edge → core hop with mutual TLS**. Trust follows a private key,
 not a source IP.
 
-1. **A dedicated, single-purpose edge CA.** Created once. It signs **nothing else**,
-   so "chains to this CA" means exactly "is a sanctioned-edge credential." Under
-   `EDGE_CA_MODE=direct` (the Docker-friendly default) the CA key **lives with the
-   control plane** (its own RBAC-locked Secret); under `EDGE_CA_MODE=cert-manager`
-   it stays inside cert-manager. Either way the key never reaches an edge — only
-   leaf certs do. See [Control-plane wiring](#control-plane-wiring-cp-issues-the-client-cert).
+1. **A dedicated, single-purpose edge CA.** Created once and reused forever; it
+   signs **nothing else**, so "chains to this CA" means exactly "is a sanctioned-edge
+   credential." By default (**managed** mode) the **control plane generates the CA on
+   first boot and persists it** to its own RBAC-locked `parapet-edge-ca` Secret — no
+   cert-manager, no out-of-band openssl. For orgs with an existing PKI, **provided**
+   mode lets the operator mount their own CA (`EDGE_CA_CERT`/`EDGE_CA_KEY`) and the CP
+   uses it without generating. Either way the key never reaches an edge — only leaf
+   certs do. See [Control-plane wiring](#control-plane-wiring-cp-issues-the-client-cert).
 
 2. **Each edge gets a short-lived client cert with a stable URI SAN
    `spiffe://parapet.moonrhythm.io/edge/<id>`.** By default the **control plane
    issues it** over the edge's existing bearer-authenticated HTTPS channel — the
-   edge sends a CSR to `POST /v1/edge-cert`, the CP signs it with the in-cluster
-   edge CA and returns only the cert chain; the **private key never leaves the
-   edge**, and the **CP decides the SAN from the token identity** (ignoring any SAN
-   in the CSR), so a compromised edge cannot request a SAN it isn't entitled to.
-   cert-manager (a per-edge `Certificate`, `usages: [client auth]`) is a
-   **k8s-only alternative** for operators who already run it. Renewal is generous
+   edge sends a CSR to `POST /v1/edge-cert`, the CP signs it with the edge CA and
+   returns only the cert chain; the **private key never leaves the edge**, and the
+   **CP decides the SAN from the token identity** (ignoring any SAN in the CSR), so a
+   compromised edge cannot request a SAN it isn't entitled to. Renewal is generous
    (renew at ~⅓ lifetime *remaining*) so it never races expiry — see
    [Edge wiring](#edge-wiring).
 
@@ -102,8 +103,8 @@ not a source IP.
 
    The SAN check is re-evaluated **per request** against an `atomic.Pointer`-held
    allow-set, so **dropping a SAN distrusts that edge within ~300 ms** — even on
-   existing keep-alive / HTTP-2 connections. That is the fast revocation lever, and
-   (per the security model) the *only* bound on a cert minted from a leaked token.
+   existing keep-alive / HTTP-2 connections. That is the fast per-edge revocation
+   lever (but **not** a defense against a stolen *CA* key — see the Security model).
 
 ### Single source of truth (onboard in one place)
 
@@ -145,40 +146,32 @@ convergence before declaring an edge trusted.
 ## Deployment models: k8s edge vs Docker edge
 
 There are two edge deployment shapes, and the data-plane client cert must work for
-**both** with the same onboarding gesture ("provision one token"). The mechanism
-that makes the cert *arrive* differs:
+**both** with the same onboarding gesture ("provision one token"). The cert always
+arrives the same way — the CP issues it via `POST /v1/edge-cert`; only how the edge
+is packaged differs:
 
 **k8s edge.** The edge runs as a Deployment in some cluster (its own or the core's).
-cert-manager is available, so a per-edge `Certificate` (issuer `parapet-edge-ca`,
-`usages: [client auth]`, URI SAN `spiffe://parapet.moonrhythm.io/edge/<id>`) is
-minted into a `kubernetes.io/tls` Secret and mounted; `edge/forward.go` reads it
-**live**. This is the cert-manager path — now a **k8s-only alternative**, not the
-default.
+The data-plane client cert rides `POST /v1/edge-cert` exactly as for Docker. An
+operator who already runs cert-manager and wants to *mount* a client cert can still
+do so via the legacy `EDGE_UPSTREAM_CLIENT_CERT`/`_KEY` file path — but that is a
+mount detail on the edge, **not a CA mode on the CP**. cert-manager is no longer part
+of this design.
 
 **Docker edge (the motivating case).** The edge is a bare `docker run` on a VM / box
 near clients (`deploy/edge/run-edge-docker.sh`). Its **only required input is
 `EDGE_CP_TOKEN`** — no cert-manager, no CRDs, no file mounts, no manual renewal. It
 already pulls its public cert+key (`GET /v1/certs`) and WAF rules (`GET /v1/waf`)
 from the control plane on `EDGE_REFRESH_INTERVAL`, fail-static, keys in memory only.
-A cert-manager-mounted client cert is **impossible** here (there is no cert-manager
-and no Secret to mount), and a hand-mounted PEM re-introduces manual file management
-and manual renewal — exactly what the token-pull model removed for the public cert.
-
-**So the data-plane identity rides the SAME channel and loop the public cert already
-rides.** The control plane **issues** the edge its data-plane client cert over the
-existing bearer-authenticated HTTPS channel: `POST /v1/edge-cert` (see
-[Control-plane wiring](#control-plane-wiring-cp-issues-the-client-cert)), CSR in,
-signed chain out, on `EDGE_REFRESH_INTERVAL`, fail-static, key in memory only. This
-is **the primary mechanism**; cert-manager is the alternative for operators who
-already run it and want the CA key out of the CP (`EDGE_CA_MODE=cert-manager`).
+The data-plane identity rides the **same channel and loop**: `POST /v1/edge-cert`,
+CSR in, signed chain out, key in memory only.
 
 | | k8s edge | Docker edge |
 |---|---|---|
 | Public cert+key | `GET /v1/certs` (token-pull) | `GET /v1/certs` (token-pull) |
 | WAF rules | `GET /v1/waf` (token-pull) | `GET /v1/waf` (token-pull) |
-| **Data-plane client cert** | cert-manager Secret **or** `POST /v1/edge-cert` | **`POST /v1/edge-cert`** (only option — no cert-manager) |
+| **Data-plane client cert** | `POST /v1/edge-cert` (mounted-cert file path optional) | **`POST /v1/edge-cert`** |
 | Required edge input | token (+ optional mounted cert Secret) | **`EDGE_CP_TOKEN`, and nothing else** |
-| Renewal | cert-manager `renewBefore` / CP loop | CP loop (`EDGE_REFRESH_INTERVAL`) |
+| Renewal | CP loop (`EDGE_REFRESH_INTERVAL`) | CP loop (`EDGE_REFRESH_INTERVAL`) |
 
 The payoff is uniformity: the Docker edge's onboarding stays "add one token to the
 registry," and the same token edit that authorizes its key/WAF fetch also makes the
@@ -232,23 +225,32 @@ base.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
 `GetConfigForClient` must be non-nil before `Serve()` and must **never** return nil
 (return last-good on any error). A startup **self-test** asserts the served config
 carries `GetCertificate` **and** `ClientCAs` **and**
-`ClientAuth == VerifyClientCertIfGiven` (not `RequireAndVerify`, which would abort
-Cloudflare/browser handshakes; not `NoClientCert`, which silently disables mTLS).
-The SNI-cert reload loop and the trust reload loop write **separate** atomics and
-never share a config object.
+`ClientAuth == VerifyClientCertIfGiven`.
 
-**The trust watch** (`controller.go` + a new `controller_trust.go` mirroring
-`controller_waf.go`): a 6th watcher, gated by `EDGE_TRUST_SECRET != ""` (default
-off ⇒ identical to today). Reuse the generic `watchResource[*v1.Secret]` for
-`POD_NAMESPACE`; on change call `reloadTrustDebounced` (a 300 ms `debounce`). It
-**never rebuilds `ctrl.mux`** (trust is orthogonal to routes) and is
-**validate-then-swap, all-or-nothing** like WAF `SetRules`: parse `ca.crt` with
-`x509.NewCertPool().AppendCertsFromPEM`; a **non-empty input that yields zero certs
-is rejected** (keep last-good, log, bump `parapet_trust_reload_rejected_total`); a
-*deliberately empty* `ca.crt` means "mTLS disabled." On success, atomically `Store`
-**both** `clientCAs` and `trustPol` together so they can never disagree. A rejected
-reload keeps last-good **and alerts loudly** — a stale allow-set silently degrades
-every edge onboarded after the rejection.
+### The trust watch
+
+`controller.go` + a new `controller_trust.go` mirroring `controller_waf.go`: a 6th
+watcher, gated by `EDGE_TRUST_SECRET != ""` (default off ⇒ identical to today).
+Reuse the generic `watchResource[*v1.Secret]` for `POD_NAMESPACE`; on change call
+`reloadTrustDebounced` (a 300 ms `debounce`). It **never rebuilds `ctrl.mux`** (trust
+is orthogonal to routes) and is **validate-then-swap, all-or-nothing** like WAF
+`SetRules`. Parse the CA bundle: read key **`tls.crt`** first (the managed
+`kubernetes.io/tls` `parapet-edge-ca` Secret), falling back to `ca.crt` (a
+hand-rolled bundle / provided-mode convention); whichever is non-empty is fed to
+`x509.NewCertPool().AppendCertsFromPEM`. A **non-empty input that yields zero certs
+is rejected** (keep last-good, log, bump `parapet_trust_reload_rejected_total`). On
+success, atomically `Store` **both** `clientCAs` and `trustPol` so they can never
+disagree. A rejected reload keeps last-good **and alerts loudly** — a stale allow-set
+silently degrades every edge onboarded after the rejection.
+
+**Runtime keep-last-good on disappearance.** Distinguish **startup absence**
+(`EDGE_TRUST_SECRET` set but the Secret/key never loaded ⇒ degrade to CIDR-only,
+safe, warn) from **runtime disappearance** (the watched Secret is DELETED, or its
+`tls.crt`/`ca.crt` goes empty, *after* a good bundle was applied). A runtime
+DELETE/empty event MUST **keep last-good `clientCAs`** and bump
+`parapet_trust_reload_rejected_total` + alert — it MUST NEVER nil the live pool,
+because nilling it instantly distrusts the whole fleet (every edge's XFF
+overwritten). Only a deliberately-empty bundle *at startup* means "mTLS disabled."
 
 **Header hardening (a real gap today, not just for mTLS):** mount a middleware
 **first** in `main.go`'s `m` chain (before `ctrl`) that **unconditionally deletes**
@@ -274,18 +276,16 @@ error if mTLS is on with TLS off, mirroring the existing https-endpoint guard at
   atomically swaps — **if validation fails, the prior pair is kept** (never clears
   the pointer, never swaps in a broken cert). `GetClientCertificate` returns
   last-good non-empty whenever possible; a never-loaded empty return is loud
-  (metric + log) and gates readiness — never a silent half-rotated (new-key/old-chain)
-  state.
-- **`edge/refresh.go`** — `RefreshEdgeCertOnce(cp, ccStore)` mirroring
-  `RefreshCertOnce`: generate an ephemeral key **into a local var** (not the live
-  store), build the CSR, `cp.FetchEdgeCert(...)`, on success `ccStore.Update(chain,
-  localKey)` as **one atomic unit**, on error fail-static (keep the in-memory cert,
-  log a warning). `RunEdgeCertRefresh(ctx, cp, ccStore, ...)` mirrors
+  (metric + log) and gates readiness — never a silent half-rotated state.
+- **`edge/refresh.go`** — `RefreshEdgeCertOnce(cp, ccStore)`: generate an ephemeral
+  key **into a local var** (not the live store), build the CSR, `cp.FetchEdgeCert(...)`,
+  on success `ccStore.Update(chain, localKey)` as **one atomic unit**, on error
+  fail-static (keep the in-memory cert, log a warning). `RunEdgeCertRefresh` mirrors
   `RunCertRefresh` but **renews on remaining-life/renew-before, not bare interval
-  equality**, with **aggressive backoff retries** (faster than the 300 s tick) as
-  expiry nears, adds **per-edge jitter** (the current `RunCertRefresh` has none, so
-  a co-booted fleet stays phase-locked — a thundering-herd risk on a signing
-  endpoint), and **honors the CP's `Retry-After`**.
+  equality**, with **aggressive backoff retries** as expiry nears, adds **per-edge
+  jitter** (the current `RunCertRefresh` has none → a co-booted fleet stays
+  phase-locked, a thundering-herd risk on a signing endpoint), and **honors the CP's
+  `Retry-After`**.
 - **`edge/forward.go` `NewForwarder`** gains a `*ClientCertStore` param (nil ⇒
   anonymous re-encrypt, back-compat); on `useTLS` it sets
   `tlsConfig.GetClientCertificate = ccStore.GetClientCertificate`.
@@ -294,10 +294,11 @@ error if mTLS is on with TLS off, mirroring the existing https-endpoint guard at
 - **Readiness is fail-closed.** When `EDGE_DATAPLANE_MTLS=true`, the readiness gate
   (`cmd/edge-proxy/main.go:197`) becomes
   `(serveAll || store.Loaded()) && clientCert.Loaded()` — a hard AND that
-  **serve-all does NOT bypass** (the headline Docker serve-all edge must not go
-  ready with no client cert and silently run untrusted). First-boot issuance
-  failure keeps the edge **not-ready** (503), not serving-while-untrusted, with a
-  bounded background retry that flips ready when the first cert lands.
+  **serve-all does NOT bypass**. First-boot issuance failure keeps the edge
+  **not-ready** (503), not serving-while-untrusted, with a bounded background retry.
+  **But CP-readiness ≠ system-readiness:** the edge cannot self-detect "the core does
+  not yet trust my CA" (trust convergence happens in another process), so it can go
+  ready and still 502 in the convergence window — see the system-readiness fail mode.
 
 The edge remains the first hop and sets **no** `TrustProxy`, so it keeps
 overwriting incoming `X-Forwarded-*` with the true client peer before forwarding —
@@ -328,11 +329,9 @@ POST /v1/edge-cert    Authorization: Bearer <token>
 It is the **only mutating endpoint** (everything else is `GET`). The CP returns
 **`chain_pem` only** (no key on the wire — the edge holds it). `Cache-Control:
 no-store` **and** `Pragma: no-cache` are set. **No ETag / `If-None-Match` / 304**: a
-fresh ephemeral key each renewal means a new public key → new leaf → new chain, so a
-304 could never legitimately fire and an erroneous one would silently freeze a cert
-toward expiry — renewal is driven **solely** by `not_after`/renew-before. Body
-capped at 16 KiB via `io.LimitReader`. Absent signer / `EDGE_CA_*` unset ⇒ the
-endpoint **404s** (fully backward-compatible, mirroring `waf == nil` → 404).
+fresh ephemeral key each renewal means a new public key → new leaf → new chain.
+Body capped at 16 KiB via `io.LimitReader`. Absent signer ⇒ the endpoint **404s**
+(fully backward-compatible).
 
 **CSR flow** (reusing `edge/refresh.go` + `edge/cp.go` `CpClient`):
 
@@ -344,19 +343,17 @@ endpoint **404s** (fully backward-compatible, mirroring `waf == nil` → 404).
 3. **Edge — POST over the bearer channel.** New `CpClient.FetchEdgeCert(csrPEM)`
    mirroring `FetchCert`/`FetchWaf`: POSTs `{"csr_pem":…}`, sets `Authorization:
    Bearer <token>`, body-capped read, returns chain+not_after+serial on 200 / error
-   otherwise (caller is fail-static). `do()` is generalized to take method+body
-   (today it is GET-only).
+   otherwise (caller fail-static). `do()` is generalized to take method+body
+   (today GET-only).
 4. **CP — verify + sign** (`handleEdgeCert`, new): `bearer(r)` + `authz.Known(token)`
    → 401; `authz.Identity(token)` → 403 if no grant; decode CSR; **whitelist the key
    type/curve BEFORE verifying** (ECDSA P-256/P-384 or Ed25519 only; reject RSA →
    400) so a `CheckSignature` DoS on an oversized key is impossible;
-   `csr.CheckSignature()` (mandatory, unconditional — an unsupported sig alg is a
-   hard 400, never a silent pass) → 400 on failure; then `Signer.Sign(csr.PublicKey,
-   authorizedSAN)`.
+   `csr.CheckSignature()` (mandatory — an unsupported sig alg is a hard 400, never a
+   silent pass) → 400 on failure; then `Signer.Sign(csr.PublicKey, authorizedSAN)`.
 5. **CP — return chain only.** 200 with `chain_pem` + `not_after` + `serial`.
-6. **Edge — assemble + hold atomically.** Pair the returned chain with the in-memory
-   key into a `tls.Certificate` (`tls.X509KeyPair`) and atomically store the
-   **complete** keypair+chain in `ClientCertStore`.
+6. **Edge — assemble + hold atomically.** Pair the chain with the in-memory key into
+   a `tls.Certificate` and atomically store the **complete** keypair+chain.
 7. **Edge — present via `GetClientCertificate`** per handshake — no restart, no file.
 
 ### Signing: template, custody, rate-limiting
@@ -364,31 +361,24 @@ endpoint **404s** (fully backward-compatible, mirroring `waf == nil` → 404).
 All in `edgecp/` + `cmd/edge-controlplane`, reusing existing primitives.
 
 **`edgecp/server.go`.** New `handleEdgeCert` + `mux.HandleFunc("POST /v1/edge-cert",
-…)`. New `signer *Signer` field (nil ⇒ 404), wired by a `WithSigner(*Signer)`
-chaining method like `WithWAF`. **Absent signer ⇒ backward-compatible.**
+…)`. New `signer atomic.Pointer[*Signer]` (nil ⇒ 404), wired by `WithSigner` like
+`WithWAF`. **Absent signer ⇒ backward-compatible.**
 
-**`edgecp/signer.go` (new).** `Signer` holds the parsed edge CA cert + key; `Sign`
-builds the `x509.Certificate` template **from a zero value — never from the parsed
-CSR** — setting ONLY:
-
-- `SerialNumber`: a fresh 128-bit CSPRNG serial (`crypto/rand`), surfaced as `serial`.
-- `NotBefore = now - EDGE_CLIENTCERT_SKEW` (default 10m), `NotAfter = now + EDGE_CLIENTCERT_TTL`.
-- `KeyUsage = DigitalSignature`; `ExtKeyUsage = [x509.ExtKeyUsageClientAuth]` ONLY.
-- `URIs = [authorizedSAN]` derived from the token (the shared-derivation package).
-  **No DNSNames, no IPAddresses, no Subject/CN of significance.**
-- `BasicConstraintsValid = true, IsCA = false`.
-
-The CSR contributes **exactly one thing: `csr.PublicKey`**. The template
-**explicitly never** assigns `Subject`/`DNSNames`/`IPAddresses`/`EmailAddresses`/
-`URIs`/`Extensions`/`ExtraExtensions` from the CSR — getting this exactly right is
-the single highest-value invariant (a verifier matching a smuggled CN, a copied
-rogue SAN, or a carried-over `basicConstraints CA:true` would defeat the model).
-**Post-sign self-check:** re-parse the issued leaf and assert `IsCA==false`,
-`KeyUsage==DigitalSignature`, `ExtKeyUsage==[ClientAuth]`, `URIs==[authorizedSAN]`,
+**`edgecp/signer.go` (new).** `Signer` holds the parsed edge CA cert + key (behind an
+interface — the **HSM/KMS seam**); `Sign` builds the leaf `x509.Certificate` template
+**from a zero value — never from the parsed CSR** — setting ONLY: `SerialNumber`
+(128-bit CSPRNG); `NotBefore = now - EDGE_CLIENTCERT_SKEW`, `NotAfter = now +
+EDGE_CLIENTCERT_TTL`; `KeyUsage = DigitalSignature`; `ExtKeyUsage =
+[ExtKeyUsageClientAuth]` ONLY; `URIs = [authorizedSAN]` from the token (the shared
+derivation package); `BasicConstraintsValid = true, IsCA = false`. The CSR
+contributes **exactly one thing: `csr.PublicKey`**. The template **explicitly never**
+assigns `Subject`/`DNSNames`/`IPAddresses`/`EmailAddresses`/`URIs`/`Extensions`/
+`ExtraExtensions` from the CSR. **Post-sign self-check (mandatory in BOTH CA modes):**
+re-parse the issued leaf and assert `IsCA==false`, `KeyUsage==DigitalSignature`,
+`ExtKeyUsage==[ClientAuth]`, `URIs==[authorizedSAN]`,
 `len(DNSNames)==len(IPAddresses)==0`; **refuse to return** a cert that fails any
-check (mirrors the `GetConfigForClient` self-test discipline). A conformance test
-feeds a CSR carrying `CA:true`, a rogue URI/DNS SAN, and a malicious CN and asserts
-none appear in the leaf.
+check. A conformance test feeds a CSR carrying `CA:true`, a rogue URI/DNS SAN, and a
+malicious CN and asserts none appear in the leaf.
 
 **`edgecp/authz.go` — per-edge identity (explicit opt-in).** Extend `Authz` with
 `identities map[string]string` (token → id) populated alongside `tokens` in
@@ -397,279 +387,489 @@ separate**, NOT auto-derived from the token's presence or its domains; `Identity
 returns `("",false)` (→ 403) unless the operator set it. A serve-all (`"*"`) token
 **MUST NOT** get a default identity. Migration defaults every token to NO identity.
 
-**CA custody — `EDGE_CA_MODE`:**
+**CA custody — managed (default) vs provided.** The edge CA is the new crown jewel
+and **lives with the CP**. Two modes, decided at boot by the **presence** of
+`EDGE_CA_CERT`/`EDGE_CA_KEY` (no `EDGE_CA_MODE` knob):
 
-- **`direct` (default — Docker-friendly).** In-process `x509.CreateCertificate` with
-  the edge CA key from `EDGE_CA_CERT`/`EDGE_CA_KEY`. **No cert-manager dependency** —
-  the whole point for a bare Docker edge. The CA key is the new crown jewel and
-  **now lives with the CP**: store it in its **own** Secret in `POD_NAMESPACE` (NOT
-  co-located with tenant TLS keys), tightest RBAC (only the CP ServiceAccount),
-  behind the CP's edge-sources-only `NetworkPolicy`. **Hot-reload** the key/cert
-  from the watched Secret (validate-then-swap, fail-closed) — NOT load-once — so CA
-  rotation needs no CP restart. Constrain the edge CA with **NameConstraints**
-  limiting URI SANs to `spiffe://parapet.moonrhythm.io/edge/*` (and EKU clientAuth),
-  so even a stolen CA key can mint less. Emit a **loud startup log** that the CP now
-  holds a fleet-minting key.
-- **`cert-manager` (k8s-only alternative).** The CP proxies a cert-manager
-  `CertificateRequest` to an `Issuer`/`ClusterIssuer` and polls. The CA key stays
-  inside cert-manager (smaller CP blast radius) but adds a hard CRD dependency and an
-  async round trip, and does **not** work without cert-manager. **Strongly preferred
-  wherever cert-manager is present.**
+- **`managed` (default — zero PKI, zero openssl, zero cert-manager).** On first boot
+  the CP **generates** a single-purpose edge CA and **persists** it to its own
+  `parapet-edge-ca` Secret (`kubernetes.io/tls`, in `POD_NAMESPACE`), reuses it
+  across restarts/replicas, and **hot-reloads** it on change. The generated CA
+  template (from a zero value): key **ECDSA P-384** (`EDGE_CA_KEY_TYPE=ed25519`
+  alt), PKCS#8; `SerialNumber` 128-bit CSPRNG; `Subject` CN `parapet-edge-ca`
+  (cosmetic); `NotBefore = now-10m`, `NotAfter = now + EDGE_CA_TTL` (default 10y —
+  the **leaf** TTL is the short knob); `KeyUsage = CertSign | CRLSign` ONLY;
+  `ExtKeyUsage = [ClientAuth]` ONLY; `BasicConstraintsValid=true, IsCA=true,
+  MaxPathLenZero=true`; `NameConstraints.PermittedURIDomains = ["parapet.moonrhythm.io"]`.
+  **Honest scope:** this pins the SAN **host** only — SPIFFE path-segment scoping to
+  `/edge/*` is *not* expressible as a URI NameConstraint (the issuance template's
+  `URIs=[authorizedSAN]` + post-sign self-check pin the path). So the constraint stops
+  cross-domain/serverAuth abuse of a stolen key, **NOT** edge-fleet impersonation. **A
+  conformance test must prove** `x509.Verify` rejects `spiffe://evil.example/edge/x`
+  and accepts `spiffe://parapet.moonrhythm.io/edge/x` under this constraint before it
+  is counted as a control. Managed mode emits a **loud startup log** that the CP now
+  HOLDS (and on first boot GENERATED) a fleet-minting CA key, and requires the new
+  `k8s` write path, the dedicated CP ServiceAccount, and `POD_NAMESPACE`.
+- **`provided` (escape hatch — operator's own PKI).** Both `EDGE_CA_CERT`/`EDGE_CA_KEY`
+  point at mounted PEM files; the CP **uses** them, **never generates**, **never
+  writes** the Secret, and **needs no `get`/`update` RBAC**. Hot-reload the mounted
+  files (validate-then-swap). **Validation (mandatory):** the CA MUST be `IsCA` and
+  carry EKU `clientAuth` (reject pure serverAuth / hard-reject `anyExtendedKeyUsage`);
+  **warn loudly (or refuse behind a flag) if it lacks
+  `NameConstraints.PermittedURIDomains`** — the leak-containment guarantee is void
+  without it. It SHOULD be a **dedicated single-purpose** CA, never a shared org
+  intermediate. Not cert-manager-specific: cert-manager may *populate* the mounted
+  Secret, but the CP sees opaque files — no CRD, no `CertificateRequest`, no polling.
 
-**`cmd/edge-controlplane/main.go`.** Load `EDGE_CA_CERT`/`EDGE_CA_KEY` (or
-cert-manager mode), build `Signer`, `server.WithSigner(signer)`. Gated on the env
-being set (absent ⇒ no signer ⇒ 404 ⇒ back-compat).
+**`cmd/edge-controlplane/main.go`.** Branch on `EDGE_CA_CERT`/`EDGE_CA_KEY`: both set
+⇒ provided (read, validate, build `Signer`); both empty ⇒ managed (`edgecp.EnsureCA`
+adopt-or-generate + persist, synchronous, before serving); exactly one set ⇒ hard
+config error (mirrors the `CP_TLS_CERT`/`CP_TLS_KEY` pairing guard at `main.go:41-44`).
+In managed mode, `POD_NAMESPACE` MUST be non-empty (downward-API `metadata.namespace`)
+— a missing `POD_NAMESPACE` is a **fatal** startup error, never a silent
+wrong-namespace write. Either branch yields one `*Signer` wired via
+`server.WithSigner(signer)`; neither ⇒ nil signer ⇒ `POST /v1/edge-cert` 404
+(back-compat).
 
 **Rate-limiting + DoS.** A **per-token** token-bucket (`EDGE_CLIENTCERT_RATE`,
 default 10/min → 429) blunts a single-token forged-CSR flood. It does **nothing**
-against a fleet-wide restart storm (N different tokens), so add a **global signing
-concurrency cap** (a bounded worker pool / semaphore around `Signer.Sign`) returning
-**429/503 + `Retry-After`** when saturated. The authz reject and the **key-type
-whitelist run before** any signing, so an unauthorized or oversized-key flood costs
-no CA work. Keep the endpoint behind the CP's existing edge-sources-only
-`NetworkPolicy`.
+against a fleet-wide restart storm (N tokens), so add a **global signing concurrency
+cap** (a bounded worker pool / semaphore around `Signer.Sign`) returning **429/503 +
+`Retry-After`** when saturated. The authz reject and the **key-type whitelist run
+before** any signing, so an unauthorized or oversized-key flood costs no CA work.
+Keep the endpoint behind the CP's edge-sources-only `NetworkPolicy`.
+
+### Managed-CA bootstrap: replica-safe create-once + anti-regeneration guard
+
+`edgecp.EnsureCA(ctx, k8sClient, podNamespace, secretName)` runs **synchronously
+before serving** (mirroring `wafReloader.LoadOnce` at `main.go:88-93`); only after it
+returns a valid `Signer` is `WithSigner` wired. Until then `POST /v1/edge-cert` 404s
+— never sign with a half-initialized/unpersisted CA.
+
+**Precondition (manifest):** the operator pre-creates an **empty** `parapet-edge-ca`
+Secret. RBAC `resourceNames` can scope `get`/`update` but **cannot** scope `create`;
+the stub lets us grant scoped `update` instead of broad namespace `create`.
+
+**The CAS read MUST be a strongly-consistent typed `Secrets(ns).Get`** (the new
+`k8s.GetSecret`), never an informer/lister cache (a stale-empty cache read can
+livelock the loser into regenerating). Algorithm `ensureCA(ctx)`:
+
+1. `GetSecret(podNamespace, parapet-edge-ca)`. Cases:
+   - **(a) populated** (`tls.crt`+`tls.key` parse into a valid CA keypair) → **ADOPT**,
+     build `Signer`, log "adopted existing edge CA", return. *(Steady state, replica
+     scale-up, and the CAS-loser all land here.)*
+   - **(b) guard annotation present but `tls.crt` empty** → **HARD ANOMALY** (a
+     populated CA was re-blanked). **NEVER regenerate** (a regenerate is
+     indistinguishable from the catastrophic re-blank and would distrust the whole
+     fleet). Keep any in-memory CA, bump `parapet_edge_ca_unexpected_empty_total`,
+     alert, fail readiness. CA replacement is the **overlap rotation**, never
+     delete+regenerate.
+   - **(c) virgin empty stub** (no guard annotation, never populated) → go to 2.
+   - **(d) `NotFound`** → **fatal config error** ("operator must pre-create the empty
+     parapet-edge-ca Secret"). Do NOT fall back to a broad `create` grant.
+2. Generate keypair + self-signed CA **in memory** (local vars).
+3. On the **observed** Secret object (carrying its `resourceVersion`), set
+   `Data["tls.crt"]`/`Data["tls.key"]` **and a guard annotation**
+   `parapet.moonrhythm.io/edge-ca-generation` + populated-at timestamp, and call
+   `k8s.UpdateSecret(...)`. `Update` is a compare-and-swap on `resourceVersion`:
+   succeeds only if the stored version is unchanged.
+4. **Success** → I am the winner; use my keypair; bump `parapet_edge_ca_generated_total`.
+5. **Conflict** (`apierrors.IsConflict`, the loser path) → RE-READ and **ADOPT** the
+   winner's keypair (case a), discard mine. Still-empty re-read (transient, never
+   possible once the guard annotation is set) → jittered bounded backoff;
+   **exhaustion is a hard non-zero exit** (kubelet restarts) — never a silent
+   no-signer 404.
+
+The API server's `resourceVersion` CAS **linearizes** the replicas: exactly one
+`Update` on the empty stub wins; the other gets `Conflict` and adopts. **The Secret
+IS the lock — no leader election, no leases.**
+
+**Anti-regeneration is the load-bearing safety property.** The guard annotation
+(case b) closes the GitOps/operator re-blank hazard: a Flux/Argo sync or `kubectl
+apply` that resets the stub to empty does NOT trigger a regenerate-and-distrust. The
+pre-created stub in `deploy/` MUST carry GitOps drift-exclusion
+(`argocd.argoproj.io/sync-options: Prune=false`, an `ignoreDifferences` on `/data`,
+a Flux server-side-apply field-manager note). Alert if `parapet_edge_ca_generated_total`
+ever increments more than once across the fleet's lifetime.
+
+**Testability:** the create-once MUST be tested against
+`k8s.io/client-go/kubernetes/fake` (or envtest), which honors `resourceVersion` CAS
+and returns `IsConflict`, with a two-goroutine concurrent-generate test asserting
+exactly one CA survives and the loser adopts. The **fs backend's `UpdateSecret` is
+non-CAS** (best-effort in-memory) so managed mode against fs **regenerates per boot**
+— fine for local dev, **never** prod, and cannot validate the linearization.
+
+### Where the core gets the CA (one Secret, no publish step)
+
+The **core reads the public CA cert directly from the same `parapet-edge-ca` Secret**
+via its existing trust watch — no separate publish step, no extra CP write, no skew.
+Point the core at it: `EDGE_TRUST_SECRET=parapet-edge-ca`, reading key **`tls.crt`**
+(fallback `ca.crt`). The cert the CP signs **with** and the cert the core **trusts**
+are the **same bytes in the same Secret**, so they cannot drift; the core needs **zero
+new RBAC** (it already list/watches secrets in the namespace). (Rejected: a separate
+`parapet-edge-trust` Secret holding only `ca.crt` — a second write target and a
+re-introduced publish/skew window for nothing the namespace co-tenancy doesn't already
+concede.)
+
+**Namespace invariant:** the CP's CA Secret and the core's `EDGE_TRUST_SECRET` watch
+MUST be in the **same** namespace, and that namespace is `POD_NAMESPACE` for **both**.
+The CP's CA read/write targets `POD_NAMESPACE` (the pod's own namespace), **NOT**
+`WATCH_NAMESPACE` (which defaults to `""` = all-namespaces and cannot be a write
+target). The core already injects `POD_NAMESPACE` via the downward API
+(`deploy/deployment.yaml:38-41`); the CP manifest does not today and MUST be amended.
+
+### CA hot-reload + rotation (CP-driven, bundle-based, no cert-manager)
+
+**The signer is hot-reloadable, not boot-once.** `EnsureCA` does the create-once; a
+**CA-Secret watch** (a 2nd CP watcher, mirroring the cert `Reloader`) then keeps the
+signer live: validate-then-swap into `atomic.Pointer[*Signer]`. A boot-time-only
+signer would let a replica that booted **before** a rotation keep signing with a stale
+in-memory key — intermittent 502s during the bundle-trim step. Every replica exposes
+`parapet_edge_ca_signer_fingerprint`; the rotation interlock confirms **all** replicas
+converged before trimming.
+
+**Rotation invariant:** the NEW CA's public cert must be in the core's `ClientCAs`
+BEFORE the CP signs any leaf with the new key — else fresh leaves 502. The enabler is
+**bundle support**: `AppendCertsFromPEM` appends every CERTIFICATE block, so `tls.crt`
+can hold an **overlap bundle** (old ++ new CA concatenated), and validate-then-swap
+treats a partially-bad bundle as a rejected reload (keep last-good).
+
+**Rotation is single-writer** (Phase 1: a one-shot Job / subcommand, or
+leader-elected — NOT the steady-state `replicas: 2`). The Secret-as-lock CAS
+linearizes only create-once, not a 4-stage promote/trim state machine. So the **active
+signer is derived SOLELY from Secret content** (e.g. a `tls-active: old|new` field),
+never per-replica state, and every stage is gated on a **core-observed**
+trust-bundle-hash metric:
+
+1. Generate NEW CA in memory.
+2. Write `tls.crt = OLD ++ NEW`, stage NEW key as `tls-next.key`, keep OLD active.
+   Core's watch fires → trusts BOTH. (Invariant satisfied.)
+3. Keep signing with OLD while every short-TTL leaf renews; watch
+   `parapet_edge_clientcert_not_after` / registry-generation convergence.
+4. **Promote:** set `tls-active: new` (all replicas swap within one debounce), keep
+   BOTH certs in the bundle for ≥ one full leaf-TTL, then trim the OLD cert — only
+   after the convergence metric shows zero leaves on the old CA.
+
+**CA-key-compromise emergency:** skip overlap, write ONLY the new CA, accept the brief
+gap (existing edges 502 until they re-fetch a new-CA leaf). **This is the stolen-CA-key
+runbook** — SAN-drop cannot revoke a forged leaf riding a real SAN. Auto-rotation is
+Phase 2.
+
+### k8s client: the first write path
+
+The `k8s` client is **read-only** today (`k8s/k8s.go` exposes only `Get*`/`Watch*`;
+`cluster.go` wraps List/Watch; `fs.go` is the local fixture backend). Managed mode
+needs the **first** write path, added to the interface and **both** backends with
+package-level forwarders:
+
+- `GetSecret(ctx, ns, name) (*v1.Secret, error)` — single-object read preserving
+  `resourceVersion` for the CAS. cluster: `Secrets(ns).Get`. fs: matching secret or
+  `apierrors.NewNotFound`.
+- `UpdateSecret(ctx, ns, *v1.Secret) (*v1.Secret, error)` — the CAS write; sends
+  `s.ResourceVersion`; apiserver rejects a stale version with `Conflict`. cluster:
+  `Secrets(ns).Update`. fs: best-effort in-memory (**non-CAS**, dev-only).
+
+Import `k8s.io/apimachinery/pkg/api/errors` for `IsConflict`/`IsNotFound`. No
+`CreateSecret` in the recommended posture (the stub is pre-created; `NotFound` is
+fatal-config). The **core never uses these writes** — they live solely in the CP
+boot/rotation path. `ensureCA` is **idempotent**: re-running after a CA exists is a
+pure adopt (no write).
+
+## Deployment & RBAC (self-managed CA)
+
+The CP **stops reusing** the controller's ServiceAccount — splitting the SA is the
+prerequisite for isolating the mint/write capability from the core. Concrete manifest
+changes:
+
+1. **New `deploy/edge/serviceaccount.yaml`** — ServiceAccount `edge-controlplane`.
+2. **`controlplane.yaml`:** `serviceAccountName: edge-controlplane` (was
+   `parapet-ingress-controller`); add `POD_NAMESPACE` via downward API `fieldRef:
+   metadata.namespace` (**required** in managed mode); add a hardened `securityContext`
+   (`readOnlyRootFilesystem`, `runAsNonRoot`, `allowPrivilegeEscalation: false`) and an
+   egress `NetworkPolicy`; add `EDGE_CA_SECRET` (and optionally `EDGE_CA_TTL`,
+   `EDGE_CA_KEY_TYPE`).
+3. **New `deploy/edge/role-ca.yaml`** — namespaced Role `edge-controlplane` in
+   `POD_NAMESPACE` with secrets `get, update` scoped to
+   `resourceNames: [parapet-edge-ca]` (resourceNames scopes get/update/patch/delete
+   but **cannot** scope create — exactly why the stub is pre-created), + RoleBinding to
+   the new SA.
+4. **Cluster-wide read rebind (the migration footgun):** because the CP runs
+   `WATCH_NAMESPACE=""` (cluster-wide tenant-cert Reloader), the new SA needs a
+   **ClusterRoleBinding** to the existing `parapet-ingress-controller` read ClusterRole.
+   A namespaced RoleBinding alone **silently breaks cert distribution**. If
+   `WATCH_NAMESPACE` is pinned, a namespaced RoleBinding to the read Role suffices —
+   the binding scope MUST match `WATCH_NAMESPACE`. Ship `deploy/edge/role-binding-read.yaml`.
+5. **New `deploy/edge/ca-secret.yaml`** — the pre-created **empty** `parapet-edge-ca`
+   Secret in `POD_NAMESPACE`. (Confirm whether target k8s rejects a zero-length
+   `tls.crt` on a `kubernetes.io/tls` CREATE; if so ship it as type `Opaque` — type is
+   advisory to our code and cannot change on `Update`.) MUST carry GitOps
+   drift-exclusion so a reconciler never prunes or blanks the CP-populated Secret.
+6. **The core keeps** its namespace-wide secrets list/watch (it needs all tenant TLS
+   for SNI) and reads ONLY the public `tls.crt` from `parapet-edge-ca` via
+   `EDGE_TRUST_SECRET` — **zero new core RBAC**.
+7. **CP startup RBAC self-probe:** after `k8s.Init`, probe-List secrets in
+   `WATCH_NAMESPACE` and probe-Get the CA Secret; on 403, fatal-log naming the exact
+   missing binding.
+8. **etcd encryption-at-rest** is a managed-mode prerequisite (loud startup warning if
+   undetectable): the long-lived CA key now lives in a Secret, exposed in etcd backups
+   and to anyone with namespace secret-get without it.
 
 ## Security model
 
 **Trust boundary.** Exactly the edges holding a private key whose cert chains to the
-dedicated edge CA **and** whose URI SAN is in the live allow-set. The CA signs
-nothing else. Trust is **operator-asserted**: only an operator editing the registry
-Secret moves the boundary — never an edge action, never a token-writable
-self-registration. mTLS trust is conferred **only on `:443`**.
+dedicated edge CA **and** whose URI SAN is in the live allow-set. Trust is
+**operator-asserted**: only an operator editing the registry Secret moves the boundary.
+mTLS trust is conferred **only on `:443`**.
 
-**Spoofing.** A non-edge reaching `:443` **cannot forge trust**:
-`VerifiedChains` is populated only after the Go stack cryptographically verifies the
-presented cert against `ClientCAs`; forging requires the in-cluster CA key. And a
-compromised edge **cannot request a SAN it isn't entitled to** — the CP stamps the
-SAN from the bearer token's registry identity and ignores the CSR's SAN entirely.
+**Spoofing.** A non-edge reaching `:443` **cannot forge trust**: `VerifiedChains` is
+populated only after the Go stack cryptographically verifies the presented cert against
+`ClientCAs`; forging requires the edge CA key. A compromised edge **cannot request a SAN
+it isn't entitled to** — the CP stamps the SAN from the bearer token's registry
+identity and ignores the CSR's SAN.
 
-> **Honest scoping (read this).** mTLS authenticates the **connection, not the
-> headers.** A trusted edge — or anything wielding a stolen edge key — can still
-> set `X-Forwarded-For` to whatever it likes *for its own requests*, because
-> parapet honors a trusted hop's XFF verbatim. The claim is **"an unauthenticated
-> peer is never trusted,"** not "XFF can never be spoofed." Second caveat: with the
-> shipped `TRUST_PROXY: cloudflare` default, a non-edge from a Cloudflare CIDR
-> reaching `:443` is CIDR-trusted with no cert. So **never add edge egress CIDRs to
-> `TRUST_PROXY`** (mTLS is the edge path), and lock **both** core data-plane ports
-> with a `NetworkPolicy` to the edge/Cloudflare source set.
+> **Honest scoping.** mTLS authenticates the **connection, not the headers.** A trusted
+> edge — or anything wielding a stolen edge *leaf* key — can still set
+> `X-Forwarded-For` for its own requests; the claim is **"an unauthenticated peer is
+> never trusted,"** not "XFF can never be spoofed." Second caveat: with the shipped
+> `TRUST_PROXY: cloudflare` default, a non-edge from a Cloudflare CIDR is CIDR-trusted
+> with no cert. **Never add edge egress CIDRs to `TRUST_PROXY`**, and lock both
+> data-plane ports with a `NetworkPolicy`.
 
-**Replay.** None on the data plane — the cert is proven inside a live mTLS handshake
-(ephemeral keys, transcript signing), not a replayable bearer credential.
+**Replay.** None on the data plane — the cert is proven inside a live mTLS handshake.
 
-> **Token-minted certs outlive token revocation.** A leaked-but-not-yet-revoked
-> token POSTed to `/v1/edge-cert` mints a self-contained TLS credential the core
-> verifies cryptographically for its full TTL. Revoking the token stops *future*
-> issuance but does **not** revoke an already-minted cert — only **dropping the
-> registry entry** (which drops its SAN from the live allow-set, re-checked per
-> request) revokes it, within ~300 ms. Therefore: (1) the leaked-token runbook is
-> **"delete the registry entry,"** never "rotate only the token"; (2)
-> `EDGE_CLIENTCERT_TTL` is kept short to shrink the window; (3) **CP-issuance is
-> INCOMPATIBLE with `EDGE_TRUST_REQUIRE_SAN=false`** (CA-only mode) — the per-request
-> SAN check is the *only* bound on such a cert, so the CP MUST refuse to issue
-> and/or the core MUST refuse CA-only when the same edge CA backs issuance.
+> **Token-minted leaf certs outlive token revocation.** A leaked-but-not-yet-revoked
+> token POSTed to `/v1/edge-cert` mints a self-contained cert the core verifies for its
+> full TTL. Revoking the token stops *future* issuance but does **not** revoke a minted
+> cert — only **dropping the registry entry** (which drops its SAN from the live
+> allow-set, re-checked per request) revokes it, in ~300 ms. Runbook for a leaked
+> **token**: delete the registry entry. `EDGE_CLIENTCERT_TTL` is kept short to shrink
+> the window; **CP-issuance is INCOMPATIBLE with `EDGE_TRUST_REQUIRE_SAN=false`** (the
+> per-request SAN check is the only bound on such a cert).
 
-**Blast radius.** A leaked edge client key lets the holder spoof XFF **as that one
-edge** until its SAN is dropped (~300 ms) or its cert expires. It leaks **no** server
-TLS private key. The **crown jewel is the edge CA key** (mints any edge). Under
-`EDGE_CA_MODE=direct` it **lives with the control plane** — a deliberate,
-design-acknowledged escalation from the CP's prior posture (it distributed tenant
-*leaf* keys; it now holds a *CA* that forges fleet-wide edge trust). Mitigated by: a
-**single-purpose** CA, **NameConstraints** capping URI SANs to
-`spiffe://parapet.moonrhythm.io/edge/*`, the key in its **own** tightly-RBAC'd
-in-cluster Secret (never the tenant-cert Secret, never shipped — only the chain
-leaves the cluster), **hot-reload** for restart-free rotation, short
-`EDGE_CLIENTCERT_TTL`, per-request SAN revocation, and the
-`EDGE_CA_MODE=cert-manager` alternative that keeps the CA key out of the CP. A
-future HSM/KMS signer interface can keep the raw key out of pod memory. CA-key
-compromise is handled by the overlap rotation runbook with a metric interlock.
+**Blast radius.** A leaked edge **leaf** key lets the holder spoof XFF **as that one
+edge** until its SAN is dropped (~300 ms) or its cert expires. The **crown jewel is the
+edge CA key** (mints any edge). In **managed** mode the CP both **GENERATES and HOLDS**
+it — a deliberate escalation from the CP's prior posture (it distributed tenant *leaf*
+keys; it now holds, and mints, a *CA* that forges fleet-wide edge trust). **State this
+plainly:** a stolen edge-CA key forges the **entire** fleet's identities. NameConstraints
+(`PermittedURIDomains`) and EKU `clientAuth` only stop **cross-purpose** abuse (other URI
+domains, serverAuth leaves) — they do **not** bound edge-fleet impersonation, because a
+forged leaf carries a SAN already in the allow-set, so **per-request SAN-drop does NOT
+revoke a forged leaf without also distrusting the legitimate edge.** The **only** real
+bound on a stolen CA key is **CA rotation** (the overlap/emergency runbook); that, not
+SAN-drop, is the stolen-CA-key runbook. Mitigations that genuinely shrink the
+window/surface: a **single-purpose** CA (`KeyUsage=CertSign|CRLSign`, `MaxPathLen=0`,
+EKU `clientAuth`), its **own** tightly-RBAC'd Secret read only by the **dedicated CP
+ServiceAccount**, the CP's edge-sources-only `NetworkPolicy` + hardened pod, **provided**
+mode (key never in an in-cluster Secret) for high-assurance, and a future **HSM/KMS
+`Signer`** so the raw key never sits in pod memory. **Phase-1 honesty:** because the
+**core** SA needs namespace-wide secret read for SNI certs, the core CAN read the CA
+private key from `parapet-edge-ca` in the shared namespace — the dedicated CP SA isolates
+the **mint/write** capability, NOT key-read. Full key-read isolation requires moving
+`parapet-edge-ca` to a CP-only namespace (Phase-1 *option*, applyable manifest) or
+provided mode. The CP also concentrates risk: the same process holds cluster-wide read of
+**all** tenant TLS keys (`WATCH_NAMESPACE=""`) **and** the fleet-minting CA key — pin
+`WATCH_NAMESPACE` to specific tenant-secret namespaces to shrink this.
 
 **Fail-default: fail-closed, degrading to the static CIDR branch.** A missing trust
-Secret ⇒ `trustPol` nil ⇒ mTLS branch always false ⇒ edges distrusted (degraded but
-safe — identical to the pre-mechanism world), Cloudflare CIDR unaffected, startup
-warning logged. An empty/garbage `ca.crt` on reload ⇒ validate-then-swap **rejects**
-and keeps last-good. First-boot issuance failure ⇒ edge **not-ready** (never
-serve-while-untrusted). **No path fails open.**
+Secret ⇒ `trustPol` nil ⇒ mTLS branch false ⇒ edges distrusted (degraded but safe),
+Cloudflare CIDR unaffected. An empty/garbage `ca.crt` on reload ⇒ validate-then-swap
+**rejects** and keeps last-good. First-boot issuance failure ⇒ edge **not-ready**. A
+trust Secret that **vanishes at runtime** keeps **last-good** `clientCAs` and alerts — it
+never nils the live pool; only a *never-loaded* startup absence degrades to the CIDR
+branch. **No path fails open.**
 
-**The explicit tradeoff.** This forces re-encrypt TLS (`EDGE_UPSTREAM_TLS=true`), a
-PKI lifecycle, and the CA key living with the CP (direct mode). An **expired edge
-cert hard-fails the handshake** (502s); the CP-outage budget (= `TTL` ×
-renew-before-fraction) must exceed the operator's CP recovery SLO. Accepted: a
-cryptographic, IP-independent, per-edge-revocable identity that makes a bare Docker
-edge work with nothing but a token is worth the discipline.
+**The explicit tradeoff.** This forces re-encrypt TLS, a PKI lifecycle, and the CA key
+living with the CP (managed mode). An **expired edge cert hard-fails the handshake**
+(502s); the CP-outage budget (= `EDGE_CLIENTCERT_TTL` × renew-before-fraction) must
+exceed the operator's CP recovery SLO. Accepted: a cryptographic, IP-independent,
+per-edge-revocable identity that makes a bare Docker edge work with nothing but a token.
 
 ## Fail modes
 
 | Failure | Behavior |
 |---|---|
-| Trust Secret absent / never created | mTLS branch false for all (`trustPol` nil); edges distrusted (XFF overwritten → WAF/limits/GeoIP see edge IP); core serves; Cloudflare CIDR unaffected. **Fail-closed, degraded-not-down.** Startup warning + `parapet_trust_source{none}`. |
-| `ca.crt` edited to empty/garbage on reload | Validate-then-swap: non-empty input yielding zero certs **rejected**, last-good kept, `parapet_trust_reload_rejected_total++`, **loud alert** (a stale allow-set silently degrades edges onboarded after). A *deliberately* empty `ca.crt` = "mTLS disabled." Never fails open. |
-| Edge client cert expired / not yet renewed | `VerifyClientCertIfGiven` **aborts the handshake** → edge `:443` connection 502s. Mitigated by short-TTL + generous renew-before, live `GetClientCertificate` reload, NTP sync, alerting on `parapet_edge_clientcert_not_after`. |
-| Edge on plaintext `:80` but operator expected trust | No client cert on `:80`; `r.TLS == nil`; edge distrusted (CIDR-only). Made loud: edge errors if `EDGE_DATAPLANE_MTLS` set with TLS off; `parapet_trust_source{none}` alerts. |
-| Per-edge revocation (registry-entry delete) | **Fast path.** SAN re-checked per request against the live atomic allow-set → distrusts within ~300 ms even on existing connections. The routine revocation lever. |
-| CA-drop revocation latency | `VerifiedChains`/`ClientCAs` are consulted only at **handshake**. Dropping a CA takes effect on **new** handshakes only; existing connections keep their verified chain until they close. Mitigate: prefer SAN-drop; cap `:443` connection age; reserve CA-drop for CA-key compromise. |
-| Edge CA private key leaked (direct mode) | Attacker mints trusted edges until CA rotation. **Highest severity.** Mitigated by the own-Secret + tightest-RBAC custody, NameConstraints, the cert-manager alternative (key out of CP), and the overlap rotation runbook with a metric interlock. |
+| Trust Secret absent / never created (startup) | mTLS branch false (`trustPol` nil); edges distrusted (XFF overwritten); core serves; Cloudflare CIDR unaffected. **Fail-closed, degraded-not-down.** Startup warning + `parapet_trust_source{none}`. |
+| `ca.crt`/`tls.crt` empty/garbage on reload | Validate-then-swap **rejects**, last-good kept, `parapet_trust_reload_rejected_total++`, **loud alert**. Never fails open. |
+| Managed CA Secret deleted / blanked at RUNTIME (operator, GitOps prune, restore of the empty stub) | CP: the guard annotation makes a re-blanked-but-previously-populated stub a HARD ANOMALY — the CP **NEVER regenerates** (would mint a new CA and distrust the fleet), keeps its in-memory CA, bumps `parapet_edge_ca_unexpected_empty_total`, alerts, fails readiness. Core: a runtime DELETE/empty of `EDGE_TRUST_SECRET` keeps **LAST-GOOD** `ClientCAs` + alerts — never nils the live pool. Replacement is the overlap rotation, never delete+regenerate. The `deploy/` stub carries GitOps drift-exclusion. |
+| Two CP replicas both observe an empty stub and both generate (split-CA race) | `resourceVersion` CAS linearizes them: exactly one `Update` wins (rv advances), the other gets `Conflict`, re-reads, **ADOPTS** the winner's keypair. The Secret IS the lock — no leader election. The CAS read MUST be a strongly-consistent typed `Get` (never an informer cache, which can serve a stale-empty stub and livelock the loser); retry exhaustion is a hard non-zero exit. |
+| CP started managed with empty `POD_NAMESPACE` (downward API not wired) | **FATAL** startup error before any write — the CA Secret has no known namespace and a wrong-namespace write would land where the core never sees it. Mirrors the `CP_TLS` pairing guard. |
+| CP switched to the dedicated SA without the cluster-wide read rebind (`WATCH_NAMESPACE=""`) | The cluster-wide tenant-cert Reloader 403s → stale/empty cert store → edges fail to fetch certs → data-plane outage. MUST bind a ClusterRoleBinding to the existing read ClusterRole. The CP startup RBAC self-probe fails loud, naming the missing binding. |
+| A CP replica booted before a CA rotation keeps signing with the stale key | Prevented by the CA-Secret watch: signer is `atomic.Pointer[*Signer]`, hot-reloaded on change; the active key derives solely from Secret content (`tls-active`) so all replicas converge within one debounce. The interlock confirms all `parapet_edge_ca_signer_fingerprint` match before trimming. |
+| Edge client cert expired / CP down past `NotAfter` | `VerifyClientCertIfGiven` aborts the handshake → 502s. Until expiry, the edge keeps its last-good in-memory cert (**fail static**) and retries with backoff. Outage budget = `TTL` × renew-before-fraction; size `TTL` above the CP recovery SLO. |
+| Leaked-but-not-yet-revoked token replayed to `/v1/edge-cert` | Mints a cert for ITS OWN SAN, valid for the full TTL. Token revocation does NOT revoke it — **only deleting the registry entry** drops its SAN (per-request → distrusted ~300 ms). Bounded by short `EDGE_CLIENTCERT_TTL`. |
+| Stolen edge-CA key (managed mode) | Attacker forges the **ENTIRE fleet's** identities. NameConstraints + EKU stop only cross-purpose abuse, NOT impersonation (a forged leaf rides a real SAN, so SAN-drop can't revoke it without distrusting the legit edge). The ONLY bound is **CA ROTATION**. Phase-1 honesty: the CA key is readable by the core SA (namespace co-tenancy); the dedicated CP SA isolates mint/write, not key-read. |
+| CP signs with a CA the core's `ClientCAs` doesn't yet trust (rotation skew) | Fresh certs fail verification → 502s. Prevented by the overlap invariant (new CA in the bundle BEFORE signing with it) + the convergence interlock. CP hot-reloads the CA so rotation needs no restart. |
+| Clock skew: core clock behind the CP by > `EDGE_CLIENTCERT_SKEW` | A fresh cert is "not yet valid" at the core → handshake aborts → 502s, self-healing once skew elapses. The validator is the **core** clock. Mitigated by the NotBefore backdating (default 10m), an NTP-sync prerequisite, and a distinct notBefore/notAfter failure metric. |
+| First-boot issuance fails under `EDGE_DATAPLANE_MTLS=on` (CP down at startup) | **Fail-CLOSED on readiness:** edge stays not-ready (503), not routed to. Bounded background retry flips ready when the first cert lands. Readiness `= (serveAll || store.Loaded()) && clientCert.Loaded()` — serve-all does NOT bypass. CP HA recommended. |
+| CP readiness ("can sign") mistaken for system readiness ("core trusts the CA") | The edge cannot self-detect the core-doesn't-trust-me state and WILL go ready and serve 502s in the convergence window (core debounce + watch + etcd lag, worst-case seconds). The onboarding gate **REQUIRES** confirming `parapet_trust_source{mtls}` / the trust-bundle-hash includes the new CA before routing prod traffic; optionally an edge-side post-issuance re-encrypt probe before flipping ready. |
+| Provided-mode CA mounted without NameConstraints / clientAuth EKU | The CP validates: `IsCA` required; EKU must contain `clientAuth` (reject pure serverAuth / anyEKU); **warn loudly (or refuse behind a flag)** if `NameConstraints.PermittedURIDomains` is absent. The post-sign self-check still bounds the emitted leaf in both modes. |
+| Malformed / oversized-key / unsupported-alg CSR (DoS probe) | 16 KiB body cap (413); the **key-type/curve whitelist rejects (400) BEFORE `CheckSignature`** so an oversized-RSA verify-DoS is impossible. authz + reject precede any CA signing. |
+| Fleet-wide re-issue storm (rollout / drain / CP recovery) | Per-token rate limit does NOT help (N tokens). A **global signing concurrency cap** returns 429/503 + `Retry-After`; the edge honors it with backoff; the edge refresh loop adds **jitter** so a co-booted fleet doesn't stay phase-locked. |
+| `ClientCertStore.Update` gets an unparseable / mismatched chain | All-or-nothing: `tls.X509KeyPair(chain, heldKey)` failing keeps the PRIOR pair (never clears the pointer, never swaps a broken cert), logs + bumps a rejection metric. Never a silent half-rotated state. |
 | `GetConfigForClient` returns nil / omits `ClientAuth`/`GetCertificate` | Guarded: base config built non-nil before `Serve()`; callback returns last-good, never nil; startup self-test asserts the three properties. |
-| CP-issuance endpoint unreachable / CP down | Edge keeps its last-good in-memory client cert (**fail static**); core `:443` handshakes keep succeeding. Renewal retries with aggressive backoff as expiry nears. Only if the CP stays down PAST `NotAfter` does the handshake hard-502. Outage budget = `TTL` × renew-before-fraction. |
-| Leaked-but-not-yet-revoked token replayed to `/v1/edge-cert` | Mints a cert for ITS OWN SAN, cryptographically valid for the full TTL. Token revocation does NOT revoke it — **only deleting the registry entry** drops its SAN (re-checked per request → distrusted ~300 ms). Runbook: delete the registry entry. Bounded by short `EDGE_CLIENTCERT_TTL`. |
-| CP-issuance enabled with `EDGE_TRUST_REQUIRE_SAN=false` (CA-only) | **Refused — fail-closed.** CA-only trusts any chain to the edge CA with no per-request SAN check, so a leaked-token-minted cert would stay trusted for the full TTL. The CP refuses to issue and/or the core refuses CA-only; startup error names the conflict. |
-| Malformed / oversized-key / unsupported-alg CSR (DoS probe) | 16 KiB body cap (413) bounds bytes; the **key-type/curve whitelist rejects (400) BEFORE `CheckSignature`** so an oversized-RSA verify-DoS is impossible. `CheckSignature` is mandatory; an unsupported sig alg is a hard 400. authz + reject precede any CA signing. |
-| Fleet-wide re-issue storm (rollout / node drain / CP recovery) | Per-token rate limit does NOT help (N tokens). A **global signing concurrency cap** returns 429/503 + `Retry-After`; the edge honors it with backoff; the edge refresh loop adds **jitter** (unlike the public-cert loop) so a co-booted fleet does not stay phase-locked. |
-| CP signs with a CA the core's `ClientCAs` does not yet trust (rotation skew) | Freshly-issued certs fail verification at the core → 502s. Prevented by the overlap invariant: the new CA must be in the core's `ClientCAs` bundle (concatenated CAs allowed) BEFORE the CP signs with it; the old CA stays until the metric interlock confirms every edge re-issued. CP hot-reloads the CA so rotation needs no restart. |
-| Clock skew: core clock behind the CP by > `EDGE_CLIENTCERT_SKEW` | A fresh cert is "not yet valid" at the core → handshake aborts → 502s, self-healing once skew elapses. The validator is the **core** clock. Mitigated by the configurable NotBefore backdating (default 10m), a hard NTP-sync prerequisite between CP and core pods, and a distinct notBefore/notAfter handshake-failure metric. |
-| First-boot issuance fails under `EDGE_DATAPLANE_MTLS=on` (CP down at startup) | **Fail-CLOSED on readiness:** edge stays not-ready (503), is NOT routed to, does not serve-while-untrusted. Bounded background retry flips ready when the first cert lands. Readiness `= (serveAll || store.Loaded()) && clientCert.Loaded()` — serve-all does NOT bypass. Availability tradeoff documented; CP HA recommended. |
-| `ClientCertStore.Update` gets an unparseable / mismatched chain | All-or-nothing: `tls.X509KeyPair(chain, heldKey)` failing keeps the PRIOR complete pair (never clears the pointer, never swaps in a broken cert), logs + bumps a rejection metric. Never a silent half-rotated state. |
 
 ## Configuration
 
 | Variable | Where | Default | Meaning |
 |---|---|---|---|
-| `TRUST_PROXY` | core | `cloudflare` | **Unchanged.** Static CIDR list / `cloudflare`/`true`/`false`. Becomes the `cidrTrust` OR-branch. **Never add edge egress CIDRs here.** |
-| `EDGE_TRUST_SECRET` | core | `""` (feature **off**) | Name of the Secret in `POD_NAMESPACE` carrying `ca.crt` (edge CA PEM bundle). `edge-controlplane-tokens` (single-source) or a dedicated `parapet-edge-trust` (separation). Unset ⇒ mTLS disabled, identical to today. |
-| `EDGE_TRUST_REQUIRE_SAN` | core | `true` | Trust requires the verified leaf's URI SAN ∈ the live allow-set (enables per-edge revocation). When false (CA-only), any chain to the edge CA is trusted. **Incompatible with CP-issuance: the per-request SAN check is the ONLY bound on a cert minted from a leaked bearer token (token revocation does not revoke a minted cert). When the same edge CA backs issuance, the CP MUST refuse to issue and/or the core MUST refuse CA-only — fail-closed.** |
+| `TRUST_PROXY` | core | `cloudflare` | **Unchanged.** Static CIDR list / `cloudflare`/`true`/`false` → the `cidrTrust` OR-branch. **Never add edge egress CIDRs here.** |
+| `EDGE_TRUST_SECRET` | core | `""` (feature **off**) | Name of the Secret in `POD_NAMESPACE` carrying the edge CA **public** cert into `ClientCAs`. Set to `parapet-edge-ca` to single-source from the managed CA Secret. Reads key **`tls.crt`** first, `ca.crt` as fallback. MUST be the same namespace as the CP's CA Secret (= `POD_NAMESPACE` for both). Unset ⇒ mTLS disabled, identical to today. |
+| `EDGE_TRUST_REQUIRE_SAN` | core | `true` | Trust requires the verified leaf's URI SAN ∈ the live allow-set (enables per-edge revocation). **Incompatible with CP-issuance: the per-request SAN check is the ONLY bound on a cert minted from a leaked token. When the same edge CA backs issuance, the CP MUST refuse to issue and/or the core MUST refuse CA-only — fail-closed.** |
 | `EDGE_DATAPLANE_MTLS` | edge | `false` | Enable the CP-issued data-plane client cert (CSR → `POST /v1/edge-cert`, presented via `GetClientCertificate`). Off ⇒ anonymous re-encrypt, identical to today. Requires `EDGE_UPSTREAM_TLS=true` (loud error otherwise). When on, readiness is gated on the client cert (fail-closed). |
-| `EDGE_CLIENTCERT_KEY_TYPE` | edge | `ecdsa-p256` | Key type for the in-memory ephemeral keypair (the key that never leaves the edge). `ecdsa-p256`/`p384`/`ed25519` — matches the CP's accepted-key whitelist. RSA is not offered (bounds the CP's CSR-verify DoS surface). |
-| `EDGE_CA_CERT` | CP | `""` | PEM path to the edge CA certificate (its OWN Secret, not the tenant-cert Secret). The same CA the core loads as `ClientCAs`. Hot-reloaded. Unset ⇒ no signer ⇒ `POST /v1/edge-cert` 404 (feature off). |
-| `EDGE_CA_KEY` | CP | `""` | PEM path to the edge CA **private** key (direct mode). The new crown jewel living with the CP — its OWN tightly-RBAC'd Secret, never shipped. Hot-reloaded. A loud startup log warns the CP holds a fleet-minting key. Ideally NameConstrained. |
-| `EDGE_CA_MODE` | CP | `direct` | `direct` = in-process `x509.CreateCertificate` (no cert-manager — the Docker-friendly default). `cert-manager` = proxy a `CertificateRequest` (k8s-only; CA key stays in cert-manager; CRD dependency + async). Prefer `cert-manager` where present. |
-| `EDGE_CLIENTCERT_TTL` | CP | `1h` | Issued cert lifetime. Short — renewal is free over the loop — to bound a leaked-token-minted cert. Outage budget = `TTL` × renew-before-fraction; raise (e.g. 24–72h) if outage tolerance matters more than mint-window shrinkage (call out the tension). |
-| `EDGE_CLIENTCERT_SKEW` | CP | `10m` | NotBefore backdating slack. The cert is minted on the CP clock but **validated on the core clock** at the handshake. NTP sync between CP and core pods is a hard prerequisite. A distinct core-side notBefore/notAfter failure metric surfaces a skew regression. |
-| `EDGE_CLIENTCERT_RATE` | CP | `10/min` | Per-token issuance rate limit (429 over cap). A **global** signing concurrency cap (worker pool around `Signer.Sign`, 429/503 + `Retry-After`) is separate and necessary — the per-token limit does nothing against a fleet-wide restart storm. |
-| `EDGE_UPSTREAM_CLIENT_CERT` / `EDGE_UPSTREAM_CLIENT_KEY` | edge | `""` / `""` | **cert-manager / mounted-Secret (k8s-only) path**, superseded as the default by `EDGE_DATAPLANE_MTLS` + CP-issuance. PEM paths to a mounted client cert+key, live-reloaded from disk. Use for the k8s-edge mount case. |
+| `EDGE_CLIENTCERT_KEY_TYPE` | edge | `ecdsa-p256` | Key type for the in-memory ephemeral keypair (never leaves the edge). `ecdsa-p256`/`p384`/`ed25519` — matches the CP's accepted-key whitelist. RSA not offered (bounds the CP's CSR-verify DoS surface). |
+| `EDGE_CLIENTCERT_TTL` | CP | `1h` | Issued **leaf** cert lifetime. Short — renewal is free over the loop — to bound a leaked-token-minted cert. Outage budget = `TTL` × renew-before-fraction; raise (24–72h) if outage tolerance dominates (call out the tension). |
+| `EDGE_CLIENTCERT_SKEW` | CP | `10m` | NotBefore backdating slack. The cert is minted on the CP clock but **validated on the core clock**. NTP sync between CP and core is a hard prerequisite. |
+| `EDGE_CLIENTCERT_RATE` | CP | `10/min` | Per-token issuance rate limit (429). A **global** signing concurrency cap (429/503 + `Retry-After`) is separate and necessary — per-token does nothing against a fleet-wide restart storm. |
+| `EDGE_CA_CERT` / `EDGE_CA_KEY` | CP | `""` / `""` (⇒ managed mode) | **Provided mode:** PEM paths to a MOUNTED edge CA cert+key. Set ⇒ the CP uses them and does NOT generate/write the Secret; hot-reloaded from disk. Both-or-neither (hard config error if only one). Absent ⇒ **managed** mode (CP self-generates). Not cert-manager-specific. |
+| `EDGE_CA_SECRET` | CP | `parapet-edge-ca` | Name of the Secret in `POD_NAMESPACE` the CP adopts-or-generates the CA into (managed). Operator pre-creates it **empty** (with GitOps drift-exclusion). Keys `tls.crt`/`tls.key`; carries the `parapet.moonrhythm.io/edge-ca-generation` guard once populated. Read/written in `POD_NAMESPACE`, never `WATCH_NAMESPACE`. |
+| `EDGE_CA_TTL` | CP | `87600h` (10y) | Lifetime of a CP-**generated** edge CA cert (managed/generate path). Long-lived (the CA is the anchor; the short knob is the leaf TTL). Ignored in provided mode. *(Open: shorten to 1–2y unless convergence-gated rotation has shipped.)* |
+| `EDGE_CA_KEY_TYPE` | CP | `ecdsa-p384` | Key type for a CP-generated CA: `ecdsa-p384` (default) or `ed25519`. Ignored in provided mode. |
+| `POD_NAMESPACE` | CP | downward API `metadata.namespace` (**required in managed mode**) | The CP's own namespace; the CA Secret is read/written here (NOT `WATCH_NAMESPACE`). Empty in managed mode ⇒ fatal startup error. Must be added to `deploy/edge/controlplane.yaml` (the core already wires it). |
+| `WATCH_NAMESPACE` | CP | `""` (all namespaces) | Existing knob; documented here for its security weight. `""` = cluster-wide tenant-TLS read = highest blast radius. **Recommend pinning** to the namespace(s) holding tenant TLS Secrets. Distinct from `POD_NAMESPACE`; the CA read/write never uses it. |
+| `EDGE_UPSTREAM_CLIENT_CERT` / `_KEY` | edge | `""` / `""` | **Legacy mounted-cert (k8s-only) edge-side path**, superseded as the default by `EDGE_DATAPLANE_MTLS` + CP-issuance. PEM paths to a mounted client cert+key, live-reloaded from disk. An edge mount detail, not a CA mode. |
 | `EDGE_UPSTREAM_TLS` | edge | `false` | **Unchanged.** Must be `true` for mTLS trust. Selects the re-encrypt path. |
 | `EDGE_UPSTREAM_SNI` | edge | `""` | **Unchanged.** SNI/`ServerName` presented to the core on re-encrypt. |
 
-Metrics: `parapet_trust_source{mtls|cidr|none}` and `parapet_trust_reload_rejected_total`
-(core); `parapet_edge_clientcert_loaded` (0/1) and `parapet_edge_clientcert_not_after`
-(edge). Both planes also expose the registry generation/hash they last applied, so an
-operator can confirm convergence before declaring an edge trusted.
+Metrics: `parapet_trust_source{mtls|cidr|none}`, `parapet_trust_reload_rejected_total`
+(core); `parapet_edge_clientcert_loaded` (0/1), `parapet_edge_clientcert_not_after`
+(edge); `parapet_edge_ca_generated_total`, `parapet_edge_ca_signer_fingerprint`,
+`parapet_edge_ca_unexpected_empty_total` (CP). Both planes also expose the registry
+generation/hash they last applied, so an operator can confirm convergence before
+declaring an edge trusted.
 
 ## Onboarding flow (the payoff)
 
-1. **One-time:** create the dedicated edge CA. Under `EDGE_CA_MODE=direct`, put its
-   cert + key in their **own** RBAC-locked Secret for the CP (`EDGE_CA_CERT` /
-   `EDGE_CA_KEY`) and its cert in the core's trust Secret (`ca.crt`); under
-   `cert-manager`, create the `Issuer`. Roll the core and CP **once** to pick up the
-   new code. *This is the only restart, ever — never again per-edge.*
-2. **Per edge — grant a data-plane identity (one registry edit, no cert-manager).**
-   Add the edge's entry to `edge-controlplane-tokens` with an explicit `id` (its
-   SPIFFE identity opt-in). This single edit (a) authorizes its cert/WAF fetch, (b)
-   makes the CP **issue** its data-plane client cert on `POST /v1/edge-cert` over the
-   existing bearer channel — key generated in the edge's memory, never mounted, never
-   renewed by hand — and (c) adds its SAN `spiffe://…/edge/<id>` to the core's live
-   allow-set. *(k8s-only alternative: mint a cert-manager `Certificate`, mount the
-   Secret, set `EDGE_CA_MODE=cert-manager` + `EDGE_UPSTREAM_CLIENT_CERT`.)*
+1. **One-time, code-only:** deploy the dedicated `edge-controlplane` ServiceAccount +
+   its scoped Role/RoleBinding (`get,update` on `resourceNames: [parapet-edge-ca]`) +
+   the cluster-wide read rebind (when `WATCH_NAMESPACE=""`), pre-create the **empty**
+   `parapet-edge-ca` Secret (with GitOps drift-exclusion annotations), set
+   `POD_NAMESPACE` on the CP via the downward API, and roll the core + CP **once** to
+   pick up the new code. On first boot the CP **generates and persists** the edge CA
+   itself (managed mode) — **no openssl, no cert-manager, no out-of-band CA**. The core
+   points `EDGE_TRUST_SECRET=parapet-edge-ca` and reads the public cert from the same
+   Secret. *This is the only restart, ever — never again per-edge.* (Provided mode: skip
+   the generate — mount `EDGE_CA_CERT`/`EDGE_CA_KEY`; the CP needs no `get`/`update`.)
+2. **Per edge — grant a data-plane identity (one registry edit).** Add the edge's entry
+   to `edge-controlplane-tokens` with an explicit `id`. This single edit (a) authorizes
+   its cert/WAF fetch, (b) makes the CP **issue** its data-plane client cert on `POST
+   /v1/edge-cert` — key generated in the edge's memory, never mounted, never renewed by
+   hand — and (c) adds its SAN `spiffe://…/edge/<id>` to the core's live allow-set.
 3. **Configure the edge:** `EDGE_DATAPLANE_MTLS=true`, `EDGE_UPSTREAM_TLS=true`,
    `EDGE_UPSTREAM_ADDR` → core `:443`. For a Docker edge that's it — **no client-cert
-   file mounts**; its only input across all of this stays `EDGE_CP_TOKEN`.
-4. **Deploy.** The edge generates a keypair in memory, fetches its cert from the CP,
-   re-encrypts to `:443` presenting it; the core verifies the chain + SAN and
-   **immediately honors its `X-Forwarded-*`** — no `TRUST_PROXY` edit, no core
-   restart. Confirm via `parapet_trust_source{mtls}` and `parapet_edge_clientcert_loaded`.
+   file mounts**; its only input stays `EDGE_CP_TOKEN`.
+4. **Deploy + verify.** The edge generates a keypair in memory, fetches its cert, and
+   re-encrypts to `:443` presenting it. **Confirm `parapet_trust_source{mtls}` / the
+   trust-bundle-hash includes the CA before routing prod traffic** (the edge can't
+   self-detect the core-doesn't-trust-me window). No `TRUST_PROXY` edit, no core restart.
 5. **Revoke:** **delete the edge's registry entry** → its SAN leaves the allow-set →
-   distrusted within ~300 ms, even on live connections (deleting only the token does
-   NOT revoke an already-minted cert). For a leaked **CA** key, use the overlap
-   rotation runbook.
+   distrusted within ~300 ms (deleting only the token does NOT revoke an already-minted
+   cert). For a **leaked CA key**, SAN-drop does NOT help (a forged leaf rides a real
+   SAN) — the only fix is **CA rotation** (overlap runbook), gated on the convergence
+   metric.
 
 ## Phasing
 
-1. **Phase 1 — the primary mechanism (makes a bare Docker edge work, no cert-manager).**
-   Core: the per-request closure, `GetConfigForClient` hot-swap over a **separate**
-   atomic from the SNI cert table, the `EDGE_TRUST_SECRET` watch
-   (validate-then-swap, keep-last-good, alert-on-reject), `EDGE_TRUST_REQUIRE_SAN=true`
-   single-sourced, the unconditional `X-Forwarded-Country/-ASN` strip, the metrics.
-   **Plus CP-issuance:** `POST /v1/edge-cert`, `edgecp/signer.go` (zero-value template
-   + post-sign self-check + key-type whitelist), `Authz.Identity`, the **shared SAN
-   derivation package** imported by both binaries, `EDGE_DATAPLANE_MTLS` edge wiring
-   with atomic key+chain swap, jitter, fail-closed readiness, the global signing
-   concurrency cap. The cert-manager mount path
-   (`EDGE_CA_MODE=cert-manager` / `EDGE_UPSTREAM_CLIENT_CERT`) ships **alongside** as
-   the k8s-only alternative. `NetworkPolicy` locking core `:80`/`:443` to
-   edge/Cloudflare sources.
-2. **Phase 2 — stronger hardening.** Mutual auth of the hop (edge pins the core CA,
-   drop `InsecureSkipVerify`); CRL/OCSP via `tls.Config.VerifyConnection` if
-   revocation must beat TTL + SAN-drop; an HSM/KMS `Signer` interface so the raw edge
-   CA key need not sit in CP pod memory; real SPIRE SVID migration (the SAN naming
-   already aligns).
+1. **Phase 1 — the primary mechanism (a bare Docker edge works, no cert-manager).** Core:
+   the per-request closure, `GetConfigForClient` hot-swap over a **separate** atomic from
+   the SNI cert table, the `EDGE_TRUST_SECRET` watch (validate-then-swap, keep-last-good,
+   runtime-keep-last-good-on-delete, alert-on-reject), `EDGE_TRUST_REQUIRE_SAN=true`
+   single-sourced, the `X-Forwarded-Country/-ASN` strip, the metrics. CP-issuance: `POST
+   /v1/edge-cert`, `edgecp/signer.go` (zero-value template + post-sign self-check +
+   key-type whitelist + HSM/KMS seam interface), `Authz.Identity`, the **shared SAN
+   derivation package**, the global signing concurrency cap. **Managed-CA bootstrap:**
+   `edgecp.EnsureCA` (adopt-or-generate, ECDSA-P384, single-purpose, NameConstrained)
+   under the `resourceVersion`-CAS create-once over the pre-created empty Secret, the
+   **anti-regeneration guard**, the new `k8s.GetSecret`/`UpdateSecret` write path, the
+   CA-Secret **watch** keeping the signer hot-reloadable (`atomic.Pointer[*Signer]`), the
+   dedicated CP ServiceAccount + scoped Role + cluster-wide read rebind, `POD_NAMESPACE`
+   on the CP, the CP startup RBAC self-probe, and the CA metrics. **Provided** mode ships
+   alongside as the escape hatch. Edge: `EDGE_DATAPLANE_MTLS` wiring with atomic key+chain
+   swap, jitter, fail-closed readiness. `NetworkPolicy` locking core `:80`/`:443`.
+2. **Phase 2 — stronger hardening.** Mutual auth of the hop (edge pins the core CA, drop
+   `InsecureSkipVerify`); the CP-only-namespace CA-key-read isolation as a turnkey
+   manifest; **CA auto-rotation** (CP rotates at `NotAfter` × fraction) gated on the
+   cross-replica convergence metric; an **HSM/KMS `Signer`** so the raw CA key never sits
+   in pod memory; CRL/OCSP via `tls.Config.VerifyConnection` if revocation must beat TTL +
+   SAN-drop; real SPIRE SVID migration (the SAN naming already aligns).
 3. **Phase 3 — optional companion.** A `TRUST_PROXY_DYNAMIC=true` ConfigMap-of-CIDRs
-   OR-branch for callers that genuinely cannot present a client cert (a known
-   in-cluster plaintext `:80` caller) — same atomic + validate-then-swap discipline,
-   never panic on the watch path.
+   OR-branch for callers that genuinely cannot present a client cert — same atomic +
+   validate-then-swap discipline, never panic on the watch path.
 
 ## Alternatives considered
 
-- **CP mints key+cert and ships both (vs CSR-based).** Simpler on the edge (no
-  in-process keygen/CSR), and the only viable fallback if some edge runtime cannot do
-  x509 keygen. **Rejected as the default — strictly weaker:** it puts a *private key
-  on the wire*, re-introducing exactly the key-transits-the-channel exposure the cert
-  path otherwise avoids. The CSR form keeps the key edge-local (generated in memory;
-  only the public key + returned chain transit) for **no** added operator burden, and
-  the CP-decides-SAN property holds in both forms.
-- **Token-gated `TrustProxy` (HMAC-over-timestamp header).** A near-tie co-leader on
-  operational single-source-of-truth — which is why we **grafted** that strength (the
-  SAN allow-set comes from the same registry). Rejected as the *primary* mechanism on
-  security: the credential is a request **header** whose placement the attacker
-  controls; it is replayable for the skew window; the strip-before-upstream middleware
-  is order-fragile; HMAC verification is an O(N) CPU-amplification vector; and it adds
-  a clock-skew failure mode. mTLS has none of these.
+- **CP mints key+cert and ships both (vs CSR-based).** Simpler on the edge, the only
+  viable fallback if an edge runtime cannot do x509 keygen. **Rejected as default —
+  strictly weaker:** it puts a *private key on the wire*. The CSR form keeps the key
+  edge-local for no added operator burden.
+- **Token-gated `TrustProxy` (HMAC header).** A near-tie co-leader on operational
+  single-source-of-truth — we **grafted** that strength (the SAN allow-set from the same
+  registry). Rejected as primary on security: a replayable header credential,
+  order-fragile strip middleware, an O(N) HMAC CPU-amplification vector, and a clock-skew
+  failure mode. mTLS has none of these.
 - **Dynamic IP trust list (ConfigMap of CIDRs).** Lowest effort; we graft its
-  operator-asserted-trust principle and keep-last-good discipline. Rejected as primary:
-  it does **not raise the security bar** — anything sharing a trusted CIDR can spoof
-  XFF — and for NAT'd/dynamic edges the natural pattern widens the spoof surface. Kept
-  as the optional Phase 3 companion for the `:80` gap.
-- **SPIFFE/SPIRE workload identity (mTLS SVID).** Strongest in theory, operationally
-  disqualifying now: an out-of-cluster edge can't use in-cluster attestation, so it
-  needs SPIRE federation — a hard runtime dependency and a second rotating CA bundle
-  whose staleness breaks the data plane. We graft only its **URI-SAN naming** and
-  leave a Phase 2 migration path.
+  operator-asserted-trust principle and keep-last-good discipline. Rejected as primary: it
+  does **not raise the security bar** and widens the spoof surface for NAT'd edges. Kept as
+  the optional Phase 3 companion.
+- **SPIFFE/SPIRE workload identity.** Strongest in theory, operationally disqualifying now
+  (out-of-cluster attestation needs SPIRE federation + a second rotating CA bundle whose
+  staleness breaks the data plane). We graft only its **URI-SAN naming** and leave a Phase
+  2 migration path.
 - **CA-only mTLS (`EDGE_TRUST_REQUIRE_SAN=false`).** Supported for **non-issuance**
-  deployments (issuing the cert is the whole onboarding) but **forbidden in
-  combination with CP-issuance**: CA-only trusts any chain to the edge CA, so a cert
-  minted from a leaked token before revocation would stay trusted for the full TTL
-  with no per-request revocation lever — resurrecting exactly the split-brain
-  single-sourcing closes.
+  deployments but **forbidden with CP-issuance**: CA-only trusts any chain to the edge CA
+  with no per-request SAN check, so a cert minted from a leaked token would stay trusted
+  for the full TTL — resurrecting exactly the split-brain single-sourcing closes.
+- **cert-manager-issued CA / cert-manager-proxy issuance (removed).** An earlier draft
+  offered `EDGE_CA_MODE=cert-manager` (the CP proxies a `CertificateRequest`) and an
+  out-of-band cert-manager self-signed Issuer for the CA. **Removed:** it added a hard CRD
+  dependency, an async issuance round-trip, and an out-of-band CA-creation step that
+  defeats the zero-PKI goal for a bare Docker edge. The CP now self-manages the CA
+  (managed mode); operators with an existing PKI use **provided** mode (mounted CA, no
+  CRDs). cert-manager can still *populate* the mounted Secret, but the CP treats it as
+  opaque files — no `CertificateRequest`, no polling, no CRD.
 
 ## Open questions
 
-- **`EDGE_CLIENTCERT_TTL` default — the mint-window vs CP-outage-budget tension:** a
-  short TTL (1h) shrinks a leaked-token-minted cert's life but cuts the outage budget
-  (= `TTL` × renew-before-fraction) before an expired cert hard-502s the edge. Pin a
-  default that exceeds the operator's CP recovery SLO, or expose `TTL` + renew-before
-  as paired knobs with a guard that renew-before < `TTL` by a safe margin?
-- **`EDGE_CA_MODE=cert-manager` async issuance:** the CP proxies a `CertificateRequest`
-  and polls — what poll timeout / failure handling keeps `POST /v1/edge-cert`
-  responsive (503 + `Retry-After` and let the edge fail-static, or block up to a
-  bound)? Does it also need the global signing concurrency cap, or does cert-manager's
-  own queue suffice?
-- **HSM/KMS signer interface for direct mode:** should `Signer.Sign` be an interface so
-  the raw edge CA key need not sit in CP pod memory (the highest-severity blast
-  radius), and is a KMS round-trip per issuance acceptable against the
+- **Empty-stub feasibility:** do the target k8s versions reject a zero-length `tls.crt`
+  on a `kubernetes.io/tls` Secret CREATE? If yes, the pre-created stub must be type
+  `Opaque`. Confirm and pin one stub type.
+- **NameConstraints enforcement:** does `x509.Verify` actually enforce
+  `PermittedURIDomains` for a `spiffe://` leaf URI against `parapet.moonrhythm.io`? Add a
+  conformance test (reject `spiffe://evil.example/edge/x`, accept the legit form) **before**
+  counting NameConstraints as a security control — the stdlib's URI-SAN NameConstraint
+  support is underspecified.
+- **`EDGE_CA_TTL` default:** 10y maximizes single-theft value of a plaintext-Secret key.
+  Pin shorter (1–2y) until convergence-gated rotation ships, or keep 10y only contingent
+  on rotation being implementable? Tie the decision to whether etcd encryption-at-rest is
+  a hard prerequisite.
+- **CP-only namespace for the CA Secret:** ship the key-read-isolation manifest (core SA
+  cannot read `parapet-edge-ca`) as a Phase-1 option now, or defer? The core's SNI read is
+  namespace-wide by necessity, so co-tenancy concedes core-reads-the-key unless the CA
+  Secret moves namespaces.
+- **HSM/KMS `Signer`:** the interface lands in Phase 1; does the in-memory impl suffice
+  for first ship, and is a KMS round-trip per issuance acceptable against the
   fleet-restart-storm concurrency budget?
-- **Key reuse across a graceful restart:** should the edge re-use a surviving
-  in-memory key across a restart, or accept that every restart = one fresh
-  keygen+CSR+sign (given keys are never written to disk)? Is the per-restart signature
-  cost acceptable at fleet scale once the global cap + jitter are in place?
-- **Mutual auth of the hop:** should the edge verify the core's server cert (pin the
-  core CA, drop `InsecureSkipVerify` in `forward.go`)? Today only edge→core is
-  authenticated.
-- **Connection-age cap on `:443`:** what max lifetime balances draining stale-CA
-  connections (for CA-drop revocation) against handshake churn? The default
-  `IdleTimeout` 320 s lets a busy connection outlive a CA drop without an explicit cap.
-- **Multi-CA `ca.crt` parsing:** confirm `AppendCertsFromPEM` over a concatenated
-  bundle adds every valid block and that one malformed block doesn't silently drop the
-  good CAs — validate-then-swap must treat a partially-bad bundle as a **rejected**
-  reload.
+- **System-readiness gap:** add an edge-side post-issuance probe (test re-encrypt
+  handshake to the core before flipping ready), or accept the gap with the core-side
+  `parapet_trust_source{mtls}` / bundle-hash as a REQUIRED onboarding gate?
+- **Rotation single-writer mechanism:** ship Phase-1 rotation as a one-shot Job/subcommand,
+  or add leader election to the steady-state `replicas: 2`? The Secret-as-lock CAS
+  linearizes only create-once, not the 4-stage promote/trim.
+- **`EDGE_CLIENTCERT_TTL` vs CP-outage budget:** pin a default that exceeds the operator's
+  CP recovery SLO, or expose `TTL` + renew-before as paired knobs with a guard that
+  renew-before < `TTL` by a safe margin?
 
 ## Conformance / contract
 
 On acceptance, fold into [`SPEC.md`](SPEC.md): the trust predicate
 (`cidrTrust OR (verified-edge-CA-chain AND SAN ∈ allow-set)`), the new
-`POST /v1/edge-cert` endpoint (CSR in, chain out; CP-decided SAN; no key on the
-wire), the new env vars (`EDGE_TRUST_SECRET`, `EDGE_TRUST_REQUIRE_SAN`,
-`EDGE_DATAPLANE_MTLS`, `EDGE_CLIENTCERT_*`, `EDGE_CA_*`), the shared SAN-derivation
-package + its CP-SAN == core-allow-set conformance test, the `X-Forwarded-Country/-ASN`
-ingress strip, and the per-request order (trust evaluation precedes WAF/rate-limit,
-as today). The Rust implementation in [`rust/`](rust/) tracks the same contract or
-records a divergence.
+`POST /v1/edge-cert` endpoint (CSR in, chain out; CP-decided SAN; no key on the wire),
+the managed/provided CA model, the new env vars (`EDGE_TRUST_*`, `EDGE_DATAPLANE_MTLS`,
+`EDGE_CLIENTCERT_*`, `EDGE_CA_*`, CP `POD_NAMESPACE`/`WATCH_NAMESPACE`), the shared
+SAN-derivation package + its CP-SAN == core-allow-set conformance test, the
+NameConstraints-enforcement test, the `X-Forwarded-Country/-ASN` ingress strip, and the
+per-request order (trust evaluation precedes WAF/rate-limit). The Rust implementation in
+[`rust/`](rust/) tracks the same contract or records a divergence.
 
 [TLS SNI fallback memory]: the proxy serves a self-signed fallback on an SNI miss
 when the live cert table loses `GetCertificate`; the `GetConfigForClient` self-test


### PR DESCRIPTION
## What

Drafts **`EDGE-AUTOTRUST.md`** — a design for how the in-cluster **core** proxy comes to trust a newly-deployed **edge** proxy **automatically**, without an operator editing `TRUST_PROXY` and restarting the core. **Status: DRAFT / design-only — no code changes.**

## The problem

The core trusts the edge only via `TRUST_PROXY` (`cmd/parapet-ingress-controller/main.go:214-237`), read once at boot and frozen for the process. Adding/replacing an edge means **edit the env + restart the front-door pod**, and the CIDR model is brittle for out-of-cluster, NAT'd/autoscaling edges.

## The pivot

`parapet.TrustProxy` is a `Conditional = func(r *http.Request) bool` evaluated **per request**. A closure installed once can read an `atomic.Pointer` policy hot-swapped from a watched Secret — **no restart** — and it already sees `r.TLS`, so trust can be a cryptographic identity check instead of an IP match.

## Recommended mechanism: edge mTLS (client-cert-as-trust)

- Edge presents a client cert (from a dedicated single-purpose edge CA) on the re-encrypt hop; core's `:443` uses `VerifyClientCertIfGiven` + a `ClientCAs` pool from a watched Secret (hot-swapped via `GetConfigForClient`, kept separate from the SNI cert table).
- Trust = verified chain **AND** the leaf's SPIFFE-style URI SAN is in a live allow-set **single-sourced from the existing `edge-controlplane-tokens` registry** → onboarding/offboarding is one edit, both planes converge in ~300 ms, and a token delete = data-plane revoke.
- Coexists with `TRUST_PROXY: cloudflare` as a pure OR-branch; **fail-closed** (missing/garbage policy degrades edges to distrusted, never trusts an unknown source).

## Notes for reviewers

- **It was a near-tie.** A judge-panel design pass scored a **token-header (HMAC)** approach marginally higher on ops; mTLS won on security. The token approach is written up as the **documented fallback** — reopen that section if PKI overhead is unwanted.
- **A real existing gap surfaced:** `forwardGeoHeaders` (`main.go:329`) only *overwrites* `X-Forwarded-Country/-ASN` when a GeoIP DB is loaded, so a no-DB core forwards a **client-forged** value upstream. The spec proposes an unconditional ingress strip.
- On acceptance, the contract bits fold into `SPEC.md` and the architecture into `EDGE.md` (per `CLAUDE.md`). Open questions are listed at the end of the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)