### PR TITLE
feat(edgecp): convergence reader — fail-closed cross-plane interlock (read-only)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ RUN mkdir -p /geoip && \
 	if [ -n "$GEOIP_DB_URL" ] || [ -n "$ASN_DB_URL" ]; then \
 		apt-get update && apt-get -y install --no-install-recommends curl ca-certificates; \
 	fi && \
-	if [ -n "$GEOIP_DB_URL" ]; then curl -fsSL "$GEOIP_DB_URL" -o /geoip/ip-to-country.mmdb; fi && \
-	if [ -n "$ASN_DB_URL" ]; then curl -fsSL "$ASN_DB_URL" -o /geoip/ip-to-asn.mmdb; fi && \
+	if [ -n "$GEOIP_DB_URL" ]; then curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 30 "$GEOIP_DB_URL" -o /geoip/ip-to-country.mmdb; fi && \
+	if [ -n "$ASN_DB_URL" ]; then curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 30 "$ASN_DB_URL" -o /geoip/ip-to-asn.mmdb; fi && \
 	ls -l /geoip
 
 FROM debian:trixie-slim

--- a/Dockerfile.edge
+++ b/Dockerfile.edge
@@ -38,8 +38,8 @@ RUN mkdir -p /geoip && \
 	if [ -n "$GEOIP_DB_URL" ] || [ -n "$ASN_DB_URL" ]; then \
 		apt-get update && apt-get -y install --no-install-recommends curl ca-certificates; \
 	fi && \
-	if [ -n "$GEOIP_DB_URL" ]; then curl -fsSL "$GEOIP_DB_URL" -o /geoip/ip-to-country.mmdb; fi && \
-	if [ -n "$ASN_DB_URL" ]; then curl -fsSL "$ASN_DB_URL" -o /geoip/ip-to-asn.mmdb; fi && \
+	if [ -n "$GEOIP_DB_URL" ]; then curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 30 "$GEOIP_DB_URL" -o /geoip/ip-to-country.mmdb; fi && \
+	if [ -n "$ASN_DB_URL" ]; then curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 30 "$ASN_DB_URL" -o /geoip/ip-to-asn.mmdb; fi && \
 	ls -l /geoip
 
 # ---- runtime ----

--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -652,6 +652,11 @@ not Prometheus counters (a Pushgateway would be a new failure domain).
 | `EDGE_CA_SECRET` | CP | `parapet-edge-ca` | The CA Secret in a CP-only namespace; Job writes (scoped), serving reads (read-only + read-watch). Pre-created empty, GitOps drift-exclusion. |
 | `EDGE_CA_TTL` | CP | `8760h–17520h` (1–2 y) | Edge CA cert lifetime. **Shortened** from 10 y now that rotation is a routine on-demand primitive — but kept comfortably longer than the expected revoke-driven rotation interval so a scheduled CA expiry doesn't collide with on-demand rotations. |
 | `POD_NAMESPACE` / `WATCH_NAMESPACE` | CP | downward API (**required**) / `""` | CA Secret namespace (read serving-managed, write Job); pin `WATCH_NAMESPACE` to shrink the cluster-wide tenant-TLS read blast radius. |
