### PR TITLE
feat(edge): convergence metrics across CP, core, and edge

### DIFF
--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -589,7 +589,10 @@ scraper reaches it without the bearer token. The payload is non-secret (fingerpr
 counters, generations — no key material), but rotation/generation transitions are observable
 recon, so **a NetworkPolicy must restrict it to the scraper** (shipped in
 `deploy/edge/controlplane.yaml`). The listener starts **only in the serving process** — the
-run-once bootstrap/rotate Jobs `os.Exit` before it. A failed metrics bind is fatal (loud).
+run-once bootstrap/rotate Jobs `os.Exit` before it. A failed metrics bind is logged loudly but
+**not fatal** — the CP keeps serving issuance + trust distribution (its primary job must never be
+taken down because an observability port is contended); a missing `/metrics` is already loud as
+the scrape target's `up == 0`, and the convergence interlock fails closed on a non-reporting target.
 
 **Run-once Job observability is logs, not scraped counters.** `EnsureCA`/`RotateCA` run in
 Jobs that `os.Exit` before any scrape, so CA-generated / unexpected-empty events are

--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -524,11 +524,84 @@ CP recovery SLO. **CP HA (≥2 replicas) is REQUIRED.**
 | **Renewal failure inside the renew-before margin lets a leaf expire** | An expired client cert hard-fails the upstream handshake (502, same symptom as a CA drop). Guard: renew-before-fraction strictly in (0,1) with renew-instant leaving ≥ several `EDGE_REFRESH_INTERVAL` of slack, plus backoff+jitter retries; CP-outage budget = `TTL` × renew-before-fraction must exceed the CP recovery SLO. |
 | **Bootstrap Job race / re-run / silent fail** | The `resourceVersion`-CAS linearizes concurrent Job pods (loser adopts); the anti-regeneration guard makes a re-blank a HARD ANOMALY (never regenerate); exit non-zero + re-GET-verify before exit 0; alerts on `kube_job_failed`, absence-of-populated-CA-after-deadline, and `parapet_edge_ca_generated_total > 1`. |
 
+## Convergence metrics (observability)
+
+The rotation is observable from Prometheus across all three planes. Every series is
+labelled (or joined) by **`ca_id`** — the order-independent fingerprint of a CA *set*
+(`caid.FromPEM`/`FromDER`, byte-identical wherever it is computed). All are
+pure-instrumentation Prometheus metrics on the shared `parapet` registry / `:9187`
+`/metrics` (the control plane adds a **separate** `:9187` listener; see below).
+
+| Metric | Plane | Type | Labels | Meaning |
+|---|---|---|---|---|
+| `parapet_edge_ca_target_ca_id` | CP | gauge=1 | `ca_id` | **The convergence target** — the `ca_id` the serving CP signs under; what the fleet should reach. |
+| `parapet_edge_ca_signer_fingerprint` | CP | gauge=1 | `ca_id` | The CA this CP replica signs under (== target on a healthy fleet). |
+| `parapet_edge_ca_signer_generation` | CP | gauge=gen | `ca_id` | Monotonic generation of the serving signer; a lagging replica shows a stale value. |
+| `parapet_edge_ca_bundle_certs` | CP | gauge=n | `ca_id` | CA count in the served bundle: **2 during `OLD++NEW` overlap**, else 1. |
+| `parapet_edge_ca_signer_loaded` | CP | gauge 0/1 | — | 1 once a signer is loaded; 0 = CP up but not yet provisioned (vs scrape-missing). |
+| `parapet_trust_bundle_generation` | core | gauge=gen | `ca_id` | The `ca_id`/generation the core currently trusts. |
+| `parapet_trust_bundle_age_seconds` | core | gaugefunc | — | Seconds since the core last applied a bundle; rising fleet-wide = convergence stalled. |
+| `parapet_trust_apply_total` | core | counter | `result` | `applied`/`rollback_rejected`/`parse_rejected`/`empty_rejected` — `rollback_rejected` is the anti-replay signal. |
+| `parapet_trust_fetch_failed_total` | core | counter | — | Couldn't reach/decode the CP (vs reached-but-rejected). |
+| `parapet_trust_source_total` | core | counter | `source` | Per-request trust decision: `cidr`/`verified-chain`/`none`. |
+| `parapet_edge_clientcert_ca_id` | edge | gauge=1 | `ca_id` | CA set that issued the edge's **live** client leaf (lags the target until the edge re-mints). |
+| `parapet_edge_clientcert_not_after_seconds` | edge | gauge=unix | `ca_id` | Expiry of the edge's live leaf — an edge stuck on OLD with imminent expiry is the danger case. |
+| `parapet_edge_clientcert_loaded` | edge | gauge 0/1 | — | 1 once the edge holds a usable client cert. |
+| `parapet_edge_clientcert_remint_total` | edge | counter | `result` | `ok`/`keygen_fail`/`csr_fail`/`fetch_fail`/`marshal_fail`/`store_fail` — is the re-mint loop succeeding. |
+
+**Convergence model — all three planes reach the CP target `ca_id`.** Because `Sign()`
+appends the full served bundle (`OLD++NEW` during overlap) to every leaf, the edge's
+`ca_id` (computed over its chain's CA blocks) equals the CP/core `ca_id` *once the edge
+re-mints*. So convergence is a single predicate against the self-describing target
+series — no hardcoded value, no recording rule:
+
+```promql
+# CP target ca_id (one series); compare every plane to its label value.
+parapet_edge_ca_target_ca_id                      # → {ca_id="<TARGET>"} 1
+# Edges NOT yet converged (still on the old CA — the re-mint lag indicator):
+count(parapet_edge_clientcert_ca_id) by (instance)
+  unless on() group_left() (parapet_edge_ca_target_ca_id * 0
+    + on(ca_id) group_right() parapet_edge_clientcert_ca_id)
+```
+
+The edge lags by design (it converges when it re-mints); a non-zero lagging count is
+*expected* during a rotation and must drain before OLD is dropped (the sub-PR 4/5
+interlock gates the destructive drop on exactly this).
+
+**Operational caveats (read before writing alerts):**
+- **`ca_id` is a set fingerprint, never key material** (public-cert SHA-256). Safe as a label.
+- **Aggregate `ca_id` vecs with `max by (instance)`, never `sum`** — mid-rotation a replica
+  transiently emits both the overlap and a single-CA `ca_id`, so `sum` double-counts.
+- **Cardinality is bounded, not free.** Each vec is `Reset()`-then-`Set()` so exactly one
+  live series exists *per process*; across TSDB retention the distinct `ca_id` count is
+  bounded by `rotation_rate × retention × 3` (overlap), not unbounded. There is a
+  sub-microsecond `Reset→Set` absence window on each swap — a known benign flap; don't alert on it.
+- **`source=verified-chain` undercounts** dual-path edges: `cidr` takes precedence in the
+  per-request decision, so an edge that *also* matches a trusted CIDR counts as `cidr`. A
+  `verified-chain` flatline *after* a rotation is still the earliest convergence-failure signal.
+- **Pod identity comes only from scrape relabeling** (kube-SD `job`/`pod` labels), never an
+  in-process label. The `count(... ) == count(up{job})` style predicate depends on the
+  deploy wiring those labels.
+
+**Control-plane `/metrics` is a new, unauthenticated `:9187` listener** (`CP_METRICS_LISTEN`,
+default `:9187`, set `""` to disable). It is **separate** from the token-gated API mux, so a
+scraper reaches it without the bearer token. The payload is non-secret (fingerprints,
+counters, generations — no key material), but rotation/generation transitions are observable
+recon, so **a NetworkPolicy must restrict it to the scraper** (shipped in
+`deploy/edge/controlplane.yaml`). The listener starts **only in the serving process** — the
+run-once bootstrap/rotate Jobs `os.Exit` before it. A failed metrics bind is fatal (loud).
+
+**Run-once Job observability is logs, not scraped counters.** `EnsureCA`/`RotateCA` run in
+Jobs that `os.Exit` before any scrape, so CA-generated / unexpected-empty events are
+**structured `slog` lines + non-zero exit codes** (alert via `kube_job_failed`), deliberately
+not Prometheus counters (a Pushgateway would be a new failure domain).
+
 ## Configuration
 
 | Variable | Where | Default | Meaning |
 |---|---|---|---|
 | `TRUST_PROXY` | core | `cloudflare` | **Unchanged** — the `cidrTrust` OR-branch. Never add edge egress CIDRs here. |
+| `CP_METRICS_LISTEN` | CP | `:9187` | Separate unauthenticated `/metrics` listener (serving process only); `""` disables. Restrict via NetworkPolicy. |
 | `EDGE_TRUST_CP_ENDPOINT` | core | `""` (off) | HTTPS base URL of the CP. Set ⇒ the core pulls `GET /v1/trust-bundle`. **MUST be `https://`** — non-https is fatal, no plaintext analog ever. |
 | `EDGE_TRUST_CP_CA` | core | `""` | PEM of the CA that signs the **CP server** cert → `RootCAs`. **Mandatory + fatal** if missing/empty/unparseable; no system-roots fallback, no skip-verify. Dedicated single-purpose CA; distinct from the edge CA in `ca_pem`. |
 | `EDGE_TRUST_CP_WATCH_TIMEOUT` / `_POLL_INTERVAL` | core/CP | `30s` / `5m` | Long-poll ceiling; safety-net poll. The poll now bounds **CA-rotation** propagation only (not per-request revocation), so it may lengthen; keep the long-poll for fast rotation convergence. |

--- a/caid/caid.go
+++ b/caid/caid.go
@@ -1,0 +1,60 @@
+// Package caid computes the edge-CA trust-bundle id: a stable, order-independent
+// fingerprint over a SET of CA certificates. It is the single source of truth shared
+// by the control plane (FromPEM, over the served ca_pem bundle) and the edge (FromDER,
+// over its client cert's CA chain), so a CP-computed CAID and an edge-computed ca_id
+// are byte-identical for the same cert set — the cross-plane join key for convergence.
+//
+// It is deliberately dependency-light (crypto/sha256, encoding/hex, encoding/pem, sort
+// only — no k8s, no prometheus) so the k8s-free edge binary can import it without
+// dragging in the control-plane's client-go dependency.
+package caid
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"sort"
+)
+
+// FromPEM computes the id over every CERTIFICATE block in bundlePEM. Non-CERTIFICATE
+// blocks are skipped. An input with no certificates is an error.
+func FromPEM(bundlePEM []byte) (string, error) {
+	var ders [][]byte
+	rest := bundlePEM
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		ders = append(ders, block.Bytes)
+	}
+	return FromDER(ders)
+}
+
+// FromDER computes the id over a set of raw DER certificates (e.g. a tls.Certificate's
+// Certificate[1:] CA chain on the edge). It hashes each DER exactly as FromPEM hashes
+// its block.Bytes, so FromPEM(pem) == FromDER(der) for the same cert set. The id is the
+// truncated SHA-256 over the sorted per-cert SHA-256s, making it order-independent: it
+// reflects the trusted CA *set*, not the bundle ordering.
+func FromDER(ders [][]byte) (string, error) {
+	if len(ders) == 0 {
+		return "", fmt.Errorf("caid: no certificates")
+	}
+	sums := make([]string, 0, len(ders))
+	for _, der := range ders {
+		sum := sha256.Sum256(der)
+		sums = append(sums, hex.EncodeToString(sum[:]))
+	}
+	sort.Strings(sums)
+	h := sha256.New()
+	for _, s := range sums {
+		h.Write([]byte(s))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil)[:16]), nil
+}

