### PR TITLE
feat(edge-revoke): active-signer-fingerprint OLD-drop interlock + EDGE_CA_REVOKE orchestrator (sub-PR 5)

### DIFF
--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -453,6 +453,40 @@ step — else the compromised edge mints a fresh NEW-CA leaf off a lagging repli
 the overlap and survives the drop. Residual: a leaf minted in the sub-second
 pre-convergence window (if the barrier was skipped) survives to the next rotation.
 
+**The active-signer-fingerprint refinement (implemented).** `ca_id` convergence (step 3
+above) proves the edge holds the OLD++NEW *bundle* but **NOT that its leaf is *signed by*
+NEW**: `Sign()` appends the full served bundle to every leaf, so
+`parapet_edge_clientcert_ca_id` is byte-identical for `active=old` and `active=new`. After
+the OLD-drop the core's `ClientCAs={NEW}`, so an OLD-*signed* leaf fails verification → a
+502 for that otherwise-good edge. So the active flip (step 4) is a **separate gated phase**
+the revoke tool drives strictly *after* the ca_id widen barrier and *before* the drop, and
+an **active-signer fingerprint** is threaded CP→edge→converge so the drop interlock
+*cryptographically* asserts every good edge's leaf is NEW-signed, not merely inferred from
+the bundle ca_id:
+- CP: `Signer.ActiveFP()` (the sha256 of the CA actually signing) rides every
+  cert/edge-cert/WAF/trust-bundle response (`X-Parapet-Signing-Cert-Fp` / `signing_cert_fp`)
+  and the `parapet_edge_ca_active_signer_fp{ca_id,sigfp}` gauge. The signer reloader's no-op
+  short-circuit keys on the **(ca_id, active-fp) tuple** so the `active=old→new` flip (an
+  unchanged bundle ⇒ unchanged ca_id) actually installs the NEW signer instead of silently
+  no-op'ing.
+- Edge: `deriveIssuerFP` resolves *which* chain CA signed the live leaf
+  (AuthorityKeyId==SubjectKeyId, exactly-one-match, fail-closed) → `SignerFP()` →
+  `parapet_edge_clientcert_signer_fp`; the proactive re-mint triggers on a divergence on
+  **either** axis (ca_id OR signer fp), so the flip re-chains the leaf to NEW.
+- Drop interlock (`edgecp/converge`): the destructive gate additionally requires every CP
+  replica + every good edge to be NEW-signed (`signer fp == NEW`), the blacklist to have
+  converged on every replica (`authz gen == AuthzGeneration(post-revoke registry)`), and the
+  **CP-authoritative issuance ledger** (`parapet_edge_ca_issued_total{edge_id,sigfp}`) to
+  show the revoked id with **zero** issuances under NEW — a guarantee that does NOT rest on
+  the (forgeable) edge self-report. The revoked id is **exempt** from the live-OLD vetoes (it
+  is the intended casualty; vetoing on it would deadlock the revoke).
+
+The CA-Secret state machine is `overlap`/`active=old` (`RotateCA`, a pure non-destructive
+widen) → `active=new` (`SetActiveNew`, reversible) → `trimmed` (`TrimCA`, the destructive
+NEW-only drop; requires `active=new` first so OLD isn't dropped while it is the active
+signer). The `EDGE_CA_REVOKE` one-shot orchestrator sequences all of it, gating each
+irreversible step on `converge-status` and resuming idempotently on retry.
+
 ### k8s client: the first write path (Job-only)
 
 `GetSecret` + `UpdateSecret` are added but **`UpdateSecret` is invoked SOLELY by the
