### PR TITLE
chore: upgrade Go 1.26.3 → 1.26.4

### DIFF
--- a/.github/workflows/edge-e2e.yaml
+++ b/.github/workflows/edge-e2e.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
       - name: Install test deps (openssl, curl, python3, nc)
         run: |
           sudo apt-get update

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        go: ['1.26.3']
+        go: ['1.26.4']
     name: Go ${{ matrix.go }}
     steps:
     - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ fails on unformatted files. See the umbrella [`Makefile`](Makefile) for the
 combined `make test` (Go + Rust) target.
 
 ### Docker image
-- Builder: `golang:1.26.3-trixie` with `libbrotli-dev` (CGO enabled, `-tags=cbrotli`)
+- Builder: `golang:1.26.4-trixie` with `libbrotli-dev` (CGO enabled, `-tags=cbrotli`)
 - Runtime: `debian:trixie-slim` with `libbrotli1` and `ca-certificates`
 - Build args: `VERSION` (injected as `main.version`), `GOAMD64` (v3 default, v1 for compatibility image)
 
@@ -153,7 +153,7 @@ All path-filtered to `**/*.go` + `go.mod`/`go.sum` (plus `Dockerfile*`) so they 
 
 ```
 module github.com/moonrhythm/parapet-ingress-controller
-go 1.26.3
+go 1.26.4
 ```
 
 The module lives at the repo root, so `go install` targets are `…/parapet-ingress-controller/cmd/parapet-ingress-controller`. (The Rust implementation lives in `rust/`; the repo hosts two implementations of one behavior contract.) Key dependencies: `github.com/moonrhythm/parapet`, `k8s.io/client-go`, `go.opentelemetry.io`, `github.com/prometheus/client_golang`, `cloud.google.com/go/profiler`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.26.3-trixie AS build
+FROM golang:1.26.4-trixie AS build
 
 ARG VERSION
 ARG GOAMD64

--- a/Dockerfile.edge
+++ b/Dockerfile.edge
@@ -7,7 +7,7 @@
 # distroless/static. Build context is the repo root:
 #
 #     docker build -f Dockerfile.edge -t parapet-edge .
-FROM golang:1.26.3-trixie AS build
+FROM golang:1.26.4-trixie AS build
 
 ARG VERSION
 ARG GOAMD64

--- a/Dockerfile.edge-controlplane
+++ b/Dockerfile.edge-controlplane
@@ -5,7 +5,7 @@
 # over HTTPS REST. See EDGE.md. Build context is the repo root:
 #
 #     docker build -f Dockerfile.edge-controlplane -t parapet-edge-controlplane .
-FROM golang:1.26.3-trixie AS build
+FROM golang:1.26.4-trixie AS build
 
 ARG VERSION
 ARG GOAMD64

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moonrhythm/parapet-ingress-controller
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cloud.google.com/go/profiler v0.6.0


### PR DESCRIPTION
Bumps the toolchain to **Go 1.26.4** ([released 2026-06-02](https://go.dev/doc/devel/release)), a security release with fixes to `crypto/x509`, `mime`, and `net/textproto` (plus compiler/runtime/`go fix`/`crypto/fips140` bug fixes).

## Changes — every Go version pin
- `go.mod` `go` directive `1.26.3` → `1.26.4` (enforces the ≥1.26.4 toolchain floor)
- `Dockerfile`, `Dockerfile.edge`, `Dockerfile.edge-controlplane` builders → `golang:1.26.4-trixie`
- `.github/workflows/go-test.yaml` (matrix) + `edge-e2e.yaml` (`go-version`)
- `CLAUDE.md` doc references

Verified locally on go1.26.4: `go build/vet/test ./...` pass, `gofmt` clean; `git grep` finds no remaining `1.26.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)