+| `EDGE_CONVERGE_STATUS` | CP (Job/CLI) | false | Run-once **convergence reader**: query Prometheus, exit 0 only if every plane reached the target `ca_id`, else 1 with named blockers. **Read-only** — what sub-PR 5's revoke Job calls before the OLD-drop. Never on the serving path. |
+| `EDGE_CONVERGE_PROM_URL` / `_EXPECTED_CP` / `_EXPECTED_CORE` / `_MIN_EDGES` | CP (Job) | — | Prometheus API base; expected CP-replica and core counts; and the **edge-count floor** (a registry/scrape drift that empties the expected-edge set must fail closed, not converge vacuously — `MIN_EDGES` ≤ 0 is itself refused). A missing reporter ⇒ count mismatch ⇒ block. |
+| `EDGE_CONVERGE_FRESHNESS` / `_STABLE_READS` / `_POLL_INTERVAL` / `_SCRAPE_INTERVAL` | CP (Job) | `5m` / `2` / `30s` / `15s` | Liveness window; consecutive converged reads required; gap between them; the scrape interval. The reader **refuses** unless `poll × reads ≥ 2×scrape` AND `≥ EDGE_REFRESH_INTERVAL` (a flap can't read as converged). |
+| `EDGE_CONVERGE_EXCLUDE` | CP (Job) | `""` | `id=reason,…` — LOUD, reason-required convergence-veto waivers for decommissioned edges (echoed in the verdict; an empty reason is refused). |
+| `EDGE_CONVERGE_REVOKED_TOKEN` / `_CP_URL` / `_CP_CA` | CP (Job) | `""` | The revoked token + CP endpoint for the absence probe (must be rejected 401/403). Absent ⇒ `revoked-unverified` (fail-closed). |
 
 Registry shape: `{"<token>":{"id":...,"domains":[...],"disabled":bool}}`. New trust-bundle
 field `ca_id`. Metrics: `parapet_trust_source{mtls|cidr|none|file}`,

--- a/cmd/edge-controlplane/converge.go
+++ b/cmd/edge-controlplane/converge.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/moonrhythm/parapet-ingress-controller/edgecp/converge"
+)
+
+// runConvergeStatus is the run-once converge-status mode (EDGE_CONVERGE_STATUS=true): it
+// reads the cross-plane convergence state from Prometheus and exits 0 ONLY when every
+// plane has reached the target ca_id, else 1 with the named blockers. It is what sub-PR
+// 5's revoke Job calls before the destructive OLD-drop. It performs NO writes.
+//
+// It NEVER touches the serving issuance path; the Prometheus client is confined here.
+func runConvergeStatus() {
+	promURL := os.Getenv("EDGE_CONVERGE_PROM_URL")
+	if promURL == "" {
+		slog.Error("EDGE_CONVERGE_PROM_URL is required for converge-status")
+		os.Exit(1)
+	}
+	cfg := converge.Config{
+		ExpectedCP:   envInt("EDGE_CONVERGE_EXPECTED_CP", 0),
+		ExpectedCore: envInt("EDGE_CONVERGE_EXPECTED_CORE", 0),
+		MinEdges:     envInt("EDGE_CONVERGE_MIN_EDGES", 0),
+		Freshness:    DefaultDuration("EDGE_CONVERGE_FRESHNESS", 5*time.Minute),
+		Exclude:      parseExcludes(os.Getenv("EDGE_CONVERGE_EXCLUDE")),
+	}
+	stableReads := envInt("EDGE_CONVERGE_STABLE_READS", 2)
+	pollInterval := DefaultDuration("EDGE_CONVERGE_POLL_INTERVAL", 30*time.Second)
+	scrapeInterval := DefaultDuration("EDGE_CONVERGE_SCRAPE_INTERVAL", 15*time.Second)
+	refreshInterval := DefaultDuration("EDGE_REFRESH_INTERVAL", 300*time.Second)
+
+	// Cadence safety (a refusal, not a default): the reads must SPAN enough time to
+	// distinguish a swap-window blip from steady state — at least 2 scrapes AND one
+	// refresh interval. Otherwise a flapping gauge could read converged in the gap.
+	if stableReads < 2 {
+		slog.Error("EDGE_CONVERGE_STABLE_READS must be >= 2 (one read can't distinguish a flap)")
+		os.Exit(1)
+	}
+	if pollInterval <= 0 {
+		slog.Error("EDGE_CONVERGE_POLL_INTERVAL must be > 0")
+		os.Exit(1)
+	}
+	if err := checkCadence(cadenceWindow(pollInterval, stableReads), scrapeInterval, refreshInterval); err != nil {
+		slog.Error("converge cadence unsafe", "err", err)
+		os.Exit(1)
+	}
+
+	q, err := converge.NewPromQuerier(promURL)
+	if err != nil {
+		slog.Error("converge: prometheus client", "err", err)
+		os.Exit(1)
+	}
+
+	// The revoked-token absence probe (proves the blacklisted token can no longer mint a
+	// NEW-CA leaf). Optional inputs; absent ⇒ the probe does not run ⇒ the predicate
+	// fail-closes with revoked-unverified (correct for a revoke-driven drop).
+	revokedToken := os.Getenv("EDGE_CONVERGE_REVOKED_TOKEN")
+	cpURL := os.Getenv("EDGE_CONVERGE_CP_URL")
+	// A pinned CA that was requested but can't be read is a HARD error — never silently
+	// fall back to system roots for the security probe.
+	var cpCA []byte
+	if p := os.Getenv("EDGE_CONVERGE_CP_CA"); p != "" {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			slog.Error("converge: cannot read EDGE_CONVERGE_CP_CA (pin requested)", "path", p, "err", err)
+			os.Exit(1)
+		}
+		cpCA = b
+	}
+
+	ctx := context.Background()
+	var last converge.Result
+	for i := 0; i < stableReads; i++ {
+		if i > 0 {
+			time.Sleep(pollInterval)
+		}
+		obs, err := converge.Snapshot(ctx, q, cfg.Freshness, time.Now())
+		if err != nil {
+			slog.Error("converge: prometheus query failed; NOT converged (fail-closed)", "err", err)
+			os.Exit(1)
+		}
+		if revokedToken != "" && cpURL != "" {
+			if status, ran := probeRevoked(cpURL, cpCA, revokedToken); ran {
+				obs.RevokedProbeRan = true
+				obs.RevokedProbeStatus = status
+			}
+		}
+		last = converge.Evaluate(obs, cfg, time.Now())
+		if !last.Converged {
+			break // a single non-converged read is decisive (fail-closed)
+		}
+	}
+
+	if !last.Converged {
+		slog.Error("NOT converged — OLD CA must NOT be dropped", "target", last.Target, "blockers", blockerStrings(last.Blockers))
+		os.Exit(1)
+	}
+	for _, ex := range last.Excluded {
+		slog.Warn("converge: edge excluded from the convergence veto", "edge_id", ex.EdgeID, "reason", ex.Reason)
+	}
+	slog.Info("CONVERGED — every plane has reached the target ca_id; OLD CA is safe to drop",
+		"target", last.Target, "stable_reads", stableReads)
+	os.Exit(0)
+}
+
+// cadenceWindow is the wall-clock the stable reads SPAN: N reads have N-1 gaps.
+func cadenceWindow(poll time.Duration, reads int) time.Duration {
+	return poll * time.Duration(reads-1)
+}
+
+// checkCadence refuses a window too short to distinguish a swap-window flap from steady
+// state: it must cover at least 2 scrapes AND one refresh interval.
+func checkCadence(window, scrape, refresh time.Duration) error {
+	if window < 2*scrape {
+		return fmt.Errorf("read window %s < 2×scrape_interval %s", window, 2*scrape)
+	}
+	if window < refresh {
+		return fmt.Errorf("read window %s < EDGE_REFRESH_INTERVAL %s", window, refresh)
+	}
+	return nil
+}
+
+func blockerStrings(bs []converge.Blocker) []string {
+	out := make([]string, len(bs))
+	for i, b := range bs {
+		out[i] = b.Plane + "/" + b.Reporter + ":" + b.Reason
+	}
+	return out
+}
+
+// parseExcludes parses "id1=reason one,id2=reason two" into reason-required excludes.
+func parseExcludes(s string) []converge.ExcludedEdge {
+	var out []converge.ExcludedEdge
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		id, reason, _ := strings.Cut(part, "=")
+		out = append(out, converge.ExcludedEdge{EdgeID: strings.TrimSpace(id), Reason: strings.TrimSpace(reason)})
+	}
+	return out
+}
+
+// probeRevoked POSTs to the CP's /v1/edge-cert with the (allegedly revoked) token. A
+// disabled token is rejected at auth (401/403) BEFORE the CSR is parsed, so a minimal
+// body suffices. ran=false on a transport error (the caller leaves RevokedProbeRan=false
+// ⇒ fail-closed). The CP server cert is verified against cpCA when provided.
+func probeRevoked(cpURL string, cpCA []byte, token string) (status int, ran bool) {
+	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	if len(cpCA) > 0 {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(cpCA) {
+			// A pin was requested but the PEM is unusable: fail closed (ran=false ⇒
+			// revoked-unverified) rather than verify against system roots.
+			slog.Error("converge: EDGE_CONVERGE_CP_CA is not a usable certificate; not probing (fail-closed)")
+			return 0, false
+		}
+		tlsCfg.RootCAs = pool
+	}
+	c := &http.Client{Timeout: 10 * time.Second, Transport: &http.Transport{TLSClientConfig: tlsCfg}}
+	req, err := http.NewRequest(http.MethodPost, strings.TrimRight(cpURL, "/")+"/v1/edge-cert", bytes.NewReader([]byte(`{}`)))
+	if err != nil {
+		return 0, false
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.Do(req)
+	if err != nil {
+		return 0, false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode, true
+}

--- a/cmd/edge-controlplane/generation_test.go
+++ b/cmd/edge-controlplane/generation_test.go
@@ -74,3 +74,23 @@ func TestDuplicateEdgeID(t *testing.T) {
 		t.Errorf("duplicate id must be reported, got %q", got)
 	}
 }
+
+func TestCadenceWindowAndCheck(t *testing.T) {
+	// N reads span N-1 gaps (the off-by-one the review caught).
+	if got := cadenceWindow(30*time.Second, 2); got != 30*time.Second {
+		t.Errorf("cadenceWindow(30s,2) = %v, want 30s", got)
+	}
+	if got := cadenceWindow(60*time.Second, 3); got != 120*time.Second {
+		t.Errorf("cadenceWindow(60s,3) = %v, want 120s", got)
+	}
+	// window must cover >= 2 scrapes AND >= refresh.
+	if err := checkCadence(120*time.Second, 15*time.Second, 60*time.Second); err != nil {
+		t.Errorf("ample window must pass: %v", err)
+	}
+	if err := checkCadence(20*time.Second, 15*time.Second, 60*time.Second); err == nil {
+		t.Error("window < refresh must be refused")
+	}
+	if err := checkCadence(20*time.Second, 15*time.Second, 10*time.Second); err == nil {
+		t.Error("window < 2×scrape must be refused")
+	}
+}

--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -94,6 +94,13 @@ func main() {
 	clientCertTTL := DefaultDuration("EDGE_CLIENTCERT_TTL", edgecp.DefaultClientCertTTL)
 	clientCertSkew := DefaultDuration("EDGE_CLIENTCERT_SKEW", edgecp.DefaultClientCertSkew)
 
+	// Run-once converge-status (a Job/CLI): read the cross-plane convergence state from
+	// Prometheus and exit 0 only if every plane reached the target ca_id. Read-only, no
+	// k8s, no TLS, no serving — what sub-PR 5's revoke Job calls before the OLD-drop.
+	if os.Getenv("EDGE_CONVERGE_STATUS") == "true" {
+		runConvergeStatus() // exits
+	}
+
 	// Run-once CA bootstrap (a Job): adopt-or-generate the edge CA into its Secret
 	// (never regenerate a once-populated CA — the anti-regeneration guard), then
 	// exit. Needs neither tokens nor TLS; it never serves.

--- a/edgecp/converge/import_boundary_test.go
+++ b/edgecp/converge/import_boundary_test.go
@@ -1,0 +1,44 @@
+package converge_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The convergence reader pulls in the Prometheus HTTP API client. That dependency — and
+// the converge package itself — must NEVER reach the serving / issuance / trust request
+// path, so a Prometheus outage can't break cert issuance or the trust bundle. This is the
+// mechanical guarantee (a test, not a comment): the serving packages must not transitively
+// import edgecp/converge or client_golang/api.
+//
+// cmd/edge-controlplane is deliberately NOT listed — it HOSTS the converge-status CLI in a
+// run-once exec branch (the whole binary links the package, but the issuance HANDLERS in
+// the edgecp package never call it; that handler-package boundary is what this enforces).
+func TestServingPathDoesNotImportConvergeOrPromClient(t *testing.T) {
+	const (
+		convergePkg = "github.com/moonrhythm/parapet-ingress-controller/edgecp/converge"
+		promAPIPkg  = "github.com/prometheus/client_golang/api"
+	)
+	servingPkgs := []string{
+		"github.com/moonrhythm/parapet-ingress-controller/edgecp", // the CP issuance/trust handlers
+		"github.com/moonrhythm/parapet-ingress-controller/edge",   // the edge data plane
+		"github.com/moonrhythm/parapet-ingress-controller/cmd/edge-proxy",
+		"github.com/moonrhythm/parapet-ingress-controller/trust", // the core trust manager
+		"github.com/moonrhythm/parapet-ingress-controller/metric",
+	}
+	for _, pkg := range servingPkgs {
+		out, err := exec.Command("go", "list", "-deps", pkg).Output()
+		if err != nil {
+			t.Fatalf("go list -deps %s: %v", pkg, err)
+		}
+		deps := string(out)
+		for _, forbidden := range []string{convergePkg, promAPIPkg} {
+			for _, line := range strings.Split(deps, "\n") {
+				if strings.TrimSpace(line) == forbidden {
+					t.Errorf("%s transitively imports %s — the serving path must stay decoupled from the Prometheus reader", pkg, forbidden)
+				}
+			}
+		}
+	}
+}

--- a/edgecp/converge/predicate.go
+++ b/edgecp/converge/predicate.go
@@ -1,0 +1,279 @@
+// Package converge evaluates whether an edge-CA rotation has CONVERGED across every
+// plane — every serving control-plane replica, every core, and every good edge has
+// reached the target ca_id — so the destructive OLD-drop (sub-PR 5) can proceed. It is
+// the metric-gated, never-timer-gated interlock from EDGE-AUTOTRUST.md.
+//
+// Evaluate is a PURE function over a metric snapshot (Observations), with zero I/O, so
+// the safety predicate is exhaustively unit-testable without a live Prometheus. The
+// Prometheus querying that builds Observations lives in source.go. The whole package is
+// imported ONLY by the run-once converge-status CLI branch — NEVER by the serving issuance
+// path (asserted by import_boundary_test.go), so a Prometheus outage can't break issuance.
+//
+// FAIL-CLOSED is the contract: the only unsafe move is dropping OLD too early, so a
+// missing / partitioned / stale / unverified reporter ALWAYS blocks. Convergence is
+// observed==expected COUNTS (never a vacuous all-equal that is also true when nobody
+// reports).
+package converge
+
+import "time"
+
+// Blocker names one reason convergence is not met: which plane, which reporter, why.
+type Blocker struct {
+	Plane    string // cp | core | edge | revoked | config
+	Reporter string // instance / edge_id / "" for plane-wide
+	Reason   string // see the reason constants below
+}
+
+// Blocker reason constants (stable strings, surfaced in the verdict).
+const (
+	ReasonCPTargetSplit       = "cp-target-split"        // CP replicas disagree on the target ca_id
+	ReasonGenerationSplit     = "generation-split"       // same ca_id but divergent generation across CP replicas
+	ReasonExpectedSetEmpty    = "expected-set-empty"     // zero series across the whole expected set (misconfig)
+	ReasonNoTarget            = "no-target"              // no CP advertises a target ca_id
+	ReasonCountMismatch       = "count-mismatch"         // observed reporters != expected count
+	ReasonUpDown              = "up-down"                // reporter scraped but up==0
+	ReasonNeverScraped        = "never-scraped"          // expected reporter has no series at all (vs booting)
+	ReasonWrongCAID           = "wrong-ca_id"            // reporter holds a ca_id != target (not converged)
+	ReasonNotOverlap          = "not-overlap"            // CP bundle_certs != 2 (OLD++NEW must still be present pre-drop)
+	ReasonTargetNotObserved   = "target-not-observed"    // edge hasn't observed the CP target yet
+	ReasonRefreshStale        = "refresh-stale"          // edge poll loop hasn't run in the window (frozen-but-scrapable)
+	ReasonRemintChurn         = "remint-churn"           // edge has FAILED re-mints in the window
+	ReasonLiveOldLeaf         = "live-old-leaf"          // an edge is live on a non-target leaf (even if registry-disabled)
+	ReasonAuthzSplit          = "authz-split"            // CP replicas disagree on the authz generation (blacklist not converged)
+	ReasonEdgeCountBelowFloor = "edge-count-below-floor" // fewer expected edges than the operator floor (registry/scrape drift)
+	ReasonRevokedUnverified   = "revoked-unverified"     // the revoked-token absence probe did not run (fail-closed)
+	ReasonRevokedLeafPresent  = "revoked-leaf-present"   // the revoked token can still mint (probe got 2xx)
+)
+
+// Config is the operator/Job input. The target ca_id is NOT configured — it is derived
+// from the self-describing CP target series (cp-target-split if replicas disagree).
+type Config struct {
+	ExpectedCP   int // serving CP replicas expected to report
+	ExpectedCore int // cores expected to report
+	MinEdges     int // FLOOR on the discovered expected-edge set — a registry/scrape
+	// drift that empties ExpectedEdges must fail closed, not converge
+	// vacuously (the edge loop running zero times). Operator-supplied,
+	// a `<` floor (the fleet is registry-scaled, so `!=` would over-block).
+	Freshness time.Duration // window within which a reporter must have refreshed
+	Exclude   []ExcludedEdge
+}
+
+// ExcludedEdge is a LOUD, reason-required convergence-veto waiver for a decommissioned
+// edge (never a default; recorded in Result). An empty Reason makes Evaluate refuse.
+type ExcludedEdge struct {
+	EdgeID string
+	Reason string
+}
+
+// CPReplica is one serving control-plane replica's scraped state.
+type CPReplica struct {
+	Instance    string
+	Up          bool
+	TargetCAID  string  // edge_ca_target_ca_id label
+	SignerCAID  string  // edge_ca_signer_fingerprint label
+	SignerGen   uint64  // edge_ca_signer_generation value
+	BundleCerts int     // edge_ca_bundle_certs value (2 during OLD++NEW overlap)
+	AuthzGen    float64 // edge_authz_generation value
+}
+
+// CoreReplica is one core's scraped state.
+type CoreReplica struct {
+	Instance string
+	Up       bool
+	HeldCAID string // ca_id from trust_bundle_generation
+}
+
+// EdgeReporter is one edge's scraped state, keyed by its stable edge_id.
+type EdgeReporter struct {
+	EdgeID            string
+	Up                bool
+	LiveCAID          string // edge_clientcert_ca_id label
+	ObservedTarget    string // edge_cp_target_ca_id label
+	RefreshedInWindow bool   // increase(edge_refresh_total[Freshness]) >= 1
+	FailedRemints     bool   // increase(edge_clientcert_remint_total{result!="ok"}[Freshness]) > 0
+}
+
+// Observations is the cross-plane metric snapshot Evaluate scores. source.go builds it
+// from Prometheus; tests build it directly.
+type Observations struct {
+	CP            []CPReplica
+	Core          []CoreReplica
+	Edges         []EdgeReporter // every edge observed LIVE in the window (expected or not)
+	ExpectedEdges []string       // edge_ids from edge_registry_total==1 (expected-to-converge set)
+
+	RevokedProbeRan    bool // the revoked-token absence probe was executed
+	RevokedProbeStatus int  // its HTTP status (401/403 ⇒ revoked; 2xx ⇒ still mints)
+}
+
+// Result is the verdict. Converged is true ONLY when Blockers is empty.
+type Result struct {
+	Converged bool
+	Target    string // the resolved target ca_id ("" if unresolved)
+	Blockers  []Blocker
+	Excluded  []ExcludedEdge // the waivers applied (echoed for the audit trail)
+}
+
+// Evaluate scores convergence against the target ca_id derived from the CP target series.
+// Pure: no I/O, no clock beyond `now`. Returns Converged=false with named Blockers for
+// every reason the drop is unsafe.
+func Evaluate(obs Observations, cfg Config, now time.Time) Result {
+	r := Result{Excluded: cfg.Exclude}
+
+	// A reason-required exclude is non-negotiable: an empty Reason is a silent waiver.
+	for _, ex := range cfg.Exclude {
+		if ex.Reason == "" {
+			r.Blockers = append(r.Blockers, Blocker{Plane: "config", Reporter: ex.EdgeID, Reason: "exclude-without-reason"})
+		}
+	}
+	excluded := map[string]bool{}
+	for _, ex := range cfg.Exclude {
+		excluded[ex.EdgeID] = true
+	}
+
+	// Misconfig guard: a sane gate needs positive expectations (incl. an edge floor) so
+	// the drop can never be gated on a vacuously-empty plane. MinEdges<=0 is itself a
+	// misconfig — the floor must not be silently disabled.
+	if cfg.ExpectedCP <= 0 || cfg.ExpectedCore <= 0 || cfg.MinEdges <= 0 {
+		r.Blockers = append(r.Blockers, Blocker{Plane: "config", Reason: "expected-counts-unset"})
+	}
+	if len(obs.CP) == 0 && len(obs.Core) == 0 && len(obs.Edges) == 0 && len(obs.ExpectedEdges) == 0 {
+		r.Blockers = append(r.Blockers, Blocker{Plane: "config", Reason: ReasonExpectedSetEmpty})
+		return finalize(r) // nothing to score against; fail closed
+	}
+
+	// (1) Resolve the target T from the self-describing CP target series. Disagreement is
+	// a hard block — never silently pick one and compute downstream against it.
+	targets := map[string]int{}
+	for _, cp := range obs.CP {
+		if cp.Up && cp.TargetCAID != "" {
+			targets[cp.TargetCAID]++
+		}
+	}
+	switch len(targets) {
+	case 0:
+		r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reason: ReasonNoTarget})
+		return finalize(r)
+	case 1:
+		for t := range targets {
+			r.Target = t
+		}
+	default:
+		r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reason: ReasonCPTargetSplit})
+		return finalize(r)
+	}
+	T := r.Target
+
+	// (2) CP plane: every replica up, signing under T, still serving OLD++NEW (2 certs),
+	// with ONE generation for T (the generation-split tripwire) and agreement on authz.
+	cpAtT, gens, authz := 0, map[uint64]bool{}, map[float64]bool{}
+	for _, cp := range obs.CP {
+		if !cp.Up {
+			r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reporter: cp.Instance, Reason: ReasonUpDown})
+			continue
+		}
+		if cp.SignerCAID != T {
+			r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reporter: cp.Instance, Reason: ReasonWrongCAID})
+			continue
+		}
+		if cp.BundleCerts != 2 {
+			r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reporter: cp.Instance, Reason: ReasonNotOverlap})
+		}
+		gens[cp.SignerGen] = true
+		authz[cp.AuthzGen] = true
+		cpAtT++
+	}
+	if len(gens) > 1 {
+		r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reason: ReasonGenerationSplit})
+	}
+	if len(authz) > 1 {
+		r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reason: ReasonAuthzSplit})
+	}
+	if cpAtT != cfg.ExpectedCP {
+		r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reason: ReasonCountMismatch})
+	}
+
+	// (3) Core plane: every core up and HOLDING T. A converged-and-idle core (held==T,
+	// age growing because forward-only suppresses re-apply) is converged — age is NOT a
+	// staleness signal once held==T, so we don't gate on it here.
+	coreAtT := 0
+	for _, c := range obs.Core {
+		if !c.Up {
+			r.Blockers = append(r.Blockers, Blocker{Plane: "core", Reporter: c.Instance, Reason: ReasonUpDown})
+			continue
+		}
+		if c.HeldCAID != T {
+			r.Blockers = append(r.Blockers, Blocker{Plane: "core", Reporter: c.Instance, Reason: ReasonWrongCAID})
+			continue
+		}
+		coreAtT++
+	}
+	if coreAtT != cfg.ExpectedCore {
+		r.Blockers = append(r.Blockers, Blocker{Plane: "core", Reason: ReasonCountMismatch})
+	}
+
+	// (4) Edge plane. FAIL-CLOSED FLOOR first: an empty/short ExpectedEdges (registry
+	// metric drift, a mislabeled scrape, or the edge_registry_total query returning
+	// nothing) would otherwise let the per-edge loop run zero times and the edge plane
+	// pass vacuously — converging with healthy CP/core and dropping OLD on a fleet that
+	// never re-minted. The operator floor turns that into a hard block.
+	if len(obs.ExpectedEdges) < cfg.MinEdges {
+		r.Blockers = append(r.Blockers, Blocker{Plane: "edge", Reason: ReasonEdgeCountBelowFloor})
+	}
+
+	// Every EXPECTED (registry==1, not excluded) edge must be up, live on T, have observed
+	// T, have a fresh poll-loop heartbeat, and no FAILED re-mints.
+	byID := map[string]EdgeReporter{}
+	for _, e := range obs.Edges {
+		byID[e.EdgeID] = e
+	}
+	for _, id := range obs.ExpectedEdges {
+		if excluded[id] {
+			continue
+		}
+		e, ok := byID[id]
+		if !ok {
+			r.Blockers = append(r.Blockers, Blocker{Plane: "edge", Reporter: id, Reason: ReasonNeverScraped})
+			continue
+		}
+		switch {
+		case !e.Up:
+			r.Blockers = append(r.Blockers, Blocker{Plane: "edge", Reporter: id, Reason: ReasonUpDown})
+		case e.LiveCAID != T:
+			r.Blockers = append(r.Blockers, Blocker{Plane: "edge", Reporter: id, Reason: ReasonWrongCAID})
+		case e.ObservedTarget != T:
+			r.Blockers = append(r.Blockers, Blocker{Plane: "edge", Reporter: id, Reason: ReasonTargetNotObserved})
+		case !e.RefreshedInWindow:
+			r.Blockers = append(r.Blockers, Blocker{Plane: "edge", Reporter: id, Reason: ReasonRefreshStale})
+		case e.FailedRemints:
+			r.Blockers = append(r.Blockers, Blocker{Plane: "edge", Reporter: id, Reason: ReasonRemintChurn})
+		}
+	}
+
+	// (5) Live-OLD-leaf veto: ANY edge observed live on a non-target leaf blocks — even
+	// one merely registry-disabled but still RUNNING — unless explicitly excluded. The
+	// expected-to-converge set (the veto driver) is decoupled from the still-running-and-
+	// trusted set (the actual blast radius); registry==0 does NOT silently waive it.
+	for _, e := range obs.Edges {
+		if excluded[e.EdgeID] {
+			continue
+		}
+		if e.Up && e.LiveCAID != "" && e.LiveCAID != T {
+			r.Blockers = append(r.Blockers, Blocker{Plane: "edge", Reporter: e.EdgeID, Reason: ReasonLiveOldLeaf})
+		}
+	}
+
+	// (6) Revoked-token absence: the probe MUST have run (fail-closed) and the revoked
+	// token MUST be rejected (401/403). 2xx ⇒ it can still mint a NEW-CA leaf ⇒ block.
+	if !obs.RevokedProbeRan {
+		r.Blockers = append(r.Blockers, Blocker{Plane: "revoked", Reason: ReasonRevokedUnverified})
+	} else if obs.RevokedProbeStatus != 401 && obs.RevokedProbeStatus != 403 {
+		r.Blockers = append(r.Blockers, Blocker{Plane: "revoked", Reason: ReasonRevokedLeafPresent})
+	}
+
+	return finalize(r)
+}
+
+func finalize(r Result) Result {
+	r.Converged = len(r.Blockers) == 0
+	return r
+}

