### PR TITLE
feat(edge): convergence metric contracts (edge_id, liveness, registry, authz-gen)

### DIFF
--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -566,7 +566,15 @@ pure-instrumentation Prometheus metrics on the shared `parapet` registry / `:918
 | `parapet_edge_clientcert_ca_id` | edge | gauge=1 | `ca_id` | CA set that issued the edge's **live** client leaf (lags the target until the edge re-mints). |
 | `parapet_edge_clientcert_not_after_seconds` | edge | gauge=unix | `ca_id` | Expiry of the edge's live leaf — an edge stuck on OLD with imminent expiry is the danger case. |
 | `parapet_edge_clientcert_loaded` | edge | gauge 0/1 | — | 1 once the edge holds a usable client cert. |
-| `parapet_edge_clientcert_remint_total` | edge | counter | `result` | `ok`/`keygen_fail`/`csr_fail`/`fetch_fail`/`marshal_fail`/`store_fail` — is the re-mint loop succeeding. |
+| `parapet_edge_clientcert_remint_total` | edge | counter | `result`,`trigger` | `ok`/`keygen_fail`/… by `proactive`/`reactive`/`timer` — is the re-mint loop succeeding. |
+| `parapet_edge_refresh_total` | edge | counter | `edge_id` | **Independent liveness** — bumped on EVERY successful CP poll regardless of `ca_id` change. The interlock gates on `increase(...) >= 1` so a wedged-but-scrapable edge frozen at the target can't false-green. |
+| `parapet_edge_registry_total` | CP | gauge 0/1 | `edge_id` | The expected-edge reporter set (1=enabled, 0=blacklisted). The interlock reads `label_values(==1)` to discover which edges must converge. |
+| `parapet_edge_authz_generation` | CP | gauge | — | Replica-identical fingerprint of the loaded token registry — the blacklist-barrier (B0) signal (all CP replicas must agree before a revoke flips the active CA). |
+
+> **`edge_id` label.** Every edge convergence metric carries an `edge_id` (from `EDGE_ID`,
+> matching the CP token id) so the interlock joins per-edge by a reschedule-stable key, not
+> the ephemeral pod/`instance`. A scrape-config `edge_id` relabel (kube-SD) should be
+> asserted to match the in-metric `edge_id`. Duplicate ids are refused at CP startup.
 
 **Convergence model — all three planes reach the CP target `ca_id`.** Because `Sign()`
 appends the full served bundle (`OLD++NEW` during overlap) to every leaf, the edge's
@@ -630,6 +638,7 @@ not Prometheus counters (a Pushgateway would be a new failure domain).
 | `EDGE_TRUST_CP_CACHE_FILE` / `_MAX_STALE` | core | `""` / `1h` | Warm-start hint (no trust until revalidated; bounded by max-stale). |
 | `EDGE_TRUST_REQUIRE_SAN` | core | **forced false, deprecated** | CA-only is the only model; the per-request SAN check is removed. Setting `true` with CP-issuance is a **fatal config error**. Slated for removal. |
 | `EDGE_DATAPLANE_MTLS` | edge | `false` | Enable the CP-issued client cert. Requires `EDGE_UPSTREAM_TLS=true`. Readiness gated on a loaded cert. |
+| `EDGE_ID` | edge | hostname | The edge's STABLE logical id, stamped as the `edge_id` label on every convergence metric (the OLD-drop interlock joins per-edge by it). **Required with `EDGE_DATAPLANE_MTLS=true`** and **must match this edge's CP token id**. Without mTLS, defaults to the hostname (convergence is moot). |
 | `EDGE_CLIENTCERT_TTL` | CP | **`168h` (7 d)** | Issued **leaf** lifetime (was 1 h). Buys a ~multi-day CP-outage budget (= `TTL` × renew-remaining-fraction ≈ 4.6 d). Renewal stays remaining-life (≤ 0.66×TTL, ~4.6 d remaining). The paired-knob guard: renew-before-fraction in (0,1) with ≥ several `EDGE_REFRESH_INTERVAL` of slack before expiry. |
 | `EDGE_CLIENTCERT_REMINT_JITTER` | edge | `60s` (≥ signer drain) | Max random delay before a force-re-mint (proactive or reactive), to prevent a re-mint thundering herd when `ca_id` flips fleet-wide. With exponential backoff + `Retry-After` + per-edge single-flight + a no-`ca_id`-change circuit-breaker. The periodic poll loops also jitter their FIRST tick by `[0,EDGE_REFRESH_INTERVAL]` so the signal-delivery instants decorrelate, not just the mints. |
 | `EDGE_CLIENTCERT_REMINT_BACKOFF_BASE` / `_COOLDOWN` | edge | `2s` / `5×EDGE_REFRESH_INTERVAL` | Exponential-backoff base on a non-ok mint (×2, jittered, capped at `EDGE_REFRESH_INTERVAL`); breaker-open cooldown. |

--- a/cmd/edge-controlplane/generation_test.go
+++ b/cmd/edge-controlplane/generation_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/moonrhythm/parapet-ingress-controller/edgecp"
 )
 
 func TestProvidedGeneration(t *testing.T) {
@@ -54,4 +56,21 @@ func TestProvidedGeneration(t *testing.T) {
 			t.Error("providedGeneration must never return 0")
 		}
 	})
+}
+
+func TestDuplicateEdgeID(t *testing.T) {
+	if got := duplicateEdgeID(map[string]edgecp.Entry{
+		"t1": {ID: "edge-a"},
+		"t2": {ID: "edge-b"},
+		"t3": {}, // cert-only token, no id
+		"t4": {}, // another empty id — not a collision
+	}); got != "" {
+		t.Errorf("unique ids must not report a duplicate, got %q", got)
+	}
+	if got := duplicateEdgeID(map[string]edgecp.Entry{
+		"t1": {ID: "dup"},
+		"t2": {ID: "dup"},
+	}); got != "dup" {
+		t.Errorf("duplicate id must be reported, got %q", got)
+	}
 }

--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -171,6 +171,13 @@ func main() {
 		slog.Error("no edge tokens configured (set CP_TOKENS or CP_TOKENS_FILE); refusing to start with an open key-distribution API")
 		os.Exit(1)
 	}
+	// Refuse duplicate data-plane edge ids: two tokens sharing an id would collide on the
+	// edge_id label, shadowing one edge's series and silently masking a partitioned edge
+	// as converged in the OLD-drop interlock.
+	if dupID := duplicateEdgeID(tokens); dupID != "" {
+		slog.Error("duplicate edge id across tokens; each data-plane edge id must be unique", "id", dupID)
+		os.Exit(1)
+	}
 
 	if err := k8s.Init(); err != nil {
 		slog.Error("k8s init", "err", err)
@@ -179,6 +186,9 @@ func main() {
 
 	store := edgecp.NewCertStore()
 	authz := edgecp.NewAuthzEntries(tokens)
+	// Publish the expected-edge reporter set + the blacklist-barrier fingerprint that the
+	// OLD-drop convergence interlock reads (the registry is static today).
+	edgecp.SetRegistryMetrics(tokens)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -321,6 +331,22 @@ func main() {
 		slog.Error("serve", "err", err)
 		os.Exit(1)
 	}
+}
+
+// duplicateEdgeID returns the first non-empty edge id shared by two tokens, or "" if all
+// data-plane ids are unique. Unique ids are required for the edge_id convergence join.
+func duplicateEdgeID(tokens map[string]edgecp.Entry) string {
+	seen := make(map[string]struct{}, len(tokens))
+	for _, e := range tokens {
+		if e.ID == "" {
+			continue
+		}
+		if _, dup := seen[e.ID]; dup {
+			return e.ID
+		}
+		seen[e.ID] = struct{}{}
+	}
+	return ""
 }
 
 // loadTokens reads the registry from inline JSON or a file (file wins if both are

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -75,6 +75,20 @@ func main() {
 		slog.Error("EDGE_DATAPLANE_MTLS=true requires EDGE_UPSTREAM_TLS=true (a client cert can only ride TLS)")
 		os.Exit(1)
 	}
+	// EDGE_ID is the edge's STABLE logical identity stamped on every convergence metric
+	// (the OLD-drop interlock joins per-edge by it). With data-plane mTLS it MUST be set
+	// and MUST match this edge's CP token id, or the per-edge join silently can't find
+	// the edge (it would either block forever or, worse, let a partitioned edge be
+	// shadowed). Without mTLS, convergence is moot — default to the hostname.
+	edgeID := os.Getenv("EDGE_ID")
+	if dataplaneMTLS && edgeID == "" {
+		slog.Error("EDGE_ID is required with EDGE_DATAPLANE_MTLS=true (it must match this edge's CP token id; the convergence interlock joins on it)")
+		os.Exit(1)
+	}
+	if edgeID == "" {
+		edgeID, _ = os.Hostname()
+	}
+	edge.SetEdgeID(edgeID)
 	refreshInterval := time.Duration(envInt64("EDGE_REFRESH_INTERVAL", 300)) * time.Second
 	if refreshInterval <= 0 { // a 0/negative value would panic time.NewTicker
 		refreshInterval = 300 * time.Second

--- a/edge/metrics.go
+++ b/edge/metrics.go
@@ -6,38 +6,41 @@ import (
 )
 
 // Edge data-plane convergence metrics: which CA set issued the edge's LIVE client
-// leaf (its ca_id), when that leaf expires, and whether the re-mint loop is healthy.
-// During a rotation the edge's ca_id LAGS the control-plane target until the edge
-// re-mints (it then matches, because Sign() appends the full served bundle to the
-// leaf) — so this is the per-edge convergence/re-mint progress indicator. Registered on
-// the shared parapet registry, served on the edge's existing :9187. Pure instrumentation.
+// leaf (its ca_id), when that leaf expires, whether the re-mint loop is healthy, and a
+// poll-liveness counter. During a rotation the edge's ca_id LAGS the control-plane
+// target until the edge re-mints — so this is the per-edge convergence/re-mint progress
+// indicator the OLD-drop interlock reads. Registered on the shared parapet registry,
+// served on the edge's existing :9187. Pure instrumentation.
 //
-// The ca_id-labelled gauges are Reset() then Set() on each swap, so exactly one live
-// series exists per process. ca_id is a public-cert fingerprint, never key material.
+// Every series carries an edge_id label (the process's STABLE logical identity, from
+// EDGE_ID — matching the CP token registry id), so the interlock joins per-edge by a
+// reschedule-stable key, not the ephemeral pod/instance. The ca_id-labelled gauges are
+// Reset() then Set() on each swap, so exactly one live series per process. ca_id is a
+// public-cert fingerprint, never key material.
 var (
 	edgeClientCertCAID = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: prom.Namespace,
 		Name:      "edge_clientcert_ca_id",
 		Help:      "CA set that issued the edge's live data-plane client leaf, by ca_id (value 1).",
-	}, []string{"ca_id"})
+	}, []string{"ca_id", "edge_id"})
 
 	edgeClientCertNotAfter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: prom.Namespace,
 		Name:      "edge_clientcert_not_after_seconds",
 		Help:      "Expiry (unix seconds) of the edge's live data-plane client leaf, by ca_id.",
-	}, []string{"ca_id"})
+	}, []string{"ca_id", "edge_id"})
 
-	edgeClientCertLoaded = prometheus.NewGauge(prometheus.GaugeOpts{
+	edgeClientCertLoaded = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: prom.Namespace,
 		Name:      "edge_clientcert_loaded",
 		Help:      "1 once the edge holds a usable data-plane client cert, else 0.",
-	})
+	}, []string{"edge_id"})
 
 	edgeRemint = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: prom.Namespace,
 		Name:      "edge_clientcert_remint_total",
 		Help:      "Edge data-plane cert re-mint attempts by result (ok|keygen_fail|csr_fail|fetch_fail|marshal_fail|store_fail|breaker_open) and trigger (proactive|reactive|timer).",
-	}, []string{"result", "trigger"})
+	}, []string{"result", "trigger", "edge_id"})
 
 	// edgeCPTargetCAID is the edge-OBSERVED CP target ca_id (from the X-Parapet-CA-Id
 	// signal). The OLD-drop convergence interlock compares this against the live
@@ -46,11 +49,37 @@ var (
 		Namespace: prom.Namespace,
 		Name:      "edge_cp_target_ca_id",
 		Help:      "CP target ca_id the edge last observed (value 1).",
-	}, []string{"ca_id"})
+	}, []string{"ca_id", "edge_id"})
+
+	// edgeRefresh is bumped on EVERY successful CP poll (a /v1/certs fetch or the
+	// trust-bundle read), regardless of whether ca_id changed. It is the INDEPENDENT
+	// liveness signal: the ca_id/target gauges are Reset-then-Set only when something
+	// changes, so a wedged poll loop would freeze them at the target while up==1 stays
+	// fresh — a frozen edge could then false-green. The interlock gates on
+	// increase(edge_refresh_total[Freshness]) >= 1 to prove the loop actually ran.
+	edgeRefresh = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_refresh_total",
+		Help:      "Successful control-plane polls (proves the refresh loop is alive, independent of ca_id change).",
+	}, []string{"edge_id"})
 )
 
 func init() {
-	prom.Registry().MustRegister(edgeClientCertCAID, edgeClientCertNotAfter, edgeClientCertLoaded, edgeRemint, edgeCPTargetCAID)
+	prom.Registry().MustRegister(edgeClientCertCAID, edgeClientCertNotAfter, edgeClientCertLoaded, edgeRemint, edgeCPTargetCAID, edgeRefresh)
+}
+
+// edgeID is the process's logical identity, stamped on every metric. Defaults to
+// "unknown" so a series is NEVER edge_id="" (which would shadow another edge in the
+// interlock join). Set once at startup via SetEdgeID.
+var edgeID = "unknown"
+
+// SetEdgeID stamps the process's logical edge identity (EDGE_ID) onto every edge
+// convergence metric. Call once before serving. An empty id is ignored (keeps the
+// "unknown" default — the edge binary refuses to start without EDGE_ID when mTLS is on).
+func SetEdgeID(id string) {
+	if id != "" {
+		edgeID = id
+	}
 }
 
 // setClientCertMetrics records the live leaf's ca_id and expiry (Reset()-then-Set so
@@ -61,16 +90,16 @@ func setClientCertMetrics(caID string, notAfterUnix int64) {
 	edgeClientCertCAID.Reset()
 	edgeClientCertNotAfter.Reset()
 	if caID != "" {
-		edgeClientCertCAID.WithLabelValues(caID).Set(1)
-		edgeClientCertNotAfter.WithLabelValues(caID).Set(float64(notAfterUnix))
+		edgeClientCertCAID.WithLabelValues(caID, edgeID).Set(1)
+		edgeClientCertNotAfter.WithLabelValues(caID, edgeID).Set(float64(notAfterUnix))
 	}
-	edgeClientCertLoaded.Set(1)
+	edgeClientCertLoaded.WithLabelValues(edgeID).Set(1)
 }
 
 // remint counts one re-mint attempt by result and trigger. Re-mints are infrequent
 // (per rotation / renewal, not per request), so resolving the label here is fine.
 func remint(result, trigger string) {
-	edgeRemint.WithLabelValues(result, trigger).Inc()
+	edgeRemint.WithLabelValues(result, trigger, edgeID).Inc()
 }
 
 // setObservedTarget records the CP target ca_id the edge last observed (Reset-then-Set,
@@ -78,6 +107,11 @@ func remint(result, trigger string) {
 func setObservedTarget(caID string) {
 	edgeCPTargetCAID.Reset()
 	if caID != "" {
-		edgeCPTargetCAID.WithLabelValues(caID).Set(1)
+		edgeCPTargetCAID.WithLabelValues(caID, edgeID).Set(1)
 	}
+}
+
+// edgeRefreshOK records one successful CP poll (the liveness heartbeat).
+func edgeRefreshOK() {
+	edgeRefresh.WithLabelValues(edgeID).Inc()
 }

--- a/edge/metrics_test.go
+++ b/edge/metrics_test.go
@@ -18,10 +18,10 @@ func TestSetClientCertMetricsOneSeries(t *testing.T) {
 	if c := testutil.CollectAndCount(edgeClientCertNotAfter); c != 1 {
 		t.Errorf("not_after: want 1 live series, got %d", c)
 	}
-	if v := testutil.ToFloat64(edgeClientCertLoaded); v != 1 {
+	if v := testutil.ToFloat64(edgeClientCertLoaded.WithLabelValues("unknown")); v != 1 {
 		t.Errorf("loaded = %v, want 1", v)
 	}
-	if v := testutil.ToFloat64(edgeClientCertNotAfter.WithLabelValues("ca-new")); v != 200 {
+	if v := testutil.ToFloat64(edgeClientCertNotAfter.WithLabelValues("ca-new", "unknown")); v != 200 {
 		t.Errorf("not_after = %v, want 200", v)
 	}
 
@@ -34,9 +34,9 @@ func TestSetClientCertMetricsOneSeries(t *testing.T) {
 
 func TestRemintEnum(t *testing.T) {
 	for _, result := range []string{"ok", "keygen_fail", "csr_fail", "fetch_fail", "marshal_fail", "store_fail", "breaker_open"} {
-		before := testutil.ToFloat64(edgeRemint.WithLabelValues(result, "reactive"))
+		before := testutil.ToFloat64(edgeRemint.WithLabelValues(result, "reactive", "unknown"))
 		remint(result, "reactive")
-		if got := testutil.ToFloat64(edgeRemint.WithLabelValues(result, "reactive")); got != before+1 {
+		if got := testutil.ToFloat64(edgeRemint.WithLabelValues(result, "reactive", "unknown")); got != before+1 {
 			t.Errorf("remint(%q): %v -> %v, want +1", result, before, got)
 		}
 	}
@@ -48,11 +48,33 @@ func TestSetObservedTargetOneSeries(t *testing.T) {
 	if c := testutil.CollectAndCount(edgeCPTargetCAID); c != 1 {
 		t.Errorf("observed-target: want 1 live series, got %d", c)
 	}
-	if v := testutil.ToFloat64(edgeCPTargetCAID.WithLabelValues("ca-b")); v != 1 {
+	if v := testutil.ToFloat64(edgeCPTargetCAID.WithLabelValues("ca-b", "unknown")); v != 1 {
 		t.Errorf("observed-target ca-b = %v, want 1", v)
 	}
 	setObservedTarget("") // clears
 	if c := testutil.CollectAndCount(edgeCPTargetCAID); c != 0 {
 		t.Errorf("empty target must clear the series, got %d", c)
+	}
+}
+
+// SetEdgeID stamps the edge_id label onto every metric, and edgeRefreshOK is an
+// independent liveness heartbeat (bumps regardless of any ca_id change).
+func TestEdgeIDStampingAndLiveness(t *testing.T) {
+	old := edgeID
+	edgeID = "edge-7"
+	defer func() { edgeID = old }()
+
+	setClientCertMetrics("ca-z", 123)
+	if v := testutil.ToFloat64(edgeClientCertCAID.WithLabelValues("ca-z", "edge-7")); v != 1 {
+		t.Error("ca_id series must carry the edge_id label")
+	}
+	if v := testutil.ToFloat64(edgeClientCertLoaded.WithLabelValues("edge-7")); v != 1 {
+		t.Error("loaded must carry the edge_id label")
+	}
+
+	before := testutil.ToFloat64(edgeRefresh.WithLabelValues("edge-7"))
+	edgeRefreshOK()
+	if got := testutil.ToFloat64(edgeRefresh.WithLabelValues("edge-7")); got != before+1 {
+		t.Errorf("edge_refresh_total: %v → %v, want +1", before, got)
 	}
 }

--- a/edge/refresh.go
+++ b/edge/refresh.go
@@ -79,6 +79,7 @@ func RunEdgeCertRefresh(ctx context.Context, coord *RemintCoordinator, interval 
 		case <-t.C:
 			coord.MaybeRenew()
 			if caID, err := coord.cp.FetchTrustBundleCAID(); err == nil {
+				edgeRefreshOK() // liveness for the idle edge that polls no per-domain cert
 				coord.Observe(caID)
 			}
 		}
@@ -106,6 +107,9 @@ func RefreshCertOnce(cp *CpClient, store *CertStore, domain string, coord *Remin
 		} else {
 			slog.Warn("edge: cert PEM unparseable; keeping cached copy", "domain", domain)
 		}
+	}
+	if err == nil {
+		edgeRefreshOK() // liveness: a successful CP poll (200 or 304), independent of any ca_id change
 	}
 	coord.Observe(res.CAID)
 }

--- a/edge/refresh_test.go
+++ b/edge/refresh_test.go
@@ -58,18 +58,18 @@ func TestRefreshEdgeCertOnceOK(t *testing.T) {
 	}
 	store := NewClientCertStore()
 
-	before := testutil.ToFloat64(edgeRemint.WithLabelValues("ok", "timer"))
+	before := testutil.ToFloat64(edgeRemint.WithLabelValues("ok", "timer", "unknown"))
 	if got, _ := RefreshEdgeCertOnce(cp, store, "timer"); got != "ok" {
 		t.Fatalf("result = %q, want ok", got)
 	}
-	if testutil.ToFloat64(edgeRemint.WithLabelValues("ok", "timer")) != before+1 {
+	if testutil.ToFloat64(edgeRemint.WithLabelValues("ok", "timer", "unknown")) != before+1 {
 		t.Error("ok remint counter not incremented")
 	}
 	if !store.Loaded() {
 		t.Error("store should hold a cert after a successful re-mint")
 	}
 	// The edge-derived ca_id must equal the CP signer's CAID (same CA set, via caid).
-	if v := testutil.ToFloat64(edgeClientCertCAID.WithLabelValues(signer.CAID())); v != 1 {
+	if v := testutil.ToFloat64(edgeClientCertCAID.WithLabelValues(signer.CAID(), "unknown")); v != 1 {
 		t.Errorf("edge ca_id series for %q not set to 1", signer.CAID())
 	}
 }
@@ -86,11 +86,11 @@ func TestRefreshEdgeCertOnceFetchFail(t *testing.T) {
 	}
 	store := NewClientCertStore()
 
-	before := testutil.ToFloat64(edgeRemint.WithLabelValues("fetch_fail", "timer"))
+	before := testutil.ToFloat64(edgeRemint.WithLabelValues("fetch_fail", "timer", "unknown"))
 	if got, _ := RefreshEdgeCertOnce(cp, store, "timer"); got != "fetch_fail" {
 		t.Fatalf("result = %q, want fetch_fail", got)
 	}
-	if testutil.ToFloat64(edgeRemint.WithLabelValues("fetch_fail", "timer")) != before+1 {
+	if testutil.ToFloat64(edgeRemint.WithLabelValues("fetch_fail", "timer", "unknown")) != before+1 {
 		t.Error("fetch_fail remint counter not incremented")
 	}
 	if store.Loaded() {

--- a/edgecp/metrics.go
+++ b/edgecp/metrics.go
@@ -1,6 +1,11 @@
 package edgecp
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
+	"sort"
+	"strings"
+
 	"github.com/moonrhythm/parapet/pkg/prom"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -68,8 +73,64 @@ var (
 	})
 )
 
+var (
+	// registryTotal is the EXPECTED-edge reporter set: one series per data-plane edge id
+	// in this CP's token registry, value 1 (enabled) or 0 (disabled/blacklisted). The
+	// OLD-drop interlock reads label_values(edge_registry_total==1) to discover which
+	// edges must converge. A disabled edge flips to 0 and drops from the expected set —
+	// but a still-RUNNING disabled edge presenting an OLD leaf is caught by the live-edge
+	// gate, not waved through by this.
+	registryTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_registry_total",
+		Help:      "Edges in this control plane's token registry, by edge_id (1=enabled, 0=disabled).",
+	}, []string{"edge_id"})
+
+	// authzGeneration is a deterministic fingerprint of the loaded token registry,
+	// IDENTICAL on every replica that loaded the same registry. It is the pre-rotation
+	// blacklist-barrier (B0) contract: the interlock confirms every CP replica reports
+	// the same value (so a blacklist has converged on all replicas) before a revoke
+	// flips the active CA. The hot authz-watch is deferred; today a blacklist requires
+	// restart-all-CP, which this value lets the operator verify converged.
+	authzGeneration = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_authz_generation",
+		Help:      "Deterministic fingerprint of the loaded token registry (replica-identical; the blacklist-barrier signal).",
+	})
+)
+
 func init() {
-	prom.Registry().MustRegister(signerFingerprint, signerGeneration, signerBundleCerts, signerLoaded, targetCAID, signerFloored, signerRVUnparsed)
+	prom.Registry().MustRegister(signerFingerprint, signerGeneration, signerBundleCerts, signerLoaded, targetCAID, signerFloored, signerRVUnparsed, registryTotal, authzGeneration)
+}
+
+// SetRegistryMetrics publishes the expected-edge reporter set and the authz-generation
+// fingerprint from the loaded token registry. Call once at startup (the registry is
+// static today). Only entries with a non-empty id are data-plane edges.
+func SetRegistryMetrics(entries map[string]Entry) {
+	registryTotal.Reset()
+	lines := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.ID == "" {
+			continue
+		}
+		v := 1.0
+		d := "0"
+		if e.Disabled {
+			v, d = 0.0, "1"
+		}
+		registryTotal.WithLabelValues(e.ID).Set(v)
+		lines = append(lines, e.ID+":"+d)
+	}
+	authzGeneration.Set(registryFingerprint(lines))
+}
+
+// registryFingerprint hashes the sorted "id:disabled" lines into a stable float value
+// (first 6 bytes of the digest — < 2^48, exactly representable in a float64), so every
+// replica loading the same registry reports the identical authz_generation.
+func registryFingerprint(lines []string) float64 {
+	sort.Strings(lines)
+	sum := sha256.Sum256([]byte(strings.Join(lines, ";")))
+	return float64(binary.BigEndian.Uint64(append([]byte{0, 0}, sum[:6]...)))
 }
 
 // setSignerMetrics records the active signer's ca_id, generation, and bundle size. It

--- a/edgecp/registry_test.go
+++ b/edgecp/registry_test.go
@@ -1,0 +1,42 @@
+package edgecp
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestSetRegistryMetrics(t *testing.T) {
+	SetRegistryMetrics(map[string]Entry{
+		"tok-a": {ID: "edge-a", Domains: []string{"a.com"}},
+		"tok-b": {ID: "edge-b", Domains: []string{"b.com"}, Disabled: true},
+		"tok-c": {Domains: []string{"c.com"}}, // no id (cert-only token) → not an edge
+	})
+	if v := testutil.ToFloat64(registryTotal.WithLabelValues("edge-a")); v != 1 {
+		t.Errorf("enabled edge: registry_total = %v, want 1", v)
+	}
+	if v := testutil.ToFloat64(registryTotal.WithLabelValues("edge-b")); v != 0 {
+		t.Errorf("disabled edge: registry_total = %v, want 0", v)
+	}
+	// Only the two id-bearing edges are reported.
+	if c := testutil.CollectAndCount(registryTotal); c != 2 {
+		t.Errorf("registry_total series = %d, want 2 (cert-only token excluded)", c)
+	}
+}
+
+// authz_generation must be replica-identical (same registry → same value) and change
+// when the registry changes (the blacklist-barrier signal).
+func TestAuthzGenerationFingerprint(t *testing.T) {
+	a := registryFingerprint([]string{"edge-a:0", "edge-b:1"})
+	aReordered := registryFingerprint([]string{"edge-b:1", "edge-a:0"}) // order-independent
+	if a != aReordered {
+		t.Error("fingerprint must be order-independent (replica-identical)")
+	}
+	blacklisted := registryFingerprint([]string{"edge-a:0", "edge-b:0"}) // edge-b enabled
+	if a == blacklisted {
+		t.Error("fingerprint must change when an edge's disabled flag changes")
+	}
+	if a < 0 || a >= (1<<48) {
+		t.Errorf("fingerprint %v must be a non-negative float < 2^48 (float64-exact)", a)
+	}
+}


### PR DESCRIPTION
**Sub-PR 4b-ii of 5** for edge-proxy revocation (`EDGE-AUTOTRUST.md`) — the metric *contracts* the OLD-drop convergence interlock (4b-i, next) consumes. **No reader, no destructive action**; pure instrumentation + startup guards.

Split from the reader (4b-i) per the red-team: this touches the **edge data plane + CP startup**; the reader is a new CP-side read-only package with a new Prometheus-client dep — different binaries, different blast radii, separate reviews.

## Edge
- **`edge_id` label** on every edge convergence metric (from `EDGE_ID`), so the interlock joins per-edge by a **stable logical id** (matching the CP token id), not the ephemeral pod/`instance`. `EDGE_ID` is **required with `EDGE_DATAPLANE_MTLS`** (else the join silently can't find the edge); without mTLS it defaults to the hostname.
- **`edge_refresh_total{edge_id}`** — an **independent liveness heartbeat** bumped on every successful CP poll *regardless of `ca_id` change*. This closes the red-team's headline **fail-open hole**: the `ca_id`/target gauges are Reset-then-Set only on change, so a wedged-but-scrapable edge frozen at the target would false-green while `up==1` stays fresh. The interlock gates on `increase(edge_refresh_total[Freshness]) >= 1` to prove the loop actually ran.

## Control plane
- **`edge_registry_total{edge_id}`** (1=enabled, 0=blacklisted) — the **expected-edge reporter set** the interlock discovers via `label_values(==1)`. A still-running *disabled* edge on an OLD leaf is caught by the live-edge gate, not waved through by this.
- **`edge_authz_generation`** — a **replica-identical fingerprint** of the loaded token registry: the pre-rotation **blacklist-barrier (B0)** signal (all CP replicas must agree before a revoke flips the active CA; the hot authz-watch is deferred).
- **Duplicate data-plane edge ids are refused at CP startup** — a collision would shadow one edge's series and mask a partitioned edge as converged.

## Tests
`registry_total` set (enabled/disabled/cert-only-excluded), `authz_generation` fingerprint (order-independent + changes on a blacklist flip + float64-exact), `edge_id` stamping + `edge_refresh_total` increment, `duplicateEdgeID`. `gofmt` / `go vet ./...` / `go test -race ./...` / e2e all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)