@@ -657,15 +691,22 @@ not Prometheus counters (a Pushgateway would be a new failure domain).
 | `EDGE_CONVERGE_FRESHNESS` / `_STABLE_READS` / `_POLL_INTERVAL` / `_SCRAPE_INTERVAL` | CP (Job) | `5m` / `2` / `30s` / `15s` | Liveness window; consecutive converged reads required; gap between them; the scrape interval. The reader **refuses** unless `poll × reads ≥ 2×scrape` AND `≥ EDGE_REFRESH_INTERVAL` (a flap can't read as converged). |
 | `EDGE_CONVERGE_EXCLUDE` | CP (Job) | `""` | `id=reason,…` — LOUD, reason-required convergence-veto waivers for decommissioned edges (echoed in the verdict; an empty reason is refused). |
 | `EDGE_CONVERGE_REVOKED_TOKEN` / `_CP_URL` / `_CP_CA` | CP (Job) | `""` | The revoked token + CP endpoint for the absence probe (must be rejected 401/403). Absent ⇒ `revoked-unverified` (fail-closed). |
+| `EDGE_CONVERGE_EXPECTED_CA_ID` / `_SIGNER_FP` / `_AUTHZ_GEN` / `_REVOKED_EDGE_ID` | CP (Job) | `""` / `""` / `0` / `""` | Drop-checkpoint pins. `EXPECTED_CA_ID` pins the resolved target to *this* rotation. Setting `EXPECTED_SIGNER_FP` (the NEW signing fp) switches the predicate from the ca_id widen barrier to the destructive OLD-drop gate: every CP replica + good edge must be NEW-signed, `AUTHZ_GEN` (the post-blacklist `AuthzGeneration`) must match on every replica, and `REVOKED_EDGE_ID` must have zero NEW issuances (and is exempt from the live-OLD vetoes). `SIGNER_FP` set without `AUTHZ_GEN` is a refused half-interlock. |
+| `EDGE_CA_REVOKE` | CP (Job) | false | Run-once **revoke orchestrator**: drives the full phased rotation (widen → wait Gate A → flip → wait Gate B → trim), gating each irreversible step on convergence. Requires `EDGE_CA_REVOKE_EDGE_ID`, `EDGE_CONVERGE_PROM_URL`, the live probe inputs, and the post-blacklist `CP_TOKENS` (preflight refuses unless the id is present-and-`disabled`). Idempotent/resumable; a timeout leaves the rotation at its last completed step. |
+| `EDGE_CA_REVOKE_EDGE_ID` / `EDGE_CA_REVOKE_TIMEOUT` | CP (Job) | `""` / `30m` | The edge id to sever; the per-gate convergence-wait deadline (a timeout never drops OLD — re-run resumes). |
 
 Registry shape: `{"<token>":{"id":...,"domains":[...],"disabled":bool}}`. New trust-bundle
 field `ca_id`. Metrics: `parapet_trust_source{mtls|cidr|none|file}`,
 `parapet_trust_reload_rejected_total`, `parapet_trust_rollback_rejected_total`,
 `parapet_trust_bundle_age_seconds` (core); `parapet_edge_clientcert_loaded`,
-`parapet_edge_clientcert_not_after`, **`parapet_edge_clientcert_ca_id`** (edge);
+`parapet_edge_clientcert_not_after`, **`parapet_edge_clientcert_ca_id`**,
+**`parapet_edge_clientcert_signer_fp`**, `parapet_edge_cp_active_signer_fp` (edge);
 **`parapet_edge_token_disabled_without_rotation`**, **`parapet_edge_ca_rotation_stuck`**,
 `parapet_edge_ca_generated_total`, `parapet_edge_ca_unexpected_empty_total`,
-`parapet_edge_ca_signer_fingerprint` (CP, pod-labeled). **Removed:**
+`parapet_edge_ca_signer_fingerprint`, **`parapet_edge_ca_active_signer_fp`**,
+**`parapet_edge_ca_issued_total{edge_id,sigfp}`** (the CP-authoritative issuance ledger),
+`parapet_edge_ca_signer_active_flip_failed`, `parapet_edge_authz_generation` (CP,
+pod-labeled). **Removed:**
 `parapet_trust_allowed_sans_count` and the deterministic-SAN-serialization-before-etag
 requirement.
 
@@ -691,17 +732,22 @@ requirement.
 > ⚠️ **Blacklisting a token does NOT revoke trust** — see [Revocation](#revocation--ca-rotation).
 > For a real compromise, CA rotation is mandatory.
 
-Ship a single tool, **`edge-controlplane revoke --edge <id>`**, that performs **both**
-steps as one atomic, idempotent, resumable gesture (resumable via the rotation-phase
-annotation): (1) **blacklist** — set `disabled:true` (preferred over delete; a full
-lockout); (2) **wait** until the blacklist has converged on **every** CP replica
-(pod-labeled metric) — a barrier, not a parallel step; (3) **add** the NEW CA to the
-overlap bundle; (4) good edges re-mint under NEW (proactive, jittered); (5) **confirm**
-convergence via the interlock (every good edge on NEW; the revoked id absent under NEW);
-(6) **drop** OLD — the revoked edge's OLD-CA leaf stops verifying and it is distrusted.
-Never expose a bare `blacklist` verb that does only step (1) without loudly printing
-"TRUST NOT YET REVOKED — run rotate"; `parapet_edge_token_disabled_without_rotation`
-fires until the rotation completes.
+**Implemented as the `EDGE_CA_REVOKE` run-once Job** (`runRevoke`), one idempotent,
+resumable gesture (resumable via the rotation-phase annotation + per-step CAS):
+(0) **operator blacklist** — set `disabled:true` in `CP_TOKENS` (preferred over delete; a
+full lockout) and restart the serving CPs (the hot authz-watch is deferred); the Job's
+preflight **refuses** unless the id is present-and-`disabled` and derives the
+`ExpectedAuthzGen` pin from that same registry. Then the Job: (1) **widen** the bundle to
+OLD++NEW (`RotateCA`); (2) **wait Gate A** — every CP+core+edge holds OLD++NEW (`ca_id`
+converged); (3) **flip** the active signer to NEW (`SetActiveNew`); good edges re-mint
+under NEW (proactive, jittered); (4) **wait Gate B** — the destructive-drop interlock:
+every CP replica + good edge NEW-*signed* (the active-fp gates), the blacklist converged
+on every replica (`authz gen`), the revoked id with zero NEW issuances, and the live probe
+rejecting the token; (5) **drop** OLD (`TrimCA`) — the revoked edge's OLD-CA leaf stops
+verifying and it is distrusted. A gate timeout leaves the rotation at its last completed
+step (re-run resumes) and never drops OLD. Never expose a bare `blacklist` verb that does
+only step (0) without loudly printing "TRUST NOT YET REVOKED — run revoke";
+`parapet_edge_token_disabled_without_rotation` fires until the rotation completes.
 
 ## Phasing
 

--- a/cmd/edge-controlplane/converge.go
+++ b/cmd/edge-controlplane/converge.go
@@ -33,6 +33,14 @@ func runConvergeStatus() {
 		MinEdges:     envInt("EDGE_CONVERGE_MIN_EDGES", 0),
 		Freshness:    DefaultDuration("EDGE_CONVERGE_FRESHNESS", 5*time.Minute),
 		Exclude:      parseExcludes(os.Getenv("EDGE_CONVERGE_EXCLUDE")),
+		// Active-flip drop-checkpoint pins. When ExpectedActiveSignerFP is set, the predicate
+		// runs the full interlock (every CP replica + good edge NEW-signed, blacklist
+		// converged via ExpectedAuthzGen, revoked id has zero NEW issuances). The revoke tool
+		// supplies these; an operator-driven plain rotation-drop leaves them empty (ca_id-only).
+		ExpectedTargetCAID:     os.Getenv("EDGE_CONVERGE_EXPECTED_CA_ID"),
+		ExpectedActiveSignerFP: os.Getenv("EDGE_CONVERGE_EXPECTED_SIGNER_FP"),
+		ExpectedAuthzGen:       envFloat("EDGE_CONVERGE_EXPECTED_AUTHZ_GEN", 0),
+		RevokedEdgeID:          os.Getenv("EDGE_CONVERGE_REVOKED_EDGE_ID"),
 	}
 	stableReads := envInt("EDGE_CONVERGE_STABLE_READS", 2)
 	pollInterval := DefaultDuration("EDGE_CONVERGE_POLL_INTERVAL", 30*time.Second)
@@ -84,7 +92,7 @@ func runConvergeStatus() {
 		if i > 0 {
 			time.Sleep(pollInterval)
 		}
-		obs, err := converge.Snapshot(ctx, q, cfg.Freshness, time.Now())
+		obs, err := converge.Snapshot(ctx, q, cfg.Freshness, time.Now(), cfg.RevokedEdgeID, cfg.ExpectedActiveSignerFP)
 		if err != nil {
 			slog.Error("converge: prometheus query failed; NOT converged (fail-closed)", "err", err)
 			os.Exit(1)

--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -113,6 +113,14 @@ func main() {
 		runConvergeStatus() // exits
 	}
 
+	// Run-once revoke (a Job): sever one edge id by driving the full phased CA rotation
+	// (widen → flip → trim), gating every irreversible step on cross-plane convergence.
+	// Like the other run-once modes it never serves; the Prometheus client stays confined
+	// to this CLI path. See runRevoke for the step/gate sequence and resumability.
+	if os.Getenv("EDGE_CA_REVOKE") == "true" {
+		runRevoke() // exits
+	}
+
 	// Run-once CA bootstrap (a Job): adopt-or-generate the edge CA into its Secret
 	// (never regenerate a once-populated CA — the anti-regeneration guard), then
 	// exit. Needs neither tokens nor TLS; it never serves.

--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -63,6 +63,18 @@ func envInt(key string, def int) int {
 	return def
 }
 
+// envFloat reads a float64 env var (the converge authz-generation pin is a float
+// fingerprint). An unparseable value falls back to def with a loud warning.
+func envFloat(key string, def float64) float64 {
+	if v := os.Getenv(key); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+		slog.Warn("invalid float; using default", "key", key, "value", v, "default", def)
+	}
+	return def
+}
+
 // k8sRW adapts the package-level k8s secret read/write funcs to edgecp.SecretRW for
 // the CA bootstrap (the only writer of the CA Secret).
 type k8sRW struct{}

--- a/cmd/edge-controlplane/revoke.go
+++ b/cmd/edge-controlplane/revoke.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/moonrhythm/parapet-ingress-controller/caid"
+	"github.com/moonrhythm/parapet-ingress-controller/edgecp"
+	"github.com/moonrhythm/parapet-ingress-controller/edgecp/converge"
+	"github.com/moonrhythm/parapet-ingress-controller/k8s"
+)
+
+// runRevoke is the run-once revoke orchestrator (EDGE_CA_REVOKE=true). It severs a single
+// edge id by driving the full phased CA rotation, gating every irreversible step on
+// cross-plane convergence (never on a timer). It assumes the operator has ALREADY
+// blacklisted the edge's token (disabled:true in CP_TOKENS) and restarted the serving CPs
+// — runRevoke verifies that, then:
+//
+//  1. RotateCA       — widen the bundle to OLD++NEW (non-destructive; OLD still active).
+//  2. wait (Gate A)  — every CP + core + edge holds the OLD++NEW bundle (ca_id converged).
+//  3. SetActiveNew   — flip the active signer to NEW (new leaves now chain to NEW).
+//  4. wait (Gate B)  — every CP replica + good edge is NEW-SIGNED, the blacklist converged
+//     on every replica (authz gen), the revoked id has zero NEW issuances,
+//     and the live probe rejects the revoked token.
+//  5. TrimCA         — DESTRUCTIVE: drop OLD. The core now trusts only NEW, severing every
+//     OLD-signed leaf — the revoked edge's, and any straggler.
+//
+// Every underlying step is idempotent + CAS-looped, so a crash/retry re-enters safely
+// (RotateCA/SetActiveNew/TrimCA no-op when already in their target state, and the gates
+// re-poll). It NEVER serves and confines the Prometheus client to this CLI path.
+func runRevoke() {
+	ns := os.Getenv("POD_NAMESPACE")
+	if ns == "" {
+		slog.Error("EDGE_CA_REVOKE requires POD_NAMESPACE (the CA Secret's namespace)")
+		os.Exit(1)
+	}
+	name := envOr("EDGE_CA_SECRET", "parapet-edge-ca")
+	revokedID := strings.ToLower(strings.TrimSpace(os.Getenv("EDGE_CA_REVOKE_EDGE_ID")))
+	if revokedID == "" {
+		slog.Error("EDGE_CA_REVOKE requires EDGE_CA_REVOKE_EDGE_ID (the edge id to sever)")
+		os.Exit(1)
+	}
+	promURL := os.Getenv("EDGE_CONVERGE_PROM_URL")
+	if promURL == "" {
+		slog.Error("EDGE_CA_REVOKE requires EDGE_CONVERGE_PROM_URL (the OLD-drop is convergence-gated)")
+		os.Exit(1)
+	}
+	caTTL := DefaultDuration("EDGE_CA_TTL", edgecp.DefaultCATTL)
+
+	// The base convergence expectations (counts + freshness + excludes), shared by both gates.
+	base := converge.Config{
+		ExpectedCP:   envInt("EDGE_CONVERGE_EXPECTED_CP", 0),
+		ExpectedCore: envInt("EDGE_CONVERGE_EXPECTED_CORE", 0),
+		MinEdges:     envInt("EDGE_CONVERGE_MIN_EDGES", 0),
+		Freshness:    DefaultDuration("EDGE_CONVERGE_FRESHNESS", 5*time.Minute),
+		Exclude:      parseExcludes(os.Getenv("EDGE_CONVERGE_EXCLUDE")),
+	}
+
+	// The live revoked-token probe is MANDATORY for a revoke (the predicate fail-closes
+	// without it). It proves the blacklisted token is actively rejected, not merely absent
+	// from the expected set.
+	probe := revokedProbe{
+		token: os.Getenv("EDGE_CONVERGE_REVOKED_TOKEN"),
+		cpURL: os.Getenv("EDGE_CONVERGE_CP_URL"),
+	}
+	if probe.token == "" || probe.cpURL == "" {
+		slog.Error("EDGE_CA_REVOKE requires EDGE_CONVERGE_REVOKED_TOKEN + EDGE_CONVERGE_CP_URL (the live revoked-token probe is mandatory)")
+		os.Exit(1)
+	}
+	if p := os.Getenv("EDGE_CONVERGE_CP_CA"); p != "" {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			slog.Error("EDGE_CA_REVOKE: cannot read EDGE_CONVERGE_CP_CA (pin requested)", "path", p, "err", err)
+			os.Exit(1)
+		}
+		probe.cpCA = b
+	}
+
+	stableReads := envInt("EDGE_CONVERGE_STABLE_READS", 2)
+	pollInterval := DefaultDuration("EDGE_CONVERGE_POLL_INTERVAL", 30*time.Second)
+	scrapeInterval := DefaultDuration("EDGE_CONVERGE_SCRAPE_INTERVAL", 15*time.Second)
+	refreshInterval := DefaultDuration("EDGE_REFRESH_INTERVAL", 300*time.Second)
+	deadline := DefaultDuration("EDGE_CA_REVOKE_TIMEOUT", 30*time.Minute)
+	if stableReads < 2 {
+		slog.Error("EDGE_CONVERGE_STABLE_READS must be >= 2 (one read can't distinguish a flap)")
+		os.Exit(1)
+	}
+	if err := checkCadence(cadenceWindow(pollInterval, stableReads), scrapeInterval, refreshInterval); err != nil {
+		slog.Error("EDGE_CA_REVOKE converge cadence unsafe", "err", err)
+		os.Exit(1)
+	}
+
+	// Preflight: the blacklist MUST already be applied (disabled:true) and converged on
+	// every CP. We derive the post-blacklist authz-generation pin from the SAME registry the
+	// CPs loaded — Gate B asserts every replica reports it, proving the revoke is everywhere.
+	tokens, err := loadTokens(os.Getenv("CP_TOKENS"), os.Getenv("CP_TOKENS_FILE"))
+	if err != nil {
+		slog.Error("EDGE_CA_REVOKE: load edge tokens", "err", err)
+		os.Exit(1)
+	}
+	if !idDisabled(tokens, revokedID) {
+		slog.Error("EDGE_CA_REVOKE: the edge id is not present-and-disabled in CP_TOKENS — blacklist it (disabled:true) and restart all CP first, then re-run",
+			"edge_id", revokedID)
+		os.Exit(1)
+	}
+	expectedAuthzGen := edgecp.AuthzGeneration(tokens)
+
+	q, err := converge.NewPromQuerier(promURL)
+	if err != nil {
+		slog.Error("EDGE_CA_REVOKE: prometheus client", "err", err)
+		os.Exit(1)
+	}
+	if err := k8s.Init(); err != nil {
+		slog.Error("k8s init", "err", err)
+		os.Exit(1)
+	}
+	ctx := context.Background()
+	rw := k8sRW{}
+
+	// Step 1 — widen (idempotent). The NEW cert is the bundle's last block; its fp + the
+	// bundle ca_id pin every downstream step + gate to THIS rotation.
+	bundle, err := edgecp.RotateCA(ctx, rw, ns, name, caTTL)
+	if err != nil {
+		slog.Error("EDGE_CA_REVOKE: rotate (widen) failed", "err", err)
+		os.Exit(1)
+	}
+	newFP, err := lastCertFP(bundle)
+	if err != nil {
+		slog.Error("EDGE_CA_REVOKE: derive NEW cert fingerprint", "err", err)
+		os.Exit(1)
+	}
+	targetCAID, err := caid.FromPEM(bundle)
+	if err != nil {
+		slog.Error("EDGE_CA_REVOKE: derive target ca_id", "err", err)
+		os.Exit(1)
+	}
+	slog.Info("EDGE_CA_REVOKE: widened to OLD++NEW; waiting for the trust bundle to converge",
+		"edge_id", revokedID, "target_ca_id", targetCAID, "new_fp", newFP)
+
+	// Gate A — the ca_id widen barrier (no fp pin): every core trusts NEW before we flip.
+	cfgA := base
+	cfgA.ExpectedTargetCAID = targetCAID
+	cfgA.RevokedEdgeID = revokedID // benign pre-flip (issuance gate is fp-gated, off here)
+	if err := pollUntilConverged(ctx, "widen", q, cfgA, probe, stableReads, pollInterval, deadline); err != nil {
+		slog.Error("EDGE_CA_REVOKE: widen did not converge — NOT flipping (nothing destructive done; re-run to resume)", "err", err)
+		os.Exit(1)
+	}
+
+	// Step 2 — flip the active signer to NEW (reversible until the trim).
+	if _, err := edgecp.SetActiveNew(ctx, rw, ns, name, newFP); err != nil {
+		slog.Error("EDGE_CA_REVOKE: active flip failed", "err", err)
+		os.Exit(1)
+	}
+	slog.Info("EDGE_CA_REVOKE: flipped active signer to NEW; waiting for every leaf to chain to NEW")
+
+	// Gate B — the destructive-drop interlock: everyone NEW-signed, blacklist converged,
+	// the revoked id has zero NEW issuances, and the live probe rejects the revoked token.
+	cfgB := base
+	cfgB.ExpectedTargetCAID = targetCAID
+	cfgB.ExpectedActiveSignerFP = newFP
+	cfgB.ExpectedAuthzGen = expectedAuthzGen
+	cfgB.RevokedEdgeID = revokedID
+	if err := pollUntilConverged(ctx, "drop", q, cfgB, probe, stableReads, pollInterval, deadline); err != nil {
+		slog.Error("EDGE_CA_REVOKE: drop checkpoint did not converge — NOT dropping OLD (OLD still trusted; re-run to resume)", "err", err)
+		os.Exit(1)
+	}
+
+	// Step 3 — DESTRUCTIVE: drop OLD. The core now trusts only NEW; every OLD-signed leaf
+	// (the revoked edge's, and any straggler) loses trust.
+	if _, err := edgecp.TrimCA(ctx, rw, ns, name, newFP); err != nil {
+		slog.Error("EDGE_CA_REVOKE: trim (OLD-drop) failed", "err", err)
+		os.Exit(1)
+	}
+	slog.Info("EDGE_CA_REVOKE complete: OLD dropped, fleet on NEW, revoked edge severed",
+		"edge_id", revokedID, "new_ca_id", func() string { id, _ := caid.FromPEM(bundle); return id }())
+	os.Exit(0)
+}
+
+// revokedProbe carries the inputs for the live revoked-token absence probe, stamped onto
+// each Observations before evaluation.
+type revokedProbe struct {
+	token string
+	cpURL string
+	cpCA  []byte
+}
+
+func (p revokedProbe) stamp(obs *converge.Observations) {
+	if status, ran := probeRevoked(p.cpURL, p.cpCA, p.token); ran {
+		obs.RevokedProbeRan = true
+		obs.RevokedProbeStatus = status
+	}
+}
+
+// readStable runs one stable-read sequence: stableReads consecutive Prometheus reads, each
+// with the live probe, stopping early on the first non-converged read (a single
+// non-converged read is decisive — fail-closed). Returns the last Result.
+func readStable(ctx context.Context, q converge.Querier, cfg converge.Config, probe revokedProbe, stableReads int, pollInterval time.Duration) converge.Result {
+	var last converge.Result
+	for i := 0; i < stableReads; i++ {
+		if i > 0 {
+			time.Sleep(pollInterval)
+		}
+		obs, err := converge.Snapshot(ctx, q, cfg.Freshness, time.Now(), cfg.RevokedEdgeID, cfg.ExpectedActiveSignerFP)
+		if err != nil {
+			// A Prometheus blip is transient: treat as non-converged so the outer poll loop
+			// retries, never as converged (fail-closed).
+			return converge.Result{Blockers: []converge.Blocker{{Plane: "config", Reason: "prometheus-query-failed"}}}
+		}
+		probe.stamp(&obs)
+		last = converge.Evaluate(obs, cfg, time.Now())
+		if !last.Converged {
+			break
+		}
+	}
+	return last
+}
+
+// pollUntilConverged repeats readStable until it converges or the deadline elapses. It is
+// the convergence WAIT (steps take minutes as edges re-mint): non-converged is not a
+// failure, it's "keep waiting". Only the deadline is a failure — and a timeout leaves the
+// rotation at its last completed step (re-run resumes). It logs the live blockers each pass
+// so a stall is diagnosable.
+func pollUntilConverged(ctx context.Context, label string, q converge.Querier, cfg converge.Config, probe revokedProbe, stableReads int, pollInterval, deadline time.Duration) error {
+	start := time.Now()
+	for {
+		r := readStable(ctx, q, cfg, probe, stableReads, pollInterval)
+		if r.Converged {
+			for _, ex := range r.Excluded {
+				slog.Warn("EDGE_CA_REVOKE: edge excluded from the convergence veto", "gate", label, "edge_id", ex.EdgeID, "reason", ex.Reason)
+			}
+			slog.Info("EDGE_CA_REVOKE: gate converged", "gate", label, "target", r.Target, "waited", time.Since(start).Round(time.Second))
+			return nil
+		}
+		if time.Since(start) >= deadline {
+			return fmt.Errorf("%s gate not converged within %s; blockers=%v", label, deadline, blockerStrings(r.Blockers))
+		}
+		slog.Info("EDGE_CA_REVOKE: not yet converged; waiting", "gate", label,
+			"waited", time.Since(start).Round(time.Second), "blockers", blockerStrings(r.Blockers))
+		time.Sleep(pollInterval)
+	}
+}
+
+// idDisabled reports whether the registry holds an entry for edgeID that is disabled (the
+// canonical blacklist state). An absent id returns false (a typo'd id must not pass
+// preflight as "already revoked").
+func idDisabled(tokens map[string]edgecp.Entry, edgeID string) bool {
+	for _, e := range tokens {
+		if strings.ToLower(strings.TrimSpace(e.ID)) == edgeID {
+			return e.Disabled
+		}
+	}
+	return false
+}
+
+// lastCertFP returns the SHA-256 (hex) of the LAST CERTIFICATE block in a bundle — the NEW
+// CA during an OLD++NEW overlap (RotateCA appends NEW last). It matches the fp the serving
+// signer + the edge derive, so it is the pin every downstream step asserts.
+func lastCertFP(bundlePEM []byte) (string, error) {
+	var lastDER []byte
+	rest := bundlePEM
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			lastDER = block.Bytes
+		}
+	}
+	if lastDER == nil {
+		return "", fmt.Errorf("bundle has no CERTIFICATE block")
+	}
+	sum := sha256.Sum256(lastDER)
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/cmd/edge-controlplane/revoke_test.go
+++ b/cmd/edge-controlplane/revoke_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/moonrhythm/parapet-ingress-controller/edgecp"
+	"github.com/moonrhythm/parapet-ingress-controller/edgecp/converge"
+)
+
+// pemDER decodes the first PEM block and returns its DER bytes.
+func pemDER(t *testing.T, certPEM []byte) []byte {
+	t.Helper()
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		t.Fatal("no PEM block")
+	}
+	return block.Bytes
+}
+
+func TestIDDisabled(t *testing.T) {
+	tokens := map[string]edgecp.Entry{
+		"tok-a": {ID: "edge-a", Disabled: false},
+		"tok-b": {ID: "edge-b", Disabled: true},
+		"tok-c": {ID: "Edge-C", Disabled: true}, // case-folded match
+	}
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		{"edge-b", true},  // present + disabled
+		{"edge-c", true},  // case-insensitive
+		{"edge-a", false}, // present but still enabled
+		{"edge-z", false}, // absent (typo guard)
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := idDisabled(tokens, tc.id); got != tc.want {
+			t.Errorf("idDisabled(%q) = %v, want %v", tc.id, got, tc.want)
+		}
+	}
+}
+
+func TestLastCertFP(t *testing.T) {
+	old, _, err := edgecp.GenerateCA(time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newCert, _, err := edgecp.GenerateCA(time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle := append(append([]byte(nil), old...), newCert...)
+
+	got, err := lastCertFP(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The NEW (last) cert's fp is the sha256 of its DER (decode the second block).
+	want := fpOfLastCert(t, newCert)
+	if got != want {
+		t.Errorf("lastCertFP picked the wrong block: got %s, want the NEW (last) %s", got, want)
+	}
+	// Sanity: the OLD cert alone has a different fp (proves we didn't pick the first).
+	if got == fpOfLastCert(t, old) {
+		t.Error("lastCertFP returned the OLD fp — must be the LAST block")
+	}
+}
+
+func TestLastCertFPEmpty(t *testing.T) {
+	if _, err := lastCertFP([]byte("not a cert")); err == nil {
+		t.Error("a bundle with no CERTIFICATE block must error")
+	}
+}
+
+// fpOfLastCert sha256s the single CERTIFICATE block in certPEM.
+func fpOfLastCert(t *testing.T, certPEM []byte) string {
+	t.Helper()
+	fp, err := lastCertFP(certPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fp
+}
+
+// emptyQuerier returns no series for any query, so Snapshot yields empty Observations and
+// Evaluate never converges — exercising the wait loop's deadline (fail) path.
+type emptyQuerier struct{}
+
+func (emptyQuerier) Query(_ context.Context, _ string, _ time.Time) (model.Vector, error) {
+	return model.Vector{}, nil
+}
+
+func TestPollUntilConvergedTimesOut(t *testing.T) {
+	// A fast probe server (returns 401, like a rejected revoked token) so readStable's live
+	// probe doesn't stall the test on a real dial.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	cfg := converge.Config{ExpectedCP: 2, ExpectedCore: 1, MinEdges: 1, Freshness: time.Minute}
+	probe := revokedProbe{token: "tok", cpURL: srv.URL}
+
+	start := time.Now()
+	err := pollUntilConverged(context.Background(), "test", emptyQuerier{}, cfg, probe,
+		2, 5*time.Millisecond, 20*time.Millisecond)
+	if err == nil {
+		t.Fatal("an empty (never-converging) snapshot must time out with an error")
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Error("the deadline must bound the wait")
+	}
+}
+
+func TestFingerprintHelpersStable(t *testing.T) {
+	// lastCertFP must equal a hand-rolled sha256-of-DER for a single cert.
+	cert, _, err := edgecp.GenerateCA(time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der := pemDER(t, cert)
+	sum := sha256.Sum256(der)
+	if got, _ := lastCertFP(cert); got != hex.EncodeToString(sum[:]) {
+		t.Errorf("lastCertFP = %s, want sha256(DER) %s", got, hex.EncodeToString(sum[:]))
+	}
+}

--- a/deploy/edge/e2e/run.sh
+++ b/deploy/edge/e2e/run.sh
@@ -335,4 +335,22 @@ CERT_CAID="$(curl -sS -D - -o /dev/null --cacert "$WORK/ca.crt" -H "Authorizatio
   || { echo "cert-arm ca_id='$CERT_CAID' signer ca_id='$SIG_CAID'" >&2; fail "/v1/certs X-Parapet-CA-Id missing or != signer ca_id"; }
 echo "  ✓ /v1/certs advertises X-Parapet-CA-Id ($CERT_CAID) matching the signer"
 
+# Active-signer fingerprint signal (the revoke interlock's load-bearing axis): the ca_id is
+# identical for active=OLD/NEW during an overlap, so the edge re-mints + the OLD-drop gates
+# on the SIGNER fp, not the ca_id. Assert the live binary advertises it on /v1/certs (header)
+# AND the tokenless trust bundle (body), both equal to parapet_edge_ca_active_signer_fp.
+say "10. active-signer fp signal: /v1/certs + /v1/trust-bundle advertise signing_cert_fp"
+SIG_FP="$(grep -oE 'parapet_edge_ca_active_signer_fp\{[^}]*sigfp="[^"]+"' <<<"$MET" | grep -oE 'sigfp="[^"]+"' | cut -d'"' -f2)"
+[ -n "$SIG_FP" ] || { grep parapet_edge_ca_active <<<"$MET" >&2; fail "could not read active signer fp from /metrics"; }
+CERT_FP="$(curl -sS -D - -o /dev/null --cacert "$WORK/ca.crt" -H "Authorization: Bearer $TOKEN" \
+  --resolve "localhost:$CP_PORT:127.0.0.1" "https://localhost:$CP_PORT/v1/certs?sni=$DOMAIN" \
+  | grep -i '^x-parapet-signing-cert-fp:' | tr -d '\r' | awk '{print $2}')"
+[ "$CERT_FP" = "$SIG_FP" ] \
+  || { echo "cert-arm fp='$CERT_FP' signer fp='$SIG_FP'" >&2; fail "/v1/certs X-Parapet-Signing-Cert-Fp missing or != active signer fp"; }
+TB_FP="$(curl -sS --cacert "$WORK/ca.crt" --resolve "localhost:$CP_PORT:127.0.0.1" \
+  "https://localhost:$CP_PORT/v1/trust-bundle" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("signing_cert_fp",""))')"
+[ "$TB_FP" = "$SIG_FP" ] \
+  || { echo "trust-bundle fp='$TB_FP' signer fp='$SIG_FP'" >&2; fail "/v1/trust-bundle signing_cert_fp missing or != active signer fp"; }
+echo "  ✓ /v1/certs + /v1/trust-bundle advertise signing_cert_fp ($SIG_FP) matching the active signer"
+
 say "E2E PASSED"

--- a/edge/clientcert.go
+++ b/edge/clientcert.go
@@ -1,8 +1,11 @@
 package edge
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -24,6 +27,11 @@ type ClientCertStore struct {
 	// observer compares the CP target against; correct after a fail-static (it tracks
 	// the cert actually in use, not a failed attempt).
 	caid atomic.Pointer[string]
+	// signerFP is the fingerprint of the CA in the chain that SIGNED the live leaf (OLD
+	// vs NEW during an overlap). The ca_id is identical for active=OLD/NEW, so this is
+	// the load-bearing signal that the leaf chains to NEW and survives the OLD-drop. ""
+	// when the issuer can't be uniquely resolved (fail-closed at the interlock).
+	signerFP atomic.Pointer[string]
 }
 
 func NewClientCertStore() *ClientCertStore { return &ClientCertStore{} }
@@ -64,11 +72,16 @@ func (s *ClientCertStore) Update(chainPEM, keyPEM []byte) error {
 		caID, _ = caid.FromDER(cert.Certificate[1:])
 	}
 	s.caid.Store(&caID) // store even when "" (single-CA chain / too-short)
+	// Derive the ISSUER fp: which CA in the chain SIGNED this leaf. This is what proves
+	// the leaf chains to NEW (vs OLD) during an overlap — the ca_id can't, since both
+	// append the same bundle. Republished on every successful Update, never cached.
+	signerFP := deriveIssuerFP(cert.Leaf, cert.Certificate)
+	s.signerFP.Store(&signerFP)
 	var notAfter int64
 	if cert.Leaf != nil {
 		notAfter = cert.Leaf.NotAfter.Unix()
 	}
-	setClientCertMetrics(caID, notAfter)
+	setClientCertMetrics(caID, signerFP, notAfter)
 	return nil
 }
 
@@ -84,6 +97,63 @@ func (s *ClientCertStore) CAID() string {
 		return *p
 	}
 	return ""
+}
+
+// SignerFP returns the fingerprint of the CA that signed the live leaf, or "" if it
+// can't be uniquely resolved. The interlock requires it == the target (NEW) before the
+// OLD-drop, proving the leaf survives.
+func (s *ClientCertStore) SignerFP() string {
+	if p := s.signerFP.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// deriveIssuerFP returns the SHA-256 (hex) of the CA cert in the chain (Certificate[1:])
+// that SIGNED the leaf, matching the CP's active-signer fp (sha256 of the same CA DER).
+// It matches by AuthorityKeyId == SubjectKeyId; falls back to a signature check; and
+// REQUIRES EXACTLY ONE match (a 2-cert overlap bundle is order-dependent, so first-match
+// is unsafe — it could false-RED a NEW-signed leaf or false-GREEN an OLD-signed one).
+// Returns "" on no/ambiguous match (fail-closed: the interlock blocks on "").
+func deriveIssuerFP(leaf *x509.Certificate, chain [][]byte) string {
+	if leaf == nil || len(chain) < 2 {
+		return ""
+	}
+	caDERs := chain[1:]
+	cas := make([]*x509.Certificate, 0, len(caDERs))
+	for _, der := range caDERs {
+		c, err := x509.ParseCertificate(der)
+		if err != nil {
+			return ""
+		}
+		cas = append(cas, c)
+	}
+	match := -1
+	if len(leaf.AuthorityKeyId) > 0 {
+		for i, c := range cas {
+			if bytes.Equal(c.SubjectKeyId, leaf.AuthorityKeyId) {
+				if match >= 0 {
+					return "" // ambiguous (duplicate SKID)
+				}
+				match = i
+			}
+		}
+	}
+	if match < 0 { // fail-soft fallback: which CA actually verifies the leaf signature?
+		for i, c := range cas {
+			if leaf.CheckSignatureFrom(c) == nil {
+				if match >= 0 {
+					return ""
+				}
+				match = i
+			}
+		}
+	}
+	if match < 0 {
+		return ""
+	}
+	sum := sha256.Sum256(caDERs[match])
+	return hex.EncodeToString(sum[:])
 }
 
 // Validity returns the live leaf's NotBefore/NotAfter for remaining-life renewal (the

--- a/edge/clientcert_test.go
+++ b/edge/clientcert_test.go
@@ -4,8 +4,10 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/hex"
 	"encoding/pem"
 	"math/big"
 	"net/http/httptest"
@@ -102,5 +104,105 @@ func TestClientCertStoreAllOrNothing(t *testing.T) {
 	}
 	if s.Loaded() {
 		t.Error("a failed Update must not mark loaded")
+	}
+}
+
+// fpOfPEM returns the SHA-256 (hex) of a single cert PEM's DER — the same value the CP and
+// deriveIssuerFP compute.
+func fpOfPEM(t *testing.T, certPEM []byte) string {
+	t.Helper()
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		t.Fatal("no PEM block")
+	}
+	sum := sha256.Sum256(block.Bytes)
+	return hex.EncodeToString(sum[:])
+}
+
+// chainDERs splits a leaf-first chain PEM into its CERTIFICATE DER blocks (leaf, then CAs).
+func chainDERs(t *testing.T, chainPEM []byte) [][]byte {
+	t.Helper()
+	var ders [][]byte
+	rest := chainPEM
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			ders = append(ders, block.Bytes)
+		}
+	}
+	return ders
+}
+
+// deriveIssuerFP must resolve WHICH CA in the chain signed the leaf (the load-bearing
+// active=OLD-vs-NEW signal), matching on AuthorityKeyId==SubjectKeyId, and FAIL CLOSED ("")
+// on no/ambiguous match — a wrong answer would false-green an OLD-signed leaf at the drop.
+func TestDeriveIssuerFP(t *testing.T) {
+	// Two real edge CAs (edgecp.GenerateCA stamps an explicit SubjectKeyId, so a leaf's
+	// AuthorityKeyId equals its signer's SubjectKeyId — the anchor we match on).
+	oldCert, oldKey, err := edgecp.GenerateCA(time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newCert, newKey, err := edgecp.GenerateCA(time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldFP, newFP := fpOfPEM(t, oldCert), fpOfPEM(t, newCert)
+	bundle := append(append([]byte(nil), oldCert...), newCert...)
+
+	mint := func(keyPEM []byte, activeFP string) (*x509.Certificate, [][]byte) {
+		sg, _, err := edgecp.NewProvidedSignerActive(bundle, keyPEM, activeFP, time.Hour, time.Minute)
+		if err != nil {
+			t.Fatal(err)
+		}
+		k, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		chainPEM, _, _, err := sg.Sign(k.Public(), "edge-x")
+		if err != nil {
+			t.Fatal(err)
+		}
+		ders := chainDERs(t, chainPEM)
+		leaf, err := x509.ParseCertificate(ders[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		return leaf, ders
+	}
+
+	// NEW-signed leaf over the OLD++NEW chain → the NEW CA's fp.
+	newLeaf, newChain := mint(newKey, newFP)
+	if got := deriveIssuerFP(newLeaf, newChain); got != newFP {
+		t.Errorf("NEW-signed leaf: deriveIssuerFP = %s, want NEW %s", got, newFP)
+	}
+	// OLD-signed leaf → the OLD CA's fp (proves it discriminates, not first-match).
+	oldLeaf, oldChain := mint(oldKey, oldFP)
+	if got := deriveIssuerFP(oldLeaf, oldChain); got != oldFP {
+		t.Errorf("OLD-signed leaf: deriveIssuerFP = %s, want OLD %s", got, oldFP)
+	}
+
+	// Ambiguous: the signing CA appears TWICE in the chain → two SKID matches → "".
+	caDER := newChain[len(newChain)-1] // the NEW CA block
+	ambiguous := [][]byte{newChain[0], caDER, caDER}
+	if got := deriveIssuerFP(newLeaf, ambiguous); got != "" {
+		t.Errorf("ambiguous (duplicate signer): want \"\", got %s", got)
+	}
+	// No match: only an unrelated CA in the chain → "" (neither SKID nor signature matches).
+	otherCert, _, err := edgecp.GenerateCA(time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherDER := chainDERs(t, otherCert)[0]
+	if got := deriveIssuerFP(newLeaf, [][]byte{newChain[0], otherDER}); got != "" {
+		t.Errorf("no matching CA: want \"\", got %s", got)
+	}
+	// Too short (no CA block) → "".
+	if got := deriveIssuerFP(newLeaf, [][]byte{newChain[0]}); got != "" {
+		t.Errorf("chain with no CA: want \"\", got %s", got)
+	}
+	if got := deriveIssuerFP(nil, newChain); got != "" {
+		t.Errorf("nil leaf: want \"\", got %s", got)
 	}
 }

--- a/edge/cp.go
+++ b/edge/cp.go
@@ -70,6 +70,10 @@ type CertFetch struct {
 	// force-re-mint signal that rides the edge's existing /v1/certs poll. "" means the
 	// CP didn't advertise one (old CP / no signer); the edge fail-statics on "".
 	CAID string
+	// SignerFP is the CP's active signing fp from X-Parapet-Signing-Cert-Fp (every arm) —
+	// the tuple's other half: an active=OLD→NEW flip changes THIS at an identical CAID,
+	// so the edge must re-mint on the (CAID, SignerFP) tuple to obtain a NEW-signed leaf.
+	SignerFP string
 }
 
 type certBody struct {
@@ -94,9 +98,10 @@ func (c *CpClient) FetchCert(sni, currentEtag string) (CertFetch, error) {
 	// all responses are 304), the 200, AND the 404 (a missing-cert sni still learns
 	// the CP target). Steady state is ~100% 304s, so the 304 arm is load-bearing.
 	caID := resp.Header.Get("X-Parapet-CA-Id")
+	signerFP := resp.Header.Get("X-Parapet-Signing-Cert-Fp")
 	switch resp.StatusCode {
 	case http.StatusNotModified:
-		return CertFetch{Unchanged: true, CAID: caID}, nil
+		return CertFetch{Unchanged: true, CAID: caID, SignerFP: signerFP}, nil
 	case http.StatusOK:
 		var body certBody
 		if err := json.NewDecoder(io.LimitReader(resp.Body, maxCertBody)).Decode(&body); err != nil {
@@ -107,11 +112,12 @@ func (c *CpClient) FetchCert(sni, currentEtag string) (CertFetch, error) {
 			KeyPEM:   []byte(body.KeyPEM),
 			Etag:     resp.Header.Get("ETag"),
 			CAID:     caID,
+			SignerFP: signerFP,
 		}, nil
 	default:
-		// Surface the target with the error so the caller can still observe a ca_id
-		// flip even when the per-sni cert is missing (404).
-		return CertFetch{CAID: caID}, fmt.Errorf("control plane returned %d for sni %q", resp.StatusCode, sni)
+		// Surface the target with the error so the caller can still observe a flip
+		// even when the per-sni cert is missing (404).
+		return CertFetch{CAID: caID, SignerFP: signerFP}, fmt.Errorf("control plane returned %d for sni %q", resp.StatusCode, sni)
 	}
 }
 
@@ -127,6 +133,7 @@ type WafFetch struct {
 	HostZoneMap map[string]string
 	Etag        string
 	CAID        string // signer target ca_id (secondary force-re-mint confirmer; 200 only)
+	SignerFP    string // active signing fp (200 only)
 }
 
 type wafBody struct {
@@ -135,6 +142,7 @@ type wafBody struct {
 	Zones       map[string]string `json:"zones"`
 	HostZoneMap map[string]string `json:"host_zone_map"`
 	CAID        string            `json:"ca_id"`
+	SigningFP   string            `json:"signing_cert_fp"`
 }
 
 // FetchWaf fetches the WAF payload (global YAML + zones + host->zone map) scoped
@@ -163,6 +171,7 @@ func (c *CpClient) FetchWaf(currentEtag string) (WafFetch, error) {
 			HostZoneMap: body.HostZoneMap,
 			Etag:        resp.Header.Get("ETag"),
 			CAID:        body.CAID,
+			SignerFP:    body.SigningFP,
 		}, nil
 	default:
 		return WafFetch{}, fmt.Errorf("control plane returned %d for /v1/waf", resp.StatusCode)
@@ -175,6 +184,7 @@ type EdgeCertFetch struct {
 	NotAfter string // RFC3339, for renewal scheduling
 	Serial   string
 	CAID     string // signer ca_id, so the edge self-confirms convergence post-mint
+	SignerFP string // active signing fp that minted this leaf
 	// RetryAfter is the parsed Retry-After delay on a 429/503 (signer saturated),
 	// returned ALONGSIDE the error so the coordinator can back off the whole fleet.
 	RetryAfter time.Duration
@@ -185,10 +195,11 @@ type edgeCertReqBody struct {
 }
 
 type edgeCertRespBody struct {
-	ChainPEM string `json:"chain_pem"`
-	NotAfter string `json:"not_after"`
-	Serial   string `json:"serial"`
-	CAID     string `json:"ca_id"`
+	ChainPEM  string `json:"chain_pem"`
+	NotAfter  string `json:"not_after"`
+	Serial    string `json:"serial"`
+	CAID      string `json:"ca_id"`
+	SigningFP string `json:"signing_cert_fp"`
 }
 
 // FetchEdgeCert posts a CSR to POST /v1/edge-cert and returns the signed chain. The
@@ -231,6 +242,7 @@ func (c *CpClient) FetchEdgeCert(csrPEM []byte) (EdgeCertFetch, error) {
 		NotAfter: body.NotAfter,
 		Serial:   body.Serial,
 		CAID:     body.CAID,
+		SignerFP: body.SigningFP,
 	}, nil
 }
 
@@ -256,28 +268,30 @@ func parseRetryAfter(v string) time.Duration {
 }
 
 type trustBundleBody struct {
-	CAID string `json:"ca_id"`
+	CAID      string `json:"ca_id"`
+	SigningFP string `json:"signing_cert_fp"`
 }
 
-// FetchTrustBundleCAID reads ONLY the ca_id from the tokenless GET /v1/trust-bundle
-// (the same public endpoint the core polls). It lets an mTLS edge observe a CA rotation
-// even when it polls no per-domain cert and no WAF (serve-all, no traffic, WAF off) —
-// it rides the edge-cert refresh tick, not a new loop. The bearer token is sent (the
-// endpoint ignores it). Errors are the caller's to fail-static on.
-func (c *CpClient) FetchTrustBundleCAID() (string, error) {
+// FetchTrustBundleSignal reads the (ca_id, active signer fp) tuple from the tokenless GET
+// /v1/trust-bundle (the same public endpoint the core polls). It lets an mTLS edge observe
+// a CA rotation OR an active=OLD→NEW flip even when it polls no per-domain cert and no WAF
+// (serve-all, no traffic, WAF off) — it rides the edge-cert refresh tick, not a new loop.
+// The bearer token is sent (the endpoint ignores it). Errors are the caller's to
+// fail-static on.
+func (c *CpClient) FetchTrustBundleSignal() (caID, signerFP string, err error) {
 	resp, err := c.do(c.base+"/v1/trust-bundle", "")
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("control plane returned %d for /v1/trust-bundle", resp.StatusCode)
+		return "", "", fmt.Errorf("control plane returned %d for /v1/trust-bundle", resp.StatusCode)
 	}
 	var body trustBundleBody
 	if err := json.NewDecoder(io.LimitReader(resp.Body, maxCertBody)).Decode(&body); err != nil {
-		return "", fmt.Errorf("decode: %w", err)
+		return "", "", fmt.Errorf("decode: %w", err)
 	}
-	return body.CAID, nil
+	return body.CAID, body.SigningFP, nil
 }
 
 // do issues an authorized GET, optionally with If-None-Match. The body must be

--- a/edge/cp_signal_test.go
+++ b/edge/cp_signal_test.go
@@ -49,16 +49,19 @@ func TestFetchCertCarriesCAIDOnEveryArm(t *testing.T) {
 	}
 }
 
-func TestFetchTrustBundleCAID(t *testing.T) {
+func TestFetchTrustBundleSignal(t *testing.T) {
 	cp := newSignalCP(t, func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"generation":3,"ca_pem":"x","ca_id":"tb-abc"}`))
+		_, _ = w.Write([]byte(`{"generation":3,"ca_pem":"x","ca_id":"tb-abc","signing_cert_fp":"fp-new"}`))
 	})
-	id, err := cp.FetchTrustBundleCAID()
+	id, fp, err := cp.FetchTrustBundleSignal()
 	if err != nil {
 		t.Fatal(err)
 	}
 	if id != "tb-abc" {
 		t.Errorf("ca_id = %q, want tb-abc", id)
+	}
+	if fp != "fp-new" {
+		t.Errorf("signer fp = %q, want fp-new", fp)
 	}
 }
 

--- a/edge/metrics.go
+++ b/edge/metrics.go
@@ -62,10 +62,27 @@ var (
 		Name:      "edge_refresh_total",
 		Help:      "Successful control-plane polls (proves the refresh loop is alive, independent of ca_id change).",
 	}, []string{"edge_id"})
+
+	// edgeClientCertSignerFP is the fp of the CA that SIGNED the edge's live leaf — the
+	// load-bearing proof the leaf chains to NEW (survives the OLD-drop). The ca_id is
+	// identical for active=OLD/NEW, so the interlock gates the drop on THIS, not ca_id.
+	edgeClientCertSignerFP = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_clientcert_signer_fp",
+		Help:      "Fingerprint of the CA that signed the edge's live data-plane leaf (value 1).",
+	}, []string{"sigfp", "edge_id"})
+
+	// edgeCPActiveSignerFP is the CP-announced active signing fp the edge last observed —
+	// the target the edge re-mints toward (the tuple's other half beside cp_target_ca_id).
+	edgeCPActiveSignerFP = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_cp_active_signer_fp",
+		Help:      "CP active signing fp the edge last observed (value 1).",
+	}, []string{"sigfp", "edge_id"})
 )
 
 func init() {
-	prom.Registry().MustRegister(edgeClientCertCAID, edgeClientCertNotAfter, edgeClientCertLoaded, edgeRemint, edgeCPTargetCAID, edgeRefresh)
+	prom.Registry().MustRegister(edgeClientCertCAID, edgeClientCertNotAfter, edgeClientCertLoaded, edgeRemint, edgeCPTargetCAID, edgeRefresh, edgeClientCertSignerFP, edgeCPActiveSignerFP)
 }
 
 // edgeID is the process's logical identity, stamped on every metric. Defaults to
@@ -86,14 +103,26 @@ func SetEdgeID(id string) {
 // only one ca_id series survives a rotation) and marks the cert loaded. An empty caID
 // (chain too short to carry a CA block) sets only loaded, leaving the ca_id vecs clear.
 // Called only from the single ClientCertStore.Update writer (the re-mint loop).
-func setClientCertMetrics(caID string, notAfterUnix int64) {
+func setClientCertMetrics(caID, signerFP string, notAfterUnix int64) {
 	edgeClientCertCAID.Reset()
 	edgeClientCertNotAfter.Reset()
+	edgeClientCertSignerFP.Reset()
 	if caID != "" {
 		edgeClientCertCAID.WithLabelValues(caID, edgeID).Set(1)
 		edgeClientCertNotAfter.WithLabelValues(caID, edgeID).Set(float64(notAfterUnix))
 	}
+	if signerFP != "" {
+		edgeClientCertSignerFP.WithLabelValues(signerFP, edgeID).Set(1)
+	}
 	edgeClientCertLoaded.WithLabelValues(edgeID).Set(1)
+}
+
+// setObservedSignerFP records the CP-announced active signing fp the edge last observed.
+func setObservedSignerFP(fp string) {
+	edgeCPActiveSignerFP.Reset()
+	if fp != "" {
+		edgeCPActiveSignerFP.WithLabelValues(fp, edgeID).Set(1)
+	}
 }
 
 // remint counts one re-mint attempt by result and trigger. Re-mints are infrequent

--- a/edge/metrics_test.go
+++ b/edge/metrics_test.go
@@ -9,8 +9,8 @@ import (
 // setClientCertMetrics keeps exactly one ca_id series across re-mints, and an empty
 // ca_id (too-short chain) sets only loaded without leaving a ca_id series.
 func TestSetClientCertMetricsOneSeries(t *testing.T) {
-	setClientCertMetrics("ca-old", 100)
-	setClientCertMetrics("ca-new", 200) // re-mint onto a new CA set
+	setClientCertMetrics("ca-old", "", 100)
+	setClientCertMetrics("ca-new", "", 200) // re-mint onto a new CA set
 
 	if c := testutil.CollectAndCount(edgeClientCertCAID); c != 1 {
 		t.Errorf("ca_id: want 1 live series after re-mint, got %d", c)
@@ -26,7 +26,7 @@ func TestSetClientCertMetricsOneSeries(t *testing.T) {
 	}
 
 	// Empty ca_id: loaded stays 1, but no ca_id/not_after series.
-	setClientCertMetrics("", 0)
+	setClientCertMetrics("", "", 0)
 	if c := testutil.CollectAndCount(edgeClientCertCAID); c != 0 {
 		t.Errorf("empty ca_id must leave no series, got %d", c)
 	}
@@ -64,7 +64,7 @@ func TestEdgeIDStampingAndLiveness(t *testing.T) {
 	edgeID = "edge-7"
 	defer func() { edgeID = old }()
 
-	setClientCertMetrics("ca-z", 123)
+	setClientCertMetrics("ca-z", "", 123)
 	if v := testutil.ToFloat64(edgeClientCertCAID.WithLabelValues("ca-z", "edge-7")); v != 1 {
 		t.Error("ca_id series must carry the edge_id label")
 	}

--- a/edge/refresh.go
+++ b/edge/refresh.go
@@ -78,9 +78,9 @@ func RunEdgeCertRefresh(ctx context.Context, coord *RemintCoordinator, interval 
 			return
 		case <-t.C:
 			coord.MaybeRenew()
-			if caID, err := coord.cp.FetchTrustBundleCAID(); err == nil {
+			if caID, signerFP, err := coord.cp.FetchTrustBundleSignal(); err == nil {
 				edgeRefreshOK() // liveness for the idle edge that polls no per-domain cert
-				coord.Observe(caID)
+				coord.Observe(caID, signerFP)
 			}
 		}
 	}
@@ -88,9 +88,10 @@ func RunEdgeCertRefresh(ctx context.Context, coord *RemintCoordinator, interval 
 
 // RefreshCertOnce fetches one domain's cert from the control plane
 // (ETag-revalidated) and swaps it into the store; fail-static on error. It then
-// Observes the X-Parapet-CA-Id force-re-mint signal that rides EVERY response arm
-// (200/304/404 — res.CAID is set even on the error arm), so a CA rotation is detected
-// on the edge's existing cert poll regardless of cert outcome. coord is nil when
+// Observes the (X-Parapet-CA-Id, X-Parapet-Signing-Cert-Fp) force-re-mint tuple that
+// rides EVERY response arm (200/304/404 — both are set even on the error arm), so a CA
+// rotation OR an active=OLD→NEW flip is detected on the edge's existing cert poll
+// regardless of cert outcome. coord is nil when
 // data-plane mTLS is off (Observe is a no-op). Used by the periodic loop and
 // (serve-all) by the on-demand TLS handshake path.
 func RefreshCertOnce(cp *CpClient, store *CertStore, domain string, coord *RemintCoordinator) {
@@ -111,7 +112,7 @@ func RefreshCertOnce(cp *CpClient, store *CertStore, domain string, coord *Remin
 	if err == nil {
 		edgeRefreshOK() // liveness: a successful CP poll (200 or 304), independent of any ca_id change
 	}
-	coord.Observe(res.CAID)
+	coord.Observe(res.CAID, res.SignerFP)
 }
 
 // RefreshCertsAll fetches every domain once (sequentially). Returns how many are

--- a/edge/remint.go
+++ b/edge/remint.go
@@ -38,6 +38,7 @@ type RemintCoordinator struct {
 	proactiveNoConverge int
 	proactiveBreakerEnd time.Time
 	lastTarget          string // last observed CP target ca_id (the proactive convergence yardstick)
+	lastTargetFP        string // last observed CP active signer fp (the active=OLD→NEW flip yardstick)
 }
 
 func NewRemintCoordinator(cp *CpClient, store *ClientCertStore, cfg RemintConfig) *RemintCoordinator {
@@ -65,23 +66,35 @@ func NewRemintCoordinator(cp *CpClient, store *ClientCertStore, cfg RemintConfig
 	return &RemintCoordinator{cp: cp, store: store, cfg: cfg, backoff: cfg.BackoffBase}
 }
 
-// Observe drives the PROACTIVE path: it compares the CP target ca_id against the edge's
-// OWN HELD-LEAF ca_id (never against a previous observation, so a mid-rotation boot
-// re-mints on first poll) and triggers a re-mint on a mismatch. target=="" (old CP / no
-// signer) and live=="" (held chain too short / single-CA) are both "unknown" → never
-// trigger (fail-static; avoids an infinite hot-loop). Safe to call from the public-TLS
-// handshake path (Trigger is non-blocking).
-func (c *RemintCoordinator) Observe(target string) {
+// Observe drives the PROACTIVE path: it compares the CP target TUPLE (ca_id + active
+// signer fp) against the edge's OWN HELD-LEAF tuple (never against a previous
+// observation, so a mid-rotation boot re-mints on first poll) and triggers a re-mint on
+// a mismatch on EITHER axis:
+//   - ca_id mismatch: a CA-set rotation — new trust material to mint against.
+//   - signer_fp mismatch: an active=OLD→NEW flip at an UNCHANGED bundle ca_id (both
+//     active states append the same OLD++NEW bundle, so ca_id can't see it). This is the
+//     load-bearing re-mint that re-chains the leaf to NEW so it survives the OLD-drop.
+//
+// Each axis is fail-static on "": target=="" (old CP / no signer) returns outright; a ""
+// held or target value on an axis is "unknown" and never triggers on that axis (avoids an
+// infinite hot-loop). Safe to call from the public-TLS handshake path (Trigger is
+// non-blocking).
+func (c *RemintCoordinator) Observe(target, targetFP string) {
 	if c == nil || target == "" {
 		return
 	}
 	setObservedTarget(target)
-	live := c.store.CAID()
+	setObservedSignerFP(targetFP)
+	liveCA := c.store.CAID()
+	liveFP := c.store.SignerFP()
 	c.mu.Lock()
 	c.lastTarget = target
+	c.lastTargetFP = targetFP
 	c.mu.Unlock()
-	if live == "" || target == live {
-		return // unknown held value, or already converged
+	caMismatch := liveCA != "" && target != liveCA
+	fpMismatch := targetFP != "" && liveFP != "" && targetFP != liveFP
+	if !caMismatch && !fpMismatch {
+		return // unknown held value, or already converged on both axes
 	}
 	c.Trigger("proactive")
 }
@@ -138,15 +151,16 @@ func (c *RemintCoordinator) Trigger(trigger string) {
 func (c *RemintCoordinator) runOnce(trigger string) {
 	c.mu.Lock()
 	target := c.lastTarget
+	targetFP := c.lastTargetFP
 	backoff := c.backoff
 	c.mu.Unlock()
 
-	before := c.store.CAID()
+	beforeCA, beforeFP := c.store.CAID(), c.store.SignerFP()
 	if j := fullJitter(c.cfg.Jitter); j > 0 {
 		time.Sleep(j)
 	}
 	result, retryAfter := RefreshEdgeCertOnce(c.cp, c.store, trigger)
-	after := c.store.CAID()
+	afterCA, afterFP := c.store.CAID(), c.store.SignerFP()
 
 	var openedReactive, openedProactive bool
 	var sleepFor time.Duration
@@ -154,9 +168,12 @@ func (c *RemintCoordinator) runOnce(trigger string) {
 	switch {
 	case result == "ok":
 		c.backoff = c.cfg.BackoffBase // any successful mint clears the backoff
-		flipped := after != before
+		// "flipped" = the leaf material actually changed on EITHER axis (a CA-set rotation
+		// OR an active=OLD→NEW re-chain at an unchanged bundle ca_id). Both are real new
+		// trust material, so both reset the reactive breaker.
+		flipped := afterCA != beforeCA || afterFP != beforeFP
 
-		// Reactive breaker: keyed on whether the leaf's CA SET actually changed.
+		// Reactive breaker: keyed on whether the leaf material actually changed.
 		if flipped {
 			c.reactiveNoFlip = 0
 			c.reactiveBreakerEnd = time.Time{}
@@ -168,9 +185,12 @@ func (c *RemintCoordinator) runOnce(trigger string) {
 			}
 		}
 
-		// Proactive breaker: keyed on whether the mint reached the OBSERVED target.
+		// Proactive breaker: keyed on whether the mint reached the OBSERVED target TUPLE —
+		// the ca_id AND (when known) the active signer fp. An unchanged ca_id with the fp
+		// still on OLD is NOT converged, so the active-flip re-mint isn't scored as success.
 		if trigger == "proactive" {
-			if target != "" && after == target {
+			fpConverged := targetFP == "" || afterFP == targetFP
+			if target != "" && afterCA == target && fpConverged {
 				c.proactiveNoConverge = 0
 				c.proactiveBreakerEnd = time.Time{}
 			} else {

--- a/edge/remint_test.go
+++ b/edge/remint_test.go
@@ -81,6 +81,30 @@ func TestObserveTriggersProactive(t *testing.T) {
 	}
 }
 
+// The active=OLD→NEW flip leaves the bundle ca_id UNCHANGED (both append OLD++NEW) and
+// changes only the signer fp — so Observe must trigger on a signer-fp divergence even when
+// the ca_id matches the held leaf, or the edge would never re-chain to NEW and would 502 at
+// the OLD-drop.
+func TestObserveTriggersOnSignerFPFlip(t *testing.T) {
+	coord, store := testCoord(t, RemintConfig{})
+	if _, _ = RefreshEdgeCertOnce(coord.cp, store, "timer"); !store.Loaded() {
+		t.Fatal("pre-mint failed")
+	}
+	liveCA, liveFP := store.CAID(), store.SignerFP()
+	if liveCA == "" || liveFP == "" {
+		t.Fatalf("need a known held tuple, got ca=%q fp=%q", liveCA, liveFP)
+	}
+	// SAME ca_id, DIFFERENT active signer fp (the flip). Must attempt a re-mint.
+	coord.Observe(liveCA, "a-different-signer-fp")
+	waitFor(t, func() bool { return !coordInFlight(coord) && store.CAID() == liveCA })
+	coord.mu.Lock()
+	noConverge := coord.proactiveNoConverge
+	coord.mu.Unlock()
+	if noConverge == 0 {
+		t.Error("a same-ca_id signer-fp flip must trigger a proactive re-mint")
+	}
+}
+
 // K reactive ok-mints that don't change ca_id open the reactive breaker. Reaching the
 // CP target does NOT reset it (the core may still reject); only a genuine ca_id FLIP does.
 func TestReactiveBreaker(t *testing.T) {

--- a/edge/remint_test.go
+++ b/edge/remint_test.go
@@ -48,8 +48,8 @@ func TestObserveNoOps(t *testing.T) {
 	cp, _ := NewCpClient(srv.URL, "tok", nil)
 	coord.cp = cp
 
-	coord.Observe("")            // unknown target → no-op
-	coord.Observe("some-target") // live=="" (no cert held) → no-op
+	coord.Observe("", "")            // unknown target → no-op
+	coord.Observe("some-target", "") // live=="" (no cert held) → no-op
 	time.Sleep(20 * time.Millisecond)
 	if reqs != 0 {
 		t.Errorf("Observe must not mint when target/live unknown, got %d requests", reqs)
@@ -69,7 +69,7 @@ func TestObserveTriggersProactive(t *testing.T) {
 		t.Fatal("pre-minted cert has no ca_id")
 	}
 	// A DIFFERENT observed target must trigger a re-mint (request count rises).
-	coord.Observe("a-different-target")
+	coord.Observe("a-different-target", "")
 	waitFor(t, func() bool { return !coordInFlight(coord) && store.CAID() == live })
 	// (the fake CP always signs the same ca_id, so the edge stays at `live`; the point
 	// is that a mint WAS attempted — verified via the proactive breaker climbing.)
@@ -101,7 +101,7 @@ func TestReactiveBreaker(t *testing.T) {
 
 	// Edge already AT the target but the core keeps rejecting (after==target, no flip):
 	// this must NOT reset — re-minting the same ca_id can't fix a core-side reject.
-	coord.Observe(z) // lastTarget = z (== live; converged, no trigger)
+	coord.Observe(z, "") // lastTarget = z (== live; converged, no trigger)
 	coord.runOnce("reactive")
 	coord.mu.Lock()
 	stillClimbing := coord.reactiveNoFlip

--- a/edge/wafrefresh.go
+++ b/edge/wafrefresh.go
@@ -24,10 +24,10 @@ func RefreshWafOnce(cp *CpClient, w *EdgeWAF, coord *RemintCoordinator) {
 			slog.Info("edge: WAF rulesets updated", "generation", res.Generation)
 		}
 	}
-	// Secondary force-re-mint confirmer: the WAF body carries ca_id on the 200 arm only
-	// (the 304 carries nothing — /v1/certs is the guaranteed carrier). res.CAID is ""
-	// on 304/err, and Observe("") is a no-op.
-	coord.Observe(res.CAID)
+	// Secondary force-re-mint confirmer: the WAF body carries the (ca_id, signer fp) tuple
+	// on the 200 arm only (the 304 carries nothing — /v1/certs is the guaranteed carrier).
+	// Both are "" on 304/err, and Observe("", …) is a no-op.
+	coord.Observe(res.CAID, res.SignerFP)
 }
 
 // RunWafRefresh runs the periodic WAF refresh forever. The first tick is jittered by

--- a/edgecp/ca.go
+++ b/edgecp/ca.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -74,9 +75,20 @@ func GenerateCA(ttl time.Duration) (certPEM, keyPEM []byte, err error) {
 		return nil, nil, fmt.Errorf("ca serial: %w", err)
 	}
 	now := time.Now()
+	// Explicit SubjectKeyId (SHA-256 of the SPKI). x509.CreateCertificate copies the
+	// issuer's SubjectKeyId into a leaf's AuthorityKeyId, so an overlap leaf carries the
+	// SKID of the CA that SIGNED it — the anchor the edge uses to derive the active
+	// signer fingerprint (OLD vs NEW). Set it ourselves rather than rely on the stdlib's
+	// implicit SHA-1 derivation (asserted non-empty in ca_test).
+	spki, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ca spki: %w", err)
+	}
+	skid := sha256.Sum256(spki)
 	tmpl := &x509.Certificate{
 		SerialNumber:          sn,
 		Subject:               pkix.Name{CommonName: "parapet-edge-ca"},
+		SubjectKeyId:          skid[:],
 		NotBefore:             now.Add(-DefaultClientCertSkew),
 		NotAfter:              now.Add(ttl),
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,

--- a/edgecp/ca.go
+++ b/edgecp/ca.go
@@ -41,6 +41,10 @@ const (
 	caActiveAnnotation = "parapet.moonrhythm.io/edge-ca-active"
 
 	caPhaseOverlap = "overlap"
+	// caPhaseTrimmed marks a completed OLD-drop: tls.crt is NEW-only, tls.key is the NEW
+	// key, tls-new.key is gone, active is back to the single-CA default. The destructive
+	// TrimCA writes it; its presence (with 1 cert) makes a re-run idempotent.
+	caPhaseTrimmed = "trimmed"
 	caActiveOld    = "old"
 	caActiveNew    = "new"
 
@@ -224,6 +228,28 @@ func reencodeCertBundle(certPEM []byte) (bundle []byte, count int, err error) {
 	return bundle, count, nil
 }
 
+// splitCertBundle parses every CERTIFICATE block (all-or-nothing) and returns each as
+// its own normalized one-block PEM, in bundle order (OLD first, NEW last). It is the
+// per-cert counterpart of reencodeCertBundle, used by TrimCA to keep exactly one block.
+func splitCertBundle(certPEM []byte) (certs [][]byte, err error) {
+	rest := certPEM
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+			return nil, fmt.Errorf("parse cert in bundle: %w", err)
+		}
+		certs = append(certs, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: block.Bytes}))
+	}
+	return certs, nil
+}
+
 // RotateCA performs the NON-DESTRUCTIVE half of a CA rotation: on a populated
 // single-CA Secret it generates a NEW CA in memory and CAS-writes tls.crt =
 // OLD++NEW, stages the NEW key in tls-new.key, and stamps phase=overlap /
@@ -321,4 +347,199 @@ func RotateCA(ctx context.Context, rw SecretRW, namespace, name string, ttl time
 		return append([]byte(nil), newBundle...), nil
 	}
 	return nil, fmt.Errorf("rotate edge CA: exhausted CAS retries for %s/%s", namespace, name)
+}
+
+// SetActiveNew flips the ACTIVE signing key from OLD to NEW during an OLD++NEW overlap:
+// it writes only the caActiveAnnotation ("old" → "new") so every serving replica's
+// reloader rebuilds its Signer to sign new leaves under the NEW key. It is NON-destructive
+// — the served bundle stays OLD++NEW (both still trusted), so an in-flight OLD-signed leaf
+// keeps verifying; only freshly-minted leaves change to NEW. It is REVERSIBLE (flip back to
+// "old") until TrimCA drops OLD.
+//
+// It is the second rotation step. It MUST run after the ca_id widen convergence (every
+// core trusts NEW) and before TrimCA — the revoke tool orders the steps and gates each on
+// converge-status; SetActiveNew itself only enforces the structural preconditions.
+//
+// expectedNewFP, when non-empty, PINS the NEW cert (the last block): the bundle's last
+// fingerprint must equal it, so a reordered/foreign bundle can't flip the active key onto
+// the wrong cert. Idempotent: a re-run on an already-flipped Secret (active=new) is a
+// no-op. CAS-looped like RotateCA. Returns the (unchanged) OLD++NEW bundle PEM.
+func SetActiveNew(ctx context.Context, rw SecretRW, namespace, name, expectedNewFP string) (bundlePEM []byte, err error) {
+	const maxAttempts = 5
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		sec, err := rw.GetSecret(ctx, namespace, name)
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("edge CA secret %s/%s not found — flip only runs on an overlapping CA", namespace, name)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("get edge CA secret: %w", err)
+		}
+
+		crt := sec.Data["tls.crt"]
+		certs, err := splitCertBundle(crt)
+		if err != nil {
+			return nil, fmt.Errorf("edge CA secret %s/%s has an unparseable bundle: %w", namespace, name, err)
+		}
+		fps := certBundleFPs(crt)
+		phase := sec.Annotations[caRotationPhaseAnnotation]
+		active := sec.Annotations[caActiveAnnotation]
+
+		// Idempotency: already flipped. Re-assert the pin so a re-run still validates the
+		// state it converged to (never returns "ok" on a surprise bundle).
+		if active == caActiveNew {
+			if expectedNewFP != "" && (len(fps) == 0 || fps[len(fps)-1] != expectedNewFP) {
+				return nil, fmt.Errorf("edge CA secret %s/%s is active=new but its last cert fp != expected — investigate", namespace, name)
+			}
+			return append([]byte(nil), crt...), nil
+		}
+
+		// Structural preconditions: a clean 2-cert overlap with a staged NEW key.
+		if phase != caPhaseOverlap || len(certs) != 2 {
+			return nil, fmt.Errorf("edge CA secret %s/%s is not in a 2-cert overlap (phase=%q, certs=%d) — rotate before flipping", namespace, name, phase, len(certs))
+		}
+		newKey := sec.Data[caNewKeyField]
+		if len(newKey) == 0 {
+			return nil, fmt.Errorf("edge CA secret %s/%s has no staged %s — cannot flip", namespace, name, caNewKeyField)
+		}
+		newCert := certs[len(certs)-1] // NEW is last
+		if expectedNewFP != "" && fps[len(fps)-1] != expectedNewFP {
+			return nil, fmt.Errorf("edge CA secret %s/%s last cert fp != expected NEW fp — refusing to flip onto the wrong cert", namespace, name)
+		}
+		// The flip only lands if the staged key actually matches the NEW cert; verify HERE
+		// so a mismatch is a loud error, not a silent reloader wedge minting OLD forever.
+		if !validCAKeypair(newCert, newKey) {
+			return nil, fmt.Errorf("edge CA secret %s/%s staged %s does not match the NEW cert — refusing to flip", namespace, name, caNewKeyField)
+		}
+
+		if sec.Annotations == nil {
+			sec.Annotations = map[string]string{}
+		}
+		sec.Annotations[caActiveAnnotation] = caActiveNew
+
+		if _, err := rw.UpdateSecret(ctx, namespace, sec); err != nil {
+			if apierrors.IsConflict(err) {
+				continue
+			}
+			return nil, fmt.Errorf("persist active flip: %w", err)
+		}
+		check, err := rw.GetSecret(ctx, namespace, name)
+		if err != nil {
+			return nil, fmt.Errorf("verify active flip: %w", err)
+		}
+		if check.Annotations[caActiveAnnotation] != caActiveNew {
+			return nil, fmt.Errorf("post-flip verify: active annotation is %q, want %q", check.Annotations[caActiveAnnotation], caActiveNew)
+		}
+		return append([]byte(nil), crt...), nil
+	}
+	return nil, fmt.Errorf("flip edge CA active key: exhausted CAS retries for %s/%s", namespace, name)
+}
+
+// TrimCA performs the DESTRUCTIVE OLD-drop: it rewrites the Secret to NEW-only (tls.crt =
+// the NEW cert, tls.key = the staged NEW key), deletes tls-new.key, and stamps
+// phase=trimmed / active=old (the single-CA steady state). After it lands, the core's
+// strictPool trusts ONLY the NEW CA, so every OLD-signed leaf — the revoked edge's, and any
+// good edge that hasn't re-minted — loses trust and is severed.
+//
+// THIS IS THE IRREVERSIBLE STEP. Its safety rests on the CALLER having gated it on
+// converge-status (every CP replica + good edge NEW-signed, blacklist converged, revoked id
+// with zero NEW issuances). TrimCA enforces only the STRUCTURAL invariants that make the
+// drop well-formed; it does NOT and cannot re-check fleet convergence:
+//   - active MUST be "new" (dropping OLD while OLD is still the active signer would orphan
+//     the signing key and break issuance) — the active flip must have happened first;
+//   - exactly 2 certs in a clean overlap;
+//   - expectedNewFP (REQUIRED) must equal the last (NEW) cert's fp — the operator names the
+//     exact cert to KEEP, so a reordered/foreign bundle can't drop the wrong one;
+//   - the staged NEW key must match that NEW cert.
+//
+// Idempotent / resumable: a re-run on an already-trimmed Secret (phase=trimmed, 1 cert
+// whose fp == expectedNewFP, matching tls.key) is a no-op returning the NEW bundle. CAS-looped.
+func TrimCA(ctx context.Context, rw SecretRW, namespace, name, expectedNewFP string) (bundlePEM []byte, err error) {
+	if expectedNewFP == "" {
+		return nil, fmt.Errorf("TrimCA requires the expected NEW cert fingerprint (the cert to KEEP) — refusing a blind destructive drop")
+	}
+	const maxAttempts = 5
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		sec, err := rw.GetSecret(ctx, namespace, name)
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("edge CA secret %s/%s not found — trim only runs on an overlapping CA", namespace, name)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("get edge CA secret: %w", err)
+		}
+
+		crt := sec.Data["tls.crt"]
+		certs, err := splitCertBundle(crt)
+		if err != nil {
+			return nil, fmt.Errorf("edge CA secret %s/%s has an unparseable bundle: %w", namespace, name, err)
+		}
+		fps := certBundleFPs(crt)
+		phase := sec.Annotations[caRotationPhaseAnnotation]
+		active := sec.Annotations[caActiveAnnotation]
+
+		// Idempotency / resume: already trimmed to the pinned NEW-only CA.
+		if phase == caPhaseTrimmed && len(certs) == 1 {
+			if fps[0] != expectedNewFP {
+				return nil, fmt.Errorf("edge CA secret %s/%s is trimmed but its single cert fp != expected NEW fp — investigate", namespace, name)
+			}
+			if !validCAKeypair(crt, sec.Data["tls.key"]) {
+				return nil, fmt.Errorf("edge CA secret %s/%s is trimmed but tls.key does not match the NEW cert — investigate", namespace, name)
+			}
+			return append([]byte(nil), crt...), nil
+		}
+
+		// Structural preconditions for the drop.
+		if active != caActiveNew {
+			return nil, fmt.Errorf("edge CA secret %s/%s active=%q — flip the active key to NEW before dropping OLD (else issuance is orphaned)", namespace, name, active)
+		}
+		if phase != caPhaseOverlap || len(certs) != 2 {
+			return nil, fmt.Errorf("edge CA secret %s/%s is not a clean 2-cert overlap (phase=%q, certs=%d) — refusing to trim", namespace, name, phase, len(certs))
+		}
+		if fps[len(fps)-1] != expectedNewFP {
+			return nil, fmt.Errorf("edge CA secret %s/%s last (NEW) cert fp != expected — refusing to drop the wrong cert", namespace, name)
+		}
+		newCert := certs[len(certs)-1]
+		newKey := sec.Data[caNewKeyField]
+		if len(newKey) == 0 || !validCAKeypair(newCert, newKey) {
+			return nil, fmt.Errorf("edge CA secret %s/%s staged %s missing/mismatched for the NEW cert — refusing to trim", namespace, name, caNewKeyField)
+		}
+
+		id, err := caBundleID(newCert)
+		if err != nil {
+			return nil, err
+		}
+		// Collapse to NEW-only: NEW cert becomes the sole tls.crt, the staged NEW key becomes
+		// tls.key, the staged field is removed, and active returns to the single-CA default.
+		sec.Data["tls.crt"] = append([]byte(nil), newCert...)
+		sec.Data["tls.key"] = append([]byte(nil), newKey...)
+		delete(sec.Data, caNewKeyField)
+		if sec.Annotations == nil {
+			sec.Annotations = map[string]string{}
+		}
+		sec.Annotations[caRotationPhaseAnnotation] = caPhaseTrimmed
+		sec.Annotations[caActiveAnnotation] = caActiveOld
+		sec.Annotations[caGenerationAnnotation] = id // re-stamp the anti-regen guard (NEVER blank)
+
+		if _, err := rw.UpdateSecret(ctx, namespace, sec); err != nil {
+			if apierrors.IsConflict(err) {
+				continue
+			}
+			return nil, fmt.Errorf("persist trimmed edge CA: %w", err)
+		}
+		check, err := rw.GetSecret(ctx, namespace, name)
+		if err != nil {
+			return nil, fmt.Errorf("verify trimmed edge CA: %w", err)
+		}
+		checkFPs := certBundleFPs(check.Data["tls.crt"])
+		if _, n, err := reencodeCertBundle(check.Data["tls.crt"]); err != nil || n != 1 {
+			return nil, fmt.Errorf("post-trim verify: want 1 cert, got %d (err=%v)", n, err)
+		}
+		if len(checkFPs) != 1 || checkFPs[0] != expectedNewFP {
+			return nil, fmt.Errorf("post-trim verify: surviving cert fp != expected NEW fp")
+		}
+		if !validCAKeypair(check.Data["tls.crt"], check.Data["tls.key"]) {
+			return nil, fmt.Errorf("post-trim verify: tls.key does not match the surviving NEW cert")
+		}
+		return append([]byte(nil), newCert...), nil
+	}
+	return nil, fmt.Errorf("trim edge CA: exhausted CAS retries for %s/%s", namespace, name)
 }

--- a/edgecp/converge/predicate.go
+++ b/edgecp/converge/predicate.go
@@ -43,6 +43,21 @@ const (
 	ReasonEdgeCountBelowFloor = "edge-count-below-floor" // fewer expected edges than the operator floor (registry/scrape drift)
 	ReasonRevokedUnverified   = "revoked-unverified"     // the revoked-token absence probe did not run (fail-closed)
 	ReasonRevokedLeafPresent  = "revoked-leaf-present"   // the revoked token can still mint (probe got 2xx)
+
+	// Active-flip drop-checkpoint reasons (fire only when cfg.ExpectedActiveSignerFP is
+	// pinned — the destructive TrimCA gate). ca_id convergence proves the OLD++NEW bundle
+	// is everywhere but NOT that a leaf is SIGNED by NEW; these gate on the signer fp so a
+	// good edge's OLD-signed leaf can't 502 after the OLD-drop.
+	ReasonTargetMismatch        = "target-mismatch"          // resolved target T != the tool's pinned ExpectedTargetCAID
+	ReasonAuthzPinUnset         = "authz-pin-unset"          // fp pinned but ExpectedAuthzGen unset (misconfig — the blacklist barrier can't be checked)
+	ReasonCPSignerSplit         = "cp-signer-split"          // CP replicas disagree on the active signer fp (some OLD, some NEW)
+	ReasonCPNotNewSigner        = "cp-not-new-signer"        // a CP replica still signs under OLD (active fp != NEW) — its mints wouldn't survive the drop
+	ReasonAuthzNotConverged     = "authz-not-converged"      // a CP replica's authz gen != the expected post-blacklist value (revoke not loaded there)
+	ReasonRevokedIssuedUnderNew = "revoked-issued-under-new" // the revoked id has >0 issuances under NEW on some replica (a NEW leaf is in flight — the drop wouldn't sever it)
+	ReasonEdgeSignerUnresolved  = "edge-signer-unresolved"   // an expected edge reports no live signer fp (deriveIssuerFP failed) — fail-closed
+	ReasonEdgeOldSigner         = "edge-old-signer"          // an expected edge's live leaf is OLD-signed (fp != NEW) — would 502 after the drop
+	ReasonEdgeSignerNotObserved = "edge-signer-not-observed" // an expected edge hasn't observed the NEW active fp target yet (its re-mint can't have aimed at it)
+	ReasonLiveOldSigner         = "live-old-signer"          // ANY non-revoked edge (even registry-disabled) live on an OLD-signed leaf
 )
 
 // Config is the operator/Job input. The target ca_id is NOT configured — it is derived
@@ -56,6 +71,28 @@ type Config struct {
 	// a `<` floor (the fleet is registry-scaled, so `!=` would over-block).
 	Freshness time.Duration // window within which a reporter must have refreshed
 	Exclude   []ExcludedEdge
+
+	// ExpectedTargetCAID, when non-empty, PINS the resolved target: the self-described CP
+	// target T must equal it, else ReasonTargetMismatch. The revoke tool sets it to the NEW
+	// ca_id it rotated to, so a concurrent or unrelated rotation can't false-converge the drop.
+	ExpectedTargetCAID string
+
+	// Drop-checkpoint pins (the destructive TrimCA gate). When ExpectedActiveSignerFP is
+	// non-empty, Evaluate runs the ACTIVE-FLIP interlock on TOP of the ca_id convergence:
+	// every CP replica + every good edge must be NEW-SIGNED (active signer fp == it), the
+	// blacklist must have converged on every replica (authz gen == ExpectedAuthzGen), and —
+	// when RevokedEdgeID is set — that id must have ZERO issuances under NEW on every
+	// replica. Empty ⇒ the ca_id-only checkpoint (the pre-flip widen barrier; back-compat).
+	ExpectedActiveSignerFP string
+	// ExpectedAuthzGen is the post-blacklist authz fingerprint every CP replica must report
+	// (the deterministic registry hash WITH the revoke applied). Required (non-zero) when
+	// ExpectedActiveSignerFP is set: it is the proof the blacklist converged fleet-wide, the
+	// precondition that drops the revoked id from the expected set and stops its minting.
+	ExpectedAuthzGen float64
+	// RevokedEdgeID, when set, is the id being severed: it is EXEMPT from the live-OLD vetoes
+	// (it is the intended casualty of the drop), and its issuance count under NEW must be
+	// zero on every replica (else a NEW-signed leaf would survive the OLD-drop).
+	RevokedEdgeID string
 }
 
 // ExcludedEdge is a LOUD, reason-required convergence-veto waiver for a decommissioned
@@ -74,6 +111,13 @@ type CPReplica struct {
 	SignerGen   uint64  // edge_ca_signer_generation value
 	BundleCerts int     // edge_ca_bundle_certs value (2 during OLD++NEW overlap)
 	AuthzGen    float64 // edge_authz_generation value
+	// ActiveSignerFP is the sigfp label of edge_ca_active_signer_fp at ca_id==T — the CA
+	// this replica is ACTUALLY signing under now. Identical bundle ca_id for active=OLD/NEW,
+	// so this is the only CP-side signal that the active flip landed here.
+	ActiveSignerFP string
+	// RevokedIssuedUnderNew is edge_ca_issued_total{edge_id=<revoked>, sigfp=<NEW>} on this
+	// replica — how many leaves it minted for the revoked id under the NEW signer. Must be 0.
+	RevokedIssuedUnderNew float64
 }
 
 // CoreReplica is one core's scraped state.
@@ -91,6 +135,12 @@ type EdgeReporter struct {
 	ObservedTarget    string // edge_cp_target_ca_id label
 	RefreshedInWindow bool   // increase(edge_refresh_total[Freshness]) >= 1
 	FailedRemints     bool   // increase(edge_clientcert_remint_total{result!="ok"}[Freshness]) > 0
+	// LiveSignerFP is edge_clientcert_signer_fp — the fp of the CA that SIGNED the live leaf.
+	// This (not LiveCAID) is what proves the leaf chains to NEW and survives the OLD-drop.
+	LiveSignerFP string
+	// ObservedSignerFP is edge_cp_active_signer_fp — the NEW active fp the edge has observed
+	// from the CP (the re-mint target's other half, mirroring ObservedTarget for ca_id).
+	ObservedSignerFP string
 }
 
 // Observations is the cross-plane metric snapshot Evaluate scores. source.go builds it
@@ -105,6 +155,12 @@ type Observations struct {
 	RevokedProbeStatus int  // its HTTP status (401/403 ⇒ revoked; 2xx ⇒ still mints)
 }
 
+// Note: the active-flip drop checkpoint (Config.ExpectedActiveSignerFP) adds NO new
+// top-level Observations fields — its signals ride existing reporters: CPReplica gains
+// ActiveSignerFP + RevokedIssuedUnderNew, EdgeReporter gains LiveSignerFP +
+// ObservedSignerFP. The single top-level revoked probe stays the live cross-check; the
+// per-replica blacklist proof is AuthzGen == Config.ExpectedAuthzGen.
+
 // Result is the verdict. Converged is true ONLY when Blockers is empty.
 type Result struct {
 	Converged bool
@@ -116,6 +172,16 @@ type Result struct {
 // Evaluate scores convergence against the target ca_id derived from the CP target series.
 // Pure: no I/O, no clock beyond `now`. Returns Converged=false with named Blockers for
 // every reason the drop is unsafe.
+//
+// Two checkpoints share this predicate, selected by Config.ExpectedActiveSignerFP:
+//   - empty ⇒ the ca_id WIDEN barrier (every plane holds the OLD++NEW bundle) — the
+//     gate the operator clears before flipping the active signer to NEW.
+//   - set ⇒ the destructive OLD-DROP gate — additionally every CP replica + every good
+//     edge must be NEW-SIGNED (signer fp == it), the blacklist converged everywhere
+//     (authz gen == ExpectedAuthzGen), and the revoked id has zero NEW issuances. ca_id
+//     convergence alone does NOT prove a leaf is signed by NEW (Sign() appends the same
+//     bundle for active=OLD/NEW), so without these gates a good edge's OLD-signed leaf
+//     would 502 the moment OLD drops.
 func Evaluate(obs Observations, cfg Config, now time.Time) Result {
 	r := Result{Excluded: cfg.Exclude}
 
@@ -135,6 +201,13 @@ func Evaluate(obs Observations, cfg Config, now time.Time) Result {
 	// misconfig — the floor must not be silently disabled.
 	if cfg.ExpectedCP <= 0 || cfg.ExpectedCore <= 0 || cfg.MinEdges <= 0 {
 		r.Blockers = append(r.Blockers, Blocker{Plane: "config", Reason: "expected-counts-unset"})
+	}
+	// The drop checkpoint is only safe with the blacklist-barrier proof: pinning the NEW
+	// signer fp WITHOUT pinning the expected authz generation would gate "everyone NEW-signed"
+	// while leaving "the revoke loaded everywhere" unchecked — a half-interlock. Refuse it.
+	fpPinned := cfg.ExpectedActiveSignerFP != ""
+	if fpPinned && cfg.ExpectedAuthzGen == 0 {
+		r.Blockers = append(r.Blockers, Blocker{Plane: "config", Reason: ReasonAuthzPinUnset})
 	}
 	if len(obs.CP) == 0 && len(obs.Core) == 0 && len(obs.Edges) == 0 && len(obs.ExpectedEdges) == 0 {
 		r.Blockers = append(r.Blockers, Blocker{Plane: "config", Reason: ReasonExpectedSetEmpty})
@@ -163,9 +236,18 @@ func Evaluate(obs Observations, cfg Config, now time.Time) Result {
 	}
 	T := r.Target
 
+	// Tool pin: the self-described target must be the SAME rotation the revoke tool drove.
+	// A mismatch means an unrelated/concurrent rotation moved T — converging the drop against
+	// it would sever the wrong CA. Fail closed and stop (downstream gates are meaningless).
+	if cfg.ExpectedTargetCAID != "" && T != cfg.ExpectedTargetCAID {
+		r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reason: ReasonTargetMismatch})
+		return finalize(r)
+	}
+
 	// (2) CP plane: every replica up, signing under T, still serving OLD++NEW (2 certs),
 	// with ONE generation for T (the generation-split tripwire) and agreement on authz.
 	cpAtT, gens, authz := 0, map[uint64]bool{}, map[float64]bool{}
+	signerFPs := map[string]bool{} // distinct active signer fps across up replicas (split tripwire)
 	for _, cp := range obs.CP {
 		if !cp.Up {
 			r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reporter: cp.Instance, Reason: ReasonUpDown})
@@ -181,12 +263,31 @@ func Evaluate(obs Observations, cfg Config, now time.Time) Result {
 		gens[cp.SignerGen] = true
 		authz[cp.AuthzGen] = true
 		cpAtT++
+
+		// Active-flip drop checkpoint (fp-pinned only): this replica must SIGN under NEW, have
+		// loaded the post-blacklist registry, and have minted nothing for the revoked id under
+		// NEW. Each is per-replica because each replica signs + enforces authz independently.
+		if fpPinned {
+			signerFPs[cp.ActiveSignerFP] = true
+			if cp.ActiveSignerFP != cfg.ExpectedActiveSignerFP {
+				r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reporter: cp.Instance, Reason: ReasonCPNotNewSigner})
+			}
+			if cp.AuthzGen != cfg.ExpectedAuthzGen {
+				r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reporter: cp.Instance, Reason: ReasonAuthzNotConverged})
+			}
+			if cfg.RevokedEdgeID != "" && cp.RevokedIssuedUnderNew > 0 {
+				r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reporter: cp.Instance, Reason: ReasonRevokedIssuedUnderNew})
+			}
+		}
 	}
 	if len(gens) > 1 {
 		r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reason: ReasonGenerationSplit})
 	}
 	if len(authz) > 1 {
 		r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reason: ReasonAuthzSplit})
+	}
+	if fpPinned && len(signerFPs) > 1 {
+		r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reason: ReasonCPSignerSplit})
 	}
 	if cpAtT != cfg.ExpectedCP {
 		r.Blockers = append(r.Blockers, Blocker{Plane: "cp", Reason: ReasonCountMismatch})
@@ -246,19 +347,37 @@ func Evaluate(obs Observations, cfg Config, now time.Time) Result {
 			r.Blockers = append(r.Blockers, Blocker{Plane: "edge", Reporter: id, Reason: ReasonRefreshStale})
 		case e.FailedRemints:
 			r.Blockers = append(r.Blockers, Blocker{Plane: "edge", Reporter: id, Reason: ReasonRemintChurn})
+		// Active-flip gates (fp-pinned only), AFTER the ca_id gates: a bundle that converged
+		// (LiveCAID==T) but whose leaf is still OLD-signed would 502 the moment OLD drops.
+		case fpPinned && e.LiveSignerFP == "":
+			r.Blockers = append(r.Blockers, Blocker{Plane: "edge", Reporter: id, Reason: ReasonEdgeSignerUnresolved})
+		case fpPinned && e.LiveSignerFP != cfg.ExpectedActiveSignerFP:
+			r.Blockers = append(r.Blockers, Blocker{Plane: "edge", Reporter: id, Reason: ReasonEdgeOldSigner})
+		case fpPinned && e.ObservedSignerFP != cfg.ExpectedActiveSignerFP:
+			r.Blockers = append(r.Blockers, Blocker{Plane: "edge", Reporter: id, Reason: ReasonEdgeSignerNotObserved})
 		}
 	}
 
-	// (5) Live-OLD-leaf veto: ANY edge observed live on a non-target leaf blocks — even
-	// one merely registry-disabled but still RUNNING — unless explicitly excluded. The
+	// (5) Live-OLD vetoes: ANY edge observed live on OLD trust material blocks — even one
+	// merely registry-disabled but still RUNNING — unless explicitly excluded. The
 	// expected-to-converge set (the veto driver) is decoupled from the still-running-and-
 	// trusted set (the actual blast radius); registry==0 does NOT silently waive it.
+	//
+	// The REVOKED id is EXEMPT: it is the intended casualty of the drop. It is still running
+	// on its last OLD-signed leaf (it can no longer mint), and severing exactly that is the
+	// drop's purpose — vetoing on it would deadlock the revoke forever.
 	for _, e := range obs.Edges {
-		if excluded[e.EdgeID] {
+		if excluded[e.EdgeID] || (cfg.RevokedEdgeID != "" && e.EdgeID == cfg.RevokedEdgeID) {
 			continue
 		}
 		if e.Up && e.LiveCAID != "" && e.LiveCAID != T {
 			r.Blockers = append(r.Blockers, Blocker{Plane: "edge", Reporter: e.EdgeID, Reason: ReasonLiveOldLeaf})
+		}
+		// Signer veto (fp-pinned): the bundle ca_id can be T (converged) while the leaf is
+		// STILL OLD-signed — that leaf fails verification the moment OLD drops. Block on any
+		// non-revoked edge holding an OLD-signed leaf.
+		if fpPinned && e.Up && e.LiveSignerFP != "" && e.LiveSignerFP != cfg.ExpectedActiveSignerFP {
+			r.Blockers = append(r.Blockers, Blocker{Plane: "edge", Reporter: e.EdgeID, Reason: ReasonLiveOldSigner})
 		}
 	}
 

--- a/edgecp/converge/predicate_test.go
+++ b/edgecp/converge/predicate_test.go
@@ -135,6 +135,109 @@ func TestEvaluateExcludeWaivesVeto(t *testing.T) {
 	}
 }
 
+// ---- Active-flip drop checkpoint (Config.ExpectedActiveSignerFP pinned) ----
+
+const (
+	newFP = "new-signer-fp"
+	oldFP = "old-signer-fp"
+)
+
+// dropConverged is a fully-converged snapshot at the DESTRUCTIVE drop checkpoint: every
+// CP replica + good edge is NEW-signed, the blacklist has converged (authz gen matches
+// the pin), and the revoked edge — still running on its last OLD-signed leaf — is exempt.
+func dropConverged() (Observations, Config) {
+	obs, cfg := converged()
+	for i := range obs.CP {
+		obs.CP[i].ActiveSignerFP = newFP
+	}
+	for i := range obs.Edges {
+		obs.Edges[i].LiveSignerFP = newFP
+		obs.Edges[i].ObservedSignerFP = newFP
+	}
+	// The revoked edge: registry-dropped (not in ExpectedEdges), still live on its OLD-signed
+	// leaf at the converged bundle ca_id T. It is the intended casualty — must not block.
+	obs.Edges = append(obs.Edges, EdgeReporter{
+		EdgeID: "revoked-x", Up: true, LiveCAID: T, ObservedTarget: T, RefreshedInWindow: true,
+		LiveSignerFP: oldFP, ObservedSignerFP: oldFP,
+	})
+	cfg.ExpectedTargetCAID = T
+	cfg.ExpectedActiveSignerFP = newFP
+	cfg.ExpectedAuthzGen = 42 // matches the fixture's AuthzGen
+	cfg.RevokedEdgeID = "revoked-x"
+	return obs, cfg
+}
+
+func TestEvaluateDropConverged(t *testing.T) {
+	obs, cfg := dropConverged()
+	r := Evaluate(obs, cfg, time.Now())
+	if !r.Converged {
+		t.Fatalf("drop checkpoint must converge with everyone NEW-signed + revoked exempt; blockers=%v", r.Blockers)
+	}
+}
+
+func TestEvaluateDropBlockers(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Observations, *Config)
+		reason string
+	}{
+		{"target-mismatch", func(_ *Observations, c *Config) { c.ExpectedTargetCAID = "other" }, ReasonTargetMismatch},
+		{"authz-pin-unset", func(_ *Observations, c *Config) { c.ExpectedAuthzGen = 0 }, ReasonAuthzPinUnset},
+		{"cp-not-new-signer", func(o *Observations, _ *Config) { o.CP[0].ActiveSignerFP = oldFP }, ReasonCPNotNewSigner},
+		{"cp-signer-split", func(o *Observations, _ *Config) { o.CP[1].ActiveSignerFP = "third-fp" }, ReasonCPSignerSplit},
+		{"authz-not-converged", func(o *Observations, _ *Config) { o.CP[0].AuthzGen, o.CP[1].AuthzGen = 99, 99 }, ReasonAuthzNotConverged},
+		{"revoked-issued-under-new", func(o *Observations, _ *Config) { o.CP[0].RevokedIssuedUnderNew = 3 }, ReasonRevokedIssuedUnderNew},
+		{"edge-old-signer", func(o *Observations, _ *Config) { o.Edges[0].LiveSignerFP = oldFP }, ReasonEdgeOldSigner},
+		{"edge-signer-unresolved", func(o *Observations, _ *Config) { o.Edges[0].LiveSignerFP = "" }, ReasonEdgeSignerUnresolved},
+		{"edge-signer-not-observed", func(o *Observations, _ *Config) { o.Edges[0].ObservedSignerFP = "stale" }, ReasonEdgeSignerNotObserved},
+		{"live-old-signer", func(o *Observations, _ *Config) {
+			o.Edges = append(o.Edges, EdgeReporter{EdgeID: "rogue", Up: true, LiveCAID: T, ObservedTarget: T, RefreshedInWindow: true, LiveSignerFP: oldFP, ObservedSignerFP: newFP})
+		}, ReasonLiveOldSigner},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obs, cfg := dropConverged()
+			tc.mutate(&obs, &cfg)
+			r := Evaluate(obs, cfg, time.Now())
+			if r.Converged {
+				t.Errorf("%s: must NOT converge", tc.name)
+			}
+			if !hasBlocker(r, tc.reason) {
+				t.Errorf("%s: want blocker %q, got %v", tc.name, tc.reason, r.Blockers)
+			}
+		})
+	}
+}
+
+// The revoked edge, still live on an OLD-signed leaf, must NOT trip the live-OLD vetoes —
+// severing exactly it is the drop's purpose. Without the exemption the revoke deadlocks.
+func TestEvaluateDropRevokedEdgeExempt(t *testing.T) {
+	obs, cfg := dropConverged()
+	r := Evaluate(obs, cfg, time.Now())
+	if hasBlocker(r, ReasonLiveOldSigner) || hasBlocker(r, ReasonLiveOldLeaf) {
+		t.Errorf("the revoked edge (live on OLD) must be exempt from the live-OLD vetoes, got %v", r.Blockers)
+	}
+	// Sanity: without naming it as revoked, the SAME edge DOES veto (proves the exemption is
+	// load-bearing, not that the leaf is invisible).
+	cfg.RevokedEdgeID = ""
+	if r := Evaluate(obs, cfg, time.Now()); !hasBlocker(r, ReasonLiveOldSigner) {
+		t.Error("an unexempted edge live on OLD must trip live-old-signer")
+	}
+}
+
+// The widen checkpoint (no fp pin) must IGNORE the active-flip signals — a fleet still on
+// OLD-signed leaves is correctly converged for the pre-flip barrier.
+func TestEvaluateWidenCheckpointIgnoresSignerFP(t *testing.T) {
+	obs, cfg := converged() // no ExpectedActiveSignerFP
+	for i := range obs.Edges {
+		obs.Edges[i].LiveSignerFP = oldFP // still OLD-signed — fine pre-flip
+	}
+	r := Evaluate(obs, cfg, time.Now())
+	if !r.Converged {
+		t.Errorf("the widen checkpoint must not gate on signer fp; blockers=%v", r.Blockers)
+	}
+}
+
 // A still-RUNNING blacklisted edge (live on OLD, registry-dropped from ExpectedEdges)
 // must STILL block — registry==0 does not silently waive a live OLD leaf.
 func TestEvaluateRunningBlacklistedEdgeStillBlocks(t *testing.T) {

--- a/edgecp/converge/source.go
+++ b/edgecp/converge/source.go
@@ -3,6 +3,7 @@ package converge
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	promapi "github.com/prometheus/client_golang/api"
@@ -48,7 +49,11 @@ func (p *promQuerier) Query(ctx context.Context, query string, ts time.Time) (mo
 //
 // `up` is joined by `instance` for CP/core (Prometheus stamps it automatically) and by
 // `edge_id` for edges (the scrape config must relabel edge_id onto the edge targets).
-func Snapshot(ctx context.Context, q Querier, freshness time.Duration, now time.Time) (Observations, error) {
+//
+// revokedEdgeID + newSignerFP scope the CP-authoritative issuance-ledger query (the
+// revoked id's leaf count under the NEW signer per replica). Both empty ⇒ that query is
+// skipped (the pre-flip / non-revoke checkpoint), leaving RevokedIssuedUnderNew at 0.
+func Snapshot(ctx context.Context, q Querier, freshness time.Duration, now time.Time, revokedEdgeID, newSignerFP string) (Observations, error) {
 	fw := model.Duration(freshness).String()
 	get := func(query string) (model.Vector, error) { return q.Query(ctx, query, now) }
 
@@ -84,11 +89,29 @@ func Snapshot(ctx context.Context, q Querier, freshness time.Duration, now time.
 	if err != nil {
 		return Observations{}, err
 	}
+	// The CA the replica is ACTUALLY signing under (active=OLD vs =NEW at an identical bundle
+	// ca_id). The sigfp label of the single live edge_ca_active_signer_fp series per instance.
+	activeFP, err := labelByInstance(get, "parapet_edge_ca_active_signer_fp", "sigfp")
+	if err != nil {
+		return Observations{}, err
+	}
+	// CP-authoritative issuance ledger: how many leaves each replica minted for the revoked
+	// id under the NEW signer. Scoped to the exact (edge_id, sigfp) so an absent series ⇒ 0
+	// ⇒ no block. Skipped unless both inputs are set (pre-flip / non-revoke checkpoint).
+	var revokedIssued map[string]float64
+	if revokedEdgeID != "" && newSignerFP != "" {
+		revokedIssued, err = valueByInstance(get, fmt.Sprintf(
+			`parapet_edge_ca_issued_total{edge_id=%q,sigfp=%q}`, promLabel(revokedEdgeID), promLabel(newSignerFP)))
+		if err != nil {
+			return Observations{}, err
+		}
+	}
 	for inst, fp := range signerFP {
 		obs.CP = append(obs.CP, CPReplica{
 			Instance: inst, Up: upByInstance[inst],
 			SignerCAID: fp, TargetCAID: targetCAID[inst],
 			SignerGen: uint64(signerGen[inst]), BundleCerts: int(bundleCerts[inst]), AuthzGen: authzGen[inst],
+			ActiveSignerFP: activeFP[inst], RevokedIssuedUnderNew: revokedIssued[inst],
 		})
 	}
 
@@ -118,10 +141,21 @@ func Snapshot(ctx context.Context, q Querier, freshness time.Duration, now time.
 	if err != nil {
 		return Observations{}, err
 	}
+	// The CA that SIGNED the edge's live leaf (OLD vs NEW), and the NEW active fp the edge
+	// has OBSERVED — the active-flip analogs of LiveCAID / ObservedTarget.
+	liveSignerFP, err := labelByLabel(get, "parapet_edge_clientcert_signer_fp", "edge_id", "sigfp")
+	if err != nil {
+		return Observations{}, err
+	}
+	observedSignerFP, err := labelByLabel(get, "parapet_edge_cp_active_signer_fp", "edge_id", "sigfp")
+	if err != nil {
+		return Observations{}, err
+	}
 	for id, ca := range liveCAID {
 		obs.Edges = append(obs.Edges, EdgeReporter{
 			EdgeID: id, Up: upByEdge[id], LiveCAID: ca,
 			ObservedTarget: observedTarget[id], RefreshedInWindow: refreshed[id], FailedRemints: failed[id],
+			LiveSignerFP: liveSignerFP[id], ObservedSignerFP: observedSignerFP[id],
 		})
 	}
 
@@ -137,6 +171,14 @@ func Snapshot(ctx context.Context, q Querier, freshness time.Duration, now time.
 	}
 
 	return obs, nil
+}
+
+// promLabel escapes a value for interpolation into a PromQL `label="..."` matcher
+// (backslash and double-quote, per the PromQL string grammar), so an edge_id / fp can't
+// break out of the matcher. The fp is hex and the edge_id a registry id, so this is
+// belt-and-suspenders, but the query is built from external input.
+func promLabel(v string) string {
+	return strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(v)
 }
 
 // labelByInstance maps instance -> the value of `label` on each sample of `query`.

--- a/edgecp/converge/source_test.go
+++ b/edgecp/converge/source_test.go
@@ -52,7 +52,7 @@ func TestSnapshotMapsAllPlanes(t *testing.T) {
 		"parapet_edge_registry_total == 1":                                 {sample(map[string]string{"edge_id": "e1"}, 1)},
 	}}
 
-	obs, err := Snapshot(context.Background(), q, 5*time.Minute, time.Now())
+	obs, err := Snapshot(context.Background(), q, 5*time.Minute, time.Now(), "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestSnapshotMapsAllPlanes(t *testing.T) {
 // A Prometheus query error must propagate (fail-closed: the caller renders no verdict).
 func TestSnapshotPropagatesQueryError(t *testing.T) {
 	q := &fakeQuerier{queryErr: errors.New("prometheus unreachable")}
-	if _, err := Snapshot(context.Background(), q, 5*time.Minute, time.Now()); err == nil {
+	if _, err := Snapshot(context.Background(), q, 5*time.Minute, time.Now(), "", ""); err == nil {
 		t.Error("a query error must propagate, not be swallowed")
 	}
 }

--- a/edgecp/issuance.go
+++ b/edgecp/issuance.go
@@ -25,10 +25,11 @@ type edgeCertRequest struct {
 }
 
 type edgeCertResponse struct {
-	ChainPEM string `json:"chain_pem"`
-	NotAfter string `json:"not_after"`
-	Serial   string `json:"serial"`
-	CAID     string `json:"ca_id,omitempty"` // signer ca_id, so the edge self-confirms convergence post-mint
+	ChainPEM  string `json:"chain_pem"`
+	NotAfter  string `json:"not_after"`
+	Serial    string `json:"serial"`
+	CAID      string `json:"ca_id,omitempty"`           // signer ca_id, so the edge self-confirms convergence post-mint
+	SigningFP string `json:"signing_cert_fp,omitempty"` // the active signing fp that minted this leaf
 }
 
 // handleEdgeCert signs an edge data-plane client cert from a CSR. Token-gated: a
@@ -102,22 +103,29 @@ func (s *Server) handleEdgeCert(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "sign failed", http.StatusInternalServerError)
 		return
 	}
+	// CP-authoritative issuance ledger: record (edge_id, active signer fp) for every mint.
+	// The revoke interlock asserts the revoked id has ZERO issuances under NEW — a
+	// guarantee that does NOT rest on the (forgeable) edge self-report.
+	recordIssuance(id, sg.ActiveFP())
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("X-Parapet-Signing-Cert-Fp", sg.ActiveFP())
 	_ = json.NewEncoder(w).Encode(edgeCertResponse{
-		ChainPEM: string(chainPEM),
-		NotAfter: notAfter.UTC().Format(time.RFC3339),
-		Serial:   serial,
-		CAID:     sg.CAID(),
+		ChainPEM:  string(chainPEM),
+		NotAfter:  notAfter.UTC().Format(time.RFC3339),
+		Serial:    serial,
+		CAID:      sg.CAID(),
+		SigningFP: sg.ActiveFP(),
 	})
 }
 
 type trustBundleResponse struct {
-	Generation uint64 `json:"generation"`
-	CAPEM      string `json:"ca_pem"`
-	CAID       string `json:"ca_id"`
+	Generation    uint64 `json:"generation"`
+	CAPEM         string `json:"ca_pem"`
+	CAID          string `json:"ca_id"`
+	SigningCertFP string `json:"signing_cert_fp,omitempty"` // active signing fp (the tuple half the edge re-mints on)
 }
 
 // handleTrustBundle serves the tokenless trust bundle {generation, ca_pem, ca_id}
@@ -157,11 +165,12 @@ func (s *Server) handleTrustBundle(w http.ResponseWriter, r *http.Request) {
 	sg := st.sg
 	gen := st.gen
 	resp := trustBundleResponse{
-		Generation: gen,
-		CAPEM:      string(sg.BundlePEM()),
-		CAID:       sg.CAID(),
+		Generation:    gen,
+		CAPEM:         string(sg.BundlePEM()),
+		CAID:          sg.CAID(),
+		SigningCertFP: sg.ActiveFP(),
 	}
-	etag := etagOfString(strconv.FormatUint(gen, 10) + "\x00" + resp.CAPEM + "\x00" + resp.CAID)
+	etag := etagOfString(strconv.FormatUint(gen, 10) + "\x00" + resp.CAPEM + "\x00" + resp.CAID + "\x00" + resp.SigningCertFP)
 	w.Header().Set("ETag", etag)
 	w.Header().Set("Cache-Control", "no-cache")
 	if match := r.Header.Get("If-None-Match"); match != "" && etagMatch(match, etag) {

--- a/edgecp/issuance_test.go
+++ b/edgecp/issuance_test.go
@@ -155,6 +155,14 @@ func TestEdgeCertEndpoint(t *testing.T) {
 		if rec.Header().Get("Cache-Control") != "no-store" {
 			t.Error("issued cert must be no-store")
 		}
+		// The active-signer fp rides both the header and the body so the edge self-confirms
+		// which CA minted its leaf (the OLD-vs-NEW active-flip signal).
+		if got := rec.Header().Get("X-Parapet-Signing-Cert-Fp"); got == "" || got != sg.ActiveFP() {
+			t.Errorf("edge-cert signing fp header = %q, want %q", got, sg.ActiveFP())
+		}
+		if resp.SigningFP != sg.ActiveFP() {
+			t.Errorf("edge-cert body signing_cert_fp = %q, want %q", resp.SigningFP, sg.ActiveFP())
+		}
 	}
 	if rec := post(""); rec.Code != http.StatusUnauthorized {
 		t.Errorf("no token: want 401, got %d", rec.Code)
@@ -211,6 +219,11 @@ func TestTrustBundleEndpoint(t *testing.T) {
 	}
 	if resp.CAID != sg.CAID() {
 		t.Errorf("ca_id = %q, want %q", resp.CAID, sg.CAID())
+	}
+	// The active-signer fp rides the trust bundle too (the idle-edge / core convergence
+	// signal), and folds into the ETag (asserted indirectly by the 304 below).
+	if resp.SigningCertFP != sg.ActiveFP() {
+		t.Errorf("trust-bundle signing_cert_fp = %q, want %q", resp.SigningCertFP, sg.ActiveFP())
 	}
 
 	// 304 on a matching If-None-Match.

--- a/edgecp/metrics.go
+++ b/edgecp/metrics.go
@@ -143,20 +143,38 @@ func recordIssuance(edgeID, signerFP string) {
 // static today). Only entries with a non-empty id are data-plane edges.
 func SetRegistryMetrics(entries map[string]Entry) {
 	registryTotal.Reset()
-	lines := make([]string, 0, len(entries))
 	for _, e := range entries {
 		if e.ID == "" {
 			continue
 		}
 		v := 1.0
-		d := "0"
 		if e.Disabled {
-			v, d = 0.0, "1"
+			v = 0.0
 		}
 		registryTotal.WithLabelValues(e.ID).Set(v)
+	}
+	authzGeneration.Set(AuthzGeneration(entries))
+}
+
+// AuthzGeneration computes the deterministic authz-generation fingerprint of a token
+// registry WITHOUT touching metrics — the same value the serving CP publishes as
+// edge_authz_generation. The revoke tool calls it on the post-blacklist registry to
+// derive the ExpectedAuthzGen pin the OLD-drop interlock asserts every replica reports
+// (the proof the blacklist converged fleet-wide). Identical inputs ⇒ identical output on
+// every replica and in the tool.
+func AuthzGeneration(entries map[string]Entry) float64 {
+	lines := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.ID == "" {
+			continue
+		}
+		d := "0"
+		if e.Disabled {
+			d = "1"
+		}
 		lines = append(lines, e.ID+":"+d)
 	}
-	authzGeneration.Set(registryFingerprint(lines))
+	return registryFingerprint(lines)
 }
 
 // registryFingerprint hashes the sorted "id:disabled" lines into a stable float value

--- a/edgecp/metrics.go
+++ b/edgecp/metrics.go
@@ -71,6 +71,36 @@ var (
 		Name:      "edge_ca_signer_rv_unparsed",
 		Help:      "1 when the CA Secret resourceVersion is non-numeric (signer frozen at last-good); 0 when parseable.",
 	})
+
+	// activeSignerFP is the fingerprint of the ACTIVE signing cert (what signs new leaves).
+	// During an OLD++NEW overlap the bundle ca_id is identical for active=OLD and =NEW, so
+	// this is the ONLY signal that distinguishes them — the interlock asserts every CP
+	// replica signs under NEW (sigfp == target) before the OLD-drop, proving issued leaves
+	// chain to NEW. Reset-then-Set under genMu like the others.
+	activeSignerFP = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_ca_active_signer_fp",
+		Help:      "The active signing cert fingerprint, by ca_id + sigfp (value 1).",
+	}, []string{"ca_id", "sigfp"})
+
+	// signerActiveFlipFailed is 1 when an active=new reload was requested but the candidate
+	// signer wouldn't build (fingerprint pin / reordered bundle) — the replica is wedged
+	// minting OLD-signed leaves. Without this it surfaces only as an unexplained converge stall.
+	signerActiveFlipFailed = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_ca_signer_active_flip_failed",
+		Help:      "1 when an active=new signer reload failed to build (replica wedged on OLD signing); 0 otherwise.",
+	})
+
+	// issuedUnderSigner is the CP-AUTHORITATIVE issuance ledger: every minted edge leaf by
+	// edge_id + the active signer fp. The revoke interlock asserts the REVOKED edge_id has
+	// ZERO issuances under NEW across all replicas — a guarantee that does NOT rest on the
+	// (forgeable) edge self-report.
+	issuedUnderSigner = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_ca_issued_total",
+		Help:      "Edge client certs minted, by edge_id + the active signer fp that signed them.",
+	}, []string{"edge_id", "sigfp"})
 )
 
 var (
@@ -100,7 +130,12 @@ var (
 )
 
 func init() {
-	prom.Registry().MustRegister(signerFingerprint, signerGeneration, signerBundleCerts, signerLoaded, targetCAID, signerFloored, signerRVUnparsed, registryTotal, authzGeneration)
+	prom.Registry().MustRegister(signerFingerprint, signerGeneration, signerBundleCerts, signerLoaded, targetCAID, signerFloored, signerRVUnparsed, registryTotal, authzGeneration, activeSignerFP, signerActiveFlipFailed, issuedUnderSigner)
+}
+
+// recordIssuance ledgers one minted edge leaf under the active signer fp (CP-authoritative).
+func recordIssuance(edgeID, signerFP string) {
+	issuedUnderSigner.WithLabelValues(edgeID, signerFP).Inc()
 }
 
 // SetRegistryMetrics publishes the expected-edge reporter set and the authz-generation
@@ -137,7 +172,7 @@ func registryFingerprint(lines []string) float64 {
 // Reset()s each ca_id vec first so only one live series remains across rotations. Call
 // it under Server.genMu (the same critical section that swaps the signer) so all five
 // gauges move together and no scrape sees a torn snapshot.
-func setSignerMetrics(caID string, gen uint64, certCount int) {
+func setSignerMetrics(caID, activeFP string, gen uint64, certCount int) {
 	signerFingerprint.Reset()
 	signerFingerprint.WithLabelValues(caID).Set(1)
 	signerGeneration.Reset()
@@ -149,4 +184,9 @@ func setSignerMetrics(caID string, gen uint64, certCount int) {
 	// convergence PromQL compares the core + edge ca_ids against, with no hardcoded value.
 	targetCAID.Reset()
 	targetCAID.WithLabelValues(caID).Set(1)
+	// the active signing fp — distinguishes active=OLD vs =NEW at an identical bundle ca_id.
+	activeSignerFP.Reset()
+	if activeFP != "" {
+		activeSignerFP.WithLabelValues(caID, activeFP).Set(1)
+	}
 }

--- a/edgecp/metrics_test.go
+++ b/edgecp/metrics_test.go
@@ -10,8 +10,8 @@ import (
 // (Reset()-then-Set) — the only guard against ca_id-label cardinality growth in a
 // long-running process — and reflect the latest signer's values.
 func TestSetSignerMetricsOneSeriesPerVec(t *testing.T) {
-	setSignerMetrics("ca-old", 1, 2)
-	setSignerMetrics("ca-new", 2, 1) // rotate: a new ca_id must not accumulate a series
+	setSignerMetrics("ca-old", "fp-old", 1, 2)
+	setSignerMetrics("ca-new", "fp-new", 2, 1) // rotate: a new ca_id must not accumulate a series
 
 	for name, c := range map[string]int{
 		"signer_fingerprint": testutil.CollectAndCount(signerFingerprint),

--- a/edgecp/metrics_test.go
+++ b/edgecp/metrics_test.go
@@ -36,4 +36,65 @@ func TestSetSignerMetricsOneSeriesPerVec(t *testing.T) {
 	if v := testutil.ToFloat64(signerFingerprint.WithLabelValues("ca-new")); v != 1 {
 		t.Errorf("fingerprint = %v, want 1", v)
 	}
+	// The active-signer fp vec is also one-series-per-rotation, keyed (ca_id, sigfp).
+	if c := testutil.CollectAndCount(activeSignerFP); c != 1 {
+		t.Errorf("active_signer_fp: want 1 live series, got %d", c)
+	}
+	if v := testutil.ToFloat64(activeSignerFP.WithLabelValues("ca-new", "fp-new")); v != 1 {
+		t.Errorf("active_signer_fp{ca-new,fp-new} = %v, want 1", v)
+	}
+}
+
+// The CP-authoritative issuance ledger is the interlock's proof a revoked id never minted
+// under NEW: it counts per (edge_id, active signer fp), so the same id under OLD vs NEW are
+// distinct series (a revoke asserts the NEW one is zero).
+func TestRecordIssuanceLedger(t *testing.T) {
+	issuedUnderSigner.Reset()
+	recordIssuance("edge-a", "fp-new")
+	recordIssuance("edge-a", "fp-new")
+	recordIssuance("edge-a", "fp-old") // same edge, OLD signer — a separate series
+	recordIssuance("edge-b", "fp-new")
+
+	if v := testutil.ToFloat64(issuedUnderSigner.WithLabelValues("edge-a", "fp-new")); v != 2 {
+		t.Errorf("issued{edge-a,fp-new} = %v, want 2", v)
+	}
+	if v := testutil.ToFloat64(issuedUnderSigner.WithLabelValues("edge-a", "fp-old")); v != 1 {
+		t.Errorf("issued{edge-a,fp-old} = %v, want 1 (OLD must not fold into NEW)", v)
+	}
+	if v := testutil.ToFloat64(issuedUnderSigner.WithLabelValues("edge-b", "fp-new")); v != 1 {
+		t.Errorf("issued{edge-b,fp-new} = %v, want 1", v)
+	}
+}
+
+// AuthzGeneration is replica-deterministic (the blacklist-barrier pin) and CHANGES when an
+// id's disabled flag flips — so a revoke moves it, letting the interlock prove the blacklist
+// converged. Order-independent (it sorts), id-only (tokens/domains don't perturb it).
+func TestAuthzGenerationDeterministicAndRevokeSensitive(t *testing.T) {
+	base := map[string]Entry{
+		"t1": {ID: "edge-a"},
+		"t2": {ID: "edge-b"},
+	}
+	reordered := map[string]Entry{
+		"t2": {ID: "edge-b"},
+		"t1": {ID: "edge-a"},
+	}
+	if AuthzGeneration(base) != AuthzGeneration(reordered) {
+		t.Error("authz generation must be order-independent (replica-deterministic)")
+	}
+	revoked := map[string]Entry{
+		"t1": {ID: "edge-a"},
+		"t2": {ID: "edge-b", Disabled: true}, // the revoke
+	}
+	if AuthzGeneration(base) == AuthzGeneration(revoked) {
+		t.Error("disabling an id must change the authz generation (the blacklist-barrier signal)")
+	}
+	// A non-data-plane entry (no id) and domain changes must NOT perturb it.
+	withNoise := map[string]Entry{
+		"t1": {ID: "edge-a", Domains: []string{"x.com"}},
+		"t2": {ID: "edge-b"},
+		"t3": {Domains: []string{"y.com"}}, // no id → ignored
+	}
+	if AuthzGeneration(base) != AuthzGeneration(withNoise) {
+		t.Error("only id+disabled may affect the authz generation")
+	}
 }

--- a/edgecp/server.go
+++ b/edgecp/server.go
@@ -100,20 +100,29 @@ func (s *Server) SetSigner(sg *Signer, generation uint64) {
 	// Convergence metrics: set all signer gauges together inside the held genMu so a
 	// scrape never tears across them. Done before close(genNotify) so a long-poll
 	// waiter that wakes and re-scrapes always observes the new series.
-	setSignerMetrics(sg.CAID(), generation, sg.BundleLen())
+	setSignerMetrics(sg.CAID(), sg.ActiveFP(), generation, sg.BundleLen())
 	close(s.genNotify)
 	s.genNotify = make(chan struct{})
+}
+
+// currentSignerKey returns the live signer's (ca_id, active-cert fingerprint) from ONE
+// atomic Load, so the two never tear across a concurrent SetSigner during a re-mint
+// storm. "" / "" when no signer is loaded.
+func (s *Server) currentSignerKey() (caID, activeFP string) {
+	if st := s.signerState.Load(); st != nil && st.sg != nil {
+		return st.sg.CAID(), st.sg.ActiveFP()
+	}
+	return "", ""
 }
 
 // CurrentCAID returns the live signer's ca_id, or "" if no signer is loaded. The
 // serving reloader compares it to a rebuilt candidate to gate SetSigner (a no-op
 // re-list must not churn the generation).
-func (s *Server) CurrentCAID() string {
-	if st := s.signerState.Load(); st != nil && st.sg != nil {
-		return st.sg.CAID()
-	}
-	return ""
-}
+func (s *Server) CurrentCAID() string { caID, _ := s.currentSignerKey(); return caID }
+
+// CurrentActiveFP returns the live signer's ACTIVE cert fingerprint — distinguishes
+// active=OLD from active=NEW during an overlap (the bundle ca_id is identical for both).
+func (s *Server) CurrentActiveFP() string { _, fp := s.currentSignerKey(); return fp }
 
 // SignerLoaded reports whether a signer has been installed (issuance is live).
 func (s *Server) SignerLoaded() bool { return s.signerState.Load() != nil }
@@ -183,8 +192,14 @@ func (s *Server) handleCert(w http.ResponseWriter, r *http.Request) {
 	// leaf issuer; it is deliberately NOT folded into entry.etag — a pure CA rotation
 	// must never force a fleet-wide cert+key re-download. Set after Known()/Allowed()
 	// (never to an unauthorized caller), before any WriteHeader so it rides the 304/404.
-	if id := s.CurrentCAID(); id != "" {
-		w.Header().Set("X-Parapet-CA-Id", id)
+	if caID, activeFP := s.currentSignerKey(); caID != "" {
+		w.Header().Set("X-Parapet-CA-Id", caID)
+		// The active signing fp rides the SAME response: during an overlap the ca_id is
+		// identical for active=OLD/NEW, so the edge must re-mint on the (ca_id, sigfp)
+		// TUPLE to pick up an active flip and obtain a NEW-signed leaf before the OLD-drop.
+		if activeFP != "" {
+			w.Header().Set("X-Parapet-Signing-Cert-Fp", activeFP)
+		}
 	}
 
 	entry, ok := s.certs.Get(sni)
@@ -211,9 +226,10 @@ func (s *Server) handleCert(w http.ResponseWriter, r *http.Request) {
 type wafResponse struct {
 	Generation  uint64            `json:"generation"`
 	GlobalRules string            `json:"global_rules"`
-	Zones       map[string]string `json:"zones"`           // zoneKey -> rules YAML
-	HostZoneMap map[string]string `json:"host_zone_map"`   // host -> zoneKey
-	CAID        string            `json:"ca_id,omitempty"` // signer target ca_id (best-effort SECONDARY force-re-mint confirmer)
+	Zones       map[string]string `json:"zones"`                     // zoneKey -> rules YAML
+	HostZoneMap map[string]string `json:"host_zone_map"`             // host -> zoneKey
+	CAID        string            `json:"ca_id,omitempty"`           // signer target ca_id (best-effort SECONDARY force-re-mint confirmer)
+	SigningFP   string            `json:"signing_cert_fp,omitempty"` // active signing fp (the tuple's other half)
 }
 
 // handleWAF serves the WAF payload scoped to the edge's allowed domains: the
@@ -231,16 +247,18 @@ func (s *Server) handleWAF(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	snap := s.waf.scoped(func(host string) bool { return s.authz.Allowed(token, host) })
+	caID, activeFP := s.currentSignerKey()
 	resp := wafResponse{
 		Generation:  snap.generation,
 		GlobalRules: snap.global,
 		Zones:       snap.zones,
 		HostZoneMap: snap.hostZone,
-		// In-body ca_id busts the ETag on the 200 arm for free (the WAF snapshot is
-		// ca_id-independent — SetSigner leaves it untouched). The steady-state 304 arm
-		// carries NOTHING, so /v1/waf is only a SECONDARY confirmer; the /v1/certs
-		// X-Parapet-CA-Id header is the guaranteed steady-state carrier.
-		CAID: s.CurrentCAID(),
+		// In-body ca_id + signing fp bust the ETag on the 200 arm for free (the WAF
+		// snapshot is signer-independent). The steady-state 304 arm carries NOTHING, so
+		// /v1/waf is only a SECONDARY confirmer; the /v1/certs headers are the guaranteed
+		// steady-state carrier.
+		CAID:      caID,
+		SigningFP: activeFP,
 	}
 	body, err := json.Marshal(resp)
 	if err != nil {

--- a/edgecp/signer.go
+++ b/edgecp/signer.go
@@ -48,7 +48,8 @@ type Signer struct {
 	bundle     []byte            // every CA public cert, PEM (OLD++NEW during overlap); served as ca_pem
 	bundlePool *x509.CertPool    // roots over `bundle`, for Sign()'s post-sign chain self-verify
 	caID       string
-	certCount  int // number of CA certs in the bundle (2 during OLD++NEW overlap, else 1)
+	activeFP   string // sha256 hex of the ACTIVE signing cert — distinguishes active=OLD vs =NEW
+	certCount  int    // number of CA certs in the bundle (2 during OLD++NEW overlap, else 1)
 	ttl        time.Duration
 	skew       time.Duration
 }
@@ -148,6 +149,7 @@ func NewProvidedSignerActive(bundlePEM, keyPEM []byte, activeFP string, ttl, ske
 		bundle:     rebuilt,
 		bundlePool: pool,
 		caID:       id,
+		activeFP:   fps[activeIx],
 		certCount:  len(certs),
 		ttl:        ttl,
 		skew:       skew,
@@ -162,6 +164,12 @@ func (s *Signer) BundlePEM() []byte { return s.bundle }
 // trust-bundle ca_id). It changes whenever a CA is added to or dropped from the
 // bundle, which is the edge's proactive force-re-mint trigger.
 func (s *Signer) CAID() string { return s.caID }
+
+// ActiveFP returns the SHA-256 (hex) of the ACTIVE signing cert — the CA that signs new
+// leaves. The bundle ca_id (CAID) is identical for active=OLD and active=NEW during an
+// OLD++NEW overlap (both append the same bundle), so ActiveFP is the ONLY signal that
+// distinguishes them — the load-bearing proof that issued leaves chain to NEW.
+func (s *Signer) ActiveFP() string { return s.activeFP }
 
 // BundleLen returns the number of CA certs in the served bundle: 2 during an
 // OLD++NEW rotation overlap, 1 otherwise. Read-only, O(1) (counted at construction).

--- a/edgecp/signerreload.go
+++ b/edgecp/signerreload.go
@@ -187,14 +187,29 @@ func (r *SignerReloader) reload(ctx context.Context) error {
 
 	cand, warnings, err := NewProvidedSignerActive(crt, keyPEM, activeFP, r.ttl, r.skew)
 	if err != nil {
+		// A FAILED active=new candidate (the fingerprint pin won't build / reordered
+		// bundle) keeps last-good = still active=old SILENTLY — the replica would mint
+		// OLD-signed leaves forever. Raise a distinct alertable gauge so a wedged replica
+		// is diagnosable, not just an unexplained converge stall.
+		if active == caActiveNew {
+			signerActiveFlipFailed.Set(1)
+		}
 		slog.Error("edgecp: build edge CA signer; keeping last-good", "err", err, "active", active)
 		return nil
+	}
+	if active == caActiveNew {
+		signerActiveFlipFailed.Set(0)
 	}
 	for _, msg := range warnings {
 		slog.Warn("edge CA: " + msg)
 	}
-	if cand.CAID() == r.server.CurrentCAID() {
-		return nil // unchanged bundle; do not churn the generation (RV-only writes are no-ops)
+	// Guard on the (ca_id, active-fp) TUPLE: an active=old→new flip leaves the OLD++NEW
+	// bundle byte-identical (same ca_id), so a ca_id-only short-circuit would make the
+	// flip a SILENT no-op and the NEW signer would never install. The active-fp is the
+	// only thing that changes at the flip.
+	curCAID, curFP := r.server.currentSignerKey()
+	if cand.CAID() == curCAID && cand.ActiveFP() == curFP {
+		return nil // unchanged bundle AND active key; do not churn the generation
 	}
 	r.server.SetSigner(cand, generation)
 	if active == "" {

--- a/edgecp/signerreload_test.go
+++ b/edgecp/signerreload_test.go
@@ -144,6 +144,66 @@ func TestSignerReloaderContradictoryAnnotationKeepsLastGood(t *testing.T) {
 	}
 }
 
+// THE load-bearing serving change: an active=old→new flip leaves the OLD++NEW bundle
+// byte-identical (same ca_id), so a ca_id-only short-circuit would make the flip a SILENT
+// no-op and the NEW signer would never install. The reloader must install it — keyed on the
+// (ca_id, active-fp) tuple — advancing the generation and re-chaining new leaves to NEW
+// while the ca_id is UNCHANGED.
+func TestSignerReloaderActiveFlipInstallsNewSigner(t *testing.T) {
+	oldCert, oldKey := mustGenerateCA(t)
+	newCert, newKey := mustGenerateCA(t)
+	overlap := append(append([]byte(nil), oldCert...), newCert...)
+	secs := []v1.Secret{caSecretObj(
+		map[string][]byte{"tls.crt": overlap, "tls.key": oldKey, caNewKeyField: newKey},
+		map[string]string{caRotationPhaseAnnotation: caPhaseOverlap, caActiveAnnotation: caActiveOld},
+	)}
+
+	srv := NewServer(NewCertStore(), NewAuthz(nil))
+	r := testReloader(srv, &secs)
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	gen1, caid1 := srvGen(srv), srv.CurrentCAID()
+	if srv.CurrentActiveFP() != fpOf(t, oldCert) {
+		t.Fatalf("pre-flip active fp = %q, want OLD %q", srv.CurrentActiveFP(), fpOf(t, oldCert))
+	}
+
+	// Flip ONLY the active annotation (a real write advances the RV); the bundle is identical.
+	secs[0].Annotations[caActiveAnnotation] = caActiveNew
+	secs[0].ResourceVersion = "300"
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if srv.CurrentCAID() != caid1 {
+		t.Errorf("ca_id must stay identical across the active flip (same OLD++NEW bundle), %q → %q", caid1, srv.CurrentCAID())
+	}
+	if srvGen(srv) <= gen1 {
+		t.Errorf("the flip must install a new signer (generation must advance), %d → %d", gen1, srvGen(srv))
+	}
+	if srv.CurrentActiveFP() != fpOf(t, newCert) {
+		t.Errorf("post-flip active fp = %q, want NEW %q", srv.CurrentActiveFP(), fpOf(t, newCert))
+	}
+	// The installed signer now signs under NEW (the whole point — leaves survive the OLD-drop).
+	sg := srv.signerState.Load().sg
+	chainPEM, _, _, err := sg.Sign(mkLeafKey(t).Public(), "edge-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !verifiesUnder(t, chainPEM, newCert) || verifiesUnder(t, chainPEM, oldCert) {
+		t.Error("after the flip, new leaves must chain to NEW, not OLD")
+	}
+
+	// A re-read at the same RV (unchanged bundle AND active) must NOT churn the generation.
+	gen2 := srvGen(srv)
+	if err := r.reload(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if srvGen(srv) != gen2 {
+		t.Errorf("a no-op re-read after the flip must not advance the generation, %d → %d", gen2, srvGen(srv))
+	}
+}
+
 func TestSignerReloaderAbsentSecretKeepsUnloaded(t *testing.T) {
 	secs := []v1.Secret{} // CA not provisioned yet
 	srv := NewServer(NewCertStore(), NewAuthz(nil))

--- a/edgecp/trim_test.go
+++ b/edgecp/trim_test.go
@@ -1,0 +1,202 @@
+package edgecp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// overlapStub returns a fakeRW in the OLD++NEW overlap (active=old) by running RotateCA on
+// a populated single-CA Secret, plus the OLD cert and the NEW cert's fingerprint.
+func overlapStub(t *testing.T) (f *fakeRW, oldCert []byte, newFP string) {
+	t.Helper()
+	f, oldCert, _ = populatedCAStub(t)
+	if _, err := RotateCA(context.Background(), f, "ns", "parapet-edge-ca", time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	fps := certBundleFPs(f.secrets["ns/parapet-edge-ca"].Data["tls.crt"])
+	if len(fps) != 2 {
+		t.Fatalf("overlap should have 2 certs, got %d", len(fps))
+	}
+	return f, oldCert, fps[1] // NEW is last
+}
+
+// sec is a short accessor for the live CA Secret.
+func sec(f *fakeRW) *v1.Secret { return f.secrets["ns/parapet-edge-ca"] }
+
+func TestSetActiveNewFlips(t *testing.T) {
+	f, _, newFP := overlapStub(t)
+
+	if _, err := SetActiveNew(context.Background(), f, "ns", "parapet-edge-ca", newFP); err != nil {
+		t.Fatal(err)
+	}
+	s := sec(f)
+	if s.Annotations[caActiveAnnotation] != caActiveNew {
+		t.Errorf("active = %q, want new", s.Annotations[caActiveAnnotation])
+	}
+	// Non-destructive: the bundle is byte-identical (still OLD++NEW), tls.key + the staged
+	// NEW key are untouched.
+	if _, n, _ := reencodeCertBundle(s.Data["tls.crt"]); n != 2 {
+		t.Errorf("flip must keep both certs, got %d", n)
+	}
+	if len(s.Data[caNewKeyField]) == 0 {
+		t.Error("flip must keep the staged NEW key (still needed until trim)")
+	}
+	// The reloader's active=new selection (NEW key + NEW fp) now signs under NEW.
+	sg, _, err := NewProvidedSignerActive(s.Data["tls.crt"], s.Data[caNewKeyField], newFP, time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sg.ActiveFP() != newFP {
+		t.Errorf("post-flip active fp = %q, want NEW %q", sg.ActiveFP(), newFP)
+	}
+}
+
+func TestSetActiveNewIdempotent(t *testing.T) {
+	f, _, newFP := overlapStub(t)
+	if _, err := SetActiveNew(context.Background(), f, "ns", "parapet-edge-ca", newFP); err != nil {
+		t.Fatal(err)
+	}
+	calls := f.updateCalls
+	if _, err := SetActiveNew(context.Background(), f, "ns", "parapet-edge-ca", newFP); err != nil {
+		t.Fatal(err)
+	}
+	if f.updateCalls != calls {
+		t.Errorf("idempotent re-run must not write, updateCalls %d → %d", calls, f.updateCalls)
+	}
+}
+
+func TestSetActiveNewPinMismatch(t *testing.T) {
+	f, _, _ := overlapStub(t)
+	if _, err := SetActiveNew(context.Background(), f, "ns", "parapet-edge-ca", "deadbeef"); err == nil {
+		t.Error("a wrong NEW-fp pin must refuse the flip")
+	}
+	if sec(f).Annotations[caActiveAnnotation] != caActiveOld {
+		t.Error("a refused flip must leave active=old")
+	}
+}
+
+func TestSetActiveNewRefusesNonOverlap(t *testing.T) {
+	f, _, _ := populatedCAStub(t) // single-CA, never rotated
+	if _, err := SetActiveNew(context.Background(), f, "ns", "parapet-edge-ca", ""); err == nil {
+		t.Error("flip must refuse a non-overlap (single-CA) Secret")
+	}
+}
+
+func TestTrimCADropsOldAndSeversOldLeaves(t *testing.T) {
+	f, oldCert, newFP := overlapStub(t)
+	s := sec(f)
+
+	// Capture an OLD-signed leaf minted during the overlap (active=old) BEFORE the drop.
+	oldSigner, _, err := NewProvidedSignerActive(s.Data["tls.crt"], s.Data["tls.key"], fpOf(t, oldCert), time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldLeafChain, _, _, err := oldSigner.Sign(mkLeafKey(t).Public(), "edge-old")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Flip then trim (the required order).
+	if _, err := SetActiveNew(context.Background(), f, "ns", "parapet-edge-ca", newFP); err != nil {
+		t.Fatal(err)
+	}
+	newBundle, err := TrimCA(context.Background(), f, "ns", "parapet-edge-ca", newFP)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s = sec(f)
+	fps := certBundleFPs(s.Data["tls.crt"])
+	if len(fps) != 1 || fps[0] != newFP {
+		t.Fatalf("trimmed tls.crt must be NEW-only, got fps=%v want [%s]", fps, newFP)
+	}
+	if len(s.Data[caNewKeyField]) != 0 {
+		t.Error("trim must delete the staged NEW key field")
+	}
+	if !validCAKeypair(s.Data["tls.crt"], s.Data["tls.key"]) {
+		t.Error("post-trim tls.key must match the surviving NEW cert")
+	}
+	if s.Annotations[caRotationPhaseAnnotation] != caPhaseTrimmed {
+		t.Errorf("phase = %q, want trimmed", s.Annotations[caRotationPhaseAnnotation])
+	}
+	if s.Annotations[caActiveAnnotation] != caActiveOld {
+		t.Errorf("active = %q, want old (single-CA default)", s.Annotations[caActiveAnnotation])
+	}
+	if s.Annotations[caGenerationAnnotation] == "" {
+		t.Error("anti-regeneration guard must remain stamped after trim")
+	}
+
+	// THE load-bearing property: an OLD-signed leaf no longer verifies against the trimmed
+	// NEW-only bundle (the revoked/un-re-minted edge is severed), while a fresh NEW leaf does.
+	if verifiesUnder(t, oldLeafChain, newBundle) {
+		t.Error("an OLD-signed leaf must NOT verify against the trimmed NEW-only CA (it must be severed)")
+	}
+	newSigner, _, err := NewProvidedSignerActive(s.Data["tls.crt"], s.Data["tls.key"], newFP, time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newLeaf, _, _, err := newSigner.Sign(mkLeafKey(t).Public(), "edge-new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !verifiesUnder(t, newLeaf, newBundle) {
+		t.Error("a NEW-signed leaf must verify against the trimmed NEW-only CA")
+	}
+}
+
+func TestTrimCARefusesActiveOld(t *testing.T) {
+	f, _, newFP := overlapStub(t) // still active=old (no flip)
+	if _, err := TrimCA(context.Background(), f, "ns", "parapet-edge-ca", newFP); err == nil {
+		t.Error("trim must refuse while active=old (dropping OLD would orphan the signing key)")
+	}
+	if _, n, _ := reencodeCertBundle(sec(f).Data["tls.crt"]); n != 2 {
+		t.Error("a refused trim must leave both certs")
+	}
+}
+
+func TestTrimCARequiresFP(t *testing.T) {
+	f, _, newFP := overlapStub(t)
+	if _, err := SetActiveNew(context.Background(), f, "ns", "parapet-edge-ca", newFP); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := TrimCA(context.Background(), f, "ns", "parapet-edge-ca", ""); err == nil {
+		t.Error("trim must require the expected NEW fp (no blind destructive drop)")
+	}
+}
+
+func TestTrimCAPinMismatch(t *testing.T) {
+	f, _, newFP := overlapStub(t)
+	if _, err := SetActiveNew(context.Background(), f, "ns", "parapet-edge-ca", newFP); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := TrimCA(context.Background(), f, "ns", "parapet-edge-ca", "deadbeef"); err == nil {
+		t.Error("a wrong NEW-fp pin must refuse the trim")
+	}
+	if _, n, _ := reencodeCertBundle(sec(f).Data["tls.crt"]); n != 2 {
+		t.Error("a refused trim must leave both certs")
+	}
+}
+
+func TestTrimCAIdempotent(t *testing.T) {
+	f, _, newFP := overlapStub(t)
+	if _, err := SetActiveNew(context.Background(), f, "ns", "parapet-edge-ca", newFP); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := TrimCA(context.Background(), f, "ns", "parapet-edge-ca", newFP); err != nil {
+		t.Fatal(err)
+	}
+	calls := f.updateCalls
+	bundle2, err := TrimCA(context.Background(), f, "ns", "parapet-edge-ca", newFP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.updateCalls != calls {
+		t.Errorf("idempotent re-trim must not write, updateCalls %d → %d", calls, f.updateCalls)
+	}
+	if fps := certBundleFPs(bundle2); len(fps) != 1 || fps[0] != newFP {
+		t.Errorf("re-trim must return the NEW-only bundle, got %v", fps)
+	}
+}


### PR DESCRIPTION
## Sub-PR 5 — sever a revoked edge by gating the destructive OLD-drop on every leaf being NEW-signed

Completes the auto-trust revocation feature. The earlier sub-PRs built the ca_id convergence interlock; this one closes **the mass-502 crux** and ships the one-shot revoke tool.

### The crux it fixes
`ca_id` convergence proves an edge holds the OLD++NEW *bundle* but **NOT that its leaf is *signed by* NEW**: `Sign()` appends the full served bundle to every leaf, so `parapet_edge_clientcert_ca_id` is byte-identical for `active=old` and `active=new`. After the OLD-drop the core's `ClientCAs={NEW}`, so an OLD-*signed* leaf fails verification → a **502 for that otherwise-good edge**. Gating the drop on ca_id alone would mass-502 the fleet.

### The resolution — an active-signer fingerprint threaded CP→edge→converge
- **CP** (`Signer.ActiveFP()`): the sha256 of the CA *actually signing* rides every cert/edge-cert/WAF/trust-bundle response (`X-Parapet-Signing-Cert-Fp` / `signing_cert_fp`) and the `parapet_edge_ca_active_signer_fp` gauge. The signer reloader's no-op short-circuit now keys on the **(ca_id, active-fp) tuple** so the `active=old→new` flip (unchanged bundle ⇒ unchanged ca_id) actually installs the NEW signer instead of silently no-op'ing. `GenerateCA` stamps an explicit `SubjectKeyId` so the issuer match doesn't rest on the stdlib's implicit derivation.
- **Edge** (`deriveIssuerFP`): resolves *which* chain CA signed the live leaf (AuthorityKeyId==SubjectKeyId, exactly-one-match, **fail-closed** on none/ambiguous) → `parapet_edge_clientcert_signer_fp`. The proactive re-mint triggers on a divergence on **either** axis (ca_id OR signer fp).
- **Drop interlock** (`edgecp/converge`): the destructive gate additionally requires every CP replica + good edge to be NEW-signed, the blacklist converged on every replica (`authz gen == AuthzGeneration(post-revoke registry)`), and the **CP-authoritative issuance ledger** (`parapet_edge_ca_issued_total{edge_id,sigfp}`) to show the revoked id with **zero** NEW issuances — a guarantee that does NOT rest on the forgeable edge self-report. The revoked id is **exempt** from the live-OLD vetoes (it is the intended casualty).

### The CA-Secret state machine (new write paths)
`overlap`/`active=old` (`RotateCA`, unchanged non-destructive widen) → `active=new` (`SetActiveNew`, reversible) → `trimmed` (`TrimCA`, the destructive NEW-only drop; refuses unless `active=new` first so OLD isn't dropped while it's the active signer). All idempotent + CAS-looped.

### The orchestrator
`EDGE_CA_REVOKE=true` (`runRevoke`) drives widen → wait Gate A (ca_id) → flip → wait Gate B (NEW-signed + blacklist + zero-NEW-issuance + live probe) → trim, gating each irreversible step on `converge-status` and resuming idempotently. A gate timeout leaves the rotation at its last completed step and **never drops OLD**. Preflight refuses unless the revoked id is present-and-`disabled` in `CP_TOKENS`.

### Safety properties preserved
- OLD-drop is **convergence-gated, never timer-gated**; fail-closed throughout.
- Private keys never leave the edge.
- The Prometheus reader stays confined to the CLI path (the import-boundary test still holds; serving handlers never reach it).

### Tests
- Predicate: the drop gates + the revoked-edge veto exemption + the widen-checkpoint-ignores-fp invariant.
- `deriveIssuerFP`: OLD-vs-NEW discrimination + fail-closed on ambiguity/no-match/nil.
- The `active=old→new` flip installs the NEW signer at an unchanged ca_id (the load-bearing serving change).
- `TrimCA` severs an OLD-signed leaf minted during the overlap while a NEW-signed leaf still verifies.
- The remint tuple, the issuance ledger / active-fp gauges, `AuthzGeneration` determinism, the revoke helpers, and the e2e (Phase 10) asserting the signal rides the real binary.
- Full suite green under `-race`; `gofmt`/`vet` clean; edge e2e passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)