### PR TITLE
feat(edgecp): resourceVersion-derived trust-bundle generation (replica-identical)

### DIFF
--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -193,17 +193,36 @@ runs alongside as a correctness backstop; the watch call avoids a whole-request
 `http.Client.Timeout` (Transport timeouts + per-attempt ctx deadline + TCP
 keep-alive). The CP `http.Server` `WriteTimeout`/`IdleTimeout` MUST be ≥ the ceiling.
 
-### Generation (content-derived, replica-identical + monotonic)
+### Generation (resourceVersion-derived, replica-identical + monotonic)
 
-`generation = max(resourceVersion)` across the source objects (the registry Secret +
-the `parapet-edge-ca` Secret). etcd is a single global monotonic revision counter, so
-this is server-assigned (identical on every CP replica), monotonic, and persisted
-across CP restarts **by construction** — no process counter. **Forward-only is now
-LOAD-BEARING for CA-rotation-as-revocation:** a replayed OLDER bundle over any TLS gap
-could re-add a just-dropped OLD CA (**re-trusting a compromised edge** whose leaf
-chains to OLD) or remove a just-added NEW CA (un-trusting a just-re-minted fleet →
-mass 502). The core swaps only on a strictly-advancing generation. (Also fixes the
-pre-existing `wafstore.go` per-process-counter flap under `replicas: 2`.)
+`generation` is the **`parapet-edge-ca` Secret's own `metadata.resourceVersion`** (a
+single source object), parsed to `uint64` (`edgecp/resourceversion.go`). etcd is a single
+global monotonic revision counter, so this is server-assigned (**identical on every CP
+replica** that reads the same object), monotonic, and persisted across CP restarts **by
+construction** — no process counter (this replaces the `prev+1` that two replicas desync,
+the `wafstore.go` flap class). **It is NOT a `max()` across objects** — a `resourceVersion`
+is only comparable within one object's history, so the token registry (when it becomes a
+Secret) gets its OWN separate generation for its own concern, never folded in.
+
+Guards: (1) the CP-side **monotonic floor** in `SetSigner` rejects `generation <= served`
+(an out-of-order watch re-list can't regress; counted by `parapet_edge_ca_signer_floored_total`);
+(2) a non-numeric `resourceVersion` (the k8s contract permits it) keeps last-good and raises
+`parapet_edge_ca_signer_rv_unparsed` (fail-closed — never `0`, never a counter fallback);
+(3) the `ca_id` no-churn gate means a metadata-only write does **not** advance generation.
+**Forward-only is LOAD-BEARING for CA-rotation-as-revocation:** a replayed OLDER bundle over
+any TLS gap could re-add a just-dropped OLD CA (**re-trusting a compromised edge**) or remove
+a just-added NEW CA (mass 502); the core swaps only on a strictly-advancing generation.
+
+**Provided mode** has no Secret RV: `generation` comes from `EDGE_CA_PROVIDED_GENERATION`
+(bump it on each rotation) or the cert file's mtime — it **must advance on every rotation**,
+or the core rejects the new bundle as a rollback.
+
+> **One-way door (rollback footgun).** Switching to a `resourceVersion`-derived generation
+> moves the value from a small counter to a large etcd revision. Once the core has applied an
+> RV-derived generation, a plain deploy **rollback** to the old counter scheme makes the core
+> reject the now-smaller generation as a rollback and **freeze trust at last-good**. Rolling
+> back requires resetting the core's remembered trust generation (restart the core after the
+> CP is rolled back). Distinct from the delete+recreate UID-reset residual.
 
 ### Warm-start cache (fail-closed)
 
@@ -620,6 +639,7 @@ not Prometheus counters (a Pushgateway would be a new failure domain).
 | `EDGE_CLIENTCERT_KEY_TYPE` / `_SKEW` / `_RATE` | edge/CP | `ecdsa-p256` / `10m` / `10/min` | Ephemeral key type; NotBefore backdate (negligible vs 7 d, but NTP between CP and core stays a prerequisite); per-token issuance limit (**per-replica**, effective N×). |
 | `EDGE_CA_BOOTSTRAP` / `--bootstrap-ca` | CP (Job) | false | One-shot CA bootstrap **and rotation** mode (`EnsureCA`: adopt/generate/never-regenerate, CAS-guarded). The only writer of the CA Secret. |
 | `EDGE_CA_CERT` / `_KEY` | CP | `""` (⇒ managed) | Provided mode (mounted CA). Both-or-neither. Absent ⇒ managed (the Job generates). |