--- a/edgecp/converge/predicate_test.go
+++ b/edgecp/converge/predicate_test.go
@@ -1,0 +1,148 @@
+package converge
+
+import (
+	"testing"
+	"time"
+)
+
+const T = "target-ca-id"
+
+// converged returns a fully-converged snapshot + config; cases mutate a copy to trip one
+// blocker each.
+func converged() (Observations, Config) {
+	obs := Observations{
+		CP: []CPReplica{
+			{Instance: "cp-0", Up: true, TargetCAID: T, SignerCAID: T, SignerGen: 100, BundleCerts: 2, AuthzGen: 42},
+			{Instance: "cp-1", Up: true, TargetCAID: T, SignerCAID: T, SignerGen: 100, BundleCerts: 2, AuthzGen: 42},
+		},
+		Core: []CoreReplica{{Instance: "core-0", Up: true, HeldCAID: T}},
+		Edges: []EdgeReporter{
+			{EdgeID: "e1", Up: true, LiveCAID: T, ObservedTarget: T, RefreshedInWindow: true},
+			{EdgeID: "e2", Up: true, LiveCAID: T, ObservedTarget: T, RefreshedInWindow: true},
+		},
+		ExpectedEdges:      []string{"e1", "e2"},
+		RevokedProbeRan:    true,
+		RevokedProbeStatus: 401,
+	}
+	cfg := Config{ExpectedCP: 2, ExpectedCore: 1, MinEdges: 2, Freshness: 5 * time.Minute}
+	return obs, cfg
+}
+
+func hasBlocker(r Result, reason string) bool {
+	for _, b := range r.Blockers {
+		if b.Reason == reason {
+			return true
+		}
+	}
+	return false
+}
+
+func TestEvaluateConverged(t *testing.T) {
+	obs, cfg := converged()
+	r := Evaluate(obs, cfg, time.Now())
+	if !r.Converged {
+		t.Fatalf("happy path must converge; blockers=%v", r.Blockers)
+	}
+	if r.Target != T {
+		t.Errorf("target = %q, want %q", r.Target, T)
+	}
+}
+
+func TestEvaluateBlockers(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Observations, *Config)
+		reason string
+	}{
+		{"cp-target-split", func(o *Observations, _ *Config) { o.CP[1].TargetCAID = "other" }, ReasonCPTargetSplit},
+		{"generation-split", func(o *Observations, _ *Config) { o.CP[1].SignerGen = 999 }, ReasonGenerationSplit},
+		{"no-target", func(o *Observations, _ *Config) { o.CP[0].TargetCAID, o.CP[1].TargetCAID = "", "" }, ReasonNoTarget},
+		{"cp-count", func(_ *Observations, c *Config) { c.ExpectedCP = 3 }, ReasonCountMismatch},
+		{"cp-up-down", func(o *Observations, _ *Config) { o.CP[0].Up = false }, ReasonUpDown},
+		{"cp-wrong-ca", func(o *Observations, _ *Config) { o.CP[0].SignerCAID = "old" }, ReasonWrongCAID},
+		{"not-overlap", func(o *Observations, _ *Config) { o.CP[0].BundleCerts = 1 }, ReasonNotOverlap},
+		{"authz-split", func(o *Observations, _ *Config) { o.CP[1].AuthzGen = 99 }, ReasonAuthzSplit},
+		{"core-wrong-ca", func(o *Observations, _ *Config) { o.Core[0].HeldCAID = "old" }, ReasonWrongCAID},
+		{"core-up-down", func(o *Observations, _ *Config) { o.Core[0].Up = false }, ReasonUpDown},
+		{"edge-never-scraped", func(o *Observations, _ *Config) { o.ExpectedEdges = append(o.ExpectedEdges, "e3") }, ReasonNeverScraped},
+		{"edge-target-not-observed", func(o *Observations, _ *Config) { o.Edges[0].ObservedTarget = "old" }, ReasonTargetNotObserved},
+		{"edge-refresh-stale", func(o *Observations, _ *Config) { o.Edges[0].RefreshedInWindow = false }, ReasonRefreshStale},
+		{"edge-remint-churn", func(o *Observations, _ *Config) { o.Edges[0].FailedRemints = true }, ReasonRemintChurn},
+		{"live-old-leaf", func(o *Observations, _ *Config) {
+			o.Edges = append(o.Edges, EdgeReporter{EdgeID: "rogue", Up: true, LiveCAID: "old", ObservedTarget: T, RefreshedInWindow: true})
+		}, ReasonLiveOldLeaf},
+		{"revoked-unverified", func(o *Observations, _ *Config) { o.RevokedProbeRan = false }, ReasonRevokedUnverified},
+		{"revoked-leaf-present", func(o *Observations, _ *Config) { o.RevokedProbeStatus = 200 }, ReasonRevokedLeafPresent},
+		{"exclude-without-reason", func(_ *Observations, c *Config) { c.Exclude = []ExcludedEdge{{EdgeID: "e1"}} }, "exclude-without-reason"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obs, cfg := converged()
+			tc.mutate(&obs, &cfg)
+			r := Evaluate(obs, cfg, time.Now())
+			if r.Converged {
+				t.Errorf("%s: must NOT converge", tc.name)
+			}
+			if !hasBlocker(r, tc.reason) {
+				t.Errorf("%s: want blocker %q, got %v", tc.name, tc.reason, r.Blockers)
+			}
+		})
+	}
+}
+
+// THE fail-open guard: a registry/scrape drift that empties ExpectedEdges, with healthy
+// CP/core, must NOT converge vacuously (the per-edge loop running zero times). The floor
+// blocks it.
+func TestEvaluateEdgeCountFloorBlocksVacuousConvergence(t *testing.T) {
+	obs, cfg := converged()
+	obs.ExpectedEdges = nil // registry query came back empty (drift / mislabeled scrape)
+	obs.Edges = nil
+	r := Evaluate(obs, cfg, time.Now())
+	if r.Converged || !hasBlocker(r, ReasonEdgeCountBelowFloor) {
+		t.Errorf("empty ExpectedEdges with a floor must block (edge-count-below-floor), got %v", r.Blockers)
+	}
+}
+
+// MinEdges<=0 is a misconfig — the floor must not be silently disableable.
+func TestEvaluateMinEdgesUnsetIsMisconfig(t *testing.T) {
+	obs, cfg := converged()
+	cfg.MinEdges = 0
+	r := Evaluate(obs, cfg, time.Now())
+	if r.Converged || !hasBlocker(r, "expected-counts-unset") {
+		t.Errorf("MinEdges<=0 must block as a misconfig, got %v", r.Blockers)
+	}
+}
+
+func TestEvaluateExpectedSetEmpty(t *testing.T) {
+	r := Evaluate(Observations{}, Config{ExpectedCP: 1, ExpectedCore: 1}, time.Now())
+	if r.Converged || !hasBlocker(r, ReasonExpectedSetEmpty) {
+		t.Errorf("empty observations must block with expected-set-empty, got %v", r.Blockers)
+	}
+}
+
+// A reason-bearing exclude waives the convergence veto for a decommissioned edge (a
+// never-scraped expected edge), and the waiver is echoed in the verdict.
+func TestEvaluateExcludeWaivesVeto(t *testing.T) {
+	obs, cfg := converged()
+	obs.ExpectedEdges = append(obs.ExpectedEdges, "e3-gone") // would be never-scraped
+	cfg.Exclude = []ExcludedEdge{{EdgeID: "e3-gone", Reason: "decommissioned 2026-06-04"}}
+	r := Evaluate(obs, cfg, time.Now())
+	if !r.Converged {
+		t.Errorf("a reason-bearing exclude must waive the veto; blockers=%v", r.Blockers)
+	}
+	if len(r.Excluded) != 1 || r.Excluded[0].EdgeID != "e3-gone" {
+		t.Error("the applied exclusion must be echoed in Result for the audit trail")
+	}
+}
+
+// A still-RUNNING blacklisted edge (live on OLD, registry-dropped from ExpectedEdges)
+// must STILL block — registry==0 does not silently waive a live OLD leaf.
+func TestEvaluateRunningBlacklistedEdgeStillBlocks(t *testing.T) {
+	obs, cfg := converged()
+	// "ghost" is NOT in ExpectedEdges (registry-disabled) but is observed live on OLD.
+	obs.Edges = append(obs.Edges, EdgeReporter{EdgeID: "ghost", Up: true, LiveCAID: "old-ca", ObservedTarget: T, RefreshedInWindow: true})
+	r := Evaluate(obs, cfg, time.Now())
+	if r.Converged || !hasBlocker(r, ReasonLiveOldLeaf) {
+		t.Errorf("a running blacklisted edge on OLD must block (live-old-leaf), got %v", r.Blockers)
+	}
+}

