### PR TITLE
feat(edge): non-destructive edge CA rotation engine (overlap phase)

### DIFF
--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -52,6 +52,7 @@ func main() {
 	caKeyPath := os.Getenv("EDGE_CA_KEY")                   // provided-mode edge CA private key
 	caSecret := os.Getenv("EDGE_CA_SECRET")                 // managed-mode edge CA Secret in POD_NAMESPACE; "" + no provided files = issuance off
 	bootstrapCA := os.Getenv("EDGE_CA_BOOTSTRAP") == "true" // run-once: self-generate the CA into its Secret, then exit
+	rotateCA := os.Getenv("EDGE_CA_ROTATE") == "true"       // run-once: stage a NEW CA alongside OLD (overlap), then exit
 	caTTL := DefaultDuration("EDGE_CA_TTL", edgecp.DefaultCATTL)
 	clientCertTTL := DefaultDuration("EDGE_CLIENTCERT_TTL", edgecp.DefaultClientCertTTL)
 	clientCertSkew := DefaultDuration("EDGE_CLIENTCERT_SKEW", edgecp.DefaultClientCertSkew)
@@ -77,6 +78,34 @@ func main() {
 			os.Exit(1)
 		}
 		slog.Info("edge CA bootstrapped/adopted", "secret", podNamespace+"/"+name)
+		os.Exit(0)
+	}
+
+	// Run-once CA rotation (a Job): stage a NEW CA alongside OLD (tls.crt =
+	// OLD++NEW, NEW key in tls-new.key, phase=overlap, active=old), then exit. This
+	// is non-destructive — OLD stays trusted and active; the serving CPs hot-reload
+	// the wider bundle and the core trusts it with no change. Like bootstrap it
+	// neither serves nor needs tokens/TLS.
+	if rotateCA {
+		name := caSecret
+		if name == "" {
+			name = "parapet-edge-ca"
+		}
+		if podNamespace == "" {
+			slog.Error("EDGE_CA_ROTATE requires POD_NAMESPACE (the CA Secret's namespace)")
+			os.Exit(1)
+		}
+		if err := k8s.Init(); err != nil {
+			slog.Error("k8s init", "err", err)
+			os.Exit(1)
+		}
+		bundle, err := edgecp.RotateCA(context.Background(), k8sRW{}, podNamespace, name, caTTL)
+		if err != nil {
+			slog.Error("rotate edge CA", "err", err)
+			os.Exit(1)
+		}
+		slog.Info("edge CA rotated to overlap (OLD++NEW staged; OLD still active)",
+			"secret", podNamespace+"/"+name, "bundle_bytes", len(bundle))
 		os.Exit(0)
 	}
 
@@ -117,7 +146,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	reloader := edgecp.NewReloader(store, watchNamespace)
+	reloader := edgecp.NewReloader(store, watchNamespace, caSecret)
 	go reloader.Start(ctx)
 
 	server := edgecp.NewServer(store, authz)
