### PR TITLE
feat(edge): force-re-mint — proactive ca_id signal + reactive floor

### DIFF
--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -223,8 +223,8 @@ The default data-plane identity is CP-issued (`EDGE_DATAPLANE_MTLS=true`; requir
 `EDGE_UPSTREAM_TLS=true`). `edge/clientcert.go` holds the leaf in an in-memory
 `ClientCertStore` (`atomic.Pointer[tls.Certificate]`); `Update` is **all-or-nothing**
 (keep the prior pair on failure). `RunEdgeCertRefresh` renews on remaining-life
-(re-mint at ≤ ⅓ of the now-7d TTL, ~the 56 h mark) with backoff + jitter +
-`Retry-After`.
+(re-mint when ≤ 0.66 × the leaf's own lifetime remains, i.e. ~4.6 d left of a 7-d
+leaf, ~2.4 d in) with backoff + jitter + `Retry-After`.
 
 ### Force-re-mint trigger: proactive overlap (primary) + reactive (floor)
 
@@ -611,8 +611,12 @@ not Prometheus counters (a Pushgateway would be a new failure domain).
 | `EDGE_TRUST_CP_CACHE_FILE` / `_MAX_STALE` | core | `""` / `1h` | Warm-start hint (no trust until revalidated; bounded by max-stale). |
 | `EDGE_TRUST_REQUIRE_SAN` | core | **forced false, deprecated** | CA-only is the only model; the per-request SAN check is removed. Setting `true` with CP-issuance is a **fatal config error**. Slated for removal. |
 | `EDGE_DATAPLANE_MTLS` | edge | `false` | Enable the CP-issued client cert. Requires `EDGE_UPSTREAM_TLS=true`. Readiness gated on a loaded cert. |
-| `EDGE_CLIENTCERT_TTL` | CP | **`168h` (7 d)** | Issued **leaf** lifetime (was 1 h). Buys a ~multi-day CP-outage budget (= `TTL` × renew-before-fraction ≈ 4.6 d). Renewal stays remaining-life (≤⅓, ~56 h mark). The paired-knob guard: renew-before-fraction in (0,1) with ≥ several `EDGE_REFRESH_INTERVAL` of slack before expiry. |
-| `EDGE_CLIENTCERT_REMINT_JITTER` | edge | `60s` (≥ signer drain) | Max random delay before a force-re-mint (proactive or reactive), to prevent a re-mint thundering herd when `ca_id` flips fleet-wide. With exponential backoff + `Retry-After` + per-edge single-flight + a no-`ca_id`-change circuit-breaker. |
+| `EDGE_CLIENTCERT_TTL` | CP | **`168h` (7 d)** | Issued **leaf** lifetime (was 1 h). Buys a ~multi-day CP-outage budget (= `TTL` × renew-remaining-fraction ≈ 4.6 d). Renewal stays remaining-life (≤ 0.66×TTL, ~4.6 d remaining). The paired-knob guard: renew-before-fraction in (0,1) with ≥ several `EDGE_REFRESH_INTERVAL` of slack before expiry. |
+| `EDGE_CLIENTCERT_REMINT_JITTER` | edge | `60s` (≥ signer drain) | Max random delay before a force-re-mint (proactive or reactive), to prevent a re-mint thundering herd when `ca_id` flips fleet-wide. With exponential backoff + `Retry-After` + per-edge single-flight + a no-`ca_id`-change circuit-breaker. The periodic poll loops also jitter their FIRST tick by `[0,EDGE_REFRESH_INTERVAL]` so the signal-delivery instants decorrelate, not just the mints. |
+| `EDGE_CLIENTCERT_REMINT_BACKOFF_BASE` / `_COOLDOWN` | edge | `2s` / `5×EDGE_REFRESH_INTERVAL` | Exponential-backoff base on a non-ok mint (×2, jittered, capped at `EDGE_REFRESH_INTERVAL`); breaker-open cooldown. |
+| `EDGE_CLIENTCERT_REMINT_BREAKER_K` / `_PROACTIVE_J` | edge | `3` / `5` | Open the **reactive** breaker after K consecutive ok-mints that don't change `ca_id` (a core-side reject re-minting can't fix); the **proactive** breaker after J ok-mints that don't reach the observed target. Transient (non-ok) mints never feed either — they're the backoff path. A genuine `ca_id` flip / convergence resets. |
+| `EDGE_CLIENTCERT_RENEW_REMAINING_FRACTION` | edge | `0.66` | Remaining-life renewal floor: re-mint when `remaining ≤ fraction × the leaf's own lifetime`. The timer floor that converges even a zero-signal edge; keep `(1-elapsed)×TTL > CP-recovery SLO`. |
+| `CP_EDGE_SIGN_CONCURRENCY` / `CP_EDGE_SIGN_RETRY_AFTER` | CP | `GOMAXPROCS` / `5s` | Bound concurrent edge-cert signs; shed the rotation re-mint surge with `503 + Retry-After` (the only fleet-aggregate backpressure — one token per edge doesn't bound the aggregate). The edge coordinator honors the `Retry-After`. |
 | `EDGE_CLIENTCERT_KEY_TYPE` / `_SKEW` / `_RATE` | edge/CP | `ecdsa-p256` / `10m` / `10/min` | Ephemeral key type; NotBefore backdate (negligible vs 7 d, but NTP between CP and core stays a prerequisite); per-token issuance limit (**per-replica**, effective N×). |
 | `EDGE_CA_BOOTSTRAP` / `--bootstrap-ca` | CP (Job) | false | One-shot CA bootstrap **and rotation** mode (`EnsureCA`: adopt/generate/never-regenerate, CAS-guarded). The only writer of the CA Secret. |
 | `EDGE_CA_CERT` / `_KEY` | CP | `""` (⇒ managed) | Provided mode (mounted CA). Both-or-neither. Absent ⇒ managed (the Job generates). |

--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -11,6 +11,8 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,6 +27,17 @@ import (
 func envOr(key, def string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
+	}
+	return def
+}
+
+// envInt reads a base-10 int from env, or returns def (on unset/invalid).
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+		slog.Warn("invalid int; using default", "key", key, "value", v, "default", def)
 	}
 	return def
 }