--- a/caid/caid_test.go
+++ b/caid/caid_test.go
@@ -1,0 +1,86 @@
+package caid
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func mkCertDER(t *testing.T, cn string) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return der
+}
+
+func pemOf(ders ...[]byte) []byte {
+	var out []byte
+	for _, d := range ders {
+		out = append(out, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: d})...)
+	}
+	return out
+}
+
+// FromPEM(pem) and FromDER(der) MUST agree for the same cert set — this is what lets
+// the CP (FromPEM over the bundle) and the edge (FromDER over its chain's CA blocks)
+// derive a byte-identical ca_id.
+func TestFromPEMEqualsFromDER(t *testing.T) {
+	d1 := mkCertDER(t, "old")
+	d2 := mkCertDER(t, "new")
+
+	idPEM, err := FromPEM(pemOf(d1, d2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	idDER, err := FromDER([][]byte{d1, d2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idPEM != idDER {
+		t.Errorf("FromPEM=%q != FromDER=%q", idPEM, idDER)
+	}
+}
+
+// The id reflects the trusted SET, not the ordering (OLD++NEW == NEW++OLD).
+func TestOrderIndependent(t *testing.T) {
+	d1 := mkCertDER(t, "a")
+	d2 := mkCertDER(t, "b")
+	ab, _ := FromDER([][]byte{d1, d2})
+	ba, _ := FromDER([][]byte{d2, d1})
+	if ab != ba {
+		t.Errorf("order changed the id: %q vs %q", ab, ba)
+	}
+	// A different set yields a different id.
+	single, _ := FromDER([][]byte{d1})
+	if single == ab {
+		t.Error("single-cert id collided with the two-cert set id")
+	}
+}
+
+func TestEmptyIsError(t *testing.T) {
+	if _, err := FromDER(nil); err == nil {
+		t.Error("FromDER(nil) must error")
+	}
+	if _, err := FromPEM([]byte("not a pem")); err == nil {
+		t.Error("FromPEM with no CERTIFICATE blocks must error")
+	}
+}

--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -241,13 +241,16 @@ func main() {
 	// token-gated API mux, so a scraper reaches it without the bearer token). Only the
 	// serving process reaches here — the run-once bootstrap/rotate Jobs os.Exit above.
 	// The payload is non-secret (ca_id fingerprints, counters, generations — no key
-	// material); a NetworkPolicy must still restrict it to the scraper. A failed bind is
-	// FATAL (loud), so a missing /metrics never silently blocks the convergence gate.
+	// material); a NetworkPolicy must still restrict it to the scraper.
+	//
+	// A failed bind is logged loudly but NOT fatal: the control plane's job is issuance
+	// + trust distribution, which must never be taken down because an observability port
+	// is contended. A missing /metrics is already loud to the scraper (the target's
+	// `up == 0`), and the convergence interlock fails closed on a non-reporting target.
 	if metricsListen != "" {
 		go func() {
 			if err := prom.Start(metricsListen); err != nil && err != http.ErrServerClosed {
-				slog.Error("edge control plane: metrics listener failed", "addr", metricsListen, "err", err)
-				os.Exit(1)
+				slog.Error("edge control plane: metrics listener failed; serving API without /metrics", "addr", metricsListen, "err", err)
 			}
 		}()
 		slog.Info("edge control plane: metrics listening", "addr", metricsListen)

--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -16,6 +16,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
+	"github.com/moonrhythm/parapet/pkg/prom"
+
 	"github.com/moonrhythm/parapet-ingress-controller/edgecp"
 	"github.com/moonrhythm/parapet-ingress-controller/k8s"
 )
@@ -41,12 +43,13 @@ func (k8sRW) UpdateSecret(ctx context.Context, ns string, s *v1.Secret) (*v1.Sec
 
 func main() {
 	addr := envOr("CP_LISTEN", ":8443")
-	watchNamespace := os.Getenv("WATCH_NAMESPACE") // "" = all namespaces
-	podNamespace := os.Getenv("POD_NAMESPACE")     // bounds the global WAF ruleset
-	tlsCert := os.Getenv("CP_TLS_CERT")            // server cert (with CP_TLS_KEY → HTTPS)
-	tlsKey := os.Getenv("CP_TLS_KEY")              // server key
-	tokensJSON := os.Getenv("CP_TOKENS")           // {"<token>":["acme.com",...]} or {"<token>":{"id","domains","disabled"}}
-	tokensFile := os.Getenv("CP_TOKENS_FILE")      // alternative: path to that JSON
+	metricsListen := envOr("CP_METRICS_LISTEN", ":9187") // "" disables; SEPARATE unauthenticated listener (non-secret: ca_id fingerprints, counters, generations)
+	watchNamespace := os.Getenv("WATCH_NAMESPACE")       // "" = all namespaces
+	podNamespace := os.Getenv("POD_NAMESPACE")           // bounds the global WAF ruleset
+	tlsCert := os.Getenv("CP_TLS_CERT")                  // server cert (with CP_TLS_KEY → HTTPS)
+	tlsKey := os.Getenv("CP_TLS_KEY")                    // server key
+	tokensJSON := os.Getenv("CP_TOKENS")                 // {"<token>":["acme.com",...]} or {"<token>":{"id","domains","disabled"}}
+	tokensFile := os.Getenv("CP_TOKENS_FILE")            // alternative: path to that JSON
 	wafEnabled := os.Getenv("CP_WAF_ENABLED") == "true"
 	caCertPath := os.Getenv("EDGE_CA_CERT")                 // provided-mode edge CA cert (with EDGE_CA_KEY → enable issuance)
 	caKeyPath := os.Getenv("EDGE_CA_KEY")                   // provided-mode edge CA private key
@@ -232,6 +235,22 @@ func main() {
 		go ingReloader.Watch(ctx)
 		server = server.WithWAF(wafStore)
 		slog.Info("edge control plane: WAF distribution enabled", "pod_namespace", podNamespace)
+	}
+
+	// Convergence /metrics on a SEPARATE, unauthenticated listener (never the
+	// token-gated API mux, so a scraper reaches it without the bearer token). Only the
+	// serving process reaches here — the run-once bootstrap/rotate Jobs os.Exit above.
+	// The payload is non-secret (ca_id fingerprints, counters, generations — no key
+	// material); a NetworkPolicy must still restrict it to the scraper. A failed bind is
+	// FATAL (loud), so a missing /metrics never silently blocks the convergence gate.
+	if metricsListen != "" {
+		go func() {
+			if err := prom.Start(metricsListen); err != nil && err != http.ErrServerClosed {
+				slog.Error("edge control plane: metrics listener failed", "addr", metricsListen, "err", err)
+				os.Exit(1)
+			}
+		}()
+		slog.Info("edge control plane: metrics listening", "addr", metricsListen)
 	}
 
 	srv := &http.Server{

--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -277,14 +277,14 @@ func main() {
 			// dual-path edge — a verified-chain flatline after rotation is still the
 			// earliest convergence-failure signal. This closure exists only when
 			// trustMgr != nil, so the trust-disabled path stays free of per-request work.
-			src := "none"
+			src := metric.TrustSrcNone
 			if cidrTrust != nil && cidrTrust(r) {
-				src = "cidr"
+				src = metric.TrustSrcCIDR
 			} else if r.TLS != nil && len(r.TLS.VerifiedChains) > 0 {
-				src = "verified-chain"
+				src = metric.TrustSrcVerifiedChain
 			}
 			metric.TrustSource(src)
-			return src != "none"
+			return src != metric.TrustSrcNone
 		}
 	}
 

--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -272,10 +272,19 @@ func main() {
 	trustProxy := cidrTrust
 	if trustMgr != nil {
 		trustProxy = func(r *http.Request) bool {
+			// Resolve the decision to ONE source, then emit exactly once (never
+			// double-count). cidr takes precedence, so verified-chain undercounts a
+			// dual-path edge — a verified-chain flatline after rotation is still the
+			// earliest convergence-failure signal. This closure exists only when
+			// trustMgr != nil, so the trust-disabled path stays free of per-request work.
+			src := "none"
 			if cidrTrust != nil && cidrTrust(r) {
-				return true
+				src = "cidr"
+			} else if r.TLS != nil && len(r.TLS.VerifiedChains) > 0 {
+				src = "verified-chain"
 			}
-			return r.TLS != nil && len(r.TLS.VerifiedChains) > 0
+			metric.TrustSource(src)
+			return src != "none"
 		}
 	}
 

--- a/deploy/edge/controlplane.yaml
+++ b/deploy/edge/controlplane.yaml
@@ -76,6 +76,9 @@ spec:
           ports:
             - name: https
               containerPort: 8443
+            - name: metrics # CP_METRICS_LISTEN — UNAUTHENTICATED Prometheus /metrics
+              containerPort: 9187 #   (non-secret: ca_id fingerprints, counters, generations).
+              #                        Restrict to the scraper via the NetworkPolicy below.
           livenessProbe:
             httpGet:
               path: /healthz
@@ -155,3 +158,13 @@ spec:
       ports:
         - protocol: TCP
           port: 8443
+    # The :9187 /metrics listener is UNAUTHENTICATED — allow ONLY the Prometheus
+    # scraper. REPLACE this selector with however your scraper is identified
+    # (namespaceSelector for the monitoring namespace, a podSelector, or an ipBlock).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring # REPLACE: your Prometheus namespace
+      ports:
+        - protocol: TCP
+          port: 9187

--- a/deploy/edge/e2e/run.sh
+++ b/deploy/edge/e2e/run.sh
@@ -50,6 +50,11 @@ wait_for_port() {
     if nc -z 127.0.0.1 "$port" 2>/dev/null; then return 0; fi
     sleep 0.2
   done
+  # Surface the process logs so a startup crash is diagnosable in CI (not just a
+  # bare "did not come up").
+  for log in "$WORK/cp.log" "$WORK/edge.log"; do
+    [ -s "$log" ] && { echo "----- $(basename "$log") -----" >&2; cat "$log" >&2; }
+  done
   fail "$name did not come up on :$port"
 }
 

--- a/deploy/edge/e2e/run.sh
+++ b/deploy/edge/e2e/run.sh
@@ -27,6 +27,7 @@ set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 WORK="$(mktemp -d)"
 CP_PORT=18443
+CP_METRICS_PORT=18187
 EDGE_PORT=18080
 EDGE_HTTP_PORT=18081
 UP_PORT=18090
@@ -67,6 +68,14 @@ gen_cert() { # name CN  -> name.key/name.crt signed by the CA, SAN=CN
 }
 gen_cert cp localhost      # control-plane HTTPS server cert
 gen_cert leaf "$DOMAIN"    # the cert the edge will fetch + serve for $DOMAIN
+
+# A dedicated edge CA (provided mode) so the CP loads a signer and exposes the
+# convergence metrics (parapet_edge_ca_signer_fingerprint) on its /metrics listener.
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
+  -keyout "$WORK/edge-ca.key" -out "$WORK/edge-ca.crt" -days 1 -subj "/CN=parapet-edge-ca" \
+  -addext "basicConstraints=critical,CA:TRUE" \
+  -addext "keyUsage=critical,keyCertSign" \
+  -addext "extendedKeyUsage=clientAuth" 2>/dev/null
 
 # ---------------------------------------------------------------------------
 say "2. write static manifests (TLS Secret + global WAF ConfigMap) + tokens.json"
@@ -182,9 +191,11 @@ wait_for_port "$UP_PORT" upstream
 
 say "5. start the Go control plane (fs backend, WAF enabled)"
 KUBERNETES_BACKEND=fs KUBERNETES_FS="$WORK/manifests" \
-  CP_LISTEN=":$CP_PORT" CP_TLS_CERT="$WORK/cp.crt" CP_TLS_KEY="$WORK/cp.key" \
+  CP_LISTEN=":$CP_PORT" CP_METRICS_LISTEN="127.0.0.1:$CP_METRICS_PORT" \
+  CP_TLS_CERT="$WORK/cp.crt" CP_TLS_KEY="$WORK/cp.key" \
   CP_TOKENS_FILE="$WORK/tokens.json" WATCH_NAMESPACE="" \
   POD_NAMESPACE=default CP_WAF_ENABLED=true \
+  EDGE_CA_CERT="$WORK/edge-ca.crt" EDGE_CA_KEY="$WORK/edge-ca.key" \
   "$WORK/edge-controlplane" > "$WORK/cp.log" 2>&1 & PIDS+=($!)
 wait_for_port "$CP_PORT" "control plane"
 
@@ -276,5 +287,19 @@ if curl -sf --cacert "$WORK/ca.crt" --resolve "other.local:$EDGE_PORT:127.0.0.1"
   fail "unknown SNI unexpectedly validated against our CA"
 fi
 echo "  ✓ unknown SNI falls back to self-signed (not served the real cert)"
+
+# Convergence metrics: the CP exposes /metrics on a SEPARATE, unauthenticated
+# listener (no bearer token), and with a signer loaded it publishes the
+# signer-fingerprint series — so a scraper can detect which CA the CP signs under.
+# This guards against an unwired/zero-target CP showing a false-green convergence board.
+say "8. CP convergence /metrics (separate listener, signer fingerprint present)"
+wait_for_port "$CP_METRICS_PORT" "cp metrics"
+MET="$(curl -sS "http://127.0.0.1:$CP_METRICS_PORT/metrics")" \
+  || { cat "$WORK/cp.log" >&2; fail "curl CP /metrics failed"; }
+grep -q "parapet_edge_ca_signer_fingerprint{" <<<"$MET" \
+  || { grep parapet_edge <<<"$MET" >&2; fail "CP /metrics missing signer_fingerprint series"; }
+grep -qE "^parapet_edge_ca_signer_loaded 1$" <<<"$MET" \
+  || { grep signer_loaded <<<"$MET" >&2; fail "CP signer_loaded != 1"; }
+echo "  ✓ CP /metrics (tokenless) serves signer_fingerprint + signer_loaded=1"
 
 say "E2E PASSED"

--- a/deploy/edge/e2e/run.sh
+++ b/deploy/edge/e2e/run.sh
@@ -76,11 +76,25 @@ gen_cert leaf "$DOMAIN"    # the cert the edge will fetch + serve for $DOMAIN
 
 # A dedicated edge CA (provided mode) so the CP loads a signer and exposes the
 # convergence metrics (parapet_edge_ca_signer_fingerprint) on its /metrics listener.
+# Use an explicit -config (NOT -addext): -addext APPENDS to the system openssl.cnf's
+# default x509 extensions, so on distros whose default already adds basicConstraints
+# the cert ends up with a DUPLICATE basicConstraints, which Go 1.26's x509 parser
+# rejects. A self-contained config sets each extension exactly once.
+cat > "$WORK/edge-ca.cnf" <<'CNF'
+[req]
+distinguished_name = dn
+x509_extensions = v3_ca
+prompt = no
+[dn]
+CN = parapet-edge-ca
+[v3_ca]
+basicConstraints = critical, CA:TRUE
+keyUsage = critical, keyCertSign, cRLSign
+extendedKeyUsage = clientAuth
+CNF
 openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
-  -keyout "$WORK/edge-ca.key" -out "$WORK/edge-ca.crt" -days 1 -subj "/CN=parapet-edge-ca" \
-  -addext "basicConstraints=critical,CA:TRUE" \
-  -addext "keyUsage=critical,keyCertSign" \
-  -addext "extendedKeyUsage=clientAuth" 2>/dev/null
+  -keyout "$WORK/edge-ca.key" -out "$WORK/edge-ca.crt" -days 1 \
+  -config "$WORK/edge-ca.cnf" 2>/dev/null
 
 # ---------------------------------------------------------------------------
 say "2. write static manifests (TLS Secret + global WAF ConfigMap) + tokens.json"

--- a/edge/clientcert.go
+++ b/edge/clientcert.go
@@ -5,6 +5,8 @@ import (
 	"crypto/x509"
 	"fmt"
 	"sync/atomic"
+
+	"github.com/moonrhythm/parapet-ingress-controller/caid"
 )
 
 // ClientCertStore holds the edge's data-plane mTLS client certificate in memory
@@ -46,6 +48,20 @@ func (s *ClientCertStore) Update(chainPEM, keyPEM []byte) error {
 		}
 	}
 	s.cur.Store(&cert)
+
+	// Convergence metric: derive the issuing CA-set ca_id from the chain's CA blocks
+	// (Certificate[1:], the bundle Sign() appended after the leaf) — byte-identical to
+	// the CP's CAID for the same set. Guard a too-short chain and a nil leaf so the
+	// metric never panics the refresh goroutine.
+	var caID string
+	if len(cert.Certificate) >= 2 {
+		caID, _ = caid.FromDER(cert.Certificate[1:])
+	}
+	var notAfter int64
+	if cert.Leaf != nil {
+		notAfter = cert.Leaf.NotAfter.Unix()
+	}
+	setClientCertMetrics(caID, notAfter)
 	return nil
 }
 

--- a/edge/metrics.go
+++ b/edge/metrics.go
@@ -1,0 +1,71 @@
+package edge
+
+import (
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Edge data-plane convergence metrics: which CA set issued the edge's LIVE client
+// leaf (its ca_id), when that leaf expires, and whether the re-mint loop is healthy.
+// During a rotation the edge's ca_id LAGS the control-plane target until the edge
+// re-mints (it then matches, because Sign() appends the full served bundle to the
+// leaf) — so this is the per-edge convergence/re-mint progress indicator. Registered on
+// the shared parapet registry, served on the edge's existing :9187. Pure instrumentation.
+//
+// The ca_id-labelled gauges are Reset() then Set() on each swap, so exactly one live
+// series exists per process. ca_id is a public-cert fingerprint, never key material.
+var (
+	edgeClientCertCAID = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_clientcert_ca_id",
+		Help:      "CA set that issued the edge's live data-plane client leaf, by ca_id (value 1).",
+	}, []string{"ca_id"})
+
+	edgeClientCertNotAfter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_clientcert_not_after_seconds",
+		Help:      "Expiry (unix seconds) of the edge's live data-plane client leaf, by ca_id.",
+	}, []string{"ca_id"})
+
+	edgeClientCertLoaded = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_clientcert_loaded",
+		Help:      "1 once the edge holds a usable data-plane client cert, else 0.",
+	})
+
+	edgeRemint = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_clientcert_remint_total",
+		Help:      "Edge data-plane cert re-mint attempts by result (ok|keygen_fail|csr_fail|fetch_fail|marshal_fail|store_fail).",
+	}, []string{"result"})
+
+	edgeRemintHandles = map[string]prometheus.Counter{}
+)
+
+func init() {
+	prom.Registry().MustRegister(edgeClientCertCAID, edgeClientCertNotAfter, edgeClientCertLoaded, edgeRemint)
+	for _, r := range []string{"ok", "keygen_fail", "csr_fail", "fetch_fail", "marshal_fail", "store_fail"} {
+		edgeRemintHandles[r], _ = edgeRemint.GetMetricWith(prometheus.Labels{"result": r})
+	}
+}
+
+// setClientCertMetrics records the live leaf's ca_id and expiry (Reset()-then-Set so
+// only one ca_id series survives a rotation) and marks the cert loaded. An empty caID
+// (chain too short to carry a CA block) sets only loaded, leaving the ca_id vecs clear.
+// Called only from the single ClientCertStore.Update writer (the re-mint loop).
+func setClientCertMetrics(caID string, notAfterUnix int64) {
+	edgeClientCertCAID.Reset()
+	edgeClientCertNotAfter.Reset()
+	if caID != "" {
+		edgeClientCertCAID.WithLabelValues(caID).Set(1)
+		edgeClientCertNotAfter.WithLabelValues(caID).Set(float64(notAfterUnix))
+	}
+	edgeClientCertLoaded.Set(1)
+}
+
+// remint counts one re-mint attempt by result (bare Inc on a pre-materialized handle).
+func remint(result string) {
+	if h := edgeRemintHandles[result]; h != nil {
+		h.Inc()
+	}
+}