--- a/edgecp/converge/source.go
+++ b/edgecp/converge/source.go
@@ -1,0 +1,190 @@
+package converge
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	promapi "github.com/prometheus/client_golang/api"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+// Querier is the minimal Prometheus instant-query surface Snapshot needs. The real impl
+// wraps the client_golang v1 API; tests inject a fake returning canned vectors — so the
+// reader is fully testable WITHOUT a live Prometheus.
+type Querier interface {
+	Query(ctx context.Context, query string, ts time.Time) (model.Vector, error)
+}
+
+// NewPromQuerier dials a Prometheus HTTP API at base (e.g. http://prometheus:9090).
+func NewPromQuerier(base string) (Querier, error) {
+	c, err := promapi.NewClient(promapi.Config{Address: base})
+	if err != nil {
+		return nil, fmt.Errorf("prometheus client: %w", err)
+	}
+	return &promQuerier{api: promv1.NewAPI(c)}, nil
+}
+
+type promQuerier struct{ api promv1.API }
+
+func (p *promQuerier) Query(ctx context.Context, query string, ts time.Time) (model.Vector, error) {
+	v, _, err := p.api.Query(ctx, query, ts)
+	if err != nil {
+		return nil, err
+	}
+	vec, ok := v.(model.Vector)
+	if !ok {
+		return nil, fmt.Errorf("query %q: expected an instant vector, got %s", query, v.Type())
+	}
+	return vec, nil
+}
+
+// Snapshot collects the cross-plane Observations from Prometheus. The plane of a series
+// is identified by WHICH metric it is (CP-only / core-only / edge-only metric names), so
+// no job-label config is needed. It does NOT run the revoked-token probe — that is an
+// HTTP call the CLI performs and stamps onto the returned Observations. A query error is
+// returned (fail-closed: the caller renders NO converged verdict on a Prometheus outage).
+//
+// `up` is joined by `instance` for CP/core (Prometheus stamps it automatically) and by
+// `edge_id` for edges (the scrape config must relabel edge_id onto the edge targets).
+func Snapshot(ctx context.Context, q Querier, freshness time.Duration, now time.Time) (Observations, error) {
+	fw := model.Duration(freshness).String()
+	get := func(query string) (model.Vector, error) { return q.Query(ctx, query, now) }
+
+	upByInstance, err := boolByLabel(get, "up", "instance", func(f float64) bool { return f == 1 })
+	if err != nil {
+		return Observations{}, err
+	}
+	upByEdge, err := boolByLabel(get, "up", "edge_id", func(f float64) bool { return f == 1 })
+	if err != nil {
+		return Observations{}, err
+	}
+
+	var obs Observations
+
+	// ---- CP plane (edge_ca_* metrics) ----
+	signerFP, err := labelByInstance(get, "parapet_edge_ca_signer_fingerprint", "ca_id")
+	if err != nil {
+		return Observations{}, err
+	}
+	targetCAID, err := labelByInstance(get, "parapet_edge_ca_target_ca_id", "ca_id")
+	if err != nil {
+		return Observations{}, err
+	}
+	signerGen, err := valueByInstance(get, "parapet_edge_ca_signer_generation")
+	if err != nil {
+		return Observations{}, err
+	}
+	bundleCerts, err := valueByInstance(get, "parapet_edge_ca_bundle_certs")
+	if err != nil {
+		return Observations{}, err
+	}
+	authzGen, err := valueByInstance(get, "parapet_edge_authz_generation")
+	if err != nil {
+		return Observations{}, err
+	}
+	for inst, fp := range signerFP {
+		obs.CP = append(obs.CP, CPReplica{
+			Instance: inst, Up: upByInstance[inst],
+			SignerCAID: fp, TargetCAID: targetCAID[inst],
+			SignerGen: uint64(signerGen[inst]), BundleCerts: int(bundleCerts[inst]), AuthzGen: authzGen[inst],
+		})
+	}
+
+	// ---- Core plane (trust_bundle_* metrics) ----
+	heldCAID, err := labelByInstance(get, "parapet_trust_bundle_generation", "ca_id")
+	if err != nil {
+		return Observations{}, err
+	}
+	for inst, ca := range heldCAID {
+		obs.Core = append(obs.Core, CoreReplica{Instance: inst, Up: upByInstance[inst], HeldCAID: ca})
+	}
+
+	// ---- Edge plane (edge_clientcert_* / edge_refresh_* metrics, keyed by edge_id) ----
+	liveCAID, err := labelByLabel(get, "parapet_edge_clientcert_ca_id", "edge_id", "ca_id")
+	if err != nil {
+		return Observations{}, err
+	}
+	observedTarget, err := labelByLabel(get, "parapet_edge_cp_target_ca_id", "edge_id", "ca_id")
+	if err != nil {
+		return Observations{}, err
+	}
+	refreshed, err := boolByLabel(get, fmt.Sprintf("increase(parapet_edge_refresh_total[%s])", fw), "edge_id", func(f float64) bool { return f >= 1 })
+	if err != nil {
+		return Observations{}, err
+	}
+	failed, err := boolByLabel(get, fmt.Sprintf(`increase(parapet_edge_clientcert_remint_total{result!="ok"}[%s])`, fw), "edge_id", func(f float64) bool { return f > 0 })
+	if err != nil {
+		return Observations{}, err
+	}
+	for id, ca := range liveCAID {
+		obs.Edges = append(obs.Edges, EdgeReporter{
+			EdgeID: id, Up: upByEdge[id], LiveCAID: ca,
+			ObservedTarget: observedTarget[id], RefreshedInWindow: refreshed[id], FailedRemints: failed[id],
+		})
+	}
+
+	// ---- Expected-edge set (edge_registry_total == 1) ----
+	reg, err := get("parapet_edge_registry_total == 1")
+	if err != nil {
+		return Observations{}, err
+	}
+	for _, s := range reg {
+		if id := string(s.Metric["edge_id"]); id != "" {
+			obs.ExpectedEdges = append(obs.ExpectedEdges, id)
+		}
+	}
+
+	return obs, nil
+}
+
+// labelByInstance maps instance -> the value of `label` on each sample of `query`.
+func labelByInstance(get func(string) (model.Vector, error), query, label string) (map[string]string, error) {
+	return labelByLabel(get, query, "instance", label)
+}
+
+// labelByLabel maps the `key` label -> the `val` label across the query's samples.
+func labelByLabel(get func(string) (model.Vector, error), query, key, val string) (map[string]string, error) {
+	vec, err := get(query)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]string, len(vec))
+	for _, s := range vec {
+		if k := string(s.Metric[model.LabelName(key)]); k != "" {
+			m[k] = string(s.Metric[model.LabelName(val)])
+		}
+	}
+	return m, nil
+}
+
+// valueByInstance maps instance -> the sample value.
+func valueByInstance(get func(string) (model.Vector, error), query string) (map[string]float64, error) {
+	vec, err := get(query)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]float64, len(vec))
+	for _, s := range vec {
+		if inst := string(s.Metric["instance"]); inst != "" {
+			m[inst] = float64(s.Value)
+		}
+	}
+	return m, nil
+}
+
+// boolByLabel maps the `key` label -> pred(value) across the query's samples.
+func boolByLabel(get func(string) (model.Vector, error), query, key string, pred func(float64) bool) (map[string]bool, error) {
+	vec, err := get(query)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]bool, len(vec))
+	for _, s := range vec {
+		if k := string(s.Metric[model.LabelName(key)]); k != "" {
+			m[k] = pred(float64(s.Value))
+		}
+	}
+	return m, nil
+}