@@ -153,6 +166,13 @@ func main() {
 	go reloader.Start(ctx)
 
 	server := edgecp.NewServer(store, authz)
+
+	// Bound concurrent edge-cert signing so a rotation's fleet-wide re-mint surge sheds
+	// with 503 + Retry-After instead of saturating the CPU-bound signer. Default to
+	// GOMAXPROCS in-flight (signing is fast; this is a safety valve, not a tight cap).
+	signConcurrency := envInt("CP_EDGE_SIGN_CONCURRENCY", runtime.GOMAXPROCS(0))
+	signRetryAfter := envInt("CP_EDGE_SIGN_RETRY_AFTER", 5)
+	server = server.WithSignConcurrency(signConcurrency, signRetryAfter)
 
 	// Data-plane client-cert issuance (POST /v1/edge-cert) + the tokenless trust
 	// bundle (GET /v1/trust-bundle). Two ways to supply the edge CA:

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -107,26 +107,46 @@ func main() {
 
 	ctx := context.Background()
 
+	// Optional data-plane mTLS: fetch a CP-issued client cert (CA-only trust), hold it
+	// in memory (never on disk), and present it on the re-encrypt hop. The re-mint
+	// coordinator owns every re-mint path (proactive on a ca_id flip observed via the
+	// /v1/certs poll, reactive on a core cert-reject, timer on remaining-life). It is
+	// built EARLY so it threads into the cert/WAF refresh loops as the force-re-mint
+	// observer; nil when mTLS is off (every coord call is a no-op).
+	var clientCertStore *edge.ClientCertStore
+	var remintCoord *edge.RemintCoordinator
+	if dataplaneMTLS {
+		clientCertStore = edge.NewClientCertStore()
+		remintCoord = edge.NewRemintCoordinator(cp, clientCertStore, edge.RemintConfig{
+			Jitter:        time.Duration(envInt64("EDGE_CLIENTCERT_REMINT_JITTER", 60)) * time.Second,
+			BackoffBase:   time.Duration(envInt64("EDGE_CLIENTCERT_REMINT_BACKOFF_BASE", 2)) * time.Second,
+			BackoffMax:    refreshInterval,
+			Cooldown:      time.Duration(envInt64("EDGE_CLIENTCERT_REMINT_COOLDOWN", int64(5*refreshInterval/time.Second))) * time.Second,
+			BreakerK:      int(envInt64("EDGE_CLIENTCERT_REMINT_BREAKER_K", 3)),
+			ProactiveJ:    int(envInt64("EDGE_CLIENTCERT_REMINT_PROACTIVE_J", 5)),
+			RenewFraction: envFloat("EDGE_CLIENTCERT_RENEW_REMAINING_FRACTION", 0.66),
+		})
+	}
+
 	if serveAll {
 		// On a handshake for an SNI not held, fetch it from the control plane (the
 		// handshake blocks on it); the CP's per-token authz still gates which SNIs
 		// resolve. The periodic refresh keeps on-demand domains rotated.
-		store.SetOnDemand(func(sni string) { edge.RefreshCertOnce(cp, store, sni) })
+		store.SetOnDemand(func(sni string) { edge.RefreshCertOnce(cp, store, sni, remintCoord) })
 		slog.Info("edge: EDGE_DOMAINS empty — serving ALL domains (certs fetched on demand)")
 	} else {
-		loaded := edge.RefreshCertsAll(cp, store, domains)
+		loaded := edge.RefreshCertsAll(cp, store, domains, remintCoord)
 		slog.Info("edge: initial cert load", "loaded", loaded, "total", len(domains))
 	}
-	go edge.RunCertRefresh(ctx, cp, store, domains, refreshInterval)
+	go edge.RunCertRefresh(ctx, cp, store, domains, refreshInterval, remintCoord)
 
-	// Optional data-plane mTLS: fetch a CP-issued client cert (CA-only trust), hold
-	// it in memory (never on disk), refresh on a timer, and present it on the
-	// re-encrypt hop. The leaf private key is generated here and never leaves.
-	var clientCertStore *edge.ClientCertStore
 	if dataplaneMTLS {
-		clientCertStore = edge.NewClientCertStore()
-		edge.RefreshEdgeCertOnce(cp, clientCertStore) // best-effort; fail-static
-		go edge.RunEdgeCertRefresh(ctx, cp, clientCertStore, refreshInterval)
+		// Startup mint is direct + UN-jittered (readiness needs it fast); the periodic
+		// loops are jittered so a simultaneous fleet restart doesn't thunder. A
+		// boot-during-overlap edge that freezes at a stale ca_id gets a proactive
+		// recheck within one interval via the jittered first cert-refresh/trust-bundle tick.
+		edge.RefreshEdgeCertOnce(cp, clientCertStore, "timer") // best-effort; fail-static
+		go edge.RunEdgeCertRefresh(ctx, remintCoord, refreshInterval)
 		slog.Info("edge: data-plane mTLS enabled (CP-issued client cert)")
 	}
 
@@ -138,8 +158,8 @@ func main() {
 	if wafEnabled {
 		country, asn = loadGeoResolvers()
 		ewaf = edge.NewEdgeWAF(country, asn)
-		edge.RefreshWafOnce(cp, ewaf)
-		go edge.RunWafRefresh(ctx, cp, ewaf, refreshInterval)
+		edge.RefreshWafOnce(cp, ewaf, remintCoord)
+		go edge.RunWafRefresh(ctx, cp, ewaf, refreshInterval, remintCoord)
 	}
 
 	// Optional response cache (off by default), from parapet/pkg/cache. The
@@ -170,10 +190,14 @@ func main() {
 	}
 
 	var getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
+	var onCertReject func()
 	if clientCertStore != nil {
 		getClientCert = clientCertStore.GetClientCertificate
+		// Reactive force-re-mint floor: a core cert-reject in the re-encrypt handshake
+		// fires a (non-blocking) reactive re-mint. nil when mTLS is off.
+		onCertReject = func() { remintCoord.Trigger("reactive") }
 	}
-	forwarder := edge.NewForwarder(upstreamAddr, upstreamTLS, upstreamSNI, getClientCert)
+	forwarder := edge.NewForwarder(upstreamAddr, upstreamTLS, upstreamSNI, getClientCert, onCertReject)
 
 	if metricsListen != "" {
 		go func() {
@@ -377,6 +401,15 @@ func envInt64(key string, def int64) int64 {
 	if v, ok := os.LookupEnv(key); ok {
 		if n, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64); err == nil {
 			return n
+		}
+	}
+	return def
+}
+
+func envFloat(key string, def float64) float64 {
+	if v, ok := os.LookupEnv(key); ok {
+		if f, err := strconv.ParseFloat(strings.TrimSpace(v), 64); err == nil {
+			return f
 		}
 	}
 	return def

--- a/deploy/edge/e2e/run.sh
+++ b/deploy/edge/e2e/run.sh
@@ -321,4 +321,18 @@ grep -qE "^parapet_edge_ca_signer_loaded 1$" <<<"$MET" \
   || { grep signer_loaded <<<"$MET" >&2; fail "CP signer_loaded != 1"; }
 echo "  ✓ CP /metrics (tokenless) serves signer_fingerprint + signer_loaded=1"
 
+# Force-re-mint signal: GET /v1/certs carries the X-Parapet-CA-Id header (the universal
+# proactive carrier that rides the edge's existing cert poll on EVERY arm, incl. 304/404).
+# Assert it is present and equals the signer fingerprint from /metrics — so a CA rotation
+# would be observable by every edge regardless of WAF/serve-all mode.
+say "9. force-re-mint signal: /v1/certs advertises X-Parapet-CA-Id"
+SIG_CAID="$(grep -oE 'parapet_edge_ca_signer_fingerprint\{ca_id="[^"]+"' <<<"$MET" | grep -oE 'ca_id="[^"]+"' | cut -d'"' -f2)"
+[ -n "$SIG_CAID" ] || fail "could not read signer ca_id from /metrics"
+CERT_CAID="$(curl -sS -D - -o /dev/null --cacert "$WORK/ca.crt" -H "Authorization: Bearer $TOKEN" \
+  --resolve "localhost:$CP_PORT:127.0.0.1" "https://localhost:$CP_PORT/v1/certs?sni=$DOMAIN" \
+  | grep -i '^x-parapet-ca-id:' | tr -d '\r' | awk '{print $2}')"
+[ "$CERT_CAID" = "$SIG_CAID" ] \
+  || { echo "cert-arm ca_id='$CERT_CAID' signer ca_id='$SIG_CAID'" >&2; fail "/v1/certs X-Parapet-CA-Id missing or != signer ca_id"; }
+echo "  ✓ /v1/certs advertises X-Parapet-CA-Id ($CERT_CAID) matching the signer"
+
 say "E2E PASSED"

--- a/edge/clientcert.go
+++ b/edge/clientcert.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"github.com/moonrhythm/parapet-ingress-controller/caid"
 )
@@ -18,6 +19,11 @@ import (
 // "Edge wiring".
 type ClientCertStore struct {
 	cur atomic.Pointer[tls.Certificate]
+	// caid is the ca_id of the CA set that issued the LIVE leaf (== the
+	// edge_clientcert_ca_id gauge). It is the AUTHORITATIVE held value the force-re-mint
+	// observer compares the CP target against; correct after a fail-static (it tracks
+	// the cert actually in use, not a failed attempt).
+	caid atomic.Pointer[string]
 }
 
 func NewClientCertStore() *ClientCertStore { return &ClientCertStore{} }
@@ -57,6 +63,7 @@ func (s *ClientCertStore) Update(chainPEM, keyPEM []byte) error {
 	if len(cert.Certificate) >= 2 {
 		caID, _ = caid.FromDER(cert.Certificate[1:])
 	}
+	s.caid.Store(&caID) // store even when "" (single-CA chain / too-short)
 	var notAfter int64
 	if cert.Leaf != nil {
 		notAfter = cert.Leaf.NotAfter.Unix()
@@ -68,3 +75,24 @@ func (s *ClientCertStore) Update(chainPEM, keyPEM []byte) error {
 // Loaded reports whether a client cert has ever been installed (readiness gate when
 // EDGE_DATAPLANE_MTLS is on).
 func (s *ClientCertStore) Loaded() bool { return s.cur.Load() != nil }
+
+// CAID returns the ca_id of the CA set that issued the LIVE leaf, or "" if none is
+// held yet (or the chain is too short to carry a CA block). This is the held-vs-target
+// convergence comparison's authoritative "live" side.
+func (s *ClientCertStore) CAID() string {
+	if p := s.caid.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// Validity returns the live leaf's NotBefore/NotAfter for remaining-life renewal (the
+// renewal threshold is a fraction of the cert's OWN lifetime, so it needs no knowledge
+// of the CP's configured TTL). ok=false when no cert is held or the leaf didn't parse.
+func (s *ClientCertStore) Validity() (notBefore, notAfter time.Time, ok bool) {
+	c := s.cur.Load()
+	if c == nil || c.Leaf == nil {
+		return time.Time{}, time.Time{}, false
+	}
+	return c.Leaf.NotBefore, c.Leaf.NotAfter, true
+}

--- a/edge/clientcert_test.go
+++ b/edge/clientcert_test.go
@@ -57,7 +57,7 @@ func TestEdgeCertIssuanceEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 	store := NewClientCertStore()
-	RefreshEdgeCertOnce(cp, store)
+	RefreshEdgeCertOnce(cp, store, "timer")
 
 	if !store.Loaded() {
 		t.Fatal("client cert not loaded after issuance")

--- a/edge/cp.go
+++ b/edge/cp.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -64,6 +65,11 @@ type CertFetch struct {
 	ChainPEM []byte
 	KeyPEM   []byte
 	Etag     string
+	// CAID is the signer's target ca_id from the X-Parapet-CA-Id response header. It
+	// is populated on EVERY status (200, 304, and even a 404) — the universal
+	// force-re-mint signal that rides the edge's existing /v1/certs poll. "" means the
+	// CP didn't advertise one (old CP / no signer); the edge fail-statics on "".
+	CAID string
 }
 
 type certBody struct {
@@ -83,9 +89,14 @@ func (c *CpClient) FetchCert(sni, currentEtag string) (CertFetch, error) {
 	}
 	defer resp.Body.Close()
 
+	// The X-Parapet-CA-Id header rides EVERY status. Read it once, up front, so the
+	// force-re-mint signal is surfaced on the 304 (the steady-state carrier — almost
+	// all responses are 304), the 200, AND the 404 (a missing-cert sni still learns
+	// the CP target). Steady state is ~100% 304s, so the 304 arm is load-bearing.
+	caID := resp.Header.Get("X-Parapet-CA-Id")
 	switch resp.StatusCode {
 	case http.StatusNotModified:
-		return CertFetch{Unchanged: true}, nil
+		return CertFetch{Unchanged: true, CAID: caID}, nil
 	case http.StatusOK:
 		var body certBody
 		if err := json.NewDecoder(io.LimitReader(resp.Body, maxCertBody)).Decode(&body); err != nil {
@@ -95,9 +106,12 @@ func (c *CpClient) FetchCert(sni, currentEtag string) (CertFetch, error) {
 			ChainPEM: []byte(body.ChainPEM),
 			KeyPEM:   []byte(body.KeyPEM),
 			Etag:     resp.Header.Get("ETag"),
+			CAID:     caID,
 		}, nil
 	default:
-		return CertFetch{}, fmt.Errorf("control plane returned %d for sni %q", resp.StatusCode, sni)
+		// Surface the target with the error so the caller can still observe a ca_id
+		// flip even when the per-sni cert is missing (404).
+		return CertFetch{CAID: caID}, fmt.Errorf("control plane returned %d for sni %q", resp.StatusCode, sni)
 	}
 }
 
@@ -112,6 +126,7 @@ type WafFetch struct {
 	Zones       map[string]string
 	HostZoneMap map[string]string
 	Etag        string
+	CAID        string // signer target ca_id (secondary force-re-mint confirmer; 200 only)
 }
 
 type wafBody struct {
@@ -119,6 +134,7 @@ type wafBody struct {
 	GlobalRules string            `json:"global_rules"`
 	Zones       map[string]string `json:"zones"`
 	HostZoneMap map[string]string `json:"host_zone_map"`
+	CAID        string            `json:"ca_id"`
 }
 
 // FetchWaf fetches the WAF payload (global YAML + zones + host->zone map) scoped
@@ -146,6 +162,7 @@ func (c *CpClient) FetchWaf(currentEtag string) (WafFetch, error) {
 			Zones:       body.Zones,
 			HostZoneMap: body.HostZoneMap,
 			Etag:        resp.Header.Get("ETag"),
+			CAID:        body.CAID,
 		}, nil
 	default:
 		return WafFetch{}, fmt.Errorf("control plane returned %d for /v1/waf", resp.StatusCode)
@@ -157,6 +174,10 @@ type EdgeCertFetch struct {
 	ChainPEM []byte // leaf-first chain (leaf + edge CA); pair with the locally-held key
 	NotAfter string // RFC3339, for renewal scheduling
 	Serial   string
+	CAID     string // signer ca_id, so the edge self-confirms convergence post-mint
+	// RetryAfter is the parsed Retry-After delay on a 429/503 (signer saturated),
+	// returned ALONGSIDE the error so the coordinator can back off the whole fleet.
+	RetryAfter time.Duration
 }
 
 type edgeCertReqBody struct {
@@ -167,6 +188,7 @@ type edgeCertRespBody struct {
 	ChainPEM string `json:"chain_pem"`
 	NotAfter string `json:"not_after"`
 	Serial   string `json:"serial"`
+	CAID     string `json:"ca_id"`
 }
 
 // FetchEdgeCert posts a CSR to POST /v1/edge-cert and returns the signed chain. The
@@ -191,7 +213,14 @@ func (c *CpClient) FetchEdgeCert(csrPEM []byte) (EdgeCertFetch, error) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
-		return EdgeCertFetch{}, fmt.Errorf("control plane returned %d for /v1/edge-cert", resp.StatusCode)
+		// On a saturated-signer shed (429/503), surface the Retry-After so the
+		// coordinator honors fleet-aggregate backpressure (one token per edge does NOT
+		// bound the aggregate). Returned with the error; the caller still fail-statics.
+		var retryAfter time.Duration
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
+			retryAfter = parseRetryAfter(resp.Header.Get("Retry-After"))
+		}
+		return EdgeCertFetch{RetryAfter: retryAfter}, fmt.Errorf("control plane returned %d for /v1/edge-cert", resp.StatusCode)
 	}
 	var body edgeCertRespBody
 	if err := json.NewDecoder(io.LimitReader(resp.Body, maxCertBody)).Decode(&body); err != nil {
@@ -201,7 +230,54 @@ func (c *CpClient) FetchEdgeCert(csrPEM []byte) (EdgeCertFetch, error) {
 		ChainPEM: []byte(body.ChainPEM),
 		NotAfter: body.NotAfter,
 		Serial:   body.Serial,
+		CAID:     body.CAID,
 	}, nil
+}
+
+// parseRetryAfter parses an HTTP Retry-After header value: either delta-seconds
+// (e.g. "5") or an HTTP-date. Returns 0 on empty/unparseable/negative.
+func parseRetryAfter(v string) time.Duration {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs < 0 {
+			return 0
+		}
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+type trustBundleBody struct {
+	CAID string `json:"ca_id"`
+}
+
+// FetchTrustBundleCAID reads ONLY the ca_id from the tokenless GET /v1/trust-bundle
+// (the same public endpoint the core polls). It lets an mTLS edge observe a CA rotation
+// even when it polls no per-domain cert and no WAF (serve-all, no traffic, WAF off) —
+// it rides the edge-cert refresh tick, not a new loop. The bearer token is sent (the
+// endpoint ignores it). Errors are the caller's to fail-static on.
+func (c *CpClient) FetchTrustBundleCAID() (string, error) {
+	resp, err := c.do(c.base+"/v1/trust-bundle", "")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("control plane returned %d for /v1/trust-bundle", resp.StatusCode)
+	}
+	var body trustBundleBody
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxCertBody)).Decode(&body); err != nil {
+		return "", fmt.Errorf("decode: %w", err)
+	}
+	return body.CAID, nil
 }
 
 // do issues an authorized GET, optionally with If-None-Match. The body must be

--- a/edge/cp_signal_test.go
+++ b/edge/cp_signal_test.go
@@ -1,0 +1,96 @@
+package edge
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func newSignalCP(t *testing.T, h http.HandlerFunc) *CpClient {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	cp, err := NewCpClient(srv.URL, "tok", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cp
+}
+
+// FetchCert must surface X-Parapet-CA-Id on the 200, the 304 (the STEADY-STATE carrier
+// — almost every response is a 304), AND the 404 (a missing-cert sni still learns the
+// target). A regression here silently disables fleet-wide proactive convergence.
+func TestFetchCertCarriesCAIDOnEveryArm(t *testing.T) {
+	cases := []struct {
+		name string
+		code int
+		body string
+	}{
+		{"200", http.StatusOK, `{"chain_pem":"c","key_pem":"k"}`},
+		{"304", http.StatusNotModified, ""},
+		{"404", http.StatusNotFound, "no cert"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cp := newSignalCP(t, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-Parapet-CA-Id", "target-123")
+				w.WriteHeader(tc.code)
+				_, _ = w.Write([]byte(tc.body))
+			})
+			res, err := cp.FetchCert("acme.com", "")
+			if tc.code == http.StatusNotFound && err == nil {
+				t.Error("404 should be an error")
+			}
+			if res.CAID != "target-123" {
+				t.Errorf("%s: CAID = %q, want target-123 (the signal must ride this arm)", tc.name, res.CAID)
+			}
+		})
+	}
+}
+
+func TestFetchTrustBundleCAID(t *testing.T) {
+	cp := newSignalCP(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"generation":3,"ca_pem":"x","ca_id":"tb-abc"}`))
+	})
+	id, err := cp.FetchTrustBundleCAID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "tb-abc" {
+		t.Errorf("ca_id = %q, want tb-abc", id)
+	}
+}
+
+func TestFetchEdgeCertRetryAfter(t *testing.T) {
+	cp := newSignalCP(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "7")
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	res, err := cp.FetchEdgeCert([]byte("csr"))
+	if err == nil {
+		t.Fatal("503 should be an error")
+	}
+	if res.RetryAfter != 7*time.Second {
+		t.Errorf("RetryAfter = %v, want 7s", res.RetryAfter)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	if got := parseRetryAfter("5"); got != 5*time.Second {
+		t.Errorf("delta-seconds: %v, want 5s", got)
+	}
+	if got := parseRetryAfter(""); got != 0 {
+		t.Errorf("empty: %v, want 0", got)
+	}
+	if got := parseRetryAfter("-3"); got != 0 {
+		t.Errorf("negative: %v, want 0", got)
+	}
+	if got := parseRetryAfter("garbage"); got != 0 {
+		t.Errorf("garbage: %v, want 0", got)
+	}
+	future := time.Now().Add(30 * time.Second).UTC().Format(http.TimeFormat)
+	if got := parseRetryAfter(future); got <= 0 || got > 31*time.Second {
+		t.Errorf("http-date: %v, want ~30s", got)
+	}
+}

--- a/edge/forward.go
+++ b/edge/forward.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 	"sync"
 
 	"github.com/moonrhythm/parapet"
@@ -38,7 +39,10 @@ type Forwarder struct {
 // it. Re-encrypt uses TLS with InsecureSkipVerify (a cluster-internal hop,
 // matching the controller's upstream posture) — the edge authenticates ITSELF to
 // the core with its client cert; it does not yet verify the core's server cert.
-func NewForwarder(addr string, useTLS bool, sni string, getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error)) *Forwarder {
+// onCertReject, when non-nil, fires when the CORE rejects the edge's data-plane client
+// cert in the re-encrypt TLS handshake — the reactive force-re-mint floor. It is the
+// coordinator's reactive Trigger; nil when data-plane mTLS is off.
+func NewForwarder(addr string, useTLS bool, sni string, getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error), onCertReject func()) *Forwarder {
 	var tr http.RoundTripper
 	if useTLS {
 		tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true} //nolint:gosec // cluster-internal hop, matches the controller's upstream posture
@@ -68,11 +72,56 @@ func NewForwarder(addr string, useTLS bool, sni string, getClientCert func(*tls.
 			if errors.Is(err, context.Canceled) {
 				return // client went away
 			}
+			// Reactive force-re-mint floor: if the CORE rejected our client cert in the
+			// handshake, fire the (non-blocking) reactive trigger BEFORE the 502. The
+			// request still 502s; once the new leaf lands, subsequent requests succeed.
+			if onCertReject != nil && isClientCertRejected(err) {
+				onCertReject()
+			}
 			slog.Warn("edge: upstream error", "addr", addr, "error", err)
 			http.Error(w, "Bad Gateway", http.StatusBadGateway)
 		},
 	}
 	return &Forwarder{rp: rp}
+}
+
+// isClientCertRejected reports whether err is the CORE rejecting the edge's client cert
+// in the re-encrypt TLS handshake — and ONLY that. It is deliberately PARANOID: a false
+// positive turns an unrelated core outage into a fleet-wide re-mint storm, so it
+// matches only a PEER-sent ("remote error: tls: ...") cert-verify alert and excludes a
+// locally-raised alert, dial errors, timeouts, and any HTTP status (a healthy core's
+// 5xx is a response that never reaches ErrorHandler).
+func isClientCertRejected(err error) bool {
+	if err == nil {
+		return false
+	}
+	// A locally-generated alert is the EDGE rejecting the core (we don't verify the core
+	// today, but be explicit) — re-minting our own cert can't fix that. Exclude it.
+	var ae *tls.AlertError
+	if errors.As(err, &ae) {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	if !strings.Contains(s, "remote error: tls:") {
+		return false // not a peer-sent TLS alert (dial error / timeout / etc.)
+	}
+	// NOTE: certificate_expired is deliberately ABSENT — an expired leaf is owned by the
+	// remaining-life renewal floor (MaybeRenew), not the reactive path. Including it would
+	// let an expiry-driven reactive mint (which produces a fresh leaf with the SAME ca_id)
+	// feed the no-flip reactive breaker.
+	for _, alert := range []string{
+		"bad certificate",      // Go's rendering of bad_certificate
+		"certificate required", // certificate_required (core wants a cert / rejected none)
+		"unknown certificate authority",
+		"unknown ca",          // unknown_ca
+		"certificate unknown", // certificate_unknown
+		"certificate revoked", // certificate_revoked
+	} {
+		if strings.Contains(s, alert) {
+			return true
+		}
+	}
+	return false
 }
 
 // ServeHandler implements parapet.Middleware. It is terminal — the next handler

--- a/edge/forward_test.go
+++ b/edge/forward_test.go
@@ -1,0 +1,89 @@
+package edge
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// isClientCertRejected must fire ONLY on a peer-sent (core) cert-verify TLS alert — a
+// false positive turns an unrelated core outage into a fleet-wide re-mint storm.
+func TestIsClientCertRejected(t *testing.T) {
+	// SHOULD re-mint: the core rejected our client cert (a received alert).
+	remint := []error{
+		errors.New("remote error: tls: bad certificate"),
+		errors.New("remote error: tls: unknown certificate authority"),
+		errors.New("remote error: tls: certificate required"),
+		errors.New("remote error: tls: certificate unknown"),
+		errors.New("remote error: tls: certificate revoked"),
+		fmt.Errorf("Get \"https://core\": %w", errors.New("remote error: tls: bad certificate")),
+	}
+	for _, e := range remint {
+		if !isClientCertRejected(e) {
+			t.Errorf("want re-mint for %q", e)
+		}
+	}
+
+	// MUST NOT re-mint: transient / unrelated / locally-raised — re-minting can't fix
+	// these and would storm.
+	noRemint := []error{
+		nil,
+		errors.New("dial tcp 10.0.0.1:443: connect: connection refused"),
+		errors.New("context deadline exceeded"),
+		errors.New("net/http: timeout awaiting response headers"),
+		errors.New("remote error: tls: handshake failure"), // not a cert-trust alert
+		errors.New("remote error: tls: protocol version not supported"),
+		errors.New("remote error: tls: certificate expired"), // expiry is the renewal floor's job, not reactive
+		errors.New("EOF"),
+		tls.AlertError(42), // a LOCALLY-raised bad_certificate (the edge rejecting the core) — excluded
+	}
+	for _, e := range noRemint {
+		if isClientCertRejected(e) {
+			t.Errorf("must NOT re-mint for %v", e)
+		}
+	}
+}
+
+// TestClassifierMatchesRealGoAlert pins the classifier against the ACTUAL error string
+// Go produces when a TLS server rejects the client's cert — the exact reactive scenario
+// (core's ClientCAs no longer trusts the edge's OLD leaf after a trim). A future Go
+// rename of the TLS-alert text would break the classifier silently; this catches it in CI
+// (the string-literal unit test above cannot — it asserts against strings WE wrote).
+func TestClassifierMatchesRealGoAlert(t *testing.T) {
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	// Require + verify a client cert against an EMPTY pool → any presented cert is rejected.
+	srv.TLS = &tls.Config{ClientAuth: tls.RequireAndVerifyClientCert, ClientCAs: x509.NewCertPool()}
+	srv.StartTLS()
+	defer srv.Close()
+
+	// A self-signed client cert the server won't trust (stands in for the OLD-CA leaf).
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "edge"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, _ := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	clientCert := tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+
+	c := srv.Client()
+	c.Transport.(*http.Transport).TLSClientConfig.Certificates = []tls.Certificate{clientCert}
+	_, err := c.Get(srv.URL)
+	if err == nil {
+		t.Fatal("handshake should have failed (server rejects the client cert)")
+	}
+	if !isClientCertRejected(err) {
+		t.Errorf("classifier must match the REAL Go cert-reject alert, got: %v", err)
+	}
+}

--- a/edge/metrics.go
+++ b/edge/metrics.go
@@ -36,17 +36,21 @@ var (
 	edgeRemint = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: prom.Namespace,
 		Name:      "edge_clientcert_remint_total",
-		Help:      "Edge data-plane cert re-mint attempts by result (ok|keygen_fail|csr_fail|fetch_fail|marshal_fail|store_fail).",
-	}, []string{"result"})
+		Help:      "Edge data-plane cert re-mint attempts by result (ok|keygen_fail|csr_fail|fetch_fail|marshal_fail|store_fail|breaker_open) and trigger (proactive|reactive|timer).",
+	}, []string{"result", "trigger"})
 
-	edgeRemintHandles = map[string]prometheus.Counter{}
+	// edgeCPTargetCAID is the edge-OBSERVED CP target ca_id (from the X-Parapet-CA-Id
+	// signal). The OLD-drop convergence interlock compares this against the live
+	// edge_clientcert_ca_id; equal ⇒ this edge has converged.
+	edgeCPTargetCAID = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_cp_target_ca_id",
+		Help:      "CP target ca_id the edge last observed (value 1).",
+	}, []string{"ca_id"})
 )
 
 func init() {
-	prom.Registry().MustRegister(edgeClientCertCAID, edgeClientCertNotAfter, edgeClientCertLoaded, edgeRemint)
-	for _, r := range []string{"ok", "keygen_fail", "csr_fail", "fetch_fail", "marshal_fail", "store_fail"} {
-		edgeRemintHandles[r], _ = edgeRemint.GetMetricWith(prometheus.Labels{"result": r})
-	}
+	prom.Registry().MustRegister(edgeClientCertCAID, edgeClientCertNotAfter, edgeClientCertLoaded, edgeRemint, edgeCPTargetCAID)
 }
 
 // setClientCertMetrics records the live leaf's ca_id and expiry (Reset()-then-Set so
@@ -63,9 +67,17 @@ func setClientCertMetrics(caID string, notAfterUnix int64) {
 	edgeClientCertLoaded.Set(1)
 }
 
-// remint counts one re-mint attempt by result (bare Inc on a pre-materialized handle).
-func remint(result string) {
-	if h := edgeRemintHandles[result]; h != nil {
-		h.Inc()
+// remint counts one re-mint attempt by result and trigger. Re-mints are infrequent
+// (per rotation / renewal, not per request), so resolving the label here is fine.
+func remint(result, trigger string) {
+	edgeRemint.WithLabelValues(result, trigger).Inc()
+}
+
+// setObservedTarget records the CP target ca_id the edge last observed (Reset-then-Set,
+// one live series). "" (no signal) clears it.
+func setObservedTarget(caID string) {
+	edgeCPTargetCAID.Reset()
+	if caID != "" {
+		edgeCPTargetCAID.WithLabelValues(caID).Set(1)
 	}
 }

--- a/edge/metrics_test.go
+++ b/edge/metrics_test.go
@@ -33,12 +33,26 @@ func TestSetClientCertMetricsOneSeries(t *testing.T) {
 }
 
 func TestRemintEnum(t *testing.T) {
-	for _, result := range []string{"ok", "keygen_fail", "csr_fail", "fetch_fail", "marshal_fail", "store_fail"} {
-		before := testutil.ToFloat64(edgeRemintHandles[result])
-		remint(result)
-		if got := testutil.ToFloat64(edgeRemintHandles[result]); got != before+1 {
+	for _, result := range []string{"ok", "keygen_fail", "csr_fail", "fetch_fail", "marshal_fail", "store_fail", "breaker_open"} {
+		before := testutil.ToFloat64(edgeRemint.WithLabelValues(result, "reactive"))
+		remint(result, "reactive")
+		if got := testutil.ToFloat64(edgeRemint.WithLabelValues(result, "reactive")); got != before+1 {
 			t.Errorf("remint(%q): %v -> %v, want +1", result, before, got)
 		}
 	}
-	remint("bogus") // no-op
+}
+
+func TestSetObservedTargetOneSeries(t *testing.T) {
+	setObservedTarget("ca-a")
+	setObservedTarget("ca-b") // rotation: one live series
+	if c := testutil.CollectAndCount(edgeCPTargetCAID); c != 1 {
+		t.Errorf("observed-target: want 1 live series, got %d", c)
+	}
+	if v := testutil.ToFloat64(edgeCPTargetCAID.WithLabelValues("ca-b")); v != 1 {
+		t.Errorf("observed-target ca-b = %v, want 1", v)
+	}
+	setObservedTarget("") // clears
+	if c := testutil.CollectAndCount(edgeCPTargetCAID); c != 0 {
+		t.Errorf("empty target must clear the series, got %d", c)
+	}
 }

--- a/edge/refresh.go
+++ b/edge/refresh.go
@@ -16,53 +16,59 @@ import (
 // the store. Fail-static: on any error the prior cert is kept. The key is generated
 // here and never written to disk — only the public-key CSR and the returned chain
 // transit. The CP stamps the SAN from the token identity, so the CSR carries none.
-// It returns (and counts) the outcome so the re-mint loop's health is observable; the
-// returned string is the parapet_edge_clientcert_remint_total result label.
-func RefreshEdgeCertOnce(cp *CpClient, store *ClientCertStore) string {
+// It returns the outcome (the parapet_edge_clientcert_remint_total result label) and,
+// on a 429/503 saturated-signer shed, the Retry-After delay — so the coordinator can
+// apply fleet-aggregate backpressure. trigger labels the metric (proactive|reactive|timer).
+func RefreshEdgeCertOnce(cp *CpClient, store *ClientCertStore, trigger string) (result string, retryAfter time.Duration) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		slog.Warn("edge: client keygen failed; keeping cached cert", "error", err)
-		remint("keygen_fail")
-		return "keygen_fail"
+		remint("keygen_fail", trigger)
+		return "keygen_fail", 0
 	}
 	csrDER, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{}, key)
 	if err != nil {
 		slog.Warn("edge: CSR build failed; keeping cached cert", "error", err)
-		remint("csr_fail")
-		return "csr_fail"
+		remint("csr_fail", trigger)
+		return "csr_fail", 0
 	}
 	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
 
 	res, err := cp.FetchEdgeCert(csrPEM)
 	if err != nil {
 		slog.Warn("edge: data-plane cert fetch failed; keeping cached cert", "error", err)
-		remint("fetch_fail")
-		return "fetch_fail"
+		remint("fetch_fail", trigger)
+		return "fetch_fail", res.RetryAfter
 	}
 	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
 	if err != nil {
 		slog.Warn("edge: key marshal failed; keeping cached cert", "error", err)
-		remint("marshal_fail")
-		return "marshal_fail"
+		remint("marshal_fail", trigger)
+		return "marshal_fail", 0
 	}
 	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
 	if err := store.Update(res.ChainPEM, keyPEM); err != nil {
 		slog.Warn("edge: data-plane cert unusable; keeping cached cert", "error", err)
-		remint("store_fail")
-		return "store_fail"
+		remint("store_fail", trigger)
+		return "store_fail", 0
 	}
-	slog.Info("edge: data-plane client cert updated", "not_after", res.NotAfter, "serial", res.Serial)
-	remint("ok")
-	return "ok"
+	slog.Info("edge: data-plane client cert updated", "not_after", res.NotAfter, "serial", res.Serial, "ca_id", res.CAID, "trigger", trigger)
+	remint("ok", trigger)
+	return "ok", 0
 }
 
-// RunEdgeCertRefresh refreshes the data-plane client cert on a timer. The first
-// tick is one interval after startup (startup already fetched the first cert).
-// Milestone 1 renews on the bare interval; remaining-life renewal, jitter, and the
-// rotation-driven force-re-mint are follow-on (see EDGE-AUTOTRUST.md).
-func RunEdgeCertRefresh(ctx context.Context, cp *CpClient, store *ClientCertStore, interval time.Duration) {
+// RunEdgeCertRefresh is the timer floor for the data-plane client cert. Each tick it
+// (1) renews when the live leaf is within its remaining-life window (MaybeRenew) and
+// (2) reads the CP target ca_id from the tokenless trust-bundle and Observes it — so an
+// mTLS edge that polls neither /v1/certs nor /v1/waf (serve-all, no traffic, WAF off)
+// still sees a CA rotation. Both ride THIS existing loop — no 4th goroutine. The first
+// tick is jittered by [0,interval] to decorrelate the fleet's poll instants.
+func RunEdgeCertRefresh(ctx context.Context, coord *RemintCoordinator, interval time.Duration) {
 	if interval <= 0 {
 		interval = 300 * time.Second
+	}
+	if !sleepCtx(ctx, fullJitter(interval)) {
+		return
 	}
 	t := time.NewTicker(interval)
 	defer t.Stop()
@@ -71,15 +77,22 @@ func RunEdgeCertRefresh(ctx context.Context, cp *CpClient, store *ClientCertStor
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			RefreshEdgeCertOnce(cp, store)
+			coord.MaybeRenew()
+			if caID, err := coord.cp.FetchTrustBundleCAID(); err == nil {
+				coord.Observe(caID)
+			}
 		}
 	}
 }
 
 // RefreshCertOnce fetches one domain's cert from the control plane
-// (ETag-revalidated) and swaps it into the store; fail-static on error. Used by
-// the periodic loop and (serve-all) by the on-demand TLS path.
-func RefreshCertOnce(cp *CpClient, store *CertStore, domain string) {
+// (ETag-revalidated) and swaps it into the store; fail-static on error. It then
+// Observes the X-Parapet-CA-Id force-re-mint signal that rides EVERY response arm
+// (200/304/404 — res.CAID is set even on the error arm), so a CA rotation is detected
+// on the edge's existing cert poll regardless of cert outcome. coord is nil when
+// data-plane mTLS is off (Observe is a no-op). Used by the periodic loop and
+// (serve-all) by the on-demand TLS handshake path.
+func RefreshCertOnce(cp *CpClient, store *CertStore, domain string, coord *RemintCoordinator) {
 	res, err := cp.FetchCert(domain, store.Etag(domain))
 	switch {
 	case err != nil:
@@ -94,25 +107,29 @@ func RefreshCertOnce(cp *CpClient, store *CertStore, domain string) {
 			slog.Warn("edge: cert PEM unparseable; keeping cached copy", "domain", domain)
 		}
 	}
+	coord.Observe(res.CAID)
 }
 
 // RefreshCertsAll fetches every domain once (sequentially). Returns how many are
-// now cached, for the startup log.
-func RefreshCertsAll(cp *CpClient, store *CertStore, domains []string) int {
+// now cached, for the startup log. coord is nil when data-plane mTLS is off.
+func RefreshCertsAll(cp *CpClient, store *CertStore, domains []string, coord *RemintCoordinator) int {
 	for _, d := range domains {
-		RefreshCertOnce(cp, store, d)
+		RefreshCertOnce(cp, store, d, coord)
 	}
 	return store.Len()
 }
 
-// RunCertRefresh runs the periodic cert refresh forever. The first tick is one
-// interval after startup (startup already did the full fetch). Each tick
-// refreshes the configured domains PLUS whatever is currently cached (deduped),
-// so on-demand-fetched domains (serve-all mode, empty domains) keep rotating.
-// No backoff/jitter; fail-static is the only resilience mechanism.
-func RunCertRefresh(ctx context.Context, cp *CpClient, store *CertStore, domains []string, interval time.Duration) {
+// RunCertRefresh runs the periodic cert refresh forever. The first tick is jittered by
+// [0,interval] to decorrelate the fleet's poll instants (a rotation flips ca_id for
+// every edge at once; un-jittered loops would hammer GET /v1/certs in lockstep). Each
+// tick refreshes the configured domains PLUS whatever is currently cached (deduped), so
+// on-demand-fetched domains (serve-all mode) keep rotating and observing. Fail-static.
+func RunCertRefresh(ctx context.Context, cp *CpClient, store *CertStore, domains []string, interval time.Duration, coord *RemintCoordinator) {
 	if interval <= 0 { // time.NewTicker panics on a non-positive interval
 		interval = 300 * time.Second
+	}
+	if !sleepCtx(ctx, fullJitter(interval)) {
+		return
 	}
 	t := time.NewTicker(interval)
 	defer t.Stop()
@@ -127,7 +144,7 @@ func RunCertRefresh(ctx context.Context, cp *CpClient, store *CertStore, domains
 					continue
 				}
 				seen[d] = struct{}{}
-				RefreshCertOnce(cp, store, d)
+				RefreshCertOnce(cp, store, d, coord)
 			}
 		}
 	}

--- a/edge/refresh_test.go
+++ b/edge/refresh_test.go
@@ -58,11 +58,11 @@ func TestRefreshEdgeCertOnceOK(t *testing.T) {
 	}
 	store := NewClientCertStore()
 
-	before := testutil.ToFloat64(edgeRemintHandles["ok"])
-	if got := RefreshEdgeCertOnce(cp, store); got != "ok" {
+	before := testutil.ToFloat64(edgeRemint.WithLabelValues("ok", "timer"))
+	if got, _ := RefreshEdgeCertOnce(cp, store, "timer"); got != "ok" {
 		t.Fatalf("result = %q, want ok", got)
 	}
-	if testutil.ToFloat64(edgeRemintHandles["ok"]) != before+1 {
+	if testutil.ToFloat64(edgeRemint.WithLabelValues("ok", "timer")) != before+1 {
 		t.Error("ok remint counter not incremented")
 	}
 	if !store.Loaded() {
@@ -86,11 +86,11 @@ func TestRefreshEdgeCertOnceFetchFail(t *testing.T) {
 	}
 	store := NewClientCertStore()
 
-	before := testutil.ToFloat64(edgeRemintHandles["fetch_fail"])
-	if got := RefreshEdgeCertOnce(cp, store); got != "fetch_fail" {
+	before := testutil.ToFloat64(edgeRemint.WithLabelValues("fetch_fail", "timer"))
+	if got, _ := RefreshEdgeCertOnce(cp, store, "timer"); got != "fetch_fail" {
 		t.Fatalf("result = %q, want fetch_fail", got)
 	}
-	if testutil.ToFloat64(edgeRemintHandles["fetch_fail"]) != before+1 {
+	if testutil.ToFloat64(edgeRemint.WithLabelValues("fetch_fail", "timer")) != before+1 {
 		t.Error("fetch_fail remint counter not incremented")
 	}
 	if store.Loaded() {

--- a/edge/remint.go
+++ b/edge/remint.go
@@ -1,0 +1,267 @@
+package edge
+
+import (
+	"context"
+	"log/slog"
+	"math/rand/v2"
+	"sync"
+	"time"
+)
+
+// RemintConfig tunes the data-plane client-cert re-mint coordinator. Zero fields get
+// sane floors in NewRemintCoordinator (the caller passes interval-derived values).
+type RemintConfig struct {
+	Jitter        time.Duration // full-jitter [0,Jitter] before EACH mint, to spread the fleet (default 60s)
+	BackoffBase   time.Duration // exponential backoff base on a non-ok mint (default 2s)
+	BackoffMax    time.Duration // backoff cap (default 300s)
+	Cooldown      time.Duration // breaker-open cooldown (default 5*BackoffMax)
+	BreakerK      int           // consecutive reactive no-flip ok-mints before the reactive breaker opens (default 3)
+	ProactiveJ    int           // proactive ok-mints that don't reach target before the proactive breaker opens (default 5)
+	RenewFraction float64       // remaining-life renewal: renew when remaining <= fraction of the leaf's own lifetime (default 0.66)
+}
+
+// RemintCoordinator is the single owner of every data-plane client-cert re-mint path
+// (proactive on a ca_id flip, reactive on a core cert-reject, timer on remaining-life).
+// It enforces per-edge single-flight, full jitter, exponential backoff, Retry-After,
+// and two independent circuit-breakers (reactive + proactive). A nil *RemintCoordinator
+// is a valid no-op receiver, so non-mTLS edges call the same code with no effect.
+type RemintCoordinator struct {
+	cp    *CpClient
+	store *ClientCertStore
+	cfg   RemintConfig
+
+	mu                  sync.Mutex
+	inFlight            bool
+	backoff             time.Duration
+	reactiveNoFlip      int
+	reactiveBreakerEnd  time.Time
+	proactiveNoConverge int
+	proactiveBreakerEnd time.Time
+	lastTarget          string // last observed CP target ca_id (the proactive convergence yardstick)
+}
+
+func NewRemintCoordinator(cp *CpClient, store *ClientCertStore, cfg RemintConfig) *RemintCoordinator {
+	if cfg.Jitter <= 0 {
+		cfg.Jitter = 60 * time.Second
+	}
+	if cfg.BackoffBase <= 0 {
+		cfg.BackoffBase = 2 * time.Second
+	}
+	if cfg.BackoffMax <= 0 {
+		cfg.BackoffMax = 300 * time.Second
+	}
+	if cfg.Cooldown <= 0 {
+		cfg.Cooldown = 5 * cfg.BackoffMax
+	}
+	if cfg.BreakerK <= 0 {
+		cfg.BreakerK = 3
+	}
+	if cfg.ProactiveJ <= 0 {
+		cfg.ProactiveJ = 5
+	}
+	if cfg.RenewFraction <= 0 || cfg.RenewFraction >= 1 {
+		cfg.RenewFraction = 0.66
+	}
+	return &RemintCoordinator{cp: cp, store: store, cfg: cfg, backoff: cfg.BackoffBase}
+}
+
+// Observe drives the PROACTIVE path: it compares the CP target ca_id against the edge's
+// OWN HELD-LEAF ca_id (never against a previous observation, so a mid-rotation boot
+// re-mints on first poll) and triggers a re-mint on a mismatch. target=="" (old CP / no
+// signer) and live=="" (held chain too short / single-CA) are both "unknown" → never
+// trigger (fail-static; avoids an infinite hot-loop). Safe to call from the public-TLS
+// handshake path (Trigger is non-blocking).
+func (c *RemintCoordinator) Observe(target string) {
+	if c == nil || target == "" {
+		return
+	}
+	setObservedTarget(target)
+	live := c.store.CAID()
+	c.mu.Lock()
+	c.lastTarget = target
+	c.mu.Unlock()
+	if live == "" || target == live {
+		return // unknown held value, or already converged
+	}
+	c.Trigger("proactive")
+}
+
+// Trigger requests a re-mint. It is NON-BLOCKING on every path: if a mint is already in
+// flight it returns immediately (a dropped trigger is re-derived by the next poll's
+// held-vs-target re-check). Reactive triggers are dropped while the reactive breaker is
+// open; proactive triggers bypass the reactive cooldown but honor the proactive breaker.
+func (c *RemintCoordinator) Trigger(trigger string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inFlight {
+		return
+	}
+	now := time.Now()
+	if trigger == "reactive" && now.Before(c.reactiveBreakerEnd) {
+		return
+	}
+	if trigger == "proactive" && now.Before(c.proactiveBreakerEnd) {
+		return
+	}
+	c.inFlight = true
+	go func() {
+		// Clear inFlight via defer + recover so a panic in the mint can NEVER strand the
+		// single-flight flag (which would brick EVERY re-mint path forever). One bad mint
+		// self-heals on the next trigger instead of wedging or crashing the edge.
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("edge: re-mint panicked; recovered", "panic", r, "trigger", trigger)
+			}
+			c.mu.Lock()
+			c.inFlight = false
+			c.mu.Unlock()
+		}()
+		c.runOnce(trigger)
+	}()
+}
+
+// runOnce executes one mint: jitter → mint → classify (converge/flip/breaker/backoff).
+// It is synchronous and does NOT manage inFlight (the Trigger goroutine owns that) —
+// tests drive it directly for deterministic breaker assertions. The two breakers are
+// scored INDEPENDENTLY, because reaching the CP target is NOT evidence a reactive
+// core-reject is resolved (the core may still reject due to its own ClientCAs lag):
+//   - ok + ca_id flipped (any trigger): new trust material → reset the reactive breaker.
+//   - ok + reactive + NO flip: futile (CP serves the same bundle; re-minting can't fix a
+//     core reject) → reactiveNoFlip++ → open the reactive breaker at K.
+//   - ok + proactive + reached target: convergence → reset the proactive breaker; else
+//     proactiveNoConverge++ → open at J (a real-but-unreachable target isn't infinite).
+//   - non-ok: transient (CP outage / saturation) → exponential backoff, honor
+//     Retry-After; NEVER breaker evidence (must keep retrying a rejected OLD leaf).
+func (c *RemintCoordinator) runOnce(trigger string) {
+	c.mu.Lock()
+	target := c.lastTarget
+	backoff := c.backoff
+	c.mu.Unlock()
+
+	before := c.store.CAID()
+	if j := fullJitter(c.cfg.Jitter); j > 0 {
+		time.Sleep(j)
+	}
+	result, retryAfter := RefreshEdgeCertOnce(c.cp, c.store, trigger)
+	after := c.store.CAID()
+
+	var openedReactive, openedProactive bool
+	var sleepFor time.Duration
+	c.mu.Lock()
+	switch {
+	case result == "ok":
+		c.backoff = c.cfg.BackoffBase // any successful mint clears the backoff
+		flipped := after != before
+
+		// Reactive breaker: keyed on whether the leaf's CA SET actually changed.
+		if flipped {
+			c.reactiveNoFlip = 0
+			c.reactiveBreakerEnd = time.Time{}
+		} else if trigger == "reactive" {
+			c.reactiveNoFlip++
+			if c.reactiveNoFlip >= c.cfg.BreakerK {
+				c.reactiveBreakerEnd = time.Now().Add(c.cfg.Cooldown)
+				openedReactive = true
+			}
+		}
+
+		// Proactive breaker: keyed on whether the mint reached the OBSERVED target.
+		if trigger == "proactive" {
+			if target != "" && after == target {
+				c.proactiveNoConverge = 0
+				c.proactiveBreakerEnd = time.Time{}
+			} else {
+				c.proactiveNoConverge++
+				if c.proactiveNoConverge >= c.cfg.ProactiveJ {
+					c.proactiveBreakerEnd = time.Now().Add(c.cfg.Cooldown)
+					openedProactive = true
+				}
+			}
+		}
+	default:
+		c.backoff = minDur(backoff*2, c.cfg.BackoffMax)
+		sleepFor = chooseSleep(backoff, retryAfter)
+	}
+	c.mu.Unlock()
+
+	if openedReactive {
+		remint("breaker_open", "reactive")
+		slog.Warn("edge: reactive re-mint breaker OPEN — re-mints aren't changing ca_id (a core-side reject re-minting can't fix); cooling down",
+			"consecutive", c.cfg.BreakerK, "cooldown", c.cfg.Cooldown)
+	}
+	if openedProactive {
+		remint("breaker_open", "proactive")
+		slog.Warn("edge: proactive re-mint breaker OPEN — mints not reaching the observed target; cooling down",
+			"consecutive", c.cfg.ProactiveJ, "target", target, "cooldown", c.cfg.Cooldown)
+	}
+
+	if sleepFor > 0 {
+		time.Sleep(sleepFor + fullJitter(c.cfg.BackoffBase))
+	}
+}
+
+// MaybeRenew triggers a "timer" re-mint when no cert is held yet, or the live leaf is
+// within its remaining-life renewal window — remaining <= RenewFraction of the cert's
+// OWN lifetime (NotAfter-NotBefore), so it needs no knowledge of the CP's TTL and the
+// renewal floor scales with whatever TTL the CP issues. This is the absolute floor that
+// converges even an edge that observes no ca_id signal at all, before its OLD leaf
+// could expire.
+func (c *RemintCoordinator) MaybeRenew() {
+	if c == nil {
+		return
+	}
+	nb, na, ok := c.store.Validity()
+	if !ok {
+		c.Trigger("timer") // nothing held yet (startup mint may have failed)
+		return
+	}
+	lifetime := na.Sub(nb)
+	if lifetime <= 0 {
+		return
+	}
+	if time.Until(na) <= time.Duration(c.cfg.RenewFraction*float64(lifetime)) {
+		c.Trigger("timer")
+	}
+}
+
+// fullJitter returns a uniformly random duration in [0, d). 0 for d<=0.
+func fullJitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int64N(int64(d)))
+}
+
+func minDur(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// chooseSleep picks the backoff delay on a non-ok mint: the CP's Retry-After when it
+// exceeds our own backoff (so the fleet honors the signer's backpressure), else backoff.
+func chooseSleep(backoff, retryAfter time.Duration) time.Duration {
+	if retryAfter > backoff {
+		return retryAfter
+	}
+	return backoff
+}
+
+// sleepCtx sleeps for d or until ctx is done; returns false if ctx ended first.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}

--- a/edge/remint_test.go
+++ b/edge/remint_test.go
@@ -1,0 +1,230 @@
+package edge
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// testCoord builds a coordinator against a fake CP that signs CSRs, with no real jitter
+// so runOnce is fast and deterministic.
+func testCoord(t *testing.T, cfg RemintConfig) (*RemintCoordinator, *ClientCertStore) {
+	t.Helper()
+	srv, _ := fakeEdgeCP(t)
+	cp, err := NewCpClient(srv.URL, "tok", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewClientCertStore()
+	cfg.Jitter = 1 // 1ns → fullJitter returns 0 (no sleep)
+	cfg.BackoffBase = 1
+	return NewRemintCoordinator(cp, store, cfg), store
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("condition not met within deadline")
+}
+
+// Observe must NOT trigger when the target is unknown (""), the held leaf is unknown
+// (""), or the edge has already converged (target == live). These would hot-loop.
+func TestObserveNoOps(t *testing.T) {
+	coord, store := testCoord(t, RemintConfig{})
+	reqs := 0
+	// Re-point at a request-counting CP.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqs++
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	cp, _ := NewCpClient(srv.URL, "tok", nil)
+	coord.cp = cp
+
+	coord.Observe("")            // unknown target → no-op
+	coord.Observe("some-target") // live=="" (no cert held) → no-op
+	time.Sleep(20 * time.Millisecond)
+	if reqs != 0 {
+		t.Errorf("Observe must not mint when target/live unknown, got %d requests", reqs)
+	}
+	_ = store
+}
+
+// Observe triggers a proactive re-mint when the CP target differs from the held leaf.
+func TestObserveTriggersProactive(t *testing.T) {
+	coord, store := testCoord(t, RemintConfig{})
+	// Pre-load a cert so store.CAID() is non-empty (the "live" side).
+	if _, _ = RefreshEdgeCertOnce(coord.cp, store, "timer"); !store.Loaded() {
+		t.Fatal("pre-mint failed")
+	}
+	live := store.CAID()
+	if live == "" {
+		t.Fatal("pre-minted cert has no ca_id")
+	}
+	// A DIFFERENT observed target must trigger a re-mint (request count rises).
+	coord.Observe("a-different-target")
+	waitFor(t, func() bool { return !coordInFlight(coord) && store.CAID() == live })
+	// (the fake CP always signs the same ca_id, so the edge stays at `live`; the point
+	// is that a mint WAS attempted — verified via the proactive breaker climbing.)
+	coord.mu.Lock()
+	noConverge := coord.proactiveNoConverge
+	coord.mu.Unlock()
+	if noConverge == 0 {
+		t.Error("a proactive mint that didn't reach the (fake) target should increment proactiveNoConverge")
+	}
+}
+
+// K reactive ok-mints that don't change ca_id open the reactive breaker. Reaching the
+// CP target does NOT reset it (the core may still reject); only a genuine ca_id FLIP does.
+func TestReactiveBreaker(t *testing.T) {
+	coord, store := testCoord(t, RemintConfig{BreakerK: 2})
+	RefreshEdgeCertOnce(coord.cp, store, "timer") // store now at ca_id Z
+	z := store.CAID()
+
+	// Two reactive no-flip mints (the CP keeps signing Z) → breaker opens.
+	coord.runOnce("reactive")
+	coord.runOnce("reactive")
+	coord.mu.Lock()
+	open := time.Now().Before(coord.reactiveBreakerEnd)
+	noFlip := coord.reactiveNoFlip
+	coord.mu.Unlock()
+	if !open || noFlip < 2 {
+		t.Fatalf("reactive breaker should be OPEN after 2 no-flip mints (noFlip=%d, open=%v)", noFlip, open)
+	}
+
+	// Edge already AT the target but the core keeps rejecting (after==target, no flip):
+	// this must NOT reset — re-minting the same ca_id can't fix a core-side reject.
+	coord.Observe(z) // lastTarget = z (== live; converged, no trigger)
+	coord.runOnce("reactive")
+	coord.mu.Lock()
+	stillClimbing := coord.reactiveNoFlip
+	coord.mu.Unlock()
+	if stillClimbing < noFlip {
+		t.Errorf("reaching the target must NOT reset the reactive breaker (was %d, now %d)", noFlip, stillClimbing)
+	}
+
+	// A genuine ca_id FLIP (new trust material) resets it.
+	other := "a-different-ca-id"
+	store.caid.Store(&other) // pretend the held leaf is now a different CA set
+	coord.runOnce("reactive")
+	coord.mu.Lock()
+	reset := coord.reactiveNoFlip
+	rOpen := time.Now().Before(coord.reactiveBreakerEnd)
+	coord.mu.Unlock()
+	if reset != 0 || rOpen {
+		t.Errorf("a genuine ca_id flip must reset+close the reactive breaker (noFlip=%d, open=%v)", reset, rOpen)
+	}
+}
+
+// J proactive ok-mints that don't reach the observed target open the proactive breaker,
+// WITHOUT touching the reactive breaker.
+func TestProactiveBreaker(t *testing.T) {
+	coord, store := testCoord(t, RemintConfig{ProactiveJ: 2})
+	RefreshEdgeCertOnce(coord.cp, store, "timer") // store at Z
+	coord.mu.Lock()
+	coord.lastTarget = "unreachable-target" // the fake CP only ever signs Z
+	coord.mu.Unlock()
+
+	coord.runOnce("proactive")
+	coord.runOnce("proactive")
+	coord.mu.Lock()
+	pOpen := time.Now().Before(coord.proactiveBreakerEnd)
+	n := coord.proactiveNoConverge
+	rOpen := time.Now().Before(coord.reactiveBreakerEnd)
+	coord.mu.Unlock()
+	if !pOpen || n < 2 {
+		t.Fatalf("proactive breaker should open after 2 non-converging mints (n=%d, open=%v)", n, pOpen)
+	}
+	if rOpen {
+		t.Error("proactive failures must NOT open the reactive breaker")
+	}
+}
+
+func TestChooseSleep(t *testing.T) {
+	if got := chooseSleep(2*time.Second, 7*time.Second); got != 7*time.Second {
+		t.Errorf("retryAfter > backoff: %v, want 7s", got)
+	}
+	if got := chooseSleep(5*time.Second, 2*time.Second); got != 5*time.Second {
+		t.Errorf("backoff >= retryAfter: %v, want 5s", got)
+	}
+	if got := chooseSleep(3*time.Second, 0); got != 3*time.Second {
+		t.Errorf("no retryAfter: %v, want 3s", got)
+	}
+}
+
+// A non-ok mint (CP down) is the BACKOFF path, never breaker evidence — a transient
+// outage during a rotation must not open the breaker while the edge presents a rejected leaf.
+func TestNonOkDoesNotOpenBreaker(t *testing.T) {
+	coord, _ := testCoord(t, RemintConfig{BreakerK: 2})
+	down := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "down", http.StatusInternalServerError)
+	}))
+	t.Cleanup(down.Close)
+	cp, _ := NewCpClient(down.URL, "tok", nil)
+	coord.cp = cp
+
+	for i := 0; i < 4; i++ {
+		coord.runOnce("reactive")
+	}
+	coord.mu.Lock()
+	open := time.Now().Before(coord.reactiveBreakerEnd)
+	noFlip := coord.reactiveNoFlip
+	coord.mu.Unlock()
+	if open || noFlip != 0 {
+		t.Errorf("transient failures must not feed the breaker (noFlip=%d, open=%v)", noFlip, open)
+	}
+}
+
+// MaybeRenew mints when nothing is held yet (the startup mint failed / never ran).
+func TestMaybeRenewMintsWhenEmpty(t *testing.T) {
+	coord, store := testCoord(t, RemintConfig{})
+	coord.MaybeRenew()
+	waitFor(t, func() bool { return store.Loaded() })
+}
+
+// Single-flight: many concurrent Triggers coalesce — at most one mint runs at a time.
+func TestSingleFlight(t *testing.T) {
+	coord, store := testCoord(t, RemintConfig{})
+	RefreshEdgeCertOnce(coord.cp, store, "timer")
+	var concurrent, maxConcurrent int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		coord.mu.Lock()
+		concurrent++
+		if concurrent > maxConcurrent {
+			maxConcurrent = concurrent
+		}
+		coord.mu.Unlock()
+		time.Sleep(20 * time.Millisecond)
+		coord.mu.Lock()
+		concurrent--
+		coord.mu.Unlock()
+		http.Error(w, "x", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	cp, _ := NewCpClient(srv.URL, "tok", nil)
+	coord.cp = cp
+
+	for i := 0; i < 10; i++ {
+		go coord.Trigger("reactive")
+	}
+	time.Sleep(100 * time.Millisecond)
+	coord.mu.Lock()
+	mc := maxConcurrent
+	coord.mu.Unlock()
+	if mc > 1 {
+		t.Errorf("single-flight violated: %d concurrent mints", mc)
+	}
+}
+
+func coordInFlight(c *RemintCoordinator) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.inFlight
+}

--- a/edge/wafrefresh.go
+++ b/edge/wafrefresh.go
@@ -10,7 +10,7 @@ import (
 // EdgeWAF. A fetch failure or a compile error is fail-static — the edge keeps its
 // last-good ruleset and never falls open to "no WAF". Per-ruleset keep-last-good
 // means a bad zone keeps its old rules while other rulesets still update.
-func RefreshWafOnce(cp *CpClient, w *EdgeWAF) {
+func RefreshWafOnce(cp *CpClient, w *EdgeWAF, coord *RemintCoordinator) {
 	res, err := cp.FetchWaf(w.Etag())
 	switch {
 	case err != nil:
@@ -24,14 +24,21 @@ func RefreshWafOnce(cp *CpClient, w *EdgeWAF) {
 			slog.Info("edge: WAF rulesets updated", "generation", res.Generation)
 		}
 	}
+	// Secondary force-re-mint confirmer: the WAF body carries ca_id on the 200 arm only
+	// (the 304 carries nothing — /v1/certs is the guaranteed carrier). res.CAID is ""
+	// on 304/err, and Observe("") is a no-op.
+	coord.Observe(res.CAID)
 }
 
-// RunWafRefresh runs the periodic WAF refresh forever. The first tick is one
-// interval after startup (startup already fetched). Same cadence as the cert
-// refresh (EDGE_REFRESH_INTERVAL); fail-static.
-func RunWafRefresh(ctx context.Context, cp *CpClient, w *EdgeWAF, interval time.Duration) {
+// RunWafRefresh runs the periodic WAF refresh forever. The first tick is jittered by
+// [0,interval] (fleet poll-instant decorrelation). Same cadence as the cert refresh
+// (EDGE_REFRESH_INTERVAL); fail-static.
+func RunWafRefresh(ctx context.Context, cp *CpClient, w *EdgeWAF, interval time.Duration, coord *RemintCoordinator) {
 	if interval <= 0 { // time.NewTicker panics on a non-positive interval
 		interval = 300 * time.Second
+	}
+	if !sleepCtx(ctx, fullJitter(interval)) {
+		return
 	}
 	t := time.NewTicker(interval)
 	defer t.Stop()
@@ -40,7 +47,7 @@ func RunWafRefresh(ctx context.Context, cp *CpClient, w *EdgeWAF, interval time.
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			RefreshWafOnce(cp, w)
+			RefreshWafOnce(cp, w, coord)
 		}
 	}
 }

--- a/edgecp/caid_join_test.go
+++ b/edgecp/caid_join_test.go
@@ -1,0 +1,70 @@
+package edgecp
+
+import (
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/moonrhythm/parapet-ingress-controller/caid"
+)
+
+// The whole force-re-mint convergence check (edge live ca_id == CP target) rests on a
+// single equality: the ca_id the CP computes over its served bundle (caid.FromPEM /
+// signer.CAID) must equal what the edge computes from its leaf chain's CA blocks
+// (caid.FromDER over Certificate[1:]). Pin it for BOTH a single CA and an OLD++NEW
+// overlap — a change to how Sign() appends the bundle would silently break convergence.
+func TestCAIDJoinKey(t *testing.T) {
+	t.Run("single-CA", func(t *testing.T) {
+		certPEM, keyPEM := mustGenerateCA(t)
+		sg, _, err := NewProvidedSigner(certPEM, keyPEM, time.Hour, time.Minute)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertJoin(t, sg)
+	})
+	t.Run("OLD++NEW-overlap", func(t *testing.T) {
+		oldCert, oldKey := mustGenerateCA(t)
+		newCert, _ := mustGenerateCA(t)
+		bundle := append(append([]byte(nil), oldCert...), newCert...)
+		sg, _, err := NewProvidedSignerActive(bundle, oldKey, fpOf(t, oldCert), time.Hour, time.Minute)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertJoin(t, sg)
+	})
+}
+
+func assertJoin(t *testing.T, sg *Signer) {
+	t.Helper()
+	chainPEM, _, _, err := sg.Sign(mkLeafKey(t).Public(), "edge-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Decode the chain into ordered DERs; [1:] are the CA blocks the edge fingerprints.
+	var ders [][]byte
+	rest := chainPEM
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			ders = append(ders, block.Bytes)
+		}
+	}
+	if len(ders) < 2 {
+		t.Fatalf("chain must be leaf + >=1 CA, got %d certs", len(ders))
+	}
+	edgeID, err := caid.FromDER(ders[1:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	cpFromPEM, err := caid.FromPEM(sg.BundlePEM())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edgeID != cpFromPEM || edgeID != sg.CAID() {
+		t.Errorf("ca_id join broken: edge(FromDER)=%q  cp(FromPEM)=%q  signer.CAID=%q", edgeID, cpFromPEM, sg.CAID())
+	}
+}

--- a/edgecp/issuance.go
+++ b/edgecp/issuance.go
@@ -28,6 +28,7 @@ type edgeCertResponse struct {
 	ChainPEM string `json:"chain_pem"`
 	NotAfter string `json:"not_after"`
 	Serial   string `json:"serial"`
+	CAID     string `json:"ca_id,omitempty"` // signer ca_id, so the edge self-confirms convergence post-mint
 }
 
 // handleEdgeCert signs an edge data-plane client cert from a CSR. Token-gated: a
@@ -80,6 +81,22 @@ func (s *Server) handleEdgeCert(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Fleet-aggregate backpressure: a rotation flips ca_id for every edge at once and
+	// each re-mints against this CPU-bound signer. One token per edge means the
+	// per-token bucket does NOT bound the aggregate, so bound the concurrent signs here
+	// and shed with 503 + Retry-After when saturated — the edge coordinator honors it.
+	// nil/disabled gate ⇒ no limit (behavior unchanged).
+	if s.signGate != nil {
+		select {
+		case s.signGate <- struct{}{}:
+			defer func() { <-s.signGate }()
+		default:
+			w.Header().Set("Retry-After", strconv.Itoa(s.signRetryAfter))
+			http.Error(w, "signer saturated", http.StatusServiceUnavailable)
+			return
+		}
+	}
+
 	chainPEM, notAfter, serial, err := sg.Sign(csr.PublicKey, id)
 	if err != nil {
 		http.Error(w, "sign failed", http.StatusInternalServerError)
@@ -93,6 +110,7 @@ func (s *Server) handleEdgeCert(w http.ResponseWriter, r *http.Request) {
 		ChainPEM: string(chainPEM),
 		NotAfter: notAfter.UTC().Format(time.RFC3339),
 		Serial:   serial,
+		CAID:     sg.CAID(),
 	})
 }
 

--- a/edgecp/server.go
+++ b/edgecp/server.go
@@ -32,6 +32,26 @@ type Server struct {
 	// readiness probe 503s until a signer has actually loaded, so an edge isn't
 	// pointed at a CP that can't yet issue/serve the trust bundle.
 	issuanceExpected atomic.Bool
+
+	// signGate bounds concurrent sg.Sign() on POST /v1/edge-cert (nil = no limit).
+	// When full, the handler sheds with 503 + Retry-After:signRetryAfter — the
+	// fleet-aggregate backpressure during a rotation's re-mint surge.
+	signGate       chan struct{}
+	signRetryAfter int
+}
+
+// WithSignConcurrency bounds concurrent edge-cert signing: at most n in flight, with
+// the given Retry-After (seconds) on a shed 503. n <= 0 disables the limit. Returns
+// the server for chaining; call once at startup.
+func (s *Server) WithSignConcurrency(n, retryAfterSecs int) *Server {
+	if n > 0 {
+		s.signGate = make(chan struct{}, n)
+	}
+	if retryAfterSecs <= 0 {
+		retryAfterSecs = 5
+	}
+	s.signRetryAfter = retryAfterSecs
+	return s
 }
 
 // signerGen is an immutable (signer, generation) pair. SetSigner replaces the whole
@@ -150,6 +170,17 @@ func (s *Server) handleCert(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Force-re-mint signal: advertise the signer's target ca_id (the edge-CA the fleet
+	// should converge to, process-global) on EVERY authorized response — 404/304/200 —
+	// so an edge observes a CA rotation on its existing /v1/certs poll regardless of
+	// cert presence or ETag state. This is the SIGNER target, orthogonal to this sni's
+	// leaf issuer; it is deliberately NOT folded into entry.etag — a pure CA rotation
+	// must never force a fleet-wide cert+key re-download. Set after Known()/Allowed()
+	// (never to an unauthorized caller), before any WriteHeader so it rides the 304/404.
+	if id := s.CurrentCAID(); id != "" {
+		w.Header().Set("X-Parapet-CA-Id", id)
+	}
+
 	entry, ok := s.certs.Get(sni)
 	if !ok {
 		http.Error(w, "no certificate for sni", http.StatusNotFound)
@@ -174,8 +205,9 @@ func (s *Server) handleCert(w http.ResponseWriter, r *http.Request) {
 type wafResponse struct {
 	Generation  uint64            `json:"generation"`
 	GlobalRules string            `json:"global_rules"`
-	Zones       map[string]string `json:"zones"`         // zoneKey -> rules YAML
-	HostZoneMap map[string]string `json:"host_zone_map"` // host -> zoneKey
+	Zones       map[string]string `json:"zones"`           // zoneKey -> rules YAML
+	HostZoneMap map[string]string `json:"host_zone_map"`   // host -> zoneKey
+	CAID        string            `json:"ca_id,omitempty"` // signer target ca_id (best-effort SECONDARY force-re-mint confirmer)
 }
 
 // handleWAF serves the WAF payload scoped to the edge's allowed domains: the
@@ -198,6 +230,11 @@ func (s *Server) handleWAF(w http.ResponseWriter, r *http.Request) {
 		GlobalRules: snap.global,
 		Zones:       snap.zones,
 		HostZoneMap: snap.hostZone,
+		// In-body ca_id busts the ETag on the 200 arm for free (the WAF snapshot is
+		// ca_id-independent — SetSigner leaves it untouched). The steady-state 304 arm
+		// carries NOTHING, so /v1/waf is only a SECONDARY confirmer; the /v1/certs
+		// X-Parapet-CA-Id header is the guaranteed steady-state carrier.
+		CAID: s.CurrentCAID(),
 	}
 	body, err := json.Marshal(resp)
 	if err != nil {

--- a/edgecp/signal_test.go
+++ b/edgecp/signal_test.go
@@ -1,0 +1,134 @@
+package edgecp
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// handleCert must emit X-Parapet-CA-Id on the 404 (no cert), the 304 (revalidate), AND
+// the 200 — the universal force-re-mint signal that rides the edge's existing poll.
+func TestHandleCertEmitsCAIDOnEveryArm(t *testing.T) {
+	certPEM, keyPEM := testEdgeCA(t)
+	signer, _, err := NewProvidedSigner(certPEM, keyPEM, time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewCertStore()
+	srv := NewServer(store, NewAuthz(map[string][]string{"tok": {"acme.com"}})).WithSigner(signer)
+	want := signer.CAID()
+	h := srv.Handler()
+
+	get := func(inm string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest("GET", "/v1/certs?sni=acme.com", nil)
+		req.Header.Set("Authorization", "Bearer tok")
+		if inm != "" {
+			req.Header.Set("If-None-Match", inm)
+		}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// 404: authorized sni, no cert in the store yet.
+	rec := get("")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("X-Parapet-CA-Id"); got != want {
+		t.Errorf("404 X-Parapet-CA-Id = %q, want %q", got, want)
+	}
+
+	// 200: load the cert.
+	store.Set([]PEMPair{mkPair(t, "acme.com")})
+	rec = get("")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("X-Parapet-CA-Id"); got != want {
+		t.Errorf("200 X-Parapet-CA-Id = %q, want %q", got, want)
+	}
+	etag := rec.Header().Get("ETag")
+
+	// 304: the SIGNAL must ride the revalidation (steady state is ~all 304s).
+	rec = get(etag)
+	if rec.Code != http.StatusNotModified {
+		t.Fatalf("want 304, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("X-Parapet-CA-Id"); got != want {
+		t.Errorf("304 X-Parapet-CA-Id = %q, want %q (the load-bearing steady-state carrier)", got, want)
+	}
+}
+
+// An unauthorized caller must NOT learn the signer state (no header on 401/403).
+func TestHandleCertNoCAIDForUnauthorized(t *testing.T) {
+	certPEM, keyPEM := testEdgeCA(t)
+	signer, _, _ := NewProvidedSigner(certPEM, keyPEM, time.Hour, time.Minute)
+	srv := NewServer(NewCertStore(), NewAuthz(map[string][]string{"tok": {"acme.com"}})).WithSigner(signer)
+	h := srv.Handler()
+
+	// 401 (no token).
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/v1/certs?sni=acme.com", nil))
+	if rec.Header().Get("X-Parapet-CA-Id") != "" {
+		t.Error("401 must not leak the CA-Id")
+	}
+	// 403 (token not allowed for this sni).
+	req := httptest.NewRequest("GET", "/v1/certs?sni=other.com", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Header().Get("X-Parapet-CA-Id") != "" {
+		t.Error("403 must not leak the CA-Id")
+	}
+}
+
+// The edge-cert response carries ca_id; the saturation gate sheds with 503+Retry-After.
+func TestEdgeCertCAIDAndSaturation(t *testing.T) {
+	certPEM, keyPEM := testEdgeCA(t)
+	signer, _, _ := NewProvidedSigner(certPEM, keyPEM, time.Hour, time.Minute)
+	authz := NewAuthzEntries(map[string]Entry{"tok": {ID: "edge-1", Domains: []string{"acme.com"}}})
+	srv := NewServer(NewCertStore(), authz).WithSigner(signer).WithSignConcurrency(1, 9)
+	h := srv.Handler()
+
+	leafKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	csr := testCSR(t, leafKey)
+	post := func() *httptest.ResponseRecorder {
+		body, _ := json.Marshal(edgeCertRequest{CSRPEM: string(csr)})
+		req := httptest.NewRequest("POST", "/v1/edge-cert", strings.NewReader(string(body)))
+		req.Header.Set("Authorization", "Bearer tok")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// Happy path: 200 with ca_id == the signer's.
+	rec := post()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (%s)", rec.Code, rec.Body)
+	}
+	var resp edgeCertResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.CAID != signer.CAID() {
+		t.Errorf("response ca_id = %q, want %q", resp.CAID, signer.CAID())
+	}
+
+	// Saturate the single signing slot → the next request sheds 503 + Retry-After.
+	srv.signGate <- struct{}{}
+	rec = post()
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("saturated: want 503, got %d", rec.Code)
+	}
+	if rec.Header().Get("Retry-After") != "9" {
+		t.Errorf("Retry-After = %q, want 9", rec.Header().Get("Retry-After"))
+	}
+	<-srv.signGate
+}

--- a/trust/e2e_test.go
+++ b/trust/e2e_test.go
@@ -61,7 +61,7 @@ func TestAutoTrustEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 	ccStore := edge.NewClientCertStore()
-	edge.RefreshEdgeCertOnce(edgeCP, ccStore)
+	edge.RefreshEdgeCertOnce(edgeCP, ccStore, "timer")
 	if !ccStore.Loaded() {
 		t.Fatal("edge did not obtain a data-plane client cert from the CP")
 	}


### PR DESCRIPTION
**Sub-PR 3 of 5** for edge-proxy revocation (`EDGE-AUTOTRUST.md`). With a 7-day leaf TTL, good edges won't naturally renew during a rotation — so the edge must be *made* to re-mint onto the new CA before OLD is dropped. This adds that, fail-static and storm-safe.

**Non-destructive:** it never drops OLD. The convergence-gated OLD-drop (the only step that can mass-502 the fleet) stays in sub-PR 5, behind the interlock this PR's `edge_cp_target_ca_id` gauge will feed.

## Signal delivery (CP)
- **`/v1/certs` advertises the signer target `ca_id` on an `X-Parapet-CA-Id` header** riding *every* authorized arm — **200, 304, and 404** (never 401/403). This is the **universal** carrier: the cert-refresh loop is the one loop every edge runs in every mode (pinned, serve-all, WAF on/off). Deliberately **not** folded into the cert ETag, so a pure CA rotation never forces a fleet-wide cert+key re-download. Secondary confirmers: `ca_id` in the `/v1/waf` body (200 only) and the `/v1/edge-cert` response.
- **Signer concurrency gate** sheds the rotation re-mint surge with `503 + Retry-After` — the only fleet-aggregate backpressure (one token per edge doesn't bound the aggregate).

## Edge
- **`RemintCoordinator`** owns every re-mint path (proactive / reactive / timer): per-edge single-flight, full jitter, exponential backoff, `Retry-After` honoring, and **two independent circuit-breakers** — reactive (K ok-mints that don't change `ca_id` → futile core-reject) and proactive (J that don't reach target → unreachable target). Transient failures are the backoff path, never breaker evidence. `Observe()` compares the CP target against the edge's **own held-leaf `ca_id`** (never a prior observation, so a mid-rotation boot re-mints on first poll); empty target/live are fail-static no-ops.
- **Reactive floor:** the forward `ErrorHandler` fires a non-blocking re-mint **only** on a peer-sent cert-verify TLS alert (`remote error: tls: ...`), excluding dial errors / timeouts / 5xx / locally-raised alerts — paranoid so a core outage can't storm. **Pinned against the real Go alert string** via a live-handshake test (guards a future Go rename).
- **Remaining-life renewal** replaces the every-interval mint (renew at a fraction of the leaf's own lifetime); the idle `mTLS+serve-all+WAF-off` edge reads the tokenless trust-bundle `ca_id` on its existing tick (no new loop). Poll loops jitter their first tick to decorrelate fleet signal-delivery instants.
- **Metrics:** `edge_clientcert_remint_total` gains a `{trigger}` label + `breaker_open`; new `edge_cp_target_ca_id` gauge for the OLD-drop interlock.

## Review
An adversarial find→verify pass (4 dimensions) surfaced 7 findings (0 false-positive), all folded — notably a **real breaker-logic bug**: reaching the target wrongly reset the *reactive* counter, so the reactive breaker could never open when the edge was already at target but the core kept rejecting. Fixed by scoring the two breakers independently (reactive = `ca_id`-flip; proactive = target-reached). Also: panic-safe `inFlight` clear (`defer`+`recover`), dropped `certificate_expired` from the classifier (renewal floor owns expiry), and added the missing proactive-breaker + `Retry-After` tests.

## Tests
`caid` join-key conformance (single-CA + overlap), `X-Parapet-CA-Id` on every arm (incl. the load-bearing 304), the real-Go-alert classifier, single-flight, both breakers (open + reset), `chooseSleep`, the saturation `503`, `Retry-After` parsing. `gofmt` / `go vet ./...` / `go test -race ./...` / e2e all green (e2e now asserts `/v1/certs` advertises the signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)