### PR TITLE
feat: managed-CA bootstrap for edge auto-trust (CP self-generates the edge CA)

### DIFF
--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/moonrhythm/parapet-ingress-controller/edgecp"
 	"github.com/moonrhythm/parapet-ingress-controller/k8s"
 )
@@ -25,6 +27,18 @@ func envOr(key, def string) string {
 	return def
 }
 
+// k8sRW adapts the package-level k8s secret read/write funcs to edgecp.SecretRW for
+// the CA bootstrap (the only writer of the CA Secret).
+type k8sRW struct{}
+
+func (k8sRW) GetSecret(ctx context.Context, ns, name string) (*v1.Secret, error) {
+	return k8s.GetSecret(ctx, ns, name)
+}
+
+func (k8sRW) UpdateSecret(ctx context.Context, ns string, s *v1.Secret) (*v1.Secret, error) {
+	return k8s.UpdateSecret(ctx, ns, s)
+}
+
 func main() {
 	addr := envOr("CP_LISTEN", ":8443")
 	watchNamespace := os.Getenv("WATCH_NAMESPACE") // "" = all namespaces
@@ -34,8 +48,37 @@ func main() {
 	tokensJSON := os.Getenv("CP_TOKENS")           // {"<token>":["acme.com",...]} or {"<token>":{"id","domains","disabled"}}
 	tokensFile := os.Getenv("CP_TOKENS_FILE")      // alternative: path to that JSON
 	wafEnabled := os.Getenv("CP_WAF_ENABLED") == "true"
-	caCertPath := os.Getenv("EDGE_CA_CERT") // provided-mode edge CA cert (with EDGE_CA_KEY → enable issuance)
-	caKeyPath := os.Getenv("EDGE_CA_KEY")   // provided-mode edge CA private key
+	caCertPath := os.Getenv("EDGE_CA_CERT")                 // provided-mode edge CA cert (with EDGE_CA_KEY → enable issuance)
+	caKeyPath := os.Getenv("EDGE_CA_KEY")                   // provided-mode edge CA private key
+	caSecret := os.Getenv("EDGE_CA_SECRET")                 // managed-mode edge CA Secret in POD_NAMESPACE; "" + no provided files = issuance off
+	bootstrapCA := os.Getenv("EDGE_CA_BOOTSTRAP") == "true" // run-once: self-generate the CA into its Secret, then exit
+	caTTL := DefaultDuration("EDGE_CA_TTL", edgecp.DefaultCATTL)
+	clientCertTTL := DefaultDuration("EDGE_CLIENTCERT_TTL", edgecp.DefaultClientCertTTL)
+	clientCertSkew := DefaultDuration("EDGE_CLIENTCERT_SKEW", edgecp.DefaultClientCertSkew)
+
+	// Run-once CA bootstrap (a Job): adopt-or-generate the edge CA into its Secret
+	// (never regenerate a once-populated CA — the anti-regeneration guard), then
+	// exit. Needs neither tokens nor TLS; it never serves.
+	if bootstrapCA {
+		name := caSecret
+		if name == "" {
+			name = "parapet-edge-ca"
+		}
+		if podNamespace == "" {
+			slog.Error("EDGE_CA_BOOTSTRAP requires POD_NAMESPACE (the CA Secret's namespace)")
+			os.Exit(1)
+		}
+		if err := k8s.Init(); err != nil {
+			slog.Error("k8s init", "err", err)
+			os.Exit(1)
+		}
+		if _, _, err := edgecp.EnsureCA(context.Background(), k8sRW{}, podNamespace, name, caTTL); err != nil {
+			slog.Error("bootstrap edge CA", "err", err)
+			os.Exit(1)
+		}
+		slog.Info("edge CA bootstrapped/adopted", "secret", podNamespace+"/"+name)
+		os.Exit(0)
+	}
 
 	// TLS is on when both cert+key are set, off when both are empty (plaintext
 	// HTTP, for a trusted private network — tunnel / mesh / VPC peering where the
@@ -80,14 +123,16 @@ func main() {
 	server := edgecp.NewServer(store, authz)
 
 	// Data-plane client-cert issuance (POST /v1/edge-cert) + the tokenless trust
-	// bundle (GET /v1/trust-bundle). Provided mode: mount the edge CA cert+key.
-	// Both-or-neither (managed mode — a bootstrap Job that self-generates the CA —
-	// is a follow-on). Absent ⇒ /v1/edge-cert 404s, /v1/trust-bundle 503s.
+	// bundle (GET /v1/trust-bundle). Two ways to supply the edge CA:
+	//   provided — mount EDGE_CA_CERT/EDGE_CA_KEY (operator's PKI).
+	//   managed  — EDGE_CA_SECRET: load the CA the bootstrap Job generated+persisted.
+	// Neither ⇒ /v1/edge-cert 404s, /v1/trust-bundle 503s (issuance off).
 	if (caCertPath != "") != (caKeyPath != "") {
 		slog.Error("EDGE_CA_CERT and EDGE_CA_KEY must be set together")
 		os.Exit(1)
 	}
-	if caCertPath != "" {
+	switch {
+	case caCertPath != "":
 		certPEM, err := os.ReadFile(caCertPath)
 		if err != nil {
 			slog.Error("read EDGE_CA_CERT", "err", err)
@@ -98,9 +143,7 @@ func main() {
 			slog.Error("read EDGE_CA_KEY", "err", err)
 			os.Exit(1)
 		}
-		ttl := DefaultDuration("EDGE_CLIENTCERT_TTL", edgecp.DefaultClientCertTTL)
-		skew := DefaultDuration("EDGE_CLIENTCERT_SKEW", edgecp.DefaultClientCertSkew)
-		signer, warnings, err := edgecp.NewProvidedSigner(certPEM, keyPEM, ttl, skew)
+		signer, warnings, err := edgecp.NewProvidedSigner(certPEM, keyPEM, clientCertTTL, clientCertSkew)
 		if err != nil {
 			slog.Error("build edge CA signer", "err", err)
 			os.Exit(1)
@@ -110,7 +153,65 @@ func main() {
 		}
 		server = server.WithSigner(signer)
 		slog.Info("edge control plane: data-plane issuance enabled (provided CA)",
-			"ca_id", signer.CAID(), "leaf_ttl", ttl)
+			"ca_id", signer.CAID(), "leaf_ttl", clientCertTTL)
+
+	case caSecret != "":
+		if podNamespace == "" {
+			slog.Error("managed edge CA (EDGE_CA_SECRET) requires POD_NAMESPACE")
+			os.Exit(1)
+		}
+		// Install the signer from the CA Secret the bootstrap Job populated. If it
+		// isn't there yet (CP started before the Job), poll and install when it
+		// lands — so the CP self-heals without a restart.
+		installSigner := func() bool {
+			// Read via the namespace-wide list the CP already has (list/watch), so
+			// serving needs no extra `get` grant — only the bootstrap Job (its own
+			// scoped SA) writes the CA.
+			secs, err := k8s.GetSecrets(ctx, podNamespace)
+			if err != nil {
+				return false
+			}
+			var crt, key []byte
+			for i := range secs {
+				if secs[i].Name == caSecret {
+					crt, key = secs[i].Data["tls.crt"], secs[i].Data["tls.key"]
+					break
+				}
+			}
+			if len(crt) == 0 || len(key) == 0 {
+				return false
+			}
+			signer, warnings, err := edgecp.NewProvidedSigner(crt, key, clientCertTTL, clientCertSkew)
+			if err != nil {
+				slog.Error("managed edge CA signer", "err", err)
+				return false
+			}
+			for _, msg := range warnings {
+				slog.Warn("edge CA: " + msg)
+			}
+			server.SetSigner(signer)
+			slog.Info("edge control plane: data-plane issuance enabled (managed CA)",
+				"ca_id", signer.CAID(), "secret", podNamespace+"/"+caSecret, "leaf_ttl", clientCertTTL)
+			return true
+		}
+		if !installSigner() {
+			slog.Warn("edge CA not yet provisioned in " + podNamespace + "/" + caSecret +
+				" — run the bootstrap Job; data-plane issuance disabled until it lands")
+			go func() {
+				t := time.NewTicker(10 * time.Second)
+				defer t.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-t.C:
+						if installSigner() {
+							return
+						}
+					}
+				}
+			}()
+		}
 	}
 
 	// Phase 2/3: optionally distribute the WAF (GET /v1/waf): the global baseline

--- a/deploy/edge/README.md
+++ b/deploy/edge/README.md
@@ -45,18 +45,23 @@ Each edge's `EDGE_DOMAINS` and its token's allow-set should match its shard. The
 isolation (an edge only holds *its* domains' keys) only holds if edges are
 sharded by domain — see [`../../EDGE.md`](../../EDGE.md) "The tradeoff".
 
-## Edge auto-trust (CA-only mTLS, provided-CA mode)
+## Edge auto-trust (CA-only mTLS)
 
 Lets the in-cluster core trust a newly-deployed edge automatically — no
 `TRUST_PROXY` edit, no core restart. Full design: [`../../EDGE-AUTOTRUST.md`](../../EDGE-AUTOTRUST.md).
-This is the **provided-CA** path (managed-CA self-bootstrap is a follow-on).
 
-1. Create a **dedicated, single-purpose edge CA** (clientAuth-issuing; ideally
-   `NameConstraints` permitting only `spiffe://parapet.moonrhythm.io/edge/*`) as a
-   `kubernetes.io/tls` Secret `parapet-edge-ca`, and mount it on the **control
-   plane** (`EDGE_CA_CERT`/`EDGE_CA_KEY`, see `controlplane.yaml`). The CP then
-   signs short-lived edge client certs (`POST /v1/edge-cert`) and serves the public
-   CA in the tokenless `GET /v1/trust-bundle`.
+1. Supply the **edge CA** to the control plane, one of two ways:
+   - **Managed (recommended):** `kubectl apply -f ca-bootstrap.yaml` — a run-once
+     Job self-generates a dedicated, single-purpose, NameConstrained edge CA into
+     the `parapet-edge-ca` Secret (adopt-if-present, never regenerate), and set
+     `EDGE_CA_SECRET=parapet-edge-ca` on the CP (see `controlplane.yaml`). **No
+     cert-manager, no hand-mounted CA — a Docker edge needs only its token.**
+   - **Provided (existing PKI):** create the dedicated CA yourself (clientAuth-issuing;
+     ideally `NameConstraints` to `spiffe://parapet.moonrhythm.io/edge/*`) as the
+     `parapet-edge-ca` Secret and mount it on the CP (`EDGE_CA_CERT`/`EDGE_CA_KEY`).
+
+   Either way the CP signs short-lived edge client certs (`POST /v1/edge-cert`) and
+   serves the public CA in the tokenless `GET /v1/trust-bundle`.
 2. Give each edge a **data-plane identity** by adding an `id` to its registry
    entry: `{"<token>": {"id": "acme-edge-1", "domains": ["acme.com"]}}` (a bare
    array still works for cert/WAF fetch, but grants no identity, so no `/v1/edge-cert`).

--- a/deploy/edge/ca-bootstrap.yaml
+++ b/deploy/edge/ca-bootstrap.yaml
@@ -1,0 +1,104 @@
+# Managed-CA bootstrap for edge auto-trust (EDGE-AUTOTRUST.md).
+#
+# A run-once Job has the control-plane binary self-generate the edge CA and persist
+# it to the parapet-edge-ca Secret (adopt-if-present, NEVER regenerate). The serving
+# control plane then loads that CA (set EDGE_CA_SECRET=parapet-edge-ca on the CP
+# Deployment, see controlplane.yaml) and signs edge client certs + serves the trust
+# bundle. With this, a Docker edge needs only its token — no hand-mounted CA.
+#
+# Apply this BEFORE (or alongside) the control plane. The CP self-heals if it starts
+# first (it polls for the CA), but ordering the Job first avoids the cold-start gap.
+# Under Helm/Argo, make the Job a pre-install/pre-upgrade hook (annotations below).
+---
+# The CA Secret, pre-created EMPTY. RBAC can scope `update` to a named Secret but
+# NOT `create`, so the operator pre-creates the stub and the Job only updates it.
+# Opaque (not kubernetes.io/tls) because some clusters reject an empty tls.crt on a
+# kubernetes.io/tls create; our code reads the keys by name regardless of type.
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: parapet-edge-ca
+  namespace: parapet-ingress-controller
+  annotations:
+    # Do NOT let GitOps prune or re-blank the CP-populated CA — that would distrust
+    # the whole fleet. Argo: keep + ignore /data drift. (Flux: set a comparable
+    # field-manager / ignore policy.)
+    argocd.argoproj.io/sync-options: Prune=false
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+data: {} # populated once by the bootstrap Job (tls.crt + tls.key + a guard annotation)
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: edge-controlplane-bootstrap
+  namespace: parapet-ingress-controller
+---
+# Scoped write: get + update on ONLY the parapet-edge-ca Secret. No create, no
+# delete, no other secrets. (The serving CP reads the CA via its existing
+# namespace-wide secrets list/watch, so it needs no extra grant.)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: edge-controlplane-bootstrap
+  namespace: parapet-ingress-controller
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["parapet-edge-ca"]
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: edge-controlplane-bootstrap
+  namespace: parapet-ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: edge-controlplane-bootstrap
+subjects:
+  - kind: ServiceAccount
+    name: edge-controlplane-bootstrap
+    namespace: parapet-ingress-controller
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: edge-controlplane-bootstrap-ca
+  namespace: parapet-ingress-controller
+  # Helm: uncomment to run as a pre-install/pre-upgrade hook (ordered before the CP).
+  # annotations:
+  #   "helm.sh/hook": pre-install,pre-upgrade
+  #   "helm.sh/hook-weight": "-5"
+  #   "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  #   "argocd.argoproj.io/hook": PreSync
+spec:
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 600 # reap the finished Job so the next sync doesn't recreate a stale one
+  template:
+    metadata:
+      name: edge-controlplane-bootstrap-ca
+    spec:
+      serviceAccountName: edge-controlplane-bootstrap
+      restartPolicy: OnFailure
+      containers:
+        - name: bootstrap
+          # Same image as the control plane (the bootstrap mode is a flag on it).
+          image: gcr.io/moonrhythm-containers/parapet-ingress-controller:controlplane-latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: EDGE_CA_BOOTSTRAP
+              value: "true"
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # - name: EDGE_CA_SECRET     # default parapet-edge-ca
+            #   value: parapet-edge-ca
+            # - name: EDGE_CA_TTL        # generated edge CA lifetime (default ~2y)
+            #   value: 17520h
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi

--- a/deploy/edge/controlplane.yaml
+++ b/deploy/edge/controlplane.yaml
@@ -49,14 +49,24 @@ spec:
             #   {"<token>": ["acme.com", "*.acme.com"], ...}
             - name: CP_TOKENS_FILE
               value: /tokens/tokens.json
-            # --- Edge auto-trust: data-plane client-cert issuance (provided-CA mode) ---
-            # Mount a DEDICATED, single-purpose edge CA (clientAuth-issuing, ideally
-            # NameConstrained to spiffe://parapet.moonrhythm.io/edge/*). The CP then
-            # signs short-lived edge client certs (POST /v1/edge-cert) and serves the
-            # PUBLIC CA in the tokenless trust bundle (GET /v1/trust-bundle). Grant a
-            # data-plane identity per edge by adding an "id" to its registry entry:
+            # --- Edge auto-trust: data-plane client-cert issuance ---
+            # The CP signs short-lived edge client certs (POST /v1/edge-cert) and
+            # serves the PUBLIC edge CA in the tokenless trust bundle
+            # (GET /v1/trust-bundle). Grant a data-plane identity per edge by adding
+            # an "id" to its registry entry:
             #   {"<token>": {"id": "acme-edge-1", "domains": ["acme.com"]}}
-            # Then uncomment the edge-ca volume + mount below. See ../../EDGE-AUTOTRUST.md.
+            # See ../../EDGE-AUTOTRUST.md. Two ways to supply the edge CA:
+            #
+            # MANAGED (recommended): a run-once bootstrap Job self-generates the CA
+            # into the parapet-edge-ca Secret (apply ca-bootstrap.yaml). No mounted
+            # CA, no cert-manager — a Docker edge needs only its token. Uncomment:
+            # - name: EDGE_CA_SECRET
+            #   value: parapet-edge-ca
+            #
+            # PROVIDED (operator's own PKI): mount a DEDICATED, single-purpose edge
+            # CA (clientAuth-issuing, ideally NameConstrained to
+            # spiffe://parapet.moonrhythm.io/edge/*) and uncomment the edge-ca volume
+            # + mount below.
             # - name: EDGE_CA_CERT
             #   value: /edge-ca/tls.crt
             # - name: EDGE_CA_KEY

--- a/edgecp/ca.go
+++ b/edgecp/ca.go
@@ -1,0 +1,166 @@
+package edgecp
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// DefaultCATTL is the lifetime of a CP-generated edge CA. It is long-lived (the CA
+// is the trust anchor; the short knob is the leaf EDGE_CLIENTCERT_TTL), but bounded
+// well above the expected revoke-driven rotation interval.
+const DefaultCATTL = 2 * 365 * 24 * time.Hour // ~2 years
+
+// caGenerationAnnotation marks a CA Secret as populated by EnsureCA. Its presence
+// (with empty data) is the anti-regeneration tripwire: a populated CA that was
+// later blanked (GitOps prune, restored-empty stub, operator error) MUST NOT be
+// regenerated — that would mint a new CA and distrust the whole fleet.
+const caGenerationAnnotation = "parapet.moonrhythm.io/edge-ca-generation"
+
+// SecretRW is the minimal secret read/CAS-write surface EnsureCA needs. It is
+// satisfied by the k8s package (cluster backend = real resourceVersion CAS) and by
+// a fake in tests.
+type SecretRW interface {
+	GetSecret(ctx context.Context, namespace, name string) (*v1.Secret, error)
+	UpdateSecret(ctx context.Context, namespace string, secret *v1.Secret) (*v1.Secret, error)
+}
+
+// GenerateCA mints a dedicated, single-purpose edge CA: ECDSA P-384, IsCA with
+// MaxPathLen 0 (signs leaves only), KeyUsage CertSign|CRLSign, EKU clientAuth, and
+// NameConstrained to the SPIFFE trust domain so even a stolen CA key can only mint
+// edge clientAuth leaves under spiffe://<SANTrustDomain>/…. Returns (certPEM, keyPEM).
+func GenerateCA(ttl time.Duration) (certPEM, keyPEM []byte, err error) {
+	if ttl <= 0 {
+		ttl = DefaultCATTL
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ca keygen: %w", err)
+	}
+	sn, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, fmt.Errorf("ca serial: %w", err)
+	}
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber:          sn,
+		Subject:               pkix.Name{CommonName: "parapet-edge-ca"},
+		NotBefore:             now.Add(-DefaultClientCertSkew),
+		NotAfter:              now.Add(ttl),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        true,
+		PermittedURIDomains:   []string{SANTrustDomain},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ca sign: %w", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ca key marshal: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}), nil
+}
+
+// EnsureCA is the run-once bootstrap: adopt the CA from the pre-created Secret if
+// present, else generate it once and persist it. It NEVER regenerates a CA that was
+// once populated (the anti-regeneration guard). The Secret is the lock: a
+// resourceVersion CAS linearizes concurrent bootstrappers (a Job is not a
+// guaranteed single writer), so on a Conflict the loser re-reads and adopts the
+// winner's CA. Returns the adopted-or-generated (certPEM, keyPEM).
+//
+// Cases on the fetched Secret:
+//   - populated (tls.crt+tls.key parse to a CA keypair) → ADOPT.
+//   - present-but-unparseable, or empty-with-the-guard-annotation → HARD ANOMALY,
+//     error (never regenerate; a populated CA was corrupted/blanked).
+//   - virgin empty stub (no guard annotation) → generate + CAS write.
+//   - NotFound → fatal config error (the operator must pre-create the empty stub;
+//     no fallback to a broad namespace `create` grant).
+func EnsureCA(ctx context.Context, rw SecretRW, namespace, name string, ttl time.Duration) (certPEM, keyPEM []byte, err error) {
+	const maxAttempts = 5
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		sec, err := rw.GetSecret(ctx, namespace, name)
+		if apierrors.IsNotFound(err) {
+			return nil, nil, fmt.Errorf("edge CA secret %s/%s not found — pre-create the empty stub (RBAC scopes update, not create)", namespace, name)
+		}
+		if err != nil {
+			return nil, nil, fmt.Errorf("get edge CA secret: %w", err)
+		}
+
+		crt := sec.Data["tls.crt"]
+		key := sec.Data["tls.key"]
+		_, hasGuard := sec.Annotations[caGenerationAnnotation]
+
+		if len(crt) > 0 || len(key) > 0 {
+			// Data present → must be a valid CA keypair to adopt; otherwise it is a
+			// corrupted/half-written CA and we refuse to regenerate over it.
+			if validCAKeypair(crt, key) {
+				return crt, key, nil
+			}
+			return nil, nil, fmt.Errorf("edge CA secret %s/%s has unparseable/mismatched material — refusing to regenerate; investigate or restore", namespace, name)
+		}
+		// Data empty.
+		if hasGuard {
+			return nil, nil, fmt.Errorf("edge CA secret %s/%s has the generation guard but EMPTY data — a populated CA was blanked; refusing to regenerate (would distrust the fleet). Restore the CA or rotate deliberately", namespace, name)
+		}
+
+		// Virgin stub → generate once and CAS-write.
+		certPEM, keyPEM, err = GenerateCA(ttl)
+		if err != nil {
+			return nil, nil, err
+		}
+		id, err := caBundleID(certPEM)
+		if err != nil {
+			return nil, nil, err
+		}
+		if sec.Data == nil {
+			sec.Data = map[string][]byte{}
+		}
+		sec.Data["tls.crt"] = certPEM
+		sec.Data["tls.key"] = keyPEM
+		if sec.Annotations == nil {
+			sec.Annotations = map[string]string{}
+		}
+		sec.Annotations[caGenerationAnnotation] = id // deterministic fingerprint of the CA we wrote
+
+		if _, err := rw.UpdateSecret(ctx, namespace, sec); err != nil {
+			if apierrors.IsConflict(err) {
+				// Another bootstrapper won the CAS; re-read and adopt its CA.
+				continue
+			}
+			return nil, nil, fmt.Errorf("persist edge CA: %w", err)
+		}
+		return certPEM, keyPEM, nil
+	}
+	return nil, nil, fmt.Errorf("ensure edge CA: exhausted CAS retries for %s/%s", namespace, name)
+}
+
+// validCAKeypair reports whether (certPEM, keyPEM) parse as a matching CA keypair.
+func validCAKeypair(certPEM, keyPEM []byte) bool {
+	if len(certPEM) == 0 || len(keyPEM) == 0 {
+		return false
+	}
+	cert, err := parseCACert(certPEM)
+	if err != nil {
+		return false
+	}
+	key, err := parsePrivateKey(keyPEM)
+	if err != nil {
+		return false
+	}
+	return publicKeyMatches(cert.PublicKey, key.Public())
+}

--- a/edgecp/ca_test.go
+++ b/edgecp/ca_test.go
@@ -1,0 +1,170 @@
+package edgecp
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// fakeRW is an in-memory SecretRW with optional one-shot Update conflict (to
+// exercise the CAS loser-adopts path) and an update counter (to prove adopt is a
+// no-op write).
+type fakeRW struct {
+	mu           sync.Mutex
+	secrets      map[string]*v1.Secret
+	updateCalls  int
+	conflictNext bool
+	onConflict   func() // mutate state so the post-conflict re-GET adopts the winner
+}
+
+func (f *fakeRW) GetSecret(_ context.Context, ns, name string) (*v1.Secret, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	s, ok := f.secrets[ns+"/"+name]
+	if !ok {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, name)
+	}
+	return s.DeepCopy(), nil
+}
+
+func (f *fakeRW) UpdateSecret(_ context.Context, ns string, s *v1.Secret) (*v1.Secret, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.updateCalls++
+	if f.conflictNext {
+		f.conflictNext = false
+		if f.onConflict != nil {
+			f.onConflict()
+		}
+		return nil, apierrors.NewConflict(schema.GroupResource{Resource: "secrets"}, s.Name, fmt.Errorf("rv changed"))
+	}
+	f.secrets[ns+"/"+s.Name] = s.DeepCopy()
+	return s.DeepCopy(), nil
+}
+
+func emptyStub(ns, name string) *v1.Secret {
+	return &v1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name}, Data: map[string][]byte{}}
+}
+
+func TestGenerateCAShape(t *testing.T) {
+	certPEM, keyPEM := mustGenerateCA(t)
+	block, _ := pem.Decode(certPEM)
+	ca, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ca.IsCA || !ca.MaxPathLenZero {
+		t.Error("want IsCA + MaxPathLen 0")
+	}
+	if ca.KeyUsage&x509.KeyUsageCertSign == 0 {
+		t.Error("want KeyUsageCertSign")
+	}
+	if len(ca.PermittedURIDomains) != 1 || ca.PermittedURIDomains[0] != SANTrustDomain {
+		t.Errorf("want NameConstraints PermittedURIDomains=[%s], got %v", SANTrustDomain, ca.PermittedURIDomains)
+	}
+	// A generated CA must pass provided-mode validation with NO warnings.
+	if _, warnings, err := NewProvidedSigner(certPEM, keyPEM, time.Hour, time.Minute); err != nil || len(warnings) != 0 {
+		t.Errorf("generated CA should validate cleanly: err=%v warnings=%v", err, warnings)
+	}
+}
+
+func TestEnsureCAGeneratesIntoVirginStub(t *testing.T) {
+	f := &fakeRW{secrets: map[string]*v1.Secret{"ns/parapet-edge-ca": emptyStub("ns", "parapet-edge-ca")}}
+	certPEM, keyPEM, err := EnsureCA(context.Background(), f, "ns", "parapet-edge-ca", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !validCAKeypair(certPEM, keyPEM) {
+		t.Fatal("EnsureCA returned an invalid CA keypair")
+	}
+	// The stub is now populated with the keypair AND the guard annotation.
+	s := f.secrets["ns/parapet-edge-ca"]
+	if len(s.Data["tls.crt"]) == 0 || len(s.Data["tls.key"]) == 0 {
+		t.Error("stub not populated")
+	}
+	if _, ok := s.Annotations[caGenerationAnnotation]; !ok {
+		t.Error("missing anti-regeneration guard annotation")
+	}
+}
+
+func TestEnsureCAAdoptsAndDoesNotRewrite(t *testing.T) {
+	certPEM, keyPEM := mustGenerateCA(t)
+	stub := emptyStub("ns", "parapet-edge-ca")
+	stub.Data["tls.crt"] = certPEM
+	stub.Data["tls.key"] = keyPEM
+	stub.Annotations = map[string]string{caGenerationAnnotation: "x"}
+	f := &fakeRW{secrets: map[string]*v1.Secret{"ns/parapet-edge-ca": stub}}
+
+	gotCert, _, err := EnsureCA(context.Background(), f, "ns", "parapet-edge-ca", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotCert) != string(certPEM) {
+		t.Error("adopt must return the EXISTING CA, not a fresh one")
+	}
+	if f.updateCalls != 0 {
+		t.Errorf("adopt must not write the Secret, got %d updates", f.updateCalls)
+	}
+}
+
+func TestEnsureCANeverRegeneratesABlankedCA(t *testing.T) {
+	// Guard annotation present but data blanked = a populated CA was wiped. Must
+	// NOT regenerate (that would distrust the whole fleet).
+	stub := emptyStub("ns", "parapet-edge-ca")
+	stub.Annotations = map[string]string{caGenerationAnnotation: "deadbeef"}
+	f := &fakeRW{secrets: map[string]*v1.Secret{"ns/parapet-edge-ca": stub}}
+	if _, _, err := EnsureCA(context.Background(), f, "ns", "parapet-edge-ca", time.Hour); err == nil {
+		t.Fatal("a guarded-but-empty CA secret must be a hard error, not a regenerate")
+	}
+	if f.updateCalls != 0 {
+		t.Error("must not write on the anomaly path")
+	}
+}
+
+func TestEnsureCAFatalOnMissingStub(t *testing.T) {
+	f := &fakeRW{secrets: map[string]*v1.Secret{}}
+	if _, _, err := EnsureCA(context.Background(), f, "ns", "parapet-edge-ca", time.Hour); err == nil {
+		t.Fatal("a missing CA stub must be a fatal config error (no broad create)")
+	}
+}
+
+func TestEnsureCAConflictAdoptsWinner(t *testing.T) {
+	winnerCert, winnerKey := mustGenerateCA(t)
+	f := &fakeRW{
+		secrets:      map[string]*v1.Secret{"ns/parapet-edge-ca": emptyStub("ns", "parapet-edge-ca")},
+		conflictNext: true,
+	}
+	// On the (simulated) CAS conflict, another bootstrapper has populated the CA.
+	f.onConflict = func() {
+		s := emptyStub("ns", "parapet-edge-ca")
+		s.Data["tls.crt"] = winnerCert
+		s.Data["tls.key"] = winnerKey
+		s.Annotations = map[string]string{caGenerationAnnotation: "winner"}
+		f.secrets["ns/parapet-edge-ca"] = s
+	}
+	gotCert, _, err := EnsureCA(context.Background(), f, "ns", "parapet-edge-ca", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotCert) != string(winnerCert) {
+		t.Error("on CAS conflict, the loser must adopt the winner's CA")
+	}
+}
+
+func mustGenerateCA(t *testing.T) (certPEM, keyPEM []byte) {
+	t.Helper()
+	c, k, err := GenerateCA(time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c, k
+}

--- a/k8s/cluster.go
+++ b/k8s/cluster.go
@@ -50,6 +50,14 @@ func (c *clusterClient) WatchSecrets(ctx context.Context, namespace string) (wat
 	return c.client.CoreV1().Secrets(namespace).Watch(ctx, metav1.ListOptions{})
 }
 
+func (c *clusterClient) GetSecret(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	return c.client.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func (c *clusterClient) UpdateSecret(ctx context.Context, namespace string, secret *v1.Secret) (*v1.Secret, error) {
+	return c.client.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
+}
+
 func (c *clusterClient) GetEndpoints(ctx context.Context, namespace string) ([]v1.Endpoints, error) {
 	list, err := c.client.CoreV1().Endpoints(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {

--- a/k8s/fs.go
+++ b/k8s/fs.go
@@ -14,8 +14,10 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apimachinery/pkg/watch"
 )
@@ -233,6 +235,36 @@ func (c *fsClient) GetSecrets(ctx context.Context, namespace string) ([]v1.Secre
 func (c *fsClient) WatchSecrets(ctx context.Context, namespace string) (watch.Interface, error) {
 	ch := make(chan watch.Event)
 	return watch.NewProxyWatcher(ch), nil
+}
+
+// GetSecret returns a copy of the named secret, or a NotFound error. The fs backend
+// is for local dev / tests; namespace is matched only when the fixture sets one.
+func (c *fsClient) GetSecret(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for i := range c.secrets {
+		s := &c.secrets[i]
+		if s.Name == name && (namespace == "" || s.Namespace == "" || s.Namespace == namespace) {
+			cp := s.DeepCopy()
+			return cp, nil
+		}
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, name)
+}
+
+// UpdateSecret replaces (or appends) the secret in memory. Best-effort and NON-CAS
+// (no resourceVersion semantics) — dev-only; the cluster backend is the real CAS.
+func (c *fsClient) UpdateSecret(ctx context.Context, namespace string, secret *v1.Secret) (*v1.Secret, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i := range c.secrets {
+		if c.secrets[i].Name == secret.Name {
+			c.secrets[i] = *secret.DeepCopy()
+			return secret.DeepCopy(), nil
+		}
+	}
+	c.secrets = append(c.secrets, *secret.DeepCopy())
+	return secret.DeepCopy(), nil
 }
 
 func (c *fsClient) GetEndpoints(ctx context.Context, namespace string) ([]v1.Endpoints, error) {

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -55,6 +55,8 @@ var client interface {
 	GetIngresses(ctx context.Context, namespace string) ([]networking.Ingress, error)
 	GetSecrets(ctx context.Context, namespace string) ([]v1.Secret, error)
 	WatchSecrets(ctx context.Context, namespace string) (watch.Interface, error)
+	GetSecret(ctx context.Context, namespace, name string) (*v1.Secret, error)
+	UpdateSecret(ctx context.Context, namespace string, secret *v1.Secret) (*v1.Secret, error)
 	GetEndpoints(ctx context.Context, namespace string) ([]v1.Endpoints, error)
 	WatchEndpoints(ctx context.Context, namespace string) (watch.Interface, error)
 	GetConfigMaps(ctx context.Context, namespace, labelSelector string) ([]v1.ConfigMap, error)
@@ -89,6 +91,18 @@ func GetSecrets(ctx context.Context, namespace string) ([]v1.Secret, error) {
 // WatchSecrets watches secrets for given namespace
 func WatchSecrets(ctx context.Context, namespace string) (watch.Interface, error) {
 	return client.WatchSecrets(ctx, namespace)
+}
+
+// GetSecret fetches one secret by namespace+name (preserving resourceVersion for
+// optimistic-concurrency updates). Used by the edge-CA bootstrap.
+func GetSecret(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	return client.GetSecret(ctx, namespace, name)
+}
+
+// UpdateSecret writes a secret back (a resourceVersion compare-and-swap on the
+// cluster backend). Used ONLY by the edge-CA bootstrap/rotation path.
+func UpdateSecret(ctx context.Context, namespace string, secret *v1.Secret) (*v1.Secret, error) {
+	return client.UpdateSecret(ctx, namespace, secret)
 }
 
 // GetEndpoints lists all endpoints


### PR DESCRIPTION
Builds on the merged provided-CA foundation (#94/#96). The control plane now **self-manages the edge CA** via a run-once bootstrap Job, so a **Docker edge needs only its token** — no operator-provisioned, hand-mounted CA, no cert-manager. This also lays the k8s-write / Job / CAS / anti-regen groundwork that revocation (CA rotation) will reuse.

## What's added (tested)
- **k8s client — the first write path:** `GetSecret` + `UpdateSecret` on the interface, the cluster backend (`CoreV1().Secrets` Get/Update — real `resourceVersion` CAS), and the fs backend (in-memory, non-CAS, dev-only). The core never uses these; they exist solely for the CA bootstrap.
- **`edgecp/ca.go`:**
  - `GenerateCA` — a dedicated, single-purpose edge CA (ECDSA P-384, `IsCA` + `MaxPathLen 0`, `KeyUsage CertSign|CRLSign`, EKU `clientAuth`, **NameConstrained** to `spiffe://parapet.moonrhythm.io/edge/*`).
  - `EnsureCA` — the run-once bootstrap: **adopt** if present, **generate** into a virgin stub, **never regenerate** a once-populated-then-blanked CA (anti-regeneration guard annotation), `resourceVersion`-**CAS** so concurrent Job pods linearize (loser re-reads + adopts), `NotFound` = **fatal** (stub must be pre-created — RBAC scopes `update`, not `create`).
- **`cmd/edge-controlplane`:** `EDGE_CA_BOOTSTRAP` one-shot mode (run `EnsureCA`, exit — no tokens/TLS); **managed serving** (`EDGE_CA_SECRET`) that reads the CA via the namespace `list` the CP already has (so serving needs **no extra RBAC**) and **self-heals** via a background poll if the CP started before the Job.
- **`deploy/edge/ca-bootstrap.yaml`:** the empty `parapet-edge-ca` stub (GitOps drift-exclusion), a scoped `get`/`update` Role + dedicated bootstrap SA, and the run-once Job (Helm pre-install / Argo PreSync hook annotations included). `controlplane.yaml` + README now lead with managed mode.

## Verification
- Unit tests (fake `SecretRW`): `GenerateCA` shape + clean provided-mode validation; `EnsureCA` generate / **adopt-no-rewrite** / **never-regenerate-blanked** / **fatal-missing-stub** / **CAS-conflict-adopts-winner**.
- Binary smoke (fs backend): bootstrap exits 0 on a stub; exits 1 with a clear "pre-create the stub" error when missing.
- `go build/vet/test ./...` green on go1.26.4, `gofmt` clean; `kubectl apply --dry-run=client` validates the manifest (all 5 objects).

## Scope
Managed-mode **rotation** (the overlap state machine + `revoke --edge`) and **force-re-mint** are the remaining follow-on — they reuse this Job + write path + CAS + anti-regen guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)