--- a/edgecp/converge/source_test.go
+++ b/edgecp/converge/source_test.go
@@ -1,0 +1,85 @@
+package converge
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+)
+
+// fakeQuerier returns canned vectors per query (so Snapshot is tested with NO live
+// Prometheus). An unmapped query returns an empty vector; queryErr forces an error.
+type fakeQuerier struct {
+	byQuery  map[string]model.Vector
+	queryErr error
+}
+
+func (f *fakeQuerier) Query(_ context.Context, q string, _ time.Time) (model.Vector, error) {
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	return f.byQuery[q], nil
+}
+
+func sample(labels map[string]string, v float64) *model.Sample {
+	m := model.Metric{}
+	for k, val := range labels {
+		m[model.LabelName(k)] = model.LabelValue(val)
+	}
+	return &model.Sample{Metric: m, Value: model.SampleValue(v)}
+}
+
+func TestSnapshotMapsAllPlanes(t *testing.T) {
+	const target = "T"
+	q := &fakeQuerier{byQuery: map[string]model.Vector{
+		"up": {
+			sample(map[string]string{"instance": "cp-0"}, 1),
+			sample(map[string]string{"instance": "core-0"}, 1),
+			sample(map[string]string{"edge_id": "e1"}, 1),
+		},
+		"parapet_edge_ca_signer_fingerprint":                               {sample(map[string]string{"instance": "cp-0", "ca_id": target}, 1)},
+		"parapet_edge_ca_target_ca_id":                                     {sample(map[string]string{"instance": "cp-0", "ca_id": target}, 1)},
+		"parapet_edge_ca_signer_generation":                                {sample(map[string]string{"instance": "cp-0", "ca_id": target}, 4242)},
+		"parapet_edge_ca_bundle_certs":                                     {sample(map[string]string{"instance": "cp-0", "ca_id": target}, 2)},
+		"parapet_edge_authz_generation":                                    {sample(map[string]string{"instance": "cp-0"}, 777)},
+		"parapet_trust_bundle_generation":                                  {sample(map[string]string{"instance": "core-0", "ca_id": target}, 4242)},
+		"parapet_edge_clientcert_ca_id":                                    {sample(map[string]string{"edge_id": "e1", "ca_id": target}, 1)},
+		"parapet_edge_cp_target_ca_id":                                     {sample(map[string]string{"edge_id": "e1", "ca_id": target}, 1)},
+		"increase(parapet_edge_refresh_total[5m])":                         {sample(map[string]string{"edge_id": "e1"}, 3)},
+		`increase(parapet_edge_clientcert_remint_total{result!="ok"}[5m])`: {sample(map[string]string{"edge_id": "e1"}, 0)},
+		"parapet_edge_registry_total == 1":                                 {sample(map[string]string{"edge_id": "e1"}, 1)},
+	}}
+
+	obs, err := Snapshot(context.Background(), q, 5*time.Minute, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(obs.CP) != 1 || obs.CP[0].SignerCAID != target || obs.CP[0].SignerGen != 4242 || obs.CP[0].BundleCerts != 2 || !obs.CP[0].Up || obs.CP[0].AuthzGen != 777 {
+		t.Errorf("CP mapping wrong: %+v", obs.CP)
+	}
+	if len(obs.Core) != 1 || obs.Core[0].HeldCAID != target || !obs.Core[0].Up {
+		t.Errorf("core mapping wrong: %+v", obs.Core)
+	}
+	if len(obs.Edges) != 1 || obs.Edges[0].EdgeID != "e1" || obs.Edges[0].LiveCAID != target || !obs.Edges[0].RefreshedInWindow || obs.Edges[0].FailedRemints || !obs.Edges[0].Up {
+		t.Errorf("edge mapping wrong: %+v", obs.Edges)
+	}
+	if len(obs.ExpectedEdges) != 1 || obs.ExpectedEdges[0] != "e1" {
+		t.Errorf("expected-edges wrong: %v", obs.ExpectedEdges)
+	}
+
+	// And the mapped snapshot evaluates as converged (end-to-end sanity).
+	obs.RevokedProbeRan, obs.RevokedProbeStatus = true, 403
+	if r := Evaluate(obs, Config{ExpectedCP: 1, ExpectedCore: 1, MinEdges: 1, Freshness: 5 * time.Minute}, time.Now()); !r.Converged {
+		t.Errorf("mapped snapshot should converge; blockers=%v", r.Blockers)
+	}
+}
+
+// A Prometheus query error must propagate (fail-closed: the caller renders no verdict).
+func TestSnapshotPropagatesQueryError(t *testing.T) {
+	q := &fakeQuerier{queryErr: errors.New("prometheus unreachable")}
+	if _, err := Snapshot(context.Background(), q, 5*time.Minute, time.Now()); err == nil {
+		t.Error("a query error must propagate, not be swallowed")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/moonrhythm/parapet v0.16.1-0.20260601131239-6c3d8c3c542f
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/common v0.67.5
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/otel/sdk v1.43.0
@@ -62,7 +63,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/mock v1.7.0-rc.1 h1:YojYx61/OLFsiv6Rw1Z96LpldJIy31o+UHmwAUMJ6/U=
 github.com/golang/mock v1.7.0-rc.1/go.mod h1:s42URUywIqd+OcERslBJvOjepvNymP31m3q8d/GkuRs=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
@@ -100,6 +102,8 @@ github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kavu/go_reuseport v1.5.0 h1:UNuiY2OblcqAtVDE8Gsg1kZz8zbBWg907sP1ceBV+bk=
@@ -127,6 +131,8 @@ github.com/moonrhythm/parapet v0.16.1-0.20260601131239-6c3d8c3c542f h1:6h8hEl8YK
 github.com/moonrhythm/parapet v0.16.1-0.20260601131239-6c3d8c3c542f/go.mod h1:mfLCzU9zBm6vn05mnOgO0G8/+pArndciyLv3BYM9HJA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oschwald/maxminddb-golang v1.13.1 h1:G3wwjdN9JmIK2o/ermkHM+98oX5fS+k5MbwsmL4MRQE=
 github.com/oschwald/maxminddb-golang v1.13.1/go.mod h1:K4pgV9N/GcK694KSTmVSDTODk4IsCNThNdTmnaBZ/F8=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=


### PR DESCRIPTION
**Sub-PR 4b-i of 5** for edge-proxy revocation (`EDGE-AUTOTRUST.md`) — the metric-gated, **never-timer-gated** interlock that decides whether an edge-CA rotation has converged across every plane, so sub-PR 5's revoke Job can safely drop OLD. **Read + decide only** — no `UpdateSecret`, no OLD-drop, no active-key flip.

## Design
- **`edgecp/converge/predicate.go`** — `Evaluate` is a **pure** function over a metric snapshot (`Observations`): zero I/O, so the safety predicate is exhaustively unit-testable without a live Prometheus. The cross-plane drop gate:
  - a single self-described **target `ca_id`** (`cp-target-split` if CP replicas disagree — never silently picks one);
  - every CP replica up, signing under T, still **OLD++NEW** (`bundle_certs==2`), with **one generation** (the `generation-split` tripwire that fires the day a future `max()` regression appears) and **agreeing authz** (the blacklist barrier B0);
  - every core **holding T** (a converged-and-idle core is **not** flagged stale — forward-only correctly suppresses re-apply);
  - every good edge live on T, having observed T, with a **fresh liveness heartbeat** (`edge_refresh_total`) and no failed re-mints;
  - **any live OLD-leaf blocks** — even a registry-disabled-but-still-running edge (the expected-to-converge set is decoupled from the still-running blast radius);
  - the **revoked token rejected** (absent probe ⇒ `revoked-unverified`, fail-closed).
  - **Fail-closed throughout**: `observed==expected` COUNTS (never a vacuous all-equal), named blocker reasons (`never-scraped` vs `up-down`, `expected-set-empty`, …). `Exclude` is a reason-required, audit-echoed veto waiver.
- **`source.go`** — a thin read-only Prometheus client (`Querier` interface); the plane of a series is its metric name (no job config). A query error **propagates** (fail-closed). Tested against canned vectors.
- **`cmd/edge-controlplane/converge.go`** — the `EDGE_CONVERGE_STATUS` run-once CLI: the stable-reads loop (**refuses an unsafe cadence**: `poll×reads` must span ≥2 scrapes and ≥`EDGE_REFRESH_INTERVAL`), the revoked-token absence probe, exit-non-zero-unless-converged. The Prometheus dep is confined to this run-once branch.
- **`import_boundary_test.go`** — a **test** asserting the serving packages (edgecp handlers, edge, cmd/edge-proxy, trust, metric) never transitively import `edgecp/converge` or `client_golang/api`, so a Prometheus outage can't break issuance.

## Tests
Table-driven over **every** blocker reason + the happy path; `expected-set-empty`; exclude-waives-veto + the running-blacklisted-edge-still-blocks case; the canned-Prom `Snapshot` mapping + query-error propagation; the import boundary. `gofmt` / `go vet ./...` / `go test -race ./...` / e2e all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)