@@ -151,67 +180,37 @@ func main() {
 		for _, msg := range warnings {
 			slog.Warn("edge CA: " + msg)
 		}
+		server.ExpectIssuance()
 		server = server.WithSigner(signer)
 		slog.Info("edge control plane: data-plane issuance enabled (provided CA)",
 			"ca_id", signer.CAID(), "leaf_ttl", clientCertTTL)
+		// NOTE: rotating a mounted (provided) CA requires remounting EDGE_CA_CERT/KEY
+		// and restarting this process — there is no fsnotify here. Managed mode (below)
+		// hot-reloads via the CA-Secret watch.
 
 	case caSecret != "":
 		if podNamespace == "" {
 			slog.Error("managed edge CA (EDGE_CA_SECRET) requires POD_NAMESPACE")
 			os.Exit(1)
 		}
-		// Install the signer from the CA Secret the bootstrap Job populated. If it
-		// isn't there yet (CP started before the Job), poll and install when it
-		// lands — so the CP self-heals without a restart.
-		installSigner := func() bool {
-			// Read via the namespace-wide list the CP already has (list/watch), so
-			// serving needs no extra `get` grant — only the bootstrap Job (its own
-			// scoped SA) writes the CA.
-			secs, err := k8s.GetSecrets(ctx, podNamespace)
-			if err != nil {
-				return false
-			}
-			var crt, key []byte
-			for i := range secs {
-				if secs[i].Name == caSecret {
-					crt, key = secs[i].Data["tls.crt"], secs[i].Data["tls.key"]
-					break
-				}
-			}
-			if len(crt) == 0 || len(key) == 0 {
-				return false
-			}
-			signer, warnings, err := edgecp.NewProvidedSigner(crt, key, clientCertTTL, clientCertSkew)
-			if err != nil {
-				slog.Error("managed edge CA signer", "err", err)
-				return false
-			}
-			for _, msg := range warnings {
-				slog.Warn("edge CA: " + msg)
-			}
-			server.SetSigner(signer)
-			slog.Info("edge control plane: data-plane issuance enabled (managed CA)",
-				"ca_id", signer.CAID(), "secret", podNamespace+"/"+caSecret, "leaf_ttl", clientCertTTL)
-			return true
+		// Hot-reload the signer from the CA Secret the bootstrap/rotation Job writes.
+		// The reloader reads via the namespace-wide list the CP already watches (no
+		// extra `get` grant) and SetSigner's on every ca_id change — so a rotation's
+		// OLD++NEW write (or a not-yet-provisioned CA landing later) propagates with
+		// no restart.
+		server.ExpectIssuance()
+		signerReloader := edgecp.NewSignerReloader(server, podNamespace, caSecret, clientCertTTL, clientCertSkew)
+		if err := signerReloader.LoadOnce(ctx); err != nil {
+			slog.Error("edgecp: initial edge CA signer load failed", "err", err)
 		}
-		if !installSigner() {
+		if server.SignerLoaded() {
+			slog.Info("edge control plane: data-plane issuance enabled (managed CA)",
+				"ca_id", server.CurrentCAID(), "secret", podNamespace+"/"+caSecret, "leaf_ttl", clientCertTTL)
+		} else {
 			slog.Warn("edge CA not yet provisioned in " + podNamespace + "/" + caSecret +
 				" — run the bootstrap Job; data-plane issuance disabled until it lands")
-			go func() {
-				t := time.NewTicker(10 * time.Second)
-				defer t.Stop()
-				for {
-					select {
-					case <-ctx.Done():
-						return
-					case <-t.C:
-						if installSigner() {
-							return
-						}
-					}
-				}
-			}()
 		}
+		go signerReloader.Watch(ctx)
 	}
 
 	// Phase 2/3: optionally distribute the WAF (GET /v1/waf): the global baseline

--- a/deploy/edge/controlplane.yaml
+++ b/deploy/edge/controlplane.yaml
@@ -113,7 +113,7 @@ spec:
             secretName: edge-controlplane-tokens # Opaque Secret with key tokens.json
         # - name: edge-ca
         #   secret:
-        #     secretName: parapet-edge-ca # kubernetes.io/tls Secret: the dedicated edge CA cert+key
+        #     secretName: parapet-edge-ca # Opaque Secret: the dedicated edge CA cert+key (see deploy/edge/ca-bootstrap.yaml)
 ---
 apiVersion: v1
 kind: Service

--- a/edgecp/ca.go
+++ b/edgecp/ca.go
@@ -27,6 +27,28 @@ const DefaultCATTL = 2 * 365 * 24 * time.Hour // ~2 years
 // regenerated — that would mint a new CA and distrust the whole fleet.
 const caGenerationAnnotation = "parapet.moonrhythm.io/edge-ca-generation"
 
+// Rotation annotations + the staged-key field. RotateCA stages a NEW CA alongside
+// OLD without dropping OLD or flipping the active key (the non-destructive overlap
+// phase). The destructive trim + active flip live in a later step.
+const (
+	// caRotationPhaseAnnotation records the rotation phase: "overlap" (OLD++NEW both
+	// trusted, OLD still active). Later phases ("converged"/"trimmed") are written by
+	// the destructive trim step, not here.
+	caRotationPhaseAnnotation = "parapet.moonrhythm.io/edge-ca-rotation-phase"
+	// caActiveAnnotation records which staged key signs new leaves: "old" (Data
+	// tls.key) or "new" (Data tls-new.key). RotateCA only ever writes "old".
+	caActiveAnnotation = "parapet.moonrhythm.io/edge-ca-active"
+
+	caPhaseOverlap = "overlap"
+	caActiveOld    = "old"
+	caActiveNew    = "new"
+
+	// caNewKeyField stages the NEW CA's private key during overlap. tls.key stays the
+	// OLD (active) key until the active flip; the serving reloader reads this field
+	// when caActiveAnnotation == "new".
+	caNewKeyField = "tls-new.key"
+)
+
 // SecretRW is the minimal secret read/CAS-write surface EnsureCA needs. It is
 // satisfied by the k8s package (cluster backend = real resourceVersion CAS) and by
 // a fake in tests.
@@ -150,6 +172,8 @@ func EnsureCA(ctx context.Context, rw SecretRW, namespace, name string, ttl time
 }
 
 // validCAKeypair reports whether (certPEM, keyPEM) parse as a matching CA keypair.
+// certPEM may be a bundle (OLD++NEW): the FIRST CERTIFICATE block must match keyPEM
+// (tls.key tracks the OLD/active cert, which is first in the bundle).
 func validCAKeypair(certPEM, keyPEM []byte) bool {
 	if len(certPEM) == 0 || len(keyPEM) == 0 {
 		return false
@@ -163,4 +187,126 @@ func validCAKeypair(certPEM, keyPEM []byte) bool {
 		return false
 	}
 	return publicKeyMatches(cert.PublicKey, key.Public())
+}
+
+// reencodeCertBundle parses every CERTIFICATE block (all-or-nothing) and re-encodes
+// them into a guaranteed well-formed PEM, returning the bundle and its cert count.
+// A non-CERTIFICATE block is skipped; an unparseable CERTIFICATE block is an error.
+func reencodeCertBundle(certPEM []byte) (bundle []byte, count int, err error) {
+	rest := certPEM
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+			return nil, 0, fmt.Errorf("parse cert in bundle: %w", err)
+		}
+		bundle = append(bundle, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: block.Bytes})...)
+		count++
+	}
+	return bundle, count, nil
+}
+
+// RotateCA performs the NON-DESTRUCTIVE half of a CA rotation: on a populated
+// single-CA Secret it generates a NEW CA in memory and CAS-writes tls.crt =
+// OLD++NEW, stages the NEW key in tls-new.key, and stamps phase=overlap /
+// active=old. It NEVER drops OLD and NEVER flips the active key — so trust only
+// widens (the core's strictPool already trusts every cert in the bundle while edges
+// keep presenting OLD-CA leaves). The destructive trim + active flip are a later
+// step. Returns the OLD++NEW bundle PEM.
+//
+// It is idempotent: a re-run on an already-overlap Secret (2 certs + a staged
+// tls-new.key) is a no-op that returns the existing bundle, so an Argo re-sync or a
+// Job retry never appends a third cert. Like EnsureCA it uses a resourceVersion CAS
+// loop, re-reading and re-evaluating idempotency on a Conflict. Cluster-backend only
+// (the fs backend's UpdateSecret is non-CAS).
+func RotateCA(ctx context.Context, rw SecretRW, namespace, name string, ttl time.Duration) (bundlePEM []byte, err error) {
+	const maxAttempts = 5
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		sec, err := rw.GetSecret(ctx, namespace, name)
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("edge CA secret %s/%s not found — rotation only runs on an existing CA", namespace, name)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("get edge CA secret: %w", err)
+		}
+
+		crt := sec.Data["tls.crt"]
+		key := sec.Data["tls.key"]
+		// Rotation requires an existing, valid CA (the active OLD pair). The first
+		// CERTIFICATE block must match tls.key.
+		if !validCAKeypair(crt, key) {
+			return nil, fmt.Errorf("edge CA secret %s/%s is not a populated/valid CA — bootstrap before rotating", namespace, name)
+		}
+
+		_, count, err := reencodeCertBundle(crt)
+		if err != nil {
+			return nil, fmt.Errorf("edge CA secret %s/%s has an unparseable bundle: %w", namespace, name, err)
+		}
+		phase := sec.Annotations[caRotationPhaseAnnotation]
+
+		// Idempotency: already in the overlap we'd produce (2 certs + staged NEW key).
+		if phase == caPhaseOverlap && count == 2 && len(sec.Data[caNewKeyField]) > 0 {
+			return append([]byte(nil), crt...), nil
+		}
+		// Any other multi-cert state is unexpected (a partial/foreign rotation); don't
+		// blindly append a third cert.
+		if count != 1 {
+			return nil, fmt.Errorf("edge CA secret %s/%s has %d certs (phase=%q) — not a clean single-CA to rotate; investigate", namespace, name, count, phase)
+		}
+
+		// Generate NEW and assemble OLD++NEW (both normalized, exactly 2 blocks).
+		oldBundle, _, err := reencodeCertBundle(crt)
+		if err != nil {
+			return nil, err
+		}
+		newCert, newKey, err := GenerateCA(ttl)
+		if err != nil {
+			return nil, err
+		}
+		newBundle := append(append([]byte(nil), oldBundle...), newCert...)
+		if _, n, err := reencodeCertBundle(newBundle); err != nil || n != 2 {
+			return nil, fmt.Errorf("assemble OLD++NEW bundle: want 2 certs, got %d (err=%v)", n, err)
+		}
+
+		id, err := caBundleID(newBundle)
+		if err != nil {
+			return nil, err
+		}
+		if sec.Data == nil {
+			sec.Data = map[string][]byte{}
+		}
+		sec.Data["tls.crt"] = newBundle
+		sec.Data[caNewKeyField] = newKey // tls.key stays OLD (active)
+		if sec.Annotations == nil {
+			sec.Annotations = map[string]string{}
+		}
+		sec.Annotations[caRotationPhaseAnnotation] = caPhaseOverlap
+		sec.Annotations[caActiveAnnotation] = caActiveOld
+		sec.Annotations[caGenerationAnnotation] = id // re-stamp (NEVER blank — keep the anti-regen guard)
+
+		if _, err := rw.UpdateSecret(ctx, namespace, sec); err != nil {
+			if apierrors.IsConflict(err) {
+				continue // re-read + re-evaluate idempotency (don't append a third cert)
+			}
+			return nil, fmt.Errorf("persist rotated edge CA: %w", err)
+		}
+
+		// Re-GET and assert the live Secret round-trips to exactly OLD++NEW before
+		// returning (mirror EnsureCA's re-verify discipline).
+		check, err := rw.GetSecret(ctx, namespace, name)
+		if err != nil {
+			return nil, fmt.Errorf("verify rotated edge CA: %w", err)
+		}
+		if _, n, err := reencodeCertBundle(check.Data["tls.crt"]); err != nil || n != 2 {
+			return nil, fmt.Errorf("post-rotation verify: want 2 certs, got %d (err=%v)", n, err)
+		}
+		return append([]byte(nil), newBundle...), nil
+	}
+	return nil, fmt.Errorf("rotate edge CA: exhausted CAS retries for %s/%s", namespace, name)
 }