+| `EDGE_CA_PROVIDED_GENERATION` | CP | cert mtime | Provided-mode trust-bundle generation (managed mode derives it from the CA Secret's `resourceVersion`). **MUST strictly advance on each provided-CA rotation** or the core rejects the new bundle as a rollback. |
 | `EDGE_CA_SECRET` | CP | `parapet-edge-ca` | The CA Secret in a CP-only namespace; Job writes (scoped), serving reads (read-only + read-watch). Pre-created empty, GitOps drift-exclusion. |
 | `EDGE_CA_TTL` | CP | `8760h–17520h` (1–2 y) | Edge CA cert lifetime. **Shortened** from 10 y now that rotation is a routine on-demand primitive — but kept comfortably longer than the expected revoke-driven rotation interval so a scheduled CA expiry doesn't collide with on-demand rotations. |
 | `POD_NAMESPACE` / `WATCH_NAMESPACE` | CP | downward API (**required**) / `""` | CA Secret namespace (read serving-managed, write Job); pin `WATCH_NAMESPACE` to shrink the cluster-wide tenant-TLS read blast radius. |

--- a/cmd/edge-controlplane/generation_test.go
+++ b/cmd/edge-controlplane/generation_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestProvidedGeneration(t *testing.T) {
+	// A temp cert file with a known mtime for the fallback cases.
+	cert := filepath.Join(t.TempDir(), "ca.crt")
+	if err := os.WriteFile(cert, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mtime := time.Unix(1_700_000_000, 0)
+	if err := os.Chtimes(cert, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("env wins", func(t *testing.T) {
+		t.Setenv("EDGE_CA_PROVIDED_GENERATION", "42")
+		if got := providedGeneration(cert); got != 42 {
+			t.Errorf("got %d, want 42", got)
+		}
+	})
+
+	t.Run("env=0 is rejected, falls back to mtime", func(t *testing.T) {
+		// 0 parses but defeats the core's anti-rollback guard — must NOT be returned.
+		t.Setenv("EDGE_CA_PROVIDED_GENERATION", "0")
+		if got := providedGeneration(cert); got != uint64(mtime.Unix()) {
+			t.Errorf("env=0 must fall through to mtime, got %d", got)
+		}
+	})
+
+	t.Run("env unparseable falls back to mtime", func(t *testing.T) {
+		t.Setenv("EDGE_CA_PROVIDED_GENERATION", "abc")
+		if got := providedGeneration(cert); got != uint64(mtime.Unix()) {
+			t.Errorf("got %d, want mtime %d", got, mtime.Unix())
+		}
+	})
+
+	t.Run("no env, missing cert -> 1", func(t *testing.T) {
+		os.Unsetenv("EDGE_CA_PROVIDED_GENERATION")
+		if got := providedGeneration(filepath.Join(t.TempDir(), "nope.crt")); got != 1 {
+			t.Errorf("got %d, want 1", got)
+		}
+	})
+
+	// The function must NEVER return 0 (a replayed-older bundle would beat it).
+	t.Run("never zero", func(t *testing.T) {
+		t.Setenv("EDGE_CA_PROVIDED_GENERATION", "00")
+		if got := providedGeneration(cert); got == 0 {
+			t.Error("providedGeneration must never return 0")
+		}
+	})
+}

--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -31,6 +31,27 @@ func envOr(key, def string) string {
 	return def
 }
 
+// providedGeneration derives the trust-bundle generation for a mounted (provided) CA,
+// which has no Secret resourceVersion. It prefers EDGE_CA_PROVIDED_GENERATION (the
+// operator bumps it on rotation — strictly-increasing for determinism), else falls back
+// to the cert file's mtime as unix seconds (a remount with a newer file advances it).
+// It must advance on every provided-CA rotation, or the core rejects the new bundle as a
+// rollback (gen <= held). 0 is never returned (cold value 1).
+func providedGeneration(caCertPath string) uint64 {
+	if v := os.Getenv("EDGE_CA_PROVIDED_GENERATION"); v != "" {
+		if n, err := strconv.ParseUint(v, 10, 64); err == nil && n > 0 {
+			return n
+		}
+		slog.Warn("EDGE_CA_PROVIDED_GENERATION must be a positive integer; falling back to cert mtime", "value", v)
+	}
+	if fi, err := os.Stat(caCertPath); err == nil {
+		if mt := fi.ModTime().Unix(); mt > 0 {
+			return uint64(mt)
+		}
+	}
+	return 1
+}
+
 // envInt reads a base-10 int from env, or returns def (on unset/invalid).
 func envInt(key string, def int) int {
 	if v := os.Getenv(key); v != "" {
@@ -204,12 +225,17 @@ func main() {
 			slog.Warn("edge CA: " + msg)
 		}
 		server.ExpectIssuance()
-		server = server.WithSigner(signer)
-		slog.Info("edge control plane: data-plane issuance enabled (provided CA)",
-			"ca_id", signer.CAID(), "leaf_ttl", clientCertTTL)
-		// NOTE: rotating a mounted (provided) CA requires remounting EDGE_CA_CERT/KEY
-		// and restarting this process — there is no fsnotify here. Managed mode (below)
+		// Provided mode has no Secret resourceVersion to derive the generation from, so
+		// take it from EDGE_CA_PROVIDED_GENERATION (operator bumps it on each rotation) or
+		// the cert file's mtime. A fixed value would make provided-CA rotation impossible
+		// (the core rejects the new bundle at gen <= held). Rotating a mounted CA thus
+		// REQUIRES remounting EDGE_CA_CERT/KEY (a newer mtime) or bumping the env, AND
+		// restarting this process — there is no fsnotify here. Managed mode (below)
 		// hot-reloads via the CA-Secret watch.
+		providedGen := providedGeneration(caCertPath)
+		server = server.WithSigner(signer, providedGen)
+		slog.Info("edge control plane: data-plane issuance enabled (provided CA)",
+			"ca_id", signer.CAID(), "generation", providedGen, "leaf_ttl", clientCertTTL)
 
 	case caSecret != "":
 		if podNamespace == "" {

--- a/edge/clientcert_test.go
+++ b/edge/clientcert_test.go
@@ -48,7 +48,7 @@ func TestEdgeCertIssuanceEndToEnd(t *testing.T) {
 	authz := edgecp.NewAuthzEntries(map[string]edgecp.Entry{
 		"tok": {ID: "acme-edge-1", Domains: []string{"acme.com"}},
 	})
-	h := edgecp.NewServer(edgecp.NewCertStore(), authz).WithSigner(signer).Handler()
+	h := edgecp.NewServer(edgecp.NewCertStore(), authz).WithSigner(signer, 1).Handler()
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 

--- a/edgecp/generation_test.go
+++ b/edgecp/generation_test.go
@@ -1,0 +1,128 @@
+package edgecp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// The monotonic floor rejects a generation <= the served one (an out-of-order re-list or
+// a not-advanced provided-CA rotation), keeps last-good, and counts the rejection.
+func TestSetSignerMonotonicFloor(t *testing.T) {
+	certA, keyA := mustGenerateCA(t)
+	certB, keyB := mustGenerateCA(t)
+	sgA, _, _ := NewProvidedSigner(certA, keyA, 0, 0)
+	sgB, _, _ := NewProvidedSigner(certB, keyB, 0, 0)
+
+	srv := NewServer(NewCertStore(), NewAuthz(nil))
+	before := testutil.ToFloat64(signerFloored)
+
+	srv.SetSigner(sgA, 5)
+	if srvGen(srv) != 5 || srv.CurrentCAID() != sgA.CAID() {
+		t.Fatalf("first install: gen=%d caid=%s", srvGen(srv), srv.CurrentCAID())
+	}
+	srv.SetSigner(sgB, 3) // older → floored
+	if srvGen(srv) != 5 || srv.CurrentCAID() != sgA.CAID() {
+		t.Error("an older generation must be floored (keep last-good)")
+	}
+	srv.SetSigner(sgB, 5) // equal → floored (provided-CA rotation that didn't advance)
+	if srvGen(srv) != 5 || srv.CurrentCAID() != sgA.CAID() {
+		t.Error("an equal generation must be floored")
+	}
+	if got := testutil.ToFloat64(signerFloored); got != before+2 {
+		t.Errorf("floored counter: %v, want +2", got-before)
+	}
+	srv.SetSigner(sgB, 6) // newer → applied
+	if srvGen(srv) != 6 || srv.CurrentCAID() != sgB.CAID() {
+		t.Error("a newer generation must apply")
+	}
+}
+
+// Two independent reloaders over the SAME CA-Secret resourceVersion compute the
+// byte-identical generation — replica-identical by construction (etcd's global revision),
+// replacing the desync-prone per-process prev+1 counter.
+func TestReplicaIdenticalGeneration(t *testing.T) {
+	oldCert, oldKey := mustGenerateCA(t)
+	secs := []v1.Secret{caSecretObj(map[string][]byte{"tls.crt": oldCert, "tls.key": oldKey}, nil)}
+	secs[0].ResourceVersion = "424242"
+
+	srv1, srv2 := NewServer(NewCertStore(), NewAuthz(nil)), NewServer(NewCertStore(), NewAuthz(nil))
+	if err := testReloader(srv1, &secs).reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := testReloader(srv2, &secs).reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if srvGen(srv1) != 424242 || srvGen(srv2) != 424242 {
+		t.Errorf("both replicas must derive gen=424242, got %d and %d", srvGen(srv1), srvGen(srv2))
+	}
+	if srv1.CurrentCAID() != srv2.CurrentCAID() {
+		t.Error("both replicas must serve the same ca_id")
+	}
+}
+
+// A non-numeric resourceVersion freezes the signer at last-good (fail-closed) and raises
+// the alertable gauge; a subsequent numeric RV recovers and clears the gauge.
+func TestSignerReloadRVUnparseableKeepsLastGood(t *testing.T) {
+	oldCert, oldKey := mustGenerateCA(t)
+	secs := []v1.Secret{caSecretObj(map[string][]byte{"tls.crt": oldCert, "tls.key": oldKey}, nil)}
+	srv := NewServer(NewCertStore(), NewAuthz(nil))
+	r := testReloader(srv, &secs)
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	gen1, caid1 := srvGen(srv), srv.CurrentCAID()
+
+	// Opaque RV + a changed bundle: must NOT swap (fail-closed), gauge → 1.
+	newCert, newKey := mustGenerateCA(t)
+	secs[0].Data["tls.crt"] = append(append([]byte(nil), oldCert...), newCert...)
+	secs[0].Data[caNewKeyField] = newKey
+	secs[0].Annotations = map[string]string{caRotationPhaseAnnotation: caPhaseOverlap, caActiveAnnotation: caActiveOld}
+	secs[0].ResourceVersion = "opaque-rv"
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if srvGen(srv) != gen1 || srv.CurrentCAID() != caid1 {
+		t.Error("an unparseable resourceVersion must keep last-good (never swap on a gen we can't order)")
+	}
+	if testutil.ToFloat64(signerRVUnparsed) != 1 {
+		t.Error("signerRVUnparsed gauge must be 1 while the RV is opaque")
+	}
+
+	// Recover: a numeric RV applies the (still-changed) bundle and clears the gauge.
+	secs[0].ResourceVersion = "500"
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if srvGen(srv) != 500 || srv.CurrentCAID() == caid1 {
+		t.Error("a numeric RV must recover and apply the changed bundle")
+	}
+	if testutil.ToFloat64(signerRVUnparsed) != 0 {
+		t.Error("signerRVUnparsed gauge must clear to 0 once the RV parses")
+	}
+}
+
+// A metadata-only write (RV bumped, tls.crt identical) must NOT advance the generation —
+// the ca_id no-churn gate suppresses it, so the core has nothing to re-apply.
+func TestMetadataOnlyPUTNoChurn(t *testing.T) {
+	oldCert, oldKey := mustGenerateCA(t)
+	secs := []v1.Secret{caSecretObj(map[string][]byte{"tls.crt": oldCert, "tls.key": oldKey}, nil)}
+	srv := NewServer(NewCertStore(), NewAuthz(nil))
+	r := testReloader(srv, &secs)
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	gen1, caid1 := srvGen(srv), srv.CurrentCAID()
+
+	// Bump only the RV (e.g. a label/annotation write) — same bundle, same ca_id.
+	secs[0].ResourceVersion = "999"
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if srvGen(srv) != gen1 || srv.CurrentCAID() != caid1 {
+		t.Errorf("a metadata-only write must not advance generation (%d→%d) — the ca_id gate suppresses it", gen1, srvGen(srv))
+	}
+}

--- a/edgecp/issuance_test.go
+++ b/edgecp/issuance_test.go
@@ -126,7 +126,7 @@ func TestEdgeCertEndpoint(t *testing.T) {
 		"tok-no-id":    {Domains: []string{"acme.com"}}, // may fetch certs, but no data-plane identity
 		"tok-disabled": {ID: "ghost", Domains: []string{"acme.com"}, Disabled: true},
 	})
-	h := NewServer(NewCertStore(), authz).WithSigner(sg).Handler()
+	h := NewServer(NewCertStore(), authz).WithSigner(sg, 1).Handler()
 
 	leafKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	csr := testCSR(t, leafKey)
@@ -190,7 +190,7 @@ func TestTrustBundleEndpoint(t *testing.T) {
 		t.Fatalf("no signer: want 503, got %d", rec.Code)
 	}
 
-	srv.SetSigner(sg)
+	srv.SetSigner(sg, 1)
 	h := srv.Handler()
 
 	// Tokenless 200 with {generation, ca_pem, ca_id}.

--- a/edgecp/metrics.go
+++ b/edgecp/metrics.go
@@ -46,10 +46,30 @@ var (
 		Name:      "edge_ca_target_ca_id",
 		Help:      "The ca_id the fleet should converge to — the serving control plane's current signer (value 1).",
 	}, []string{"ca_id"})
+
+	// signerFloored counts signer swaps rejected by the monotonic generation floor (an
+	// out-of-order re-list serving an older cached CA object). A non-zero rate means a
+	// rotation is being held back at last-good — it must be scrapeable, not just logged,
+	// because the floor turns the always-swap path into a sometimes-skip.
+	signerFloored = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_ca_signer_floored_total",
+		Help:      "Signer swaps rejected by the monotonic generation floor (older-than-served generation).",
+	})
+
+	// signerRVUnparsed is 1 while the CA Secret's resourceVersion is non-numeric (the
+	// signer is frozen at last-good and readiness will 503 if none loaded). The k8s
+	// contract permits an opaque resourceVersion, so this can be a PERMANENT stuck state
+	// — it must be alertable, not a one-shot log line.
+	signerRVUnparsed = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_ca_signer_rv_unparsed",
+		Help:      "1 when the CA Secret resourceVersion is non-numeric (signer frozen at last-good); 0 when parseable.",
+	})
 )
 
 func init() {
-	prom.Registry().MustRegister(signerFingerprint, signerGeneration, signerBundleCerts, signerLoaded, targetCAID)
+	prom.Registry().MustRegister(signerFingerprint, signerGeneration, signerBundleCerts, signerLoaded, targetCAID, signerFloored, signerRVUnparsed)
 }
 
 // setSignerMetrics records the active signer's ca_id, generation, and bundle size. It