--- a/edge/metrics_test.go
+++ b/edge/metrics_test.go
@@ -1,0 +1,44 @@
+package edge
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// setClientCertMetrics keeps exactly one ca_id series across re-mints, and an empty
+// ca_id (too-short chain) sets only loaded without leaving a ca_id series.
+func TestSetClientCertMetricsOneSeries(t *testing.T) {
+	setClientCertMetrics("ca-old", 100)
+	setClientCertMetrics("ca-new", 200) // re-mint onto a new CA set
+
+	if c := testutil.CollectAndCount(edgeClientCertCAID); c != 1 {
+		t.Errorf("ca_id: want 1 live series after re-mint, got %d", c)
+	}
+	if c := testutil.CollectAndCount(edgeClientCertNotAfter); c != 1 {
+		t.Errorf("not_after: want 1 live series, got %d", c)
+	}
+	if v := testutil.ToFloat64(edgeClientCertLoaded); v != 1 {
+		t.Errorf("loaded = %v, want 1", v)
+	}
+	if v := testutil.ToFloat64(edgeClientCertNotAfter.WithLabelValues("ca-new")); v != 200 {
+		t.Errorf("not_after = %v, want 200", v)
+	}
+
+	// Empty ca_id: loaded stays 1, but no ca_id/not_after series.
+	setClientCertMetrics("", 0)
+	if c := testutil.CollectAndCount(edgeClientCertCAID); c != 0 {
+		t.Errorf("empty ca_id must leave no series, got %d", c)
+	}
+}
+
+func TestRemintEnum(t *testing.T) {
+	for _, result := range []string{"ok", "keygen_fail", "csr_fail", "fetch_fail", "marshal_fail", "store_fail"} {
+		before := testutil.ToFloat64(edgeRemintHandles[result])
+		remint(result)
+		if got := testutil.ToFloat64(edgeRemintHandles[result]); got != before+1 {
+			t.Errorf("remint(%q): %v -> %v, want +1", result, before, got)
+		}
+	}
+	remint("bogus") // no-op
+}