--- a/edgecp/issuance.go
+++ b/edgecp/issuance.go
@@ -36,11 +36,12 @@ type edgeCertResponse struct {
 // Absent signer ⇒ 404 (issuance not configured). The private key never appears here
 // — the edge holds it; only chain_pem is returned.
 func (s *Server) handleEdgeCert(w http.ResponseWriter, r *http.Request) {
-	sg := s.signer.Load()
-	if sg == nil {
+	st := s.signerState.Load()
+	if st == nil {
 		http.Error(w, "issuance not configured", http.StatusNotFound)
 		return
 	}
+	sg := st.sg
 	token, ok := bearer(r)
 	if !ok || !s.authz.Known(token) {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
@@ -108,14 +109,15 @@ type trustBundleResponse struct {
 // blocks until the generation advances past <since> or watchTimeout elapses → 304.
 // Absent signer ⇒ 503 (not-yet-initialized; the core retries).
 func (s *Server) handleTrustBundle(w http.ResponseWriter, r *http.Request) {
-	if s.signer.Load() == nil {
+	st := s.signerState.Load()
+	if st == nil {
 		http.Error(w, "trust bundle not yet initialized", http.StatusServiceUnavailable)
 		return
 	}
 
 	if r.URL.Query().Get("watch") == "1" {
 		since, _ := strconv.ParseUint(r.URL.Query().Get("since"), 10, 64)
-		if s.gen.Load() <= since {
+		if st.gen <= since {
 			s.genMu.Lock()
 			notify := s.genNotify
 			s.genMu.Unlock()
@@ -125,15 +127,17 @@ func (s *Server) handleTrustBundle(w http.ResponseWriter, r *http.Request) {
 			case <-r.Context().Done():
 				return
 			}
+			// Re-load the snapshot: a SetSigner may have advanced it while we blocked.
+			st = s.signerState.Load()
 		}
 	}
 
-	sg := s.signer.Load()
-	if sg == nil {
+	if st == nil {
 		http.Error(w, "trust bundle not yet initialized", http.StatusServiceUnavailable)
 		return
 	}
-	gen := s.gen.Load()
+	sg := st.sg
+	gen := st.gen
 	resp := trustBundleResponse{
 		Generation: gen,
 		CAPEM:      string(sg.BundlePEM()),

--- a/edgecp/reload.go
+++ b/edgecp/reload.go
@@ -18,11 +18,15 @@ import (
 type Reloader struct {
 	store     *CertStore
 	namespace string
-	debounce  time.Duration
+	// skipSecret, if set, is the edge CA Secret's name: never load it as a tenant
+	// serving cert. The CA Secret is Opaque so the type filter already excludes it;
+	// this makes the SignerReloader its sole consumer (belt-and-suspenders).
+	skipSecret string
+	debounce   time.Duration
 }
 
-func NewReloader(store *CertStore, namespace string) *Reloader {
-	return &Reloader{store: store, namespace: namespace, debounce: 300 * time.Millisecond}
+func NewReloader(store *CertStore, namespace, skipSecret string) *Reloader {
+	return &Reloader{store: store, namespace: namespace, skipSecret: skipSecret, debounce: 300 * time.Millisecond}
 }
 
 // Start does the initial load and then watches Secrets, reloading on change.
@@ -94,6 +98,9 @@ func (r *Reloader) reload(ctx context.Context) error {
 	var pairs []PEMPair
 	for i := range secrets {
 		s := &secrets[i]
+		if r.skipSecret != "" && s.Name == r.skipSecret {
+			continue // the edge CA Secret is owned by the SignerReloader, not a tenant cert
+		}
 		if s.Type != v1.SecretTypeTLS {
 			continue
 		}

--- a/edgecp/rotate_test.go
+++ b/edgecp/rotate_test.go
@@ -1,0 +1,154 @@
+package edgecp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// populatedCAStub returns a fakeRW holding a single-CA Secret (the pre-rotation
+// state) plus the OLD cert/key for assertions.
+func populatedCAStub(t *testing.T) (f *fakeRW, oldCert, oldKey []byte) {
+	t.Helper()
+	oldCert, oldKey = mustGenerateCA(t)
+	stub := emptyStub("ns", "parapet-edge-ca")
+	stub.Data["tls.crt"] = oldCert
+	stub.Data["tls.key"] = oldKey
+	stub.Annotations = map[string]string{caGenerationAnnotation: "old-id"}
+	f = &fakeRW{secrets: map[string]*v1.Secret{"ns/parapet-edge-ca": stub}}
+	return f, oldCert, oldKey
+}
+
+func TestRotateCAAddsNewToBundle(t *testing.T) {
+	f, oldCert, oldKey := populatedCAStub(t)
+
+	bundle, err := RotateCA(context.Background(), f, "ns", "parapet-edge-ca", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, n, _ := reencodeCertBundle(bundle); n != 2 {
+		t.Errorf("returned bundle should hold 2 certs, got %d", n)
+	}
+
+	s := f.secrets["ns/parapet-edge-ca"]
+	if _, n, _ := reencodeCertBundle(s.Data["tls.crt"]); n != 2 {
+		t.Errorf("tls.crt should be OLD++NEW (2 certs), got %d", n)
+	}
+	// OLD stays first (so the active OLD key still matches block[0]) and tls.key is
+	// untouched; the NEW key is staged separately.
+	if fps := certBundleFPs(s.Data["tls.crt"]); len(fps) != 2 || fps[0] != fpOf(t, oldCert) {
+		t.Error("OLD cert must remain first in the bundle")
+	}
+	if string(s.Data["tls.key"]) != string(oldKey) {
+		t.Error("tls.key (active) must stay the OLD key during overlap")
+	}
+	if len(s.Data[caNewKeyField]) == 0 {
+		t.Error("NEW key must be staged in tls-new.key")
+	}
+	if s.Annotations[caRotationPhaseAnnotation] != caPhaseOverlap {
+		t.Errorf("phase = %q, want overlap", s.Annotations[caRotationPhaseAnnotation])
+	}
+	if s.Annotations[caActiveAnnotation] != caActiveOld {
+		t.Errorf("active = %q, want old", s.Annotations[caActiveAnnotation])
+	}
+	if s.Annotations[caGenerationAnnotation] == "" {
+		t.Error("anti-regeneration guard must remain stamped (never blanked)")
+	}
+}
+
+func TestRotateCAIdempotent(t *testing.T) {
+	f, _, _ := populatedCAStub(t)
+
+	bundle1, err := RotateCA(context.Background(), f, "ns", "parapet-edge-ca", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	callsAfterFirst := f.updateCalls
+
+	bundle2, err := RotateCA(context.Background(), f, "ns", "parapet-edge-ca", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No third cert, no write, same bundle.
+	if _, n, _ := reencodeCertBundle(f.secrets["ns/parapet-edge-ca"].Data["tls.crt"]); n != 2 {
+		t.Errorf("a re-run must not append a third cert, got %d", n)
+	}
+	if f.updateCalls != callsAfterFirst {
+		t.Errorf("idempotent re-run must not write, updateCalls %d → %d", callsAfterFirst, f.updateCalls)
+	}
+	if string(bundle1) != string(bundle2) {
+		t.Error("idempotent re-run must return the existing overlap bundle")
+	}
+}
+
+func TestRotateCAConflictReEvaluates(t *testing.T) {
+	f, oldCert, oldKey := populatedCAStub(t)
+	f.conflictNext = true
+	// On the (simulated) CAS conflict, another rotator already moved the Secret to
+	// overlap. The loser must adopt it (end at 2 certs), not append a third.
+	newCert2, newKey2 := mustGenerateCA(t)
+	f.onConflict = func() {
+		s := emptyStub("ns", "parapet-edge-ca")
+		s.Data["tls.crt"] = append(append([]byte(nil), oldCert...), newCert2...)
+		s.Data["tls.key"] = oldKey
+		s.Data[caNewKeyField] = newKey2
+		s.Annotations = map[string]string{
+			caRotationPhaseAnnotation: caPhaseOverlap,
+			caActiveAnnotation:        caActiveOld,
+			caGenerationAnnotation:    "winner",
+		}
+		f.secrets["ns/parapet-edge-ca"] = s
+	}
+
+	if _, err := RotateCA(context.Background(), f, "ns", "parapet-edge-ca", time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if _, n, _ := reencodeCertBundle(f.secrets["ns/parapet-edge-ca"].Data["tls.crt"]); n != 2 {
+		t.Errorf("after a conflict-adopt the bundle must be exactly 2 certs, got %d", n)
+	}
+}
+
+func TestRotateCARefusesUnpopulated(t *testing.T) {
+	f := &fakeRW{secrets: map[string]*v1.Secret{"ns/parapet-edge-ca": emptyStub("ns", "parapet-edge-ca")}}
+	if _, err := RotateCA(context.Background(), f, "ns", "parapet-edge-ca", time.Hour); err == nil {
+		t.Error("rotation must refuse a virgin/empty CA (only runs on an existing CA)")
+	}
+}
+
+func TestRotateCAFatalOnMissing(t *testing.T) {
+	f := &fakeRW{secrets: map[string]*v1.Secret{}}
+	if _, err := RotateCA(context.Background(), f, "ns", "parapet-edge-ca", time.Hour); err == nil {
+		t.Error("a missing CA Secret must be a fatal error (no rotation)")
+	}
+}
+
+func TestRotateCABundleRoundTrips(t *testing.T) {
+	f, _, _ := populatedCAStub(t)
+	if _, err := RotateCA(context.Background(), f, "ns", "parapet-edge-ca", time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	s := f.secrets["ns/parapet-edge-ca"]
+	crt := s.Data["tls.crt"]
+
+	// Both halves are usable: a signer on the OLD key and one on the NEW key each
+	// mint a leaf that verifies against the served OLD++NEW bundle.
+	oldSigner, _, err := NewProvidedSignerActive(crt, s.Data["tls.key"], "", time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newSigner, _, err := NewProvidedSignerActive(crt, s.Data[caNewKeyField], "", time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, sg := range map[string]*Signer{"old": oldSigner, "new": newSigner} {
+		chainPEM, _, _, err := sg.Sign(mkLeafKey(t).Public(), "edge-1")
+		if err != nil {
+			t.Fatalf("%s signer: %v", name, err)
+		}
+		if !verifiesUnder(t, chainPEM, crt) {
+			t.Errorf("%s signer: leaf must verify against the OLD++NEW bundle", name)
+		}
+	}
+}

--- a/edgecp/server.go
+++ b/edgecp/server.go
@@ -18,16 +18,27 @@ type Server struct {
 	authz *Authz
 	waf   *WafStore // optional (nil = WAF distribution disabled, /v1/waf → 404)
 
-	// signer mints data-plane leaves and provides the trust bundle. nil ⇒
-	// /v1/edge-cert 404s and /v1/trust-bundle 503s (not yet initialized). It is an
-	// atomic.Pointer so a future CA rotation can hot-swap it without restarting.
-	signer atomic.Pointer[Signer]
-	// gen is the trust-bundle generation, bumped whenever the signer (and thus the
-	// CA bundle) changes; genNotify is closed-and-replaced on each bump to wake
+	// signerState is the (signer, generation) snapshot, replaced WHOLESALE by
+	// SetSigner so a reader Loads both halves coherently (never a torn signer-from-A
+	// + gen-from-B). nil ⇒ /v1/edge-cert 404s and /v1/trust-bundle 503s (issuance
+	// not yet initialized). It is an atomic.Pointer so a CA rotation can hot-swap it
+	// without restarting. genNotify is closed-and-replaced on each bump to wake
 	// long-poll waiters. See handleTrustBundle.
-	gen       atomic.Uint64
-	genMu     sync.Mutex
-	genNotify chan struct{}
+	signerState atomic.Pointer[signerGen]
+	genMu       sync.Mutex
+	genNotify   chan struct{}
+
+	// issuanceExpected gates readiness: once set (issuance was configured), the
+	// readiness probe 503s until a signer has actually loaded, so an edge isn't
+	// pointed at a CP that can't yet issue/serve the trust bundle.
+	issuanceExpected atomic.Bool
+}
+
+// signerGen is an immutable (signer, generation) pair. SetSigner replaces the whole
+// value under genMu; readers Load it once and read both fields from the same value.
+type signerGen struct {
+	sg  *Signer
+	gen uint64
 }
 
 func NewServer(certs *CertStore, authz *Authz) *Server {
@@ -49,15 +60,37 @@ func (s *Server) WithSigner(sg *Signer) *Server {
 }
 
 // SetSigner installs (or hot-swaps, on rotation) the active Signer and bumps the
-// trust-bundle generation, waking any long-poll waiters. Safe to call concurrently.
+// trust-bundle generation, waking any long-poll waiters. The (signer, gen) pair is
+// stored as one immutable value so concurrent readers never tear it. Safe to call
+// concurrently.
 func (s *Server) SetSigner(sg *Signer) {
 	s.genMu.Lock()
 	defer s.genMu.Unlock()
-	s.signer.Store(sg)
-	s.gen.Add(1)
+	var prev uint64
+	if st := s.signerState.Load(); st != nil {
+		prev = st.gen
+	}
+	s.signerState.Store(&signerGen{sg: sg, gen: prev + 1})
 	close(s.genNotify)
 	s.genNotify = make(chan struct{})
 }
+
+// CurrentCAID returns the live signer's ca_id, or "" if no signer is loaded. The
+// serving reloader compares it to a rebuilt candidate to gate SetSigner (a no-op
+// re-list must not churn the generation).
+func (s *Server) CurrentCAID() string {
+	if st := s.signerState.Load(); st != nil && st.sg != nil {
+		return st.sg.CAID()
+	}
+	return ""
+}
+
+// SignerLoaded reports whether a signer has been installed (issuance is live).
+func (s *Server) SignerLoaded() bool { return s.signerState.Load() != nil }
+
+// ExpectIssuance marks that issuance was configured, so readiness gates on a loaded
+// signer. Call once at startup when an edge CA (managed or provided) is wired.
+func (s *Server) ExpectIssuance() { s.issuanceExpected.Store(true) }
 
 // Handler returns the mux. Mount behind HTTPS (the API ships private keys).
 func (s *Server) Handler() http.Handler {
@@ -76,9 +109,15 @@ func (s *Server) Handler() http.Handler {
 // list from the cluster succeeded), else 503 — so an edge isn't pointed at a
 // control plane that can't yet serve certs.
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Query().Get("ready") == "1" && !s.certs.Loaded() {
-		http.Error(w, "not ready", http.StatusServiceUnavailable)
-		return
+	if r.URL.Query().Get("ready") == "1" {
+		if !s.certs.Loaded() {
+			http.Error(w, "not ready: certs", http.StatusServiceUnavailable)
+			return
+		}
+		if s.issuanceExpected.Load() && !s.SignerLoaded() {
+			http.Error(w, "not ready: signer", http.StatusServiceUnavailable)
+			return
+		}
 	}
 	w.WriteHeader(http.StatusOK)
 }

--- a/edgecp/server_test.go
+++ b/edgecp/server_test.go
@@ -1,0 +1,105 @@
+package edgecp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestTrustBundleSnapshotCoherentUnderRace hammers SetSigner with two distinct CAs
+// while many concurrent GET /v1/trust-bundle requests read the bundle. The
+// (generation, ca_pem) pair must be coherent: a given generation must always map to
+// the same ca_id, and ca_id must always equal the fingerprint of the served ca_pem.
+// A torn read (separate signer + gen atomics) would let one generation report two
+// different bundles.
+func TestTrustBundleSnapshotCoherentUnderRace(t *testing.T) {
+	certA, keyA := mustGenerateCA(t)
+	certB, keyB := mustGenerateCA(t)
+	sgA, _, err := NewProvidedSigner(certA, keyA, time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sgB, _, err := NewProvidedSigner(certB, keyB, time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := NewServer(NewCertStore(), NewAuthz(nil))
+	srv.SetSigner(sgA)
+	h := srv.Handler()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writer: alternate the active signer as fast as it can.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if i%2 == 0 {
+				srv.SetSigner(sgA)
+			} else {
+				srv.SetSigner(sgB)
+			}
+		}
+	}()
+
+	var mu sync.Mutex
+	genToCAID := map[uint64]string{}
+	fail := ""
+
+	// Readers: pull the bundle and check coherence.
+	for r := 0; r < 8; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 400; i++ {
+				rec := httptest.NewRecorder()
+				h.ServeHTTP(rec, httptest.NewRequest("GET", "/v1/trust-bundle", nil))
+				if rec.Code != http.StatusOK {
+					continue
+				}
+				var resp trustBundleResponse
+				if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+					mu.Lock()
+					fail = "decode: " + err.Error()
+					mu.Unlock()
+					return
+				}
+				// ca_id must be the fingerprint of the served ca_pem.
+				gotID, err := caBundleID([]byte(resp.CAPEM))
+				if err != nil || gotID != resp.CAID {
+					mu.Lock()
+					fail = "ca_id does not match ca_pem (torn snapshot)"
+					mu.Unlock()
+					return
+				}
+				// A generation must never map to two different bundles.
+				mu.Lock()
+				if prev, ok := genToCAID[resp.Generation]; ok && prev != resp.CAID {
+					fail = "generation maps to two ca_ids (torn snapshot)"
+				} else {
+					genToCAID[resp.Generation] = resp.CAID
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+
+	// Let readers run, then stop the writer and drain.
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	if fail != "" {
+		t.Fatal(fail)
+	}
+}

--- a/edgecp/signer.go
+++ b/edgecp/signer.go
@@ -42,31 +42,89 @@ const (
 // the call site (the serving CP's CA-secret read-watch), so Sign/CAID/Bundle never
 // mutate.
 type Signer struct {
-	caCert *x509.Certificate
-	caKey  crypto.Signer
-	bundle []byte // the CA public cert(s), PEM (leaf-first if a chain); served as ca_pem
-	caID   string
-	ttl    time.Duration
-	skew   time.Duration
+	caCert     *x509.Certificate // the ACTIVE signing cert (its key signs leaves)
+	caKey      crypto.Signer     // the ACTIVE signing key (matches caCert)
+	bundle     []byte            // every CA public cert, PEM (OLD++NEW during overlap); served as ca_pem
+	bundlePool *x509.CertPool    // roots over `bundle`, for Sign()'s post-sign chain self-verify
+	caID       string
+	ttl        time.Duration
+	skew       time.Duration
 }
 
-// NewProvidedSigner builds a Signer from a mounted CA cert+key (provided mode:
-// EDGE_CA_CERT / EDGE_CA_KEY). It validates that the CA is usable for issuing
-// clientAuth leaves and returns a descriptive error otherwise. caExtraPEM, if
-// non-empty, is appended to the served bundle (an overlap OLD++NEW set during
-// rotation); a malformed extra block is rejected (all-or-nothing).
+// NewProvidedSigner builds a Signer from a single mounted CA cert+key (provided
+// mode: EDGE_CA_CERT / EDGE_CA_KEY, and the back-compat single-cert managed path).
+// It is NewProvidedSignerActive with no explicit active fingerprint — the active
+// cert is selected by matching the key's public key (unambiguous for a single CA).
 func NewProvidedSigner(certPEM, keyPEM []byte, ttl, skew time.Duration) (*Signer, []string, error) {
-	caCert, err := parseCACert(certPEM)
-	if err != nil {
-		return nil, nil, err
-	}
+	return NewProvidedSignerActive(certPEM, keyPEM, "", ttl, skew)
+}
+
+// NewProvidedSignerActive builds a Signer from a CA bundle that may hold more than
+// one CERTIFICATE block (an OLD++NEW overlap during rotation) plus the single
+// private key that signs new leaves. It selects the ACTIVE signing cert as the
+// block whose public key matches keyPEM; when activeFP != "" that block's
+// SHA-256 (hex) must also equal activeFP, pinning the active cert to the caller's
+// intent (the serving reloader derives it from the tls-active annotation). It
+// errors loudly on no match or an ambiguous match (two key-matching blocks) rather
+// than silently falling back to the first block.
+//
+// The whole bundle is served as ca_pem (BundlePEM) so the core trusts every CA in
+// it; only the active pair signs. A non-empty input whose CERTIFICATE blocks don't
+// all parse is rejected (all-or-nothing, mirroring the core's strictPool), so a
+// malformed concat fails here at the producer rather than being silently kept by a
+// downstream last-good guard.
+func NewProvidedSignerActive(bundlePEM, keyPEM []byte, activeFP string, ttl, skew time.Duration) (*Signer, []string, error) {
 	key, err := parsePrivateKey(keyPEM)
 	if err != nil {
 		return nil, nil, fmt.Errorf("parse CA key: %w", err)
 	}
-	if !publicKeyMatches(caCert.PublicKey, key.Public()) {
-		return nil, nil, fmt.Errorf("CA cert and key do not match")
+
+	// Walk every CERTIFICATE block: parse all-or-nothing, fingerprint each, and
+	// re-encode into a guaranteed well-formed served bundle.
+	var (
+		certs    []*x509.Certificate
+		fps      []string
+		rebuilt  []byte
+		keyPub   = key.Public()
+		activeIx = -1
+	)
+	rest := bundlePEM
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		c, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parse CA bundle cert: %w", err)
+		}
+		sum := sha256.Sum256(block.Bytes)
+		fp := hex.EncodeToString(sum[:])
+		if publicKeyMatches(c.PublicKey, keyPub) && (activeFP == "" || fp == activeFP) {
+			if activeIx >= 0 {
+				return nil, nil, fmt.Errorf("CA key matches more than one cert in the bundle (ambiguous active cert)")
+			}
+			activeIx = len(certs)
+		}
+		certs = append(certs, c)
+		fps = append(fps, fp)
+		rebuilt = append(rebuilt, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: block.Bytes})...)
 	}
+	if len(certs) == 0 {
+		return nil, nil, fmt.Errorf("CA bundle has no certificates")
+	}
+	if activeIx < 0 {
+		if activeFP != "" {
+			return nil, nil, fmt.Errorf("CA key matches no cert with fingerprint %s in the bundle", activeFP)
+		}
+		return nil, nil, fmt.Errorf("CA key matches no cert in the bundle")
+	}
+
+	caCert := certs[activeIx]
 	if ttl <= 0 {
 		ttl = DefaultClientCertTTL
 	}
@@ -74,17 +132,22 @@ func NewProvidedSigner(certPEM, keyPEM []byte, ttl, skew time.Duration) (*Signer
 		skew = DefaultClientCertSkew
 	}
 	warnings := validateEdgeCA(caCert)
-	id, err := caBundleID(certPEM)
+	id, err := caBundleID(rebuilt)
 	if err != nil {
 		return nil, nil, err
 	}
+	pool := x509.NewCertPool()
+	for _, c := range certs {
+		pool.AddCert(c)
+	}
 	return &Signer{
-		caCert: caCert,
-		caKey:  key,
-		bundle: append([]byte(nil), certPEM...),
-		caID:   id,
-		ttl:    ttl,
-		skew:   skew,
+		caCert:     caCert,
+		caKey:      key,
+		bundle:     rebuilt,
+		bundlePool: pool,
+		caID:       id,
+		ttl:        ttl,
+		skew:       skew,
 	}, warnings, nil
 }
 
@@ -143,6 +206,21 @@ func (s *Signer) Sign(pub crypto.PublicKey, id string) (chainPEM []byte, notAfte
 	}
 	if err = assertLeafShape(leaf, san); err != nil {
 		return nil, time.Time{}, "", fmt.Errorf("self-check: %w", err)
+	}
+	// Chain self-verify: the freshly-minted leaf MUST chain to the bundle we serve
+	// as ca_pem. A wrong active-cert/active-key pairing (the signing key's cert is
+	// not in the served bundle) produces a leaf the core would reject — fail closed
+	// here rather than shipping a dead cert.
+	pool := s.bundlePool
+	if pool == nil {
+		pool = x509.NewCertPool()
+		pool.AppendCertsFromPEM(s.bundle)
+	}
+	if _, err = leaf.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}); err != nil {
+		return nil, time.Time{}, "", fmt.Errorf("self-check verify: leaf does not chain to served bundle: %w", err)
 	}
 
 	var buf strings.Builder
@@ -285,6 +363,27 @@ func publicKeyMatches(certPub, keyPub crypto.PublicKey) bool {
 		return eq.Equal(keyPub)
 	}
 	return false
+}
+
+// certBundleFPs returns the SHA-256 (hex) of every CERTIFICATE block in order.
+// The serving reloader uses positional fingerprints (OLD first, NEW last) to pin
+// the active cert it hands NewProvidedSignerActive.
+func certBundleFPs(certPEM []byte) []string {
+	var fps []string
+	rest := certPEM
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		sum := sha256.Sum256(block.Bytes)
+		fps = append(fps, hex.EncodeToString(sum[:]))
+	}
+	return fps
 }
 
 // caBundleID computes the trust-bundle ca_id: a hex fingerprint over the sorted

--- a/edgecp/signer_test.go
+++ b/edgecp/signer_test.go
@@ -1,0 +1,173 @@
+package edgecp
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"testing"
+	"time"
+)
+
+// fpOf returns the SHA-256 (hex) of the FIRST CERTIFICATE block in certPEM — the
+// fingerprint NewProvidedSignerActive pins the active cert to.
+func fpOf(t *testing.T, certPEM []byte) string {
+	t.Helper()
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		t.Fatal("no PEM block")
+	}
+	sum := sha256.Sum256(block.Bytes)
+	return hex.EncodeToString(sum[:])
+}
+
+func mkLeafKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return k
+}
+
+// verifiesUnder reports whether the leaf chain verifies against a pool of exactly
+// the given CA cert(s) — the signed-under-which-key probe.
+func verifiesUnder(t *testing.T, chainPEM []byte, cas ...[]byte) bool {
+	t.Helper()
+	leaf, inter := parseChain(t, chainPEM)
+	roots := x509.NewCertPool()
+	for _, ca := range cas {
+		if !roots.AppendCertsFromPEM(ca) {
+			t.Fatal("append CA")
+		}
+	}
+	_, err := leaf.Verify(x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: inter,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	return err == nil
+}
+
+func TestSignerActiveKeySelectionNew(t *testing.T) {
+	oldCert, _ := mustGenerateCA(t)
+	newCert, newKey := mustGenerateCA(t)
+	bundle := append(append([]byte(nil), oldCert...), newCert...)
+
+	sg, warnings, err := NewProvidedSignerActive(bundle, newKey, fpOf(t, newCert), time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("clean CA should warn nothing, got %v", warnings)
+	}
+	// BundlePEM serves BOTH certs.
+	if _, n, _ := reencodeCertBundle(sg.BundlePEM()); n != 2 {
+		t.Errorf("bundle should hold 2 certs, got %d", n)
+	}
+
+	chainPEM, _, _, err := sg.Sign(mkLeafKey(t).Public(), "edge-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Signed under NEW: verifies against NEW alone, NOT against OLD alone.
+	if !verifiesUnder(t, chainPEM, newCert) {
+		t.Error("leaf must verify under the NEW (active) CA")
+	}
+	if verifiesUnder(t, chainPEM, oldCert) {
+		t.Error("leaf must NOT verify under OLD when NEW is active")
+	}
+}
+
+func TestSignerActiveKeySelectionOld(t *testing.T) {
+	oldCert, oldKey := mustGenerateCA(t)
+	newCert, _ := mustGenerateCA(t)
+	bundle := append(append([]byte(nil), oldCert...), newCert...)
+
+	sg, _, err := NewProvidedSignerActive(bundle, oldKey, fpOf(t, oldCert), time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chainPEM, _, _, err := sg.Sign(mkLeafKey(t).Public(), "edge-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !verifiesUnder(t, chainPEM, oldCert) {
+		t.Error("leaf must verify under the OLD (active) CA")
+	}
+	// And of course it verifies against the full OLD++NEW bundle the core trusts.
+	if !verifiesUnder(t, chainPEM, oldCert, newCert) {
+		t.Error("leaf must verify under the full bundle")
+	}
+}
+
+func TestSignerActiveKeyNoMatch(t *testing.T) {
+	oldCert, _ := mustGenerateCA(t)
+	newCert, _ := mustGenerateCA(t)
+	_, strayKey := mustGenerateCA(t) // a key for neither cert in the bundle
+	bundle := append(append([]byte(nil), oldCert...), newCert...)
+
+	if _, _, err := NewProvidedSignerActive(bundle, strayKey, "", time.Hour, time.Minute); err == nil {
+		t.Error("a key matching no cert in the bundle must error, not silently pick block[0]")
+	}
+}
+
+func TestSignerActiveKeyAmbiguous(t *testing.T) {
+	oldCert, oldKey := mustGenerateCA(t)
+	// The same cert twice → two key-matching blocks → ambiguous.
+	bundle := append(append([]byte(nil), oldCert...), oldCert...)
+	if _, _, err := NewProvidedSignerActive(bundle, oldKey, "", time.Hour, time.Minute); err == nil {
+		t.Error("a key matching more than one block must error (ambiguous active cert)")
+	}
+}
+
+func TestSignerSelfVerifyFailsClosed(t *testing.T) {
+	// Hand-build a broken Signer: active cert = OLD, but the signing key = NEW, and
+	// the served bundle is OLD-only (NEW not in it). The minted leaf is signed by NEW
+	// and cannot chain to the OLD-only bundle → Sign must fail closed.
+	oldCert, _ := mustGenerateCA(t)
+	_, newKey := mustGenerateCA(t)
+	caCert, err := parseCACert(oldCert)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newSigner, err := parsePrivateKey(newKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(oldCert)
+	sg := &Signer{
+		caCert:     caCert,
+		caKey:      newSigner,
+		bundle:     oldCert,
+		bundlePool: pool,
+		caID:       "broken",
+		ttl:        time.Hour,
+		skew:       time.Minute,
+	}
+	if _, _, _, err := sg.Sign(mkLeafKey(t).Public(), "edge-1"); err == nil {
+		t.Error("Sign must fail closed when the minted leaf can't chain to the served bundle")
+	}
+}
+
+func TestSignerBackCompatSingleCert(t *testing.T) {
+	certPEM, keyPEM := mustGenerateCA(t)
+	sg, warnings, err := NewProvidedSigner(certPEM, keyPEM, time.Hour, time.Minute)
+	if err != nil || len(warnings) != 0 {
+		t.Fatalf("single-cert path: err=%v warnings=%v", err, warnings)
+	}
+	if _, n, _ := reencodeCertBundle(sg.BundlePEM()); n != 1 {
+		t.Errorf("single-cert bundle should hold 1 cert, got %d", n)
+	}
+	chainPEM, _, _, err := sg.Sign(mkLeafKey(t).Public(), "edge-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !verifiesUnder(t, chainPEM, certPEM) {
+		t.Error("leaf must verify under the single CA")
+	}
+}

--- a/edgecp/signerreload.go
+++ b/edgecp/signerreload.go
@@ -1,0 +1,193 @@
+package edgecp
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/moonrhythm/parapet-ingress-controller/k8s"
+)
+
+// SignerReloader keeps the serving CP's active Signer in sync with the edge CA
+// Secret. It reads the CA via the namespace-wide list the CP already watches (no
+// extra `get` grant), rebuilds a Signer on every CA-Secret change, and SetSigner's
+// it — so a rotation Job's OLD++NEW write propagates to every replica without a
+// restart. Unlike the cert Reloader it is FILTERED to the CA Secret by name, and it
+// gates SetSigner on a ca_id change so an unrelated re-list never churns the
+// generation.
+//
+// Active-key selection is annotation-driven: caActiveAnnotation "old" (or absent) ⇒
+// tls.key signs and the OLD (first) cert is the active cert; "new" ⇒ tls-new.key
+// signs and the NEW (last) cert is active. The active cert is fingerprint-pinned so
+// a contradictory annotation/key combination fails closed (keep last-good) rather
+// than signing under the wrong cert. RotateCA only ever writes "old"; the "new"
+// branch is implemented now so the later active flip is not where it first runs.
+type SignerReloader struct {
+	server    *Server
+	namespace string
+	caSecret  string
+	ttl, skew time.Duration
+	debounce  time.Duration
+
+	// list reads Secrets in namespace; defaults to k8s.GetSecrets (a test seam).
+	list func(ctx context.Context, namespace string) ([]v1.Secret, error)
+}
+
+func NewSignerReloader(server *Server, namespace, caSecret string, ttl, skew time.Duration) *SignerReloader {
+	return &SignerReloader{
+		server:    server,
+		namespace: namespace,
+		caSecret:  caSecret,
+		ttl:       ttl,
+		skew:      skew,
+		debounce:  300 * time.Millisecond,
+		list:      k8s.GetSecrets,
+	}
+}
+
+// LoadOnce does a single synchronous reload (the initial install). It never errors
+// on an absent/empty CA — that just leaves the signer unloaded (readiness 503s)
+// until the bootstrap Job lands.
+func (r *SignerReloader) LoadOnce(ctx context.Context) error { return r.reload(ctx) }
+
+// Watch re-establishes a Secret watch and reloads (debounced) on every event that
+// touches the CA Secret. Blocks until ctx is cancelled; run it in a goroutine.
+func (r *SignerReloader) Watch(ctx context.Context) {
+	for ctx.Err() == nil {
+		w, err := k8s.WatchSecrets(ctx, r.namespace)
+		if err != nil {
+			slog.Error("edgecp: signer watch secrets failed; retrying", "err", err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Second):
+			}
+			continue
+		}
+		r.drain(ctx, w.ResultChan())
+		w.Stop()
+	}
+}
+
+// isCASecret reports whether a watch event concerns the CA Secret by name (so
+// unrelated tenant-cert events never trigger a signer rebuild).
+func (r *SignerReloader) isCASecret(ev watch.Event) bool {
+	s, ok := ev.Object.(*v1.Secret)
+	return ok && s.Name == r.caSecret
+}
+
+// drain coalesces a burst of CA-Secret events (debounced), ignoring events for any
+// other Secret, then reloads once. Returns when the channel closes or ctx is done.
+func (r *SignerReloader) drain(ctx context.Context, ch <-chan watch.Event) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			if !r.isCASecret(ev) {
+				continue
+			}
+			timer := time.NewTimer(r.debounce)
+		coalesce:
+			for {
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return
+				case ev2, ok := <-ch:
+					if !ok {
+						timer.Stop()
+						break coalesce
+					}
+					if !r.isCASecret(ev2) {
+						continue // ignore noise; keep counting down
+					}
+					if !timer.Stop() {
+						<-timer.C
+					}
+					timer.Reset(r.debounce)
+				case <-timer.C:
+					break coalesce
+				}
+			}
+			if err := r.reload(ctx); err != nil {
+				slog.Error("edgecp: signer reload failed", "err", err)
+			}
+		}
+	}
+}
+
+// reload lists Secrets, finds the CA Secret, builds a candidate Signer for the
+// annotation-selected active key, and SetSigner's it only when the ca_id changes.
+// Any failure (CA absent, empty key field, contradictory annotation, malformed
+// bundle) logs and KEEPS the last-good signer rather than dropping issuance.
+func (r *SignerReloader) reload(ctx context.Context) error {
+	secs, err := r.list(ctx, r.namespace)
+	if err != nil {
+		return err
+	}
+	var sec *v1.Secret
+	for i := range secs {
+		if secs[i].Name == r.caSecret {
+			sec = &secs[i]
+			break
+		}
+	}
+	if sec == nil {
+		slog.Warn("edgecp: edge CA secret not found yet", "secret", r.namespace+"/"+r.caSecret)
+		return nil
+	}
+	crt := sec.Data["tls.crt"]
+	if len(crt) == 0 {
+		slog.Warn("edgecp: edge CA secret has no tls.crt yet", "secret", r.namespace+"/"+r.caSecret)
+		return nil
+	}
+
+	// Select the active key field AND the active cert fingerprint as a coherent unit
+	// from the tls-active annotation. OLD is the first cert, NEW the last.
+	active := sec.Annotations[caActiveAnnotation]
+	fps := certBundleFPs(crt)
+	var keyPEM []byte
+	var activeFP string
+	switch active {
+	case caActiveNew:
+		keyPEM = sec.Data[caNewKeyField]
+		if len(fps) > 0 {
+			activeFP = fps[len(fps)-1]
+		}
+	default: // "old" or absent
+		keyPEM = sec.Data["tls.key"]
+		if len(fps) > 0 {
+			activeFP = fps[0]
+		}
+	}
+	if len(keyPEM) == 0 {
+		slog.Warn("edgecp: edge CA active key field empty; keeping last-good", "active", active, "secret", r.namespace+"/"+r.caSecret)
+		return nil
+	}
+
+	cand, warnings, err := NewProvidedSignerActive(crt, keyPEM, activeFP, r.ttl, r.skew)
+	if err != nil {
+		slog.Error("edgecp: build edge CA signer; keeping last-good", "err", err, "active", active)
+		return nil
+	}
+	for _, msg := range warnings {
+		slog.Warn("edge CA: " + msg)
+	}
+	if cand.CAID() == r.server.CurrentCAID() {
+		return nil // unchanged bundle; do not churn the generation
+	}
+	r.server.SetSigner(cand)
+	if active == "" {
+		active = caActiveOld
+	}
+	slog.Info("edgecp: edge CA signer installed",
+		"ca_id", cand.CAID(), "active", active, "certs", len(fps), "secret", r.namespace+"/"+r.caSecret)
+	return nil
+}

--- a/edgecp/signerreload_test.go
+++ b/edgecp/signerreload_test.go
@@ -1,0 +1,154 @@
+package edgecp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// testReloader builds a SignerReloader whose secret list is backed by *secs (so a
+// test can mutate the Secret between reloads to simulate a rotation).
+func testReloader(srv *Server, secs *[]v1.Secret) *SignerReloader {
+	r := NewSignerReloader(srv, "ns", "parapet-edge-ca", time.Hour, time.Minute)
+	r.list = func(_ context.Context, _ string) ([]v1.Secret, error) { return *secs, nil }
+	return r
+}
+
+func caSecretObj(data map[string][]byte, annotations map[string]string) v1.Secret {
+	return v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "parapet-edge-ca", Namespace: "ns", Annotations: annotations},
+		Data:       data,
+	}
+}
+
+// gen reads the current generation (0 if no signer). In-package test access.
+func srvGen(s *Server) uint64 {
+	if st := s.signerState.Load(); st != nil {
+		return st.gen
+	}
+	return 0
+}
+
+func TestSignerReloaderPicksUpRotation(t *testing.T) {
+	oldCert, oldKey := mustGenerateCA(t)
+	secs := []v1.Secret{caSecretObj(map[string][]byte{"tls.crt": oldCert, "tls.key": oldKey}, nil)}
+
+	srv := NewServer(NewCertStore(), NewAuthz(nil))
+	r := testReloader(srv, &secs)
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !srv.SignerLoaded() {
+		t.Fatal("signer should load from a single-CA secret")
+	}
+	gen1, caid1 := srvGen(srv), srv.CurrentCAID()
+
+	// Rotate: flip the Secret to OLD++NEW overlap.
+	newCert, newKey := mustGenerateCA(t)
+	secs[0].Data["tls.crt"] = append(append([]byte(nil), oldCert...), newCert...)
+	secs[0].Data[caNewKeyField] = newKey
+	secs[0].Annotations = map[string]string{caRotationPhaseAnnotation: caPhaseOverlap, caActiveAnnotation: caActiveOld}
+
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if srvGen(srv) <= gen1 {
+		t.Errorf("generation should advance on rotation, %d → %d", gen1, srvGen(srv))
+	}
+	if srv.CurrentCAID() == caid1 {
+		t.Error("ca_id should flip when the bundle widens to OLD++NEW")
+	}
+}
+
+func TestSignerReloaderNoOpReList(t *testing.T) {
+	oldCert, oldKey := mustGenerateCA(t)
+	secs := []v1.Secret{caSecretObj(map[string][]byte{"tls.crt": oldCert, "tls.key": oldKey}, nil)}
+
+	srv := NewServer(NewCertStore(), NewAuthz(nil))
+	r := testReloader(srv, &secs)
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	gen1 := srvGen(srv)
+
+	// Re-running on a byte-identical bundle must NOT churn the generation.
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if srvGen(srv) != gen1 {
+		t.Errorf("no-op re-list must not advance generation, %d → %d", gen1, srvGen(srv))
+	}
+}
+
+func TestSignerReloaderActiveNewBranch(t *testing.T) {
+	oldCert, oldKey := mustGenerateCA(t)
+	newCert, newKey := mustGenerateCA(t)
+	overlap := append(append([]byte(nil), oldCert...), newCert...)
+	secs := []v1.Secret{caSecretObj(
+		map[string][]byte{"tls.crt": overlap, "tls.key": oldKey, caNewKeyField: newKey},
+		map[string]string{caRotationPhaseAnnotation: caPhaseOverlap, caActiveAnnotation: caActiveNew},
+	)}
+
+	srv := NewServer(NewCertStore(), NewAuthz(nil))
+	r := testReloader(srv, &secs)
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !srv.SignerLoaded() {
+		t.Fatal("signer should load with active=new")
+	}
+	// The active signer signs under NEW (verifies against NEW alone, not OLD alone).
+	sg := srv.signerState.Load().sg
+	chainPEM, _, _, err := sg.Sign(mkLeafKey(t).Public(), "edge-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !verifiesUnder(t, chainPEM, newCert) {
+		t.Error("active=new must sign under the NEW CA")
+	}
+	if verifiesUnder(t, chainPEM, oldCert) {
+		t.Error("active=new must NOT sign under OLD")
+	}
+}
+
+func TestSignerReloaderContradictoryAnnotationKeepsLastGood(t *testing.T) {
+	oldCert, oldKey := mustGenerateCA(t)
+	secs := []v1.Secret{caSecretObj(map[string][]byte{"tls.crt": oldCert, "tls.key": oldKey}, nil)}
+
+	srv := NewServer(NewCertStore(), NewAuthz(nil))
+	r := testReloader(srv, &secs)
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	gen1, caid1 := srvGen(srv), srv.CurrentCAID()
+
+	// Contradiction: active=new with a staged key matching NEITHER cert in the
+	// overlap → the candidate Signer fails to build → keep last-good (no churn).
+	newCert, _ := mustGenerateCA(t)
+	_, strayKey := mustGenerateCA(t)
+	secs[0].Data["tls.crt"] = append(append([]byte(nil), oldCert...), newCert...)
+	secs[0].Data[caNewKeyField] = strayKey
+	secs[0].Annotations = map[string]string{caRotationPhaseAnnotation: caPhaseOverlap, caActiveAnnotation: caActiveNew}
+
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err) // reload itself doesn't error; it logs + keeps last-good
+	}
+	if srvGen(srv) != gen1 || srv.CurrentCAID() != caid1 {
+		t.Error("a contradictory annotation/key must keep the last-good signer (no generation change)")
+	}
+}
+
+func TestSignerReloaderAbsentSecretKeepsUnloaded(t *testing.T) {
+	secs := []v1.Secret{} // CA not provisioned yet
+	srv := NewServer(NewCertStore(), NewAuthz(nil))
+	r := testReloader(srv, &secs)
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if srv.SignerLoaded() {
+		t.Error("no signer should load when the CA secret is absent")
+	}
+}


### PR DESCRIPTION
**Sub-PR 1 of 5** for edge-proxy revocation (design: `EDGE-AUTOTRUST.md`). This is the *non-destructive rotation engine* — everything needed to stage a second edge CA and have the whole fleet (control planes + core) trust both, with **zero core changes**.

## Safety proof (why this is safe to ship alone)

This PR is **purely additive**. It NEVER writes `tls.crt = NEW-only` and NEVER flips `tls-active` to `new`:

- `RotateCA` only ever produces `tls.crt = OLD++NEW`, stages the NEW key separately in `tls-new.key`, and leaves `tls.key` (the active key) and `tls-active=old` untouched.
- The core's `trust.Manager.strictPool` already iterates **every** `CERTIFICATE` block in the bundle, so it trusts `OLD++NEW` the moment the wider bundle propagates — **no core code change**.
- Edges keep presenting OLD-CA leaves that still chain to OLD, which is still trusted.

So trust only ever **widens**. The destructive trim (`tls.crt = NEW-only`), the active-key flip, and the `revoke --edge` tool stay in the later sub-PRs — they are the only steps that can distrust an edge.

## What's in it

| Area | Change |
|---|---|
| `edgecp/signer.go` | `NewProvidedSignerActive` parses a multi-cert bundle, selects the **active** signing cert by public-key match (+ optional fingerprint pin), errors on no-match/ambiguous (never `block[0]`). `Sign()` chain-self-verifies the minted leaf against the served bundle → fails closed on a wrong cert/key pairing. `NewProvidedSigner` delegates (single-cert back-compat). |
| `edgecp/server.go` | Single immutable `(signer, generation)` snapshot behind one `atomic.Pointer` (no torn reads on `/v1/trust-bundle`). `CurrentCAID`/`SignerLoaded`/`ExpectIssuance`; readiness 503s until a signer loads when issuance is configured. |
| `edgecp/ca.go` | `RotateCA` — phase-aware, idempotent, add-only; CAS re-read on conflict; re-stamps (never blanks) the anti-regen guard; re-GET-asserts exactly 2 certs. |
| `edgecp/signerreload.go` (new) | `SignerReloader` hot-reloads the serving signer from the CA Secret on every `ca_id` change (CAID-gated, name-filtered watch); annotation-driven active-key selection with fingerprint pinning; contradictory annotation → keep last-good. |
| `cmd/edge-controlplane/main.go` | `EDGE_CA_ROTATE` run-once Job mode; managed mode now uses the never-returning `SignerReloader` watch instead of a poll-then-return goroutine. |
| `edgecp/reload.go` | Cert Reloader skips the edge CA Secret by name; `controlplane.yaml` documents it as Opaque. |

Mounted/provided CA rotation still requires remount + restart this PR (documented inline); managed mode hot-reloads.

## Tests
New: `signer_test.go` (active-key selection old/new, no-match, ambiguous, self-verify fail-closed, single-cert back-compat), `server_test.go` (coherent-snapshot race under `-race`), `rotate_test.go` (add-new, idempotent, conflict-re-evaluate, refuse-unpopulated, fatal-on-missing, bundle round-trip), `signerreload_test.go` (picks up rotation, no-op re-list, active=new branch, contradictory keeps last-good, absent-secret stays unloaded).

`gofmt`, `go vet ./...`, and `go test -race ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)