--- a/edgecp/resourceversion.go
+++ b/edgecp/resourceversion.go
@@ -1,0 +1,35 @@
+package edgecp
+
+import "strconv"
+
+// The trust-bundle generation is the resourceVersion of the SINGLE source object whose
+// change moves trust: the parapet-edge-ca Secret. etcd assigns one global, monotonic
+// revision, so every CP replica's List/Watch of that SAME object returns the SAME
+// resourceVersion — the generation is therefore replica-identical and monotonic BY
+// CONSTRUCTION, replacing the old per-process prev+1 counter that two replicas desync.
+//
+// It is deliberately NOT a max() across multiple objects. A k8s resourceVersion is
+// meaningful ONLY within one object's history (the etcd revision at which THAT object
+// last changed); maxing the resourceVersions of two DIFFERENT objects compares
+// incomparable values and can regress on one replica. When the token registry becomes a
+// Secret, it gets its OWN separate generation for its OWN concern (the authz barrier) —
+// it must NEVER be folded into this generation. DO NOT add a maxGen(...uint64) helper
+// here; that API shape invites exactly the broken cross-object max().
+
+// rvToU64 converts a Kubernetes resourceVersion to the uint64 generation. A
+// resourceVersion is normally the decimal etcd revision (client-go formats an int64), so
+// it parses cleanly — but the API contract explicitly permits an OPAQUE, non-numeric
+// value (a future or aggregated apiserver). On non-numeric/empty/overflow it returns
+// ok=false and the caller MUST keep last-good and surface it loudly; it must NEVER fall
+// back to 0 or a process counter, since a low generation would let a replayed-older
+// bundle win the core's forward-only anti-rollback check.
+func rvToU64(rv string) (uint64, bool) {
+	if rv == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseUint(rv, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}

--- a/edgecp/resourceversion_test.go
+++ b/edgecp/resourceversion_test.go
@@ -1,0 +1,27 @@
+package edgecp
+
+import "testing"
+
+func TestRVToU64(t *testing.T) {
+	cases := []struct {
+		rv     string
+		want   uint64
+		wantOk bool
+	}{
+		{"100", 100, true},
+		{"18446744073709551615", 1<<64 - 1, true}, // max uint64
+		{"0", 0, true},
+		{"", 0, false},                     // empty
+		{"abc", 0, false},                  // opaque (aggregated apiserver)
+		{"100x", 0, false},                 // trailing garbage
+		{"-1", 0, false},                   // negative
+		{"18446744073709551616", 0, false}, // overflow
+		{"  100  ", 0, false},              // whitespace not trimmed (strict)
+	}
+	for _, tc := range cases {
+		got, ok := rvToU64(tc.rv)
+		if ok != tc.wantOk || (ok && got != tc.want) {
+			t.Errorf("rvToU64(%q) = (%d,%v), want (%d,%v)", tc.rv, got, ok, tc.want, tc.wantOk)
+		}
+	}
+}

--- a/edgecp/server.go
+++ b/edgecp/server.go
@@ -72,29 +72,35 @@ func (s *Server) WithWAF(waf *WafStore) *Server {
 	return s
 }
 
-// WithSigner enables data-plane client-cert issuance and trust distribution.
-// Returns the server for chaining.
-func (s *Server) WithSigner(sg *Signer) *Server {
-	s.SetSigner(sg)
+// WithSigner enables data-plane client-cert issuance and trust distribution at the
+// given trust-bundle generation. Returns the server for chaining.
+func (s *Server) WithSigner(sg *Signer, generation uint64) *Server {
+	s.SetSigner(sg, generation)
 	return s
 }
 
-// SetSigner installs (or hot-swaps, on rotation) the active Signer and bumps the
-// trust-bundle generation, waking any long-poll waiters. The (signer, gen) pair is
-// stored as one immutable value so concurrent readers never tear it. Safe to call
-// concurrently.
-func (s *Server) SetSigner(sg *Signer) {
+// SetSigner installs (or hot-swaps, on rotation) the active Signer at the given
+// trust-bundle generation. generation is the CA Secret's resourceVersion (the etcd
+// revision — replica-identical + monotonic across CP replicas), NOT a process counter.
+//
+// It enforces a MONOTONIC FLOOR: a generation <= the currently-served one is rejected
+// (kept last-good, counted), so an out-of-order watch re-list serving an older cached CA
+// object can never regress the served generation — which would otherwise let the core
+// re-apply a replayed-older bundle (re-trusting a dropped CA / un-trusting a re-minted
+// fleet). The (signer, gen) pair is one immutable value so concurrent readers never tear
+// it. Safe to call concurrently.
+func (s *Server) SetSigner(sg *Signer, generation uint64) {
 	s.genMu.Lock()
 	defer s.genMu.Unlock()
-	var prev uint64
-	if st := s.signerState.Load(); st != nil {
-		prev = st.gen
+	if st := s.signerState.Load(); st != nil && generation <= st.gen {
+		signerFloored.Inc()
+		return
 	}
-	s.signerState.Store(&signerGen{sg: sg, gen: prev + 1})
+	s.signerState.Store(&signerGen{sg: sg, gen: generation})
 	// Convergence metrics: set all signer gauges together inside the held genMu so a
 	// scrape never tears across them. Done before close(genNotify) so a long-poll
 	// waiter that wakes and re-scrapes always observes the new series.
-	setSignerMetrics(sg.CAID(), prev+1, sg.BundleLen())
+	setSignerMetrics(sg.CAID(), generation, sg.BundleLen())
 	close(s.genNotify)
 	s.genNotify = make(chan struct{})
 }

--- a/edgecp/server_test.go
+++ b/edgecp/server_test.go
@@ -28,26 +28,27 @@ func TestTrustBundleSnapshotCoherentUnderRace(t *testing.T) {
 	}
 
 	srv := NewServer(NewCertStore(), NewAuthz(nil))
-	srv.SetSigner(sgA)
+	srv.SetSigner(sgA, 1)
 	h := srv.Handler()
 
 	var wg sync.WaitGroup
 	stop := make(chan struct{})
 
-	// Writer: alternate the active signer as fast as it can.
+	// Writer: alternate the active signer with STRICTLY-INCREASING generations (the
+	// monotonic floor rejects gen <= served, so a flat gen would be floored).
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for i := 0; ; i++ {
+		for i := 2; ; i++ {
 			select {
 			case <-stop:
 				return
 			default:
 			}
 			if i%2 == 0 {
-				srv.SetSigner(sgA)
+				srv.SetSigner(sgA, uint64(i))
 			} else {
-				srv.SetSigner(sgB)
+				srv.SetSigner(sgB, uint64(i))
 			}
 		}
 	}()

--- a/edgecp/signal_test.go
+++ b/edgecp/signal_test.go
@@ -21,7 +21,7 @@ func TestHandleCertEmitsCAIDOnEveryArm(t *testing.T) {
 		t.Fatal(err)
 	}
 	store := NewCertStore()
-	srv := NewServer(store, NewAuthz(map[string][]string{"tok": {"acme.com"}})).WithSigner(signer)
+	srv := NewServer(store, NewAuthz(map[string][]string{"tok": {"acme.com"}})).WithSigner(signer, 1)
 	want := signer.CAID()
 	h := srv.Handler()
 
@@ -70,7 +70,7 @@ func TestHandleCertEmitsCAIDOnEveryArm(t *testing.T) {
 func TestHandleCertNoCAIDForUnauthorized(t *testing.T) {
 	certPEM, keyPEM := testEdgeCA(t)
 	signer, _, _ := NewProvidedSigner(certPEM, keyPEM, time.Hour, time.Minute)
-	srv := NewServer(NewCertStore(), NewAuthz(map[string][]string{"tok": {"acme.com"}})).WithSigner(signer)
+	srv := NewServer(NewCertStore(), NewAuthz(map[string][]string{"tok": {"acme.com"}})).WithSigner(signer, 1)
 	h := srv.Handler()
 
 	// 401 (no token).
@@ -94,7 +94,7 @@ func TestEdgeCertCAIDAndSaturation(t *testing.T) {
 	certPEM, keyPEM := testEdgeCA(t)
 	signer, _, _ := NewProvidedSigner(certPEM, keyPEM, time.Hour, time.Minute)
 	authz := NewAuthzEntries(map[string]Entry{"tok": {ID: "edge-1", Domains: []string{"acme.com"}}})
-	srv := NewServer(NewCertStore(), authz).WithSigner(signer).WithSignConcurrency(1, 9)
+	srv := NewServer(NewCertStore(), authz).WithSigner(signer, 1).WithSignConcurrency(1, 9)
 	h := srv.Handler()
 
 	leafKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/edgecp/signerreload.go
+++ b/edgecp/signerreload.go
@@ -149,6 +149,19 @@ func (r *SignerReloader) reload(ctx context.Context) error {
 		return nil
 	}
 
+	// generation = the CA Secret's OWN resourceVersion (the etcd revision — see
+	// resourceversion.go: single-object, replica-identical, monotonic). Fail-closed on a
+	// non-numeric RV: keep last-good (never gen=0, which a replayed bundle could beat),
+	// log on EVERY reload (the stuck state can be permanent), and raise an alertable gauge.
+	generation, ok := rvToU64(sec.ResourceVersion)
+	if !ok {
+		slog.Error("edgecp: CA secret resourceVersion is non-numeric; keeping last-good signer (frozen until it parses)",
+			"resource_version", sec.ResourceVersion, "secret", r.namespace+"/"+r.caSecret)
+		signerRVUnparsed.Set(1)
+		return nil
+	}
+	signerRVUnparsed.Set(0)
+
 	// Select the active key field AND the active cert fingerprint as a coherent unit
 	// from the tls-active annotation. OLD is the first cert, NEW the last.
 	active := sec.Annotations[caActiveAnnotation]
@@ -181,13 +194,13 @@ func (r *SignerReloader) reload(ctx context.Context) error {
 		slog.Warn("edge CA: " + msg)
 	}
 	if cand.CAID() == r.server.CurrentCAID() {
-		return nil // unchanged bundle; do not churn the generation
+		return nil // unchanged bundle; do not churn the generation (RV-only writes are no-ops)
 	}
-	r.server.SetSigner(cand)
+	r.server.SetSigner(cand, generation)
 	if active == "" {
 		active = caActiveOld
 	}
 	slog.Info("edgecp: edge CA signer installed",
-		"ca_id", cand.CAID(), "active", active, "certs", len(fps), "secret", r.namespace+"/"+r.caSecret)
+		"ca_id", cand.CAID(), "active", active, "certs", len(fps), "generation", generation, "secret", r.namespace+"/"+r.caSecret)
 	return nil
 }

--- a/edgecp/signerreload_test.go
+++ b/edgecp/signerreload_test.go
@@ -19,7 +19,9 @@ func testReloader(srv *Server, secs *[]v1.Secret) *SignerReloader {
 
 func caSecretObj(data map[string][]byte, annotations map[string]string) v1.Secret {
 	return v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "parapet-edge-ca", Namespace: "ns", Annotations: annotations},
+		// ResourceVersion is the generation source (the etcd revision). Stamp a numeric
+		// default; rotation tests bump it (a real Secret write advances the RV).
+		ObjectMeta: metav1.ObjectMeta{Name: "parapet-edge-ca", Namespace: "ns", ResourceVersion: "100", Annotations: annotations},
 		Data:       data,
 	}
 }
@@ -46,11 +48,12 @@ func TestSignerReloaderPicksUpRotation(t *testing.T) {
 	}
 	gen1, caid1 := srvGen(srv), srv.CurrentCAID()
 
-	// Rotate: flip the Secret to OLD++NEW overlap.
+	// Rotate: flip the Secret to OLD++NEW overlap (a real write advances the RV).
 	newCert, newKey := mustGenerateCA(t)
 	secs[0].Data["tls.crt"] = append(append([]byte(nil), oldCert...), newCert...)
 	secs[0].Data[caNewKeyField] = newKey
 	secs[0].Annotations = map[string]string{caRotationPhaseAnnotation: caPhaseOverlap, caActiveAnnotation: caActiveOld}
+	secs[0].ResourceVersion = "200"
 
 	if err := r.reload(context.Background()); err != nil {
 		t.Fatal(err)

--- a/trust/e2e_test.go
+++ b/trust/e2e_test.go
@@ -40,7 +40,7 @@ func TestAutoTrustEndToEnd(t *testing.T) {
 	authz := edgecp.NewAuthzEntries(map[string]edgecp.Entry{
 		"edge-tok": {ID: "edge-1", Domains: []string{"acme.com"}},
 	})
-	cp := httptest.NewTLSServer(edgecp.NewServer(edgecp.NewCertStore(), authz).WithSigner(signer).Handler())
+	cp := httptest.NewTLSServer(edgecp.NewServer(edgecp.NewCertStore(), authz).WithSigner(signer, 100).Handler())
 	defer cp.Close()
 	cpServerCA := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cp.Certificate().Raw})
 
@@ -51,6 +51,11 @@ func TestAutoTrustEndToEnd(t *testing.T) {
 	}
 	mgr := NewManager()
 	pullInto(t, tc, mgr) // applies the bundle (edge CA) into the manager's ClientCAs
+
+	// Cross-plane: the core consumes the CP's exact (resourceVersion-derived) generation.
+	if got := mgr.Generation(); got != 100 {
+		t.Errorf("core generation = %d, want 100 (the CP's served generation)", got)
+	}
 
 	coreURL, coreClose := startCore(t, mgr)
 	defer coreClose()

--- a/trust/trust_test.go
+++ b/trust/trust_test.go
@@ -116,7 +116,7 @@ func TestTrustBundleOverTLSEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := edgecp.NewServer(edgecp.NewCertStore(), edgecp.NewAuthz(nil)).WithSigner(signer).Handler()
+	h := edgecp.NewServer(edgecp.NewCertStore(), edgecp.NewAuthz(nil)).WithSigner(signer, 1).Handler()
 	srv := httptest.NewTLSServer(h)
 	defer srv.Close()
 


### PR DESCRIPTION
**Sub-PR 4a of 5** for edge-proxy revocation (`EDGE-AUTOTRUST.md`) — the load-bearing prerequisite for the convergence interlock. **No destructive action, no convergence reader** (those are 4b / sub-PR 5). This only changes *where the trust-bundle generation comes from*.

## Why
The generation was a per-process `prev+1` counter, which two CP replicas **desync**. Once CA-rotation-as-revocation makes forward-only load-bearing, a divergent or non-monotonic generation lets a **replayed-older bundle win the core's anti-rollback check** — re-trusting a just-dropped OLD CA, or removing a just-added NEW CA and mass-502'ing a re-minted fleet.

## What
The generation is now the **`parapet-edge-ca` Secret's own `metadata.resourceVersion`** (the etcd revision): server-assigned, so **identical on every replica** reading the same object, monotonic, and persisted across restarts by construction.

- **`edgecp/resourceversion.go`** — `rvToU64`. Deliberately a **single source object, NOT a `max()` across objects** (a `resourceVersion` is only comparable within one object's history; the token registry gets its own separate generation later). The doc comment forbids a `maxGen` helper — that API shape is the trap.
- **`SetSigner(sg, generation)`** — a **monotonic floor** rejects `generation <= served` (an out-of-order watch re-list can't regress), counted by `parapet_edge_ca_signer_floored_total`.
- **`signerreload.go`** — threads `sec.ResourceVersion`; **fail-closed** on a non-numeric RV (the k8s contract permits it) — keep last-good, log every reload, raise `parapet_edge_ca_signer_rv_unparsed` (never `gen=0`, which a replayed bundle could beat). The `ca_id` no-churn gate is **kept**, so a metadata-only write doesn't advance generation.
- **Provided mode** — generation from `EDGE_CA_PROVIDED_GENERATION` or the cert mtime (a fixed `1` would make provided-CA rotation impossible: the core rejects `gen <= held`).
- **Core (`trust/`) unchanged** — its existing forward-only `apply()` consumes the generation as before; a cross-plane test pins `core.Generation() == the CP's served generation`.

## Risk + the one-way door
This touches the serving hot path (it turns an always-swap into a sometimes-skip), so it ships **first and alone** to soak before anything reads it. Documented footgun: rolling back to the counter scheme makes the core reject the now-smaller generation and **freeze trust at last-good** (rollback requires restarting the core).

## Tests
`rvToU64` table (numeric/empty/opaque/overflow/negative), the monotonic floor (older+equal → floored, counter +2, newer applies), **replica-identical** (two reloaders, same RV → byte-identical generation), RV-unparseable keeps-last-good + gauge + recovery, metadata-only-PUT no-churn, the race test rewritten for strictly-increasing gens, and the cross-plane `core.Generation() == CP generation`. `gofmt` / `go vet ./...` / `go test -race ./...` / e2e all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)