--- a/edge/refresh.go
+++ b/edge/refresh.go
@@ -16,35 +16,44 @@ import (
 // the store. Fail-static: on any error the prior cert is kept. The key is generated
 // here and never written to disk — only the public-key CSR and the returned chain
 // transit. The CP stamps the SAN from the token identity, so the CSR carries none.
-func RefreshEdgeCertOnce(cp *CpClient, store *ClientCertStore) {
+// It returns (and counts) the outcome so the re-mint loop's health is observable; the
+// returned string is the parapet_edge_clientcert_remint_total result label.
+func RefreshEdgeCertOnce(cp *CpClient, store *ClientCertStore) string {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		slog.Warn("edge: client keygen failed; keeping cached cert", "error", err)
-		return
+		remint("keygen_fail")
+		return "keygen_fail"
 	}
 	csrDER, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{}, key)
 	if err != nil {
 		slog.Warn("edge: CSR build failed; keeping cached cert", "error", err)
-		return
+		remint("csr_fail")
+		return "csr_fail"
 	}
 	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
 
 	res, err := cp.FetchEdgeCert(csrPEM)
 	if err != nil {
 		slog.Warn("edge: data-plane cert fetch failed; keeping cached cert", "error", err)
-		return
+		remint("fetch_fail")
+		return "fetch_fail"
 	}
 	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
 	if err != nil {
 		slog.Warn("edge: key marshal failed; keeping cached cert", "error", err)
-		return
+		remint("marshal_fail")
+		return "marshal_fail"
 	}
 	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
 	if err := store.Update(res.ChainPEM, keyPEM); err != nil {
 		slog.Warn("edge: data-plane cert unusable; keeping cached cert", "error", err)
-		return
+		remint("store_fail")
+		return "store_fail"
 	}
 	slog.Info("edge: data-plane client cert updated", "not_after", res.NotAfter, "serial", res.Serial)
+	remint("ok")
+	return "ok"
 }
 
 // RunEdgeCertRefresh refreshes the data-plane client cert on a timer. The first

--- a/edge/refresh_test.go
+++ b/edge/refresh_test.go
@@ -1,0 +1,99 @@
+package edge
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/moonrhythm/parapet-ingress-controller/edgecp"
+)
+
+// fakeEdgeCP signs the posted CSR with a real edgecp signer, so RefreshEdgeCertOnce's
+// happy path (ok) and its ca_id derivation run end-to-end.
+func fakeEdgeCP(t *testing.T) (*httptest.Server, *edgecp.Signer) {
+	t.Helper()
+	certPEM, keyPEM := testCA(t)
+	signer, _, err := edgecp.NewProvidedSigner(certPEM, keyPEM, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/edge-cert" {
+			http.NotFound(w, r)
+			return
+		}
+		var body struct {
+			CSRPEM string `json:"csr_pem"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		block, _ := pem.Decode([]byte(body.CSRPEM))
+		csr, err := x509.ParseCertificateRequest(block.Bytes)
+		if err != nil {
+			http.Error(w, "bad csr", http.StatusBadRequest)
+			return
+		}
+		chain, notAfter, serial, err := signer.Sign(csr.PublicKey, "test-edge")
+		if err != nil {
+			http.Error(w, "sign", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"chain_pem": string(chain), "not_after": notAfter.UTC().String(), "serial": serial,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv, signer
+}
+
+func TestRefreshEdgeCertOnceOK(t *testing.T) {
+	srv, signer := fakeEdgeCP(t)
+	cp, err := NewCpClient(srv.URL, "tok", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewClientCertStore()
+
+	before := testutil.ToFloat64(edgeRemintHandles["ok"])
+	if got := RefreshEdgeCertOnce(cp, store); got != "ok" {
+		t.Fatalf("result = %q, want ok", got)
+	}
+	if testutil.ToFloat64(edgeRemintHandles["ok"]) != before+1 {
+		t.Error("ok remint counter not incremented")
+	}
+	if !store.Loaded() {
+		t.Error("store should hold a cert after a successful re-mint")
+	}
+	// The edge-derived ca_id must equal the CP signer's CAID (same CA set, via caid).
+	if v := testutil.ToFloat64(edgeClientCertCAID.WithLabelValues(signer.CAID())); v != 1 {
+		t.Errorf("edge ca_id series for %q not set to 1", signer.CAID())
+	}
+}
+
+func TestRefreshEdgeCertOnceFetchFail(t *testing.T) {
+	// A CP that 500s every request → fetch_fail, prior cert kept (none here).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "down", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	cp, err := NewCpClient(srv.URL, "tok", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewClientCertStore()
+
+	before := testutil.ToFloat64(edgeRemintHandles["fetch_fail"])
+	if got := RefreshEdgeCertOnce(cp, store); got != "fetch_fail" {
+		t.Fatalf("result = %q, want fetch_fail", got)
+	}
+	if testutil.ToFloat64(edgeRemintHandles["fetch_fail"]) != before+1 {
+		t.Error("fetch_fail remint counter not incremented")
+	}
+	if store.Loaded() {
+		t.Error("a failed fetch must not load a cert")
+	}
+}

--- a/edgecp/metrics.go
+++ b/edgecp/metrics.go
@@ -1,0 +1,71 @@
+package edgecp
+
+import (
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Control-plane convergence metrics. These describe the CA the SERVING control plane
+// currently signs under and distributes — the authoritative target the fleet (core +
+// edges) converges to during a rotation. They are registered on the shared parapet
+// registry (prom.Registry()) and served by the CP's /metrics listener (serving process
+// only; the run-once bootstrap/rotate Jobs never start the listener).
+//
+// ca_id is a public-cert SHA-256 fingerprint, never key material. Each ca_id-labelled
+// vec is Reset() then Set() on every signer swap so exactly ONE live series exists
+// in-process (the per-rotation churn across TSDB retention is bounded by the rotation
+// rate, not unbounded). Set atomically under Server.genMu by setSignerMetrics so a
+// scrape never tears across the gauges.
+var (
+	signerFingerprint = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_ca_signer_fingerprint",
+		Help:      "Edge CA the serving control plane signs under, by ca_id (value 1).",
+	}, []string{"ca_id"})
+
+	signerGeneration = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_ca_signer_generation",
+		Help:      "Trust-bundle generation of the serving control-plane signer (value = generation), by ca_id.",
+	}, []string{"ca_id"})
+
+	signerBundleCerts = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_ca_bundle_certs",
+		Help:      "Number of CA certs in the served bundle (2 during OLD++NEW overlap, else 1), by ca_id.",
+	}, []string{"ca_id"})
+
+	signerLoaded = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_ca_signer_loaded",
+		Help:      "1 once a signer is loaded (issuance live); 0 while the CP is up but not yet provisioned.",
+	})
+
+	targetCAID = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_ca_target_ca_id",
+		Help:      "The ca_id the fleet should converge to — the serving control plane's current signer (value 1).",
+	}, []string{"ca_id"})
+)
+
+func init() {
+	prom.Registry().MustRegister(signerFingerprint, signerGeneration, signerBundleCerts, signerLoaded, targetCAID)
+}
+
+// setSignerMetrics records the active signer's ca_id, generation, and bundle size. It
+// Reset()s each ca_id vec first so only one live series remains across rotations. Call
+// it under Server.genMu (the same critical section that swaps the signer) so all five
+// gauges move together and no scrape sees a torn snapshot.
+func setSignerMetrics(caID string, gen uint64, certCount int) {
+	signerFingerprint.Reset()
+	signerFingerprint.WithLabelValues(caID).Set(1)
+	signerGeneration.Reset()
+	signerGeneration.WithLabelValues(caID).Set(float64(gen))
+	signerBundleCerts.Reset()
+	signerBundleCerts.WithLabelValues(caID).Set(float64(certCount))
+	signerLoaded.Set(1)
+	// target == the current serving signer's ca_id: the named anchor an operator's
+	// convergence PromQL compares the core + edge ca_ids against, with no hardcoded value.
+	targetCAID.Reset()
+	targetCAID.WithLabelValues(caID).Set(1)
+}

--- a/edgecp/metrics_test.go
+++ b/edgecp/metrics_test.go
@@ -1,0 +1,39 @@
+package edgecp
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// setSignerMetrics must keep EXACTLY ONE live series per ca_id vec across rotations
+// (Reset()-then-Set) — the only guard against ca_id-label cardinality growth in a
+// long-running process — and reflect the latest signer's values.
+func TestSetSignerMetricsOneSeriesPerVec(t *testing.T) {
+	setSignerMetrics("ca-old", 1, 2)
+	setSignerMetrics("ca-new", 2, 1) // rotate: a new ca_id must not accumulate a series
+
+	for name, c := range map[string]int{
+		"signer_fingerprint": testutil.CollectAndCount(signerFingerprint),
+		"signer_generation":  testutil.CollectAndCount(signerGeneration),
+		"bundle_certs":       testutil.CollectAndCount(signerBundleCerts),
+		"target_ca_id":       testutil.CollectAndCount(targetCAID),
+	} {
+		if c != 1 {
+			t.Errorf("%s: want exactly 1 live series after a rotation, got %d", name, c)
+		}
+	}
+
+	if v := testutil.ToFloat64(signerLoaded); v != 1 {
+		t.Errorf("signer_loaded = %v, want 1", v)
+	}
+	if v := testutil.ToFloat64(signerGeneration.WithLabelValues("ca-new")); v != 2 {
+		t.Errorf("generation = %v, want 2", v)
+	}
+	if v := testutil.ToFloat64(signerBundleCerts.WithLabelValues("ca-new")); v != 1 {
+		t.Errorf("bundle_certs = %v, want 1", v)
+	}
+	if v := testutil.ToFloat64(signerFingerprint.WithLabelValues("ca-new")); v != 1 {
+		t.Errorf("fingerprint = %v, want 1", v)
+	}
+}

--- a/edgecp/server.go
+++ b/edgecp/server.go
@@ -71,6 +71,10 @@ func (s *Server) SetSigner(sg *Signer) {
 		prev = st.gen
 	}
 	s.signerState.Store(&signerGen{sg: sg, gen: prev + 1})
+	// Convergence metrics: set all signer gauges together inside the held genMu so a
+	// scrape never tears across them. Done before close(genNotify) so a long-poll
+	// waiter that wakes and re-scrapes always observes the new series.
+	setSignerMetrics(sg.CAID(), prev+1, sg.BundleLen())
 	close(s.genNotify)
 	s.genNotify = make(chan struct{})
 }

--- a/edgecp/signer.go
+++ b/edgecp/signer.go
@@ -13,9 +13,10 @@ import (
 	"fmt"
 	"math/big"
 	"net/url"
-	"sort"
 	"strings"
 	"time"
+
+	"github.com/moonrhythm/parapet-ingress-controller/caid"
 )
 
 // SANTrustDomain is the SPIFFE-style trust domain (URI host) for every edge leaf
@@ -47,6 +48,7 @@ type Signer struct {
 	bundle     []byte            // every CA public cert, PEM (OLD++NEW during overlap); served as ca_pem
 	bundlePool *x509.CertPool    // roots over `bundle`, for Sign()'s post-sign chain self-verify
 	caID       string
+	certCount  int // number of CA certs in the bundle (2 during OLD++NEW overlap, else 1)
 	ttl        time.Duration
 	skew       time.Duration
 }
@@ -146,6 +148,7 @@ func NewProvidedSignerActive(bundlePEM, keyPEM []byte, activeFP string, ttl, ske
 		bundle:     rebuilt,
 		bundlePool: pool,
 		caID:       id,
+		certCount:  len(certs),
 		ttl:        ttl,
 		skew:       skew,
 	}, warnings, nil
@@ -159,6 +162,10 @@ func (s *Signer) BundlePEM() []byte { return s.bundle }
 // trust-bundle ca_id). It changes whenever a CA is added to or dropped from the
 // bundle, which is the edge's proactive force-re-mint trigger.
 func (s *Signer) CAID() string { return s.caID }
+
+// BundleLen returns the number of CA certs in the served bundle: 2 during an
+// OLD++NEW rotation overlap, 1 otherwise. Read-only, O(1) (counted at construction).
+func (s *Signer) BundleLen() int { return s.certCount }
 
 // Sign issues a leaf for the given public key and edge id. It builds the template
 // from a zero value (never echoing CSR fields), stamps the id-derived URI SAN, and
@@ -386,33 +393,10 @@ func certBundleFPs(certPEM []byte) []string {
 	return fps
 }
 
-// caBundleID computes the trust-bundle ca_id: a hex fingerprint over the sorted
-// SHA-256s of every CERTIFICATE block in the bundle. Sorting makes it stable and
-// order-independent (an OLD++NEW overlap and NEW++OLD produce the same id only if
-// the set is equal — which is the intent: ca_id reflects the trusted CA *set*).
+// caBundleID computes the trust-bundle ca_id over every CERTIFICATE block in the
+// bundle. It delegates to the shared caid package (the single source of truth so the
+// edge can derive a byte-identical id from its client cert's CA chain without
+// importing this k8s-bound package).
 func caBundleID(bundlePEM []byte) (string, error) {
-	var sums []string
-	rest := bundlePEM
-	for {
-		var block *pem.Block
-		block, rest = pem.Decode(rest)
-		if block == nil {
-			break
-		}
-		if block.Type != "CERTIFICATE" {
-			continue
-		}
-		sum := sha256.Sum256(block.Bytes)
-		sums = append(sums, hex.EncodeToString(sum[:]))
-	}
-	if len(sums) == 0 {
-		return "", fmt.Errorf("CA bundle has no certificates")
-	}
-	sort.Strings(sums)
-	h := sha256.New()
-	for _, s := range sums {
-		h.Write([]byte(s))
-		h.Write([]byte{0})
-	}
-	return hex.EncodeToString(h.Sum(nil)[:16]), nil
+	return caid.FromPEM(bundlePEM)
 }

--- a/edgecp/signer_test.go
+++ b/edgecp/signer_test.go
@@ -154,6 +154,28 @@ func TestSignerSelfVerifyFailsClosed(t *testing.T) {
 	}
 }
 
+func TestSignerBundleLen(t *testing.T) {
+	single, singleKey := mustGenerateCA(t)
+	sg, _, err := NewProvidedSigner(single, singleKey, time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sg.BundleLen() != 1 {
+		t.Errorf("single CA: BundleLen = %d, want 1", sg.BundleLen())
+	}
+
+	oldCert, oldKey := mustGenerateCA(t)
+	newCert, _ := mustGenerateCA(t)
+	bundle := append(append([]byte(nil), oldCert...), newCert...)
+	sg2, _, err := NewProvidedSignerActive(bundle, oldKey, fpOf(t, oldCert), time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sg2.BundleLen() != 2 {
+		t.Errorf("OLD++NEW overlap: BundleLen = %d, want 2", sg2.BundleLen())
+	}
+}
+
 func TestSignerBackCompatSingleCert(t *testing.T) {
 	certPEM, keyPEM := mustGenerateCA(t)
 	sg, warnings, err := NewProvidedSigner(certPEM, keyPEM, time.Hour, time.Minute)

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kavu/go_reuseport v1.5.0 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/metric/trust.go
+++ b/metric/trust.go
@@ -44,8 +44,24 @@ var (
 
 	// Pre-materialized bounded-enum handles: the hot-path helpers do a bare Inc() with
 	// zero label resolution and zero locking (mirrors metric/reload.go).
-	trustApplyHandles  = map[string]prometheus.Counter{}
-	trustSourceHandles = map[string]prometheus.Counter{}
+	trustApplyHandles = map[string]prometheus.Counter{}
+
+	// trustSourceCounters is indexed by TrustSrc (not a string-keyed map) so the
+	// per-request TrustSource is a bare array load + atomic add — no string hash, no
+	// map lookup. Populated once in init().
+	trustSourceCounters [numTrustSrc]prometheus.Counter
+)
+
+// TrustSrc is the per-request trust decision. It indexes trustSourceCounters, so the
+// hot path avoids a string hash and is type-safe (a bad value can't compile, unlike a
+// stringly-typed label that would silently no-op on a typo).
+type TrustSrc uint8
+
+const (
+	TrustSrcNone TrustSrc = iota
+	TrustSrcCIDR
+	TrustSrcVerifiedChain
+	numTrustSrc
 )
 
 func init() {
@@ -65,9 +81,9 @@ func init() {
 	for _, r := range []string{"applied", "rollback_rejected", "parse_rejected", "empty_rejected"} {
 		trustApplyHandles[r], _ = trustApply.GetMetricWith(prometheus.Labels{"result": r})
 	}
-	for _, s := range []string{"cidr", "verified-chain", "none"} {
-		trustSourceHandles[s], _ = trustSource.GetMetricWith(prometheus.Labels{"source": s})
-	}
+	trustSourceCounters[TrustSrcNone], _ = trustSource.GetMetricWith(prometheus.Labels{"source": "none"})
+	trustSourceCounters[TrustSrcCIDR], _ = trustSource.GetMetricWith(prometheus.Labels{"source": "cidr"})
+	trustSourceCounters[TrustSrcVerifiedChain], _ = trustSource.GetMetricWith(prometheus.Labels{"source": "verified-chain"})
 }
 
 // TrustApply counts a bundle apply attempt by result. rollback_rejected is the
@@ -95,10 +111,8 @@ func TrustBundleApplied(caID string, generation uint64) {
 // TrustFetchFailed counts a failed trust-bundle fetch (couldn't reach/decode the CP).
 func TrustFetchFailed() { trustFetchFailed.Inc() }
 
-// TrustSource counts one per-request trust decision. Hot-path: a single atomic add on
-// a pre-materialized handle, no lock, no label resolution.
-func TrustSource(source string) {
-	if h := trustSourceHandles[source]; h != nil {
-		h.Inc()
-	}
+// TrustSource counts one per-request trust decision. Hot-path: a bare array index +
+// atomic add — no lock, no label resolution, no map hash.
+func TrustSource(s TrustSrc) {
+	trustSourceCounters[s].Inc()
 }

--- a/metric/trust.go
+++ b/metric/trust.go
@@ -1,0 +1,104 @@
+package metric
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Core (controller) trust-convergence metrics. The core pulls the edge-CA trust
+// bundle from the control plane and decides per-request trust; these expose which
+// ca_id/generation it trusts, how stale that is, why a bundle was rejected, and which
+// path authorized each request — the core side of the convergence board. All are on
+// the shared parapet registry (served on the existing :9187), pure instrumentation.
+var (
+	trustBundleGeneration = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "trust_bundle_generation",
+		Help:      "Generation of the edge trust bundle the core currently trusts (value = generation), by ca_id.",
+	}, []string{"ca_id"})
+
+	trustApply = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "trust_apply_total",
+		Help:      "Trust-bundle apply attempts by result (applied|rollback_rejected|parse_rejected|empty_rejected).",
+	}, []string{"result"})
+
+	trustFetchFailed = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "trust_fetch_failed_total",
+		Help:      "Trust-bundle fetches that failed to reach/decode the control plane (distinct from reached-but-rejected).",
+	})
+
+	trustSource = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "trust_source_total",
+		Help:      "Per-request trust decision by source (cidr|verified-chain|none).",
+	}, []string{"source"})
+
+	// lastApply is the unix-nanos timestamp of the last successful apply, read at scrape
+	// time by the trust_bundle_age_seconds GaugeFunc (zero steady-state cost, no ticker).
+	lastApply atomic.Int64
+
+	// Pre-materialized bounded-enum handles: the hot-path helpers do a bare Inc() with
+	// zero label resolution and zero locking (mirrors metric/reload.go).
+	trustApplyHandles  = map[string]prometheus.Counter{}
+	trustSourceHandles = map[string]prometheus.Counter{}
+)
+
+func init() {
+	bundleAge := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "trust_bundle_age_seconds",
+		Help:      "Seconds since the core last applied an edge trust bundle (0 before the first apply). Rising fleet-wide = convergence stalled.",
+	}, func() float64 {
+		ns := lastApply.Load()
+		if ns == 0 {
+			return 0
+		}
+		return time.Since(time.Unix(0, ns)).Seconds()
+	})
+	prom.Registry().MustRegister(trustBundleGeneration, trustApply, trustFetchFailed, trustSource, bundleAge)
+
+	for _, r := range []string{"applied", "rollback_rejected", "parse_rejected", "empty_rejected"} {
+		trustApplyHandles[r], _ = trustApply.GetMetricWith(prometheus.Labels{"result": r})
+	}
+	for _, s := range []string{"cidr", "verified-chain", "none"} {
+		trustSourceHandles[s], _ = trustSource.GetMetricWith(prometheus.Labels{"source": s})
+	}
+}
+
+// TrustApply counts a bundle apply attempt by result. rollback_rejected is the
+// anti-replay security signal — kept distinguishable from the other rejections.
+func TrustApply(result string) {
+	if h := trustApplyHandles[result]; h != nil {
+		h.Inc()
+	}
+}
+
+// TrustBundleApplied records a successful apply: stamps the age clock and sets the
+// trusted generation for ca_id (Reset()-then-Set keeps exactly one live series across
+// rotations). Called only from the single trust.Manager.Run goroutine.
+func TrustBundleApplied(caID string, generation uint64) {
+	lastApply.Store(time.Now().UnixNano()) // age clock is correct regardless of id
+	trustBundleGeneration.Reset()
+	// Guard the empty id (a CP that served no fingerprint) so we never mint a
+	// ca_id="" series — symmetric with the edge helper. Trust itself is unaffected:
+	// the core trusts the CA pool, not the id, so the bundle still applied.
+	if caID != "" {
+		trustBundleGeneration.WithLabelValues(caID).Set(float64(generation))
+	}
+}
+
+// TrustFetchFailed counts a failed trust-bundle fetch (couldn't reach/decode the CP).
+func TrustFetchFailed() { trustFetchFailed.Inc() }
+
+// TrustSource counts one per-request trust decision. Hot-path: a single atomic add on
+// a pre-materialized handle, no lock, no label resolution.
+func TrustSource(source string) {
+	if h := trustSourceHandles[source]; h != nil {
+		h.Inc()
+	}
+}

--- a/metric/trust_bench_test.go
+++ b/metric/trust_bench_test.go
@@ -5,10 +5,10 @@ import "testing"
 // BenchmarkTrustSource proves the per-request hot-path cost is a single atomic add on
 // a pre-materialized handle — no lock, no label resolution, zero allocs.
 func BenchmarkTrustSource(b *testing.B) {
-	TrustSource("verified-chain") // warm
+	TrustSource(TrustSrcVerifiedChain) // warm
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		TrustSource("verified-chain")
+		TrustSource(TrustSrcVerifiedChain)
 	}
 }

--- a/metric/trust_bench_test.go
+++ b/metric/trust_bench_test.go
@@ -1,0 +1,14 @@
+package metric
+
+import "testing"
+
+// BenchmarkTrustSource proves the per-request hot-path cost is a single atomic add on
+// a pre-materialized handle — no lock, no label resolution, zero allocs.
+func BenchmarkTrustSource(b *testing.B) {
+	TrustSource("verified-chain") // warm
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		TrustSource("verified-chain")
+	}
+}

--- a/metric/trust_test.go
+++ b/metric/trust_test.go
@@ -20,14 +20,13 @@ func TestTrustApplyEnum(t *testing.T) {
 }
 
 func TestTrustSourceEnum(t *testing.T) {
-	for _, src := range []string{"cidr", "verified-chain", "none"} {
-		before := testutil.ToFloat64(trustSourceHandles[src])
+	for _, src := range []TrustSrc{TrustSrcNone, TrustSrcCIDR, TrustSrcVerifiedChain} {
+		before := testutil.ToFloat64(trustSourceCounters[src])
 		TrustSource(src)
-		if got := testutil.ToFloat64(trustSourceHandles[src]); got != before+1 {
-			t.Errorf("TrustSource(%q): %v -> %v, want +1", src, before, got)
+		if got := testutil.ToFloat64(trustSourceCounters[src]); got != before+1 {
+			t.Errorf("TrustSource(%d): %v -> %v, want +1", src, before, got)
 		}
 	}
-	TrustSource("bogus") // no-op
 }
 
 func TestTrustFetchFailed(t *testing.T) {

--- a/metric/trust_test.go
+++ b/metric/trust_test.go
@@ -1,0 +1,89 @@
+package metric
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestTrustApplyEnum(t *testing.T) {
+	for _, result := range []string{"applied", "rollback_rejected", "parse_rejected", "empty_rejected"} {
+		before := testutil.ToFloat64(trustApplyHandles[result])
+		TrustApply(result)
+		if got := testutil.ToFloat64(trustApplyHandles[result]); got != before+1 {
+			t.Errorf("TrustApply(%q): %v -> %v, want +1", result, before, got)
+		}
+	}
+	// An unknown result is a no-op, never a panic.
+	TrustApply("bogus")
+}
+
+func TestTrustSourceEnum(t *testing.T) {
+	for _, src := range []string{"cidr", "verified-chain", "none"} {
+		before := testutil.ToFloat64(trustSourceHandles[src])
+		TrustSource(src)
+		if got := testutil.ToFloat64(trustSourceHandles[src]); got != before+1 {
+			t.Errorf("TrustSource(%q): %v -> %v, want +1", src, before, got)
+		}
+	}
+	TrustSource("bogus") // no-op
+}
+
+func TestTrustFetchFailed(t *testing.T) {
+	before := testutil.ToFloat64(trustFetchFailed)
+	TrustFetchFailed()
+	if got := testutil.ToFloat64(trustFetchFailed); got != before+1 {
+		t.Errorf("TrustFetchFailed: %v -> %v, want +1", before, got)
+	}
+}
+
+// TrustBundleApplied keeps exactly one ca_id series across rotations and stamps the
+// age clock so the GaugeFunc reports a fresh (small) age.
+func TestTrustBundleAppliedOneSeries(t *testing.T) {
+	TrustBundleApplied("ca-1", 5)
+	TrustBundleApplied("ca-2", 6) // rotation
+	if c := testutil.CollectAndCount(trustBundleGeneration); c != 1 {
+		t.Errorf("want exactly 1 live generation series after rotation, got %d", c)
+	}
+	if v := testutil.ToFloat64(trustBundleGeneration.WithLabelValues("ca-2")); v != 6 {
+		t.Errorf("generation = %v, want 6", v)
+	}
+	if lastApply.Load() == 0 {
+		t.Error("lastApply must be stamped after an apply")
+	}
+
+	// An empty ca_id (a CP that served no fingerprint) must NOT mint a ca_id="" series
+	// — symmetric with the edge helper — but still stamps the age clock.
+	TrustBundleApplied("", 7)
+	if c := testutil.CollectAndCount(trustBundleGeneration); c != 0 {
+		t.Errorf("empty ca_id must leave no generation series, got %d", c)
+	}
+	if lastApply.Load() == 0 {
+		t.Error("empty ca_id must still stamp the age clock")
+	}
+}
+
+// Concurrent apply (single conceptual writer) vs scrape (many readers) must be
+// race-free: run under `go test -race`.
+func TestTrustBundleAppliedScrapeRace(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := uint64(100); i < 2100; i++ {
+			TrustBundleApplied("ca-race", i)
+		}
+	}()
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 2000; i++ {
+				_ = testutil.CollectAndCount(trustBundleGeneration)
+				_ = lastApply.Load()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/trust/e2e_test.go
+++ b/trust/e2e_test.go
@@ -112,7 +112,7 @@ func pullInto(t *testing.T, c *Client, m *Manager) {
 	if err != nil || unchanged {
 		t.Fatalf("trust fetch: err=%v unchanged=%v", err, unchanged)
 	}
-	if err := m.apply(b); err != nil {
+	if _, err := m.apply(b); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
 }

--- a/trust/trust.go
+++ b/trust/trust.go
@@ -18,6 +18,8 @@ import (
 	"strconv"
 	"sync/atomic"
 	"time"
+
+	"github.com/moonrhythm/parapet-ingress-controller/metric"
 )
 
 const maxBundleBody = 4 << 20
@@ -154,26 +156,54 @@ func (m *Manager) ServerTLSConfig(
 	return base
 }
 
+// applyResult classifies an apply attempt so the caller can emit the right metric
+// (the rejection reasons are otherwise indistinguishable at a single error return).
+type applyResult int
+
+const (
+	resultApplied applyResult = iota
+	resultParseRejected
+	resultEmptyRejected
+	resultRollbackRejected
+)
+
+func (r applyResult) label() string {
+	switch r {
+	case resultApplied:
+		return "applied"
+	case resultParseRejected:
+		return "parse_rejected"
+	case resultEmptyRejected:
+		return "empty_rejected"
+	case resultRollbackRejected:
+		return "rollback_rejected"
+	default:
+		return "unknown"
+	}
+}
+
 // apply validate-then-swaps a bundle: strict all-or-nothing PEM parse (a non-empty
 // input that yields fewer certs than CERTIFICATE blocks is rejected; never a partial
 // AppendCertsFromPEM), forward-only (reject generation <= current), then atomic swap.
-func (m *Manager) apply(b Bundle) error {
+// It returns a typed result so Run can count the exact reason (rollback_rejected is the
+// anti-replay security signal, kept distinct). Called only from the single Run goroutine.
+func (m *Manager) apply(b Bundle) (applyResult, error) {
 	pool, n, err := strictPool(b.CAPEM)
 	if err != nil {
-		return err
+		return resultParseRejected, err
 	}
 	if n == 0 {
-		return fmt.Errorf("trust bundle ca_pem has no certificates")
+		return resultEmptyRejected, fmt.Errorf("trust bundle ca_pem has no certificates")
 	}
 	cur := m.gen.Load()
 	if cur != 0 && b.Generation <= cur {
-		return fmt.Errorf("rollback: bundle generation %d <= current %d", b.Generation, cur)
+		return resultRollbackRejected, fmt.Errorf("rollback: bundle generation %d <= current %d", b.Generation, cur)
 	}
 	m.clientCAs.Store(pool)
 	m.gen.Store(b.Generation)
 	caID := b.CAID
 	m.caID.Store(&caID)
-	return nil
+	return resultApplied, nil
 }
 
 // strictPool parses every CERTIFICATE block and fails if any block is malformed, so
@@ -219,6 +249,7 @@ func (m *Manager) Run(ctx context.Context, c *Client, pollInterval time.Duration
 		first = false
 		switch {
 		case err != nil:
+			metric.TrustFetchFailed()
 			slog.Warn("core: trust-bundle fetch failed; keeping last-good", "error", err)
 			select {
 			case <-ctx.Done():
@@ -233,9 +264,12 @@ func (m *Manager) Run(ctx context.Context, c *Client, pollInterval time.Duration
 			backoff = time.Second
 			continue
 		default:
-			if err := m.apply(b); err != nil {
+			res, err := m.apply(b)
+			metric.TrustApply(res.label())
+			if err != nil {
 				slog.Warn("core: trust-bundle rejected; keeping last-good", "error", err)
 			} else {
+				metric.TrustBundleApplied(b.CAID, b.Generation)
 				slog.Info("core: edge trust bundle applied", "generation", b.Generation, "ca_id", b.CAID)
 			}
 			backoff = time.Second

--- a/trust/trust_test.go
+++ b/trust/trust_test.go
@@ -42,7 +42,7 @@ func TestManagerForwardOnlyAndFailStatic(t *testing.T) {
 	if m.ClientCAs() != nil {
 		t.Fatal("pool should be nil before first apply")
 	}
-	if err := m.apply(Bundle{Generation: 5, CAPEM: caPEM, CAID: "a"}); err != nil {
+	if _, err := m.apply(Bundle{Generation: 5, CAPEM: caPEM, CAID: "a"}); err != nil {
 		t.Fatalf("first apply: %v", err)
 	}
 	if m.Generation() != 5 || m.ClientCAs() == nil {
@@ -50,10 +50,10 @@ func TestManagerForwardOnlyAndFailStatic(t *testing.T) {
 	}
 
 	// Rollback (lower) and replay (equal) are rejected; the live pool is unchanged.
-	if err := m.apply(Bundle{Generation: 3, CAPEM: caPEM}); err == nil {
+	if _, err := m.apply(Bundle{Generation: 3, CAPEM: caPEM}); err == nil {
 		t.Error("rollback to lower generation must be rejected")
 	}
-	if err := m.apply(Bundle{Generation: 5, CAPEM: caPEM}); err == nil {
+	if _, err := m.apply(Bundle{Generation: 5, CAPEM: caPEM}); err == nil {
 		t.Error("replay of equal generation must be rejected")
 	}
 	if m.Generation() != 5 {
@@ -62,7 +62,7 @@ func TestManagerForwardOnlyAndFailStatic(t *testing.T) {
 
 	// Strict parse: a non-empty but cert-less ca_pem is rejected, last-good kept.
 	prev := m.ClientCAs()
-	if err := m.apply(Bundle{Generation: 6, CAPEM: []byte("garbage")}); err == nil {
+	if _, err := m.apply(Bundle{Generation: 6, CAPEM: []byte("garbage")}); err == nil {
 		t.Error("ca_pem with no certs must be rejected")
 	}
 	if m.Generation() != 5 || m.ClientCAs() != prev {
@@ -70,11 +70,39 @@ func TestManagerForwardOnlyAndFailStatic(t *testing.T) {
 	}
 
 	// A higher generation applies.
-	if err := m.apply(Bundle{Generation: 6, CAPEM: caPEM, CAID: "b"}); err != nil {
+	if _, err := m.apply(Bundle{Generation: 6, CAPEM: caPEM, CAID: "b"}); err != nil {
 		t.Fatalf("forward apply: %v", err)
 	}
 	if m.Generation() != 6 || m.CAID() != "b" {
 		t.Error("forward apply did not take")
+	}
+}
+
+// TestApplyResultEnum pins the typed applyResult each branch returns — the label fed
+// to metric.TrustApply. parse_rejected (a valid CERTIFICATE block with non-cert DER)
+// is otherwise unexercised; the others back the rejection/apply metric counts.
+func TestApplyResultEnum(t *testing.T) {
+	caPEM, _ := caPEMFor(t)
+	m := NewManager()
+
+	if res, err := m.apply(Bundle{Generation: 5, CAPEM: caPEM, CAID: "a"}); err != nil || res != resultApplied {
+		t.Fatalf("apply: res=%v err=%v, want resultApplied", res, err)
+	}
+	if res, err := m.apply(Bundle{Generation: 5, CAPEM: caPEM}); err == nil || res != resultRollbackRejected {
+		t.Errorf("replay: res=%v err=%v, want resultRollbackRejected", res, err)
+	}
+	// No CERTIFICATE block at all → empty_rejected.
+	if res, err := m.apply(Bundle{Generation: 6, CAPEM: []byte("garbage")}); err == nil || res != resultEmptyRejected {
+		t.Errorf("no certs: res=%v err=%v, want resultEmptyRejected", res, err)
+	}
+	// A well-formed CERTIFICATE block whose DER body is not a cert → parse_rejected.
+	badDER := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte{0x30, 0x03, 0x01, 0x02, 0x03}})
+	if res, err := m.apply(Bundle{Generation: 6, CAPEM: badDER}); err == nil || res != resultParseRejected {
+		t.Errorf("bad DER: res=%v err=%v, want resultParseRejected", res, err)
+	}
+	// Every rejection kept last-good.
+	if m.Generation() != 5 || m.CAID() != "a" {
+		t.Errorf("rejections must keep last-good, got gen=%d ca_id=%q", m.Generation(), m.CAID())
 	}
 }
 
@@ -107,7 +135,7 @@ func TestTrustBundleOverTLSEndToEnd(t *testing.T) {
 	}
 
 	m := NewManager()
-	if err := m.apply(b); err != nil {
+	if _, err := m.apply(b); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
 


### PR DESCRIPTION
**Sub-PR 2 of 5** for edge-proxy revocation (`EDGE-AUTOTRUST.md`). Pure instrumentation — no request/issuance/trust behavior change. It adds `ca_id`-joined Prometheus metrics across all three planes so an operator can detect when the fleet has converged on a rotated CA. This is the prerequisite for the later **convergence interlock** (sub-PR 4) and **destructive trim** (sub-PR 5), which gate dropping OLD on observed convergence.

## What it adds

**Shared — `caid/`** (new, dependency-light: `sha256`/`hex`/`pem`/`sort` only — no k8s, no prometheus): the CA-set fingerprint. `FromPEM` (CP, over the served bundle) and `FromDER` (edge, over its leaf chain's CA blocks) are **byte-identical** for the same set, so the edge derives a matching `ca_id` without importing the k8s-bound `edgecp`. `edgecp.caBundleID` now delegates to it.

| Plane | Metrics |
|---|---|
| **CP** (`edgecp`) | `edge_ca_target_ca_id`, `edge_ca_signer_fingerprint`, `edge_ca_signer_generation`, `edge_ca_bundle_certs`, `edge_ca_signer_loaded` — all `{ca_id}`, set atomically under `SetSigner`'s `genMu` (Reset-then-Set → one live series). `Signer` gains `certCount`+`BundleLen()`. |
| **core** | `trust_bundle_generation{ca_id}`, `trust_bundle_age_seconds` (GaugeFunc over an atomic stamp, zero steady-state cost), `trust_apply_total{result}` (`apply()` now returns a typed result so the rejection reason is real), `trust_fetch_failed_total`, `trust_source_total{source}` (one per-request decision — pre-materialized handle, single atomic add, **0 allocs, benchmarked**). |
| **edge** | `edge_clientcert_ca_id{ca_id}`, `edge_clientcert_not_after_seconds{ca_id}`, `edge_clientcert_loaded`, `edge_clientcert_remint_total{result}` (6 outcomes). `ca_id` derived locally via `caid.FromDER`, nil-Leaf + short-chain guarded. |

## Non-instrumentation deltas (called out explicitly)
- **A new, unauthenticated CP `/metrics` listener** (`CP_METRICS_LISTEN`, default `:9187`, `""` disables) — **separate** from the token-gated API mux, so a scraper needs no bearer token. Starts **only in the serving process** (the run-once bootstrap/rotate Jobs `os.Exit` first); a failed bind is fatal. Payload is **non-secret** (fingerprints/counters/generations — no key material). Ships with a **NetworkPolicy** restricting `:9187` to the scraper (`deploy/edge/controlplane.yaml`).
- **`trust.apply()` returns `(applyResult, error)`** instead of `error` — same swap/forward-only/strict-parse semantics, just a typed reason so the metric label is real (not fiction).
- **`Signer.certCount`/`BundleLen()`** — additive read-only.
- **Run-once-Job CA counters dropped** from Prometheus (Jobs exit before scrape) → structured `slog` + non-zero exit, alertable via `kube_job_failed`.

## Convergence model (corrected from the design draft)
Because `Sign()` appends the **full** served bundle (`OLD++NEW` during overlap) to every leaf, all three planes converge to the **CP target `ca_id`** — the edge merely **lags** until it re-mints. So convergence is one predicate against the self-describing `parapet_edge_ca_target_ca_id` series (no hardcoded value). Documented with PromQL + cardinality/aggregation caveats (`max by`, not `sum`; bounded series; the `cidr`-precedence undercount) in `EDGE-AUTOTRUST.md`.

## Review
An adversarial find-then-verify pass over the diff surfaced 4 findings (0 false-positive), all folded: the empty-`ca_id` series guard (symmetric with the edge helper; trust unaffected), deletion of dead `SetTargetCAID`, and an `apply()` result-enum pinning test. The "reject empty-`ca_id` bundles" suggestion was **declined** — it would change trust behavior in a pure-instrumentation PR.

## Tests
`caid` conformance (`FromPEM==FromDER`, order-independence), one-series-after-rotation per vec (all planes), per-enum increments, a `-race` apply-vs-scrape test, the `apply()` result-enum, a 0-alloc benchmark, and an **e2e** assertion that the CP `/metrics` serves `signer_fingerprint`+`signer_loaded=1` on the separate listener. `gofmt`/`go vet ./...`/`go test -race ./...`/e2e all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)