### PR TITLE
feat(core-trust): warm-start cache — anti-resurrection generation floor

### DIFF
--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -236,6 +236,16 @@ caps the hint's age. `parapet_trust_source{file|mtls|cidr|none}` makes the state
 alertable. (Header hardening unchanged: the core unconditionally strips client-supplied
 `X-Forwarded-Country/-ASN` at ingress.)
 
+> **Implemented** (`trust.Manager.EnableWarmStart`/`writeCache`, `apply`'s floor check). The
+> hint is realized as a generation **floor** (anti-resurrection) — the cached CA is
+> deliberately NOT loaded into `ClientCAs`, so "stays CIDR-only until revalidated" falls out
+> for free (per-request trust keys on `r.TLS.VerifiedChains`, which is empty until a live
+> apply populates the pool) and a stale-CA handshake can never reject a NEW-leaf edge.
+> Because no per-request decision is "file-sourced" under that safe design, the alertable
+> state is the **`parapet_trust_warmstart_active`** gauge (1 while running on an
+> unrevalidated floor) rather than a per-request `trust_source{file}` counter; the
+> anti-resurrection rejection is `trust_apply_total{result="floor_rejected"}`.
+
 ## Edge wiring
 
 The default data-plane identity is CP-issued (`EDGE_DATAPLANE_MTLS=true`; requires
@@ -594,9 +604,10 @@ pure-instrumentation Prometheus metrics on the shared `parapet` registry / `:918
 | `parapet_edge_ca_signer_loaded` | CP | gauge 0/1 | — | 1 once a signer is loaded; 0 = CP up but not yet provisioned (vs scrape-missing). |
 | `parapet_trust_bundle_generation` | core | gauge=gen | `ca_id` | The `ca_id`/generation the core currently trusts. |
 | `parapet_trust_bundle_age_seconds` | core | gaugefunc | — | Seconds since the core last applied a bundle; rising fleet-wide = convergence stalled. |
-| `parapet_trust_apply_total` | core | counter | `result` | `applied`/`rollback_rejected`/`parse_rejected`/`empty_rejected` — `rollback_rejected` is the anti-replay signal. |
+| `parapet_trust_apply_total` | core | counter | `result` | `applied`/`rollback_rejected`/`floor_rejected`/`parse_rejected`/`empty_rejected` — `rollback_rejected` (in-session) and `floor_rejected` (cross-restart warm-start floor) are the anti-replay/anti-resurrection signals. |
 | `parapet_trust_fetch_failed_total` | core | counter | — | Couldn't reach/decode the CP (vs reached-but-rejected). |
 | `parapet_trust_source_total` | core | counter | `source` | Per-request trust decision: `cidr`/`verified-chain`/`none`. |
+| `parapet_trust_warmstart_active` | core | gauge 0/1 | — | 1 while running on an unrevalidated warm-start floor (mTLS withheld, CIDR-only); 0 once a live fetch revalidates. Alert if it stays 1. |
 | `parapet_edge_clientcert_ca_id` | edge | gauge=1 | `ca_id` | CA set that issued the edge's **live** client leaf (lags the target until the edge re-mints). |
 | `parapet_edge_clientcert_not_after_seconds` | edge | gauge=unix | `ca_id` | Expiry of the edge's live leaf — an edge stuck on OLD with imminent expiry is the danger case. |
 | `parapet_edge_clientcert_loaded` | edge | gauge 0/1 | — | 1 once the edge holds a usable client cert. |
@@ -669,7 +680,7 @@ not Prometheus counters (a Pushgateway would be a new failure domain).
 | `EDGE_TRUST_CP_ENDPOINT` | core | `""` (off) | HTTPS base URL of the CP. Set ⇒ the core pulls `GET /v1/trust-bundle`. **MUST be `https://`** — non-https is fatal, no plaintext analog ever. |
 | `EDGE_TRUST_CP_CA` | core | `""` | PEM of the CA that signs the **CP server** cert → `RootCAs`. **Mandatory + fatal** if missing/empty/unparseable; no system-roots fallback, no skip-verify. Dedicated single-purpose CA; distinct from the edge CA in `ca_pem`. |
 | `EDGE_TRUST_CP_WATCH_TIMEOUT` / `_POLL_INTERVAL` | core/CP | `30s` / `5m` | Long-poll ceiling; safety-net poll. The poll now bounds **CA-rotation** propagation only (not per-request revocation), so it may lengthen; keep the long-poll for fast rotation convergence. |
-| `EDGE_TRUST_CP_CACHE_FILE` / `_MAX_STALE` | core | `""` / `1h` | Warm-start hint (no trust until revalidated; bounded by max-stale). |
+| `EDGE_TRUST_CP_CACHE_FILE` / `_MAX_STALE` | core | `""` (off) / `3600` (s, =1h) | Warm-start cache. After every successful poll the core persists `{generation, ca_id, ca_pem, written_at}` (public; atomic temp+rename) and on startup loads its generation as an anti-rollback **floor** (a bundle below it ⇒ `trust_apply_total{result="floor_rejected"}`), so a restart-during-outage can't resurrect a rotated-out CA via a stale CP replica. It confers **NO trust** until a live fetch revalidates — the cached CA is **not** loaded into `ClientCAs`, so trust stays CIDR-only meanwhile (`trust_warmstart_active=1`) and flips to mTLS on the first live apply. `written_at` tracks last CP **contact** (refreshed on 304s too), so `_MAX_STALE` (seconds) bounds time-since-contact: a longer outage discards the floor and cold-starts (larger = safer vs. resurrection; smaller = recovers faster from a CP-side generation reset). |
 | `EDGE_TRUST_REQUIRE_SAN` | core | **forced false, deprecated** | CA-only is the only model; the per-request SAN check is removed. Setting `true` with CP-issuance is a **fatal config error**. Slated for removal. |
 | `EDGE_DATAPLANE_MTLS` | edge | `false` | Enable the CP-issued client cert. Requires `EDGE_UPSTREAM_TLS=true`. Readiness gated on a loaded cert. |
 | `EDGE_ID` | edge | hostname | The edge's STABLE logical id, stamped as the `edge_id` label on every convergence metric (the OLD-drop interlock joins per-edge by it). **Required with `EDGE_DATAPLANE_MTLS=true`** and **must match this edge's CP token id**. Without mTLS, defaults to the hostname (convergence is moot). |

--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -260,6 +260,14 @@ func main() {
 			os.Exit(1)
 		}
 		trustMgr = trust.NewManager()
+		// Warm-start cache (optional): persist the last-good bundle so a restart-during-outage
+		// can't resurrect a rotated-out CA via a stale CP replica. The cache seeds an
+		// anti-rollback generation FLOOR; it confers NO trust until a live fetch revalidates
+		// (mTLS stays CIDR-only meanwhile). See EDGE-AUTOTRUST.md "Warm-start cache".
+		if cacheFile := config.String("EDGE_TRUST_CP_CACHE_FILE"); cacheFile != "" {
+			maxStale := time.Duration(config.IntDefault("EDGE_TRUST_CP_MAX_STALE", 3600)) * time.Second
+			trustMgr.EnableWarmStart(cacheFile, maxStale)
+		}
 		pollInterval := time.Duration(config.IntDefault("EDGE_TRUST_CP_POLL_INTERVAL", 300)) * time.Second
 		go trustMgr.Run(context.Background(), tc, pollInterval)
 		slog.Info("edge auto-trust enabled (CA-only mTLS)", "endpoint", ep)

--- a/metric/trust.go
+++ b/metric/trust.go
@@ -23,7 +23,7 @@ var (
 	trustApply = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: prom.Namespace,
 		Name:      "trust_apply_total",
-		Help:      "Trust-bundle apply attempts by result (applied|rollback_rejected|parse_rejected|empty_rejected).",
+		Help:      "Trust-bundle apply attempts by result (applied|rollback_rejected|floor_rejected|parse_rejected|empty_rejected).",
 	}, []string{"result"})
 
 	trustFetchFailed = prometheus.NewCounter(prometheus.CounterOpts{
@@ -37,6 +37,17 @@ var (
 		Name:      "trust_source_total",
 		Help:      "Per-request trust decision by source (cidr|verified-chain|none).",
 	}, []string{"source"})
+
+	// trustWarmStart is 1 while the core is running on a persisted warm-start FLOOR that
+	// has NOT yet been revalidated by a live control-plane fetch — a degraded, alertable
+	// state: edge mTLS trust is withheld (CIDR-only) until the first live bundle supersedes
+	// the floor, because the cached CA could be one the operator just rotated out. It flips
+	// to 0 on the first successful live apply (or is 0 from the start when no cache loaded).
+	trustWarmStart = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "trust_warmstart_active",
+		Help:      "1 while running on an unrevalidated warm-start floor (mTLS trust withheld, CIDR-only); 0 once a live fetch revalidates.",
+	})
 
 	// lastApply is the unix-nanos timestamp of the last successful apply, read at scrape
 	// time by the trust_bundle_age_seconds GaugeFunc (zero steady-state cost, no ticker).
@@ -76,9 +87,9 @@ func init() {
 		}
 		return time.Since(time.Unix(0, ns)).Seconds()
 	})
-	prom.Registry().MustRegister(trustBundleGeneration, trustApply, trustFetchFailed, trustSource, bundleAge)
+	prom.Registry().MustRegister(trustBundleGeneration, trustApply, trustFetchFailed, trustSource, trustWarmStart, bundleAge)
 
-	for _, r := range []string{"applied", "rollback_rejected", "parse_rejected", "empty_rejected"} {
+	for _, r := range []string{"applied", "rollback_rejected", "floor_rejected", "parse_rejected", "empty_rejected"} {
 		trustApplyHandles[r], _ = trustApply.GetMetricWith(prometheus.Labels{"result": r})
 	}
 	trustSourceCounters[TrustSrcNone], _ = trustSource.GetMetricWith(prometheus.Labels{"source": "none"})
@@ -110,6 +121,17 @@ func TrustBundleApplied(caID string, generation uint64) {
 
 // TrustFetchFailed counts a failed trust-bundle fetch (couldn't reach/decode the CP).
 func TrustFetchFailed() { trustFetchFailed.Inc() }
+
+// TrustWarmStart sets the warm-start-active state (1 = running on an unrevalidated floor,
+// mTLS withheld; 0 = revalidated / no cache). Set true at startup when a floor loads, false
+// on the first successful live apply.
+func TrustWarmStart(active bool) {
+	if active {
+		trustWarmStart.Set(1)
+		return
+	}
+	trustWarmStart.Set(0)
+}
 
 // TrustSource counts one per-request trust decision. Hot-path: a bare array index +
 // atomic add — no lock, no label resolution, no map hash.

--- a/metric/trust_test.go
+++ b/metric/trust_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestTrustApplyEnum(t *testing.T) {
-	for _, result := range []string{"applied", "rollback_rejected", "parse_rejected", "empty_rejected"} {
+	for _, result := range []string{"applied", "rollback_rejected", "floor_rejected", "parse_rejected", "empty_rejected"} {
 		before := testutil.ToFloat64(trustApplyHandles[result])
 		TrustApply(result)
 		if got := testutil.ToFloat64(trustApplyHandles[result]); got != before+1 {
@@ -26,6 +26,17 @@ func TestTrustSourceEnum(t *testing.T) {
 		if got := testutil.ToFloat64(trustSourceCounters[src]); got != before+1 {
 			t.Errorf("TrustSource(%d): %v -> %v, want +1", src, before, got)
 		}
+	}
+}
+
+func TestTrustWarmStart(t *testing.T) {
+	TrustWarmStart(true)
+	if v := testutil.ToFloat64(trustWarmStart); v != 1 {
+		t.Errorf("warmstart active = %v, want 1", v)
+	}
+	TrustWarmStart(false) // a live fetch revalidated
+	if v := testutil.ToFloat64(trustWarmStart); v != 0 {
+		t.Errorf("warmstart after revalidation = %v, want 0", v)
 	}
 }
 

--- a/trust/trust.go
+++ b/trust/trust.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -97,10 +98,31 @@ func (c *Client) Fetch(sinceGen uint64, watch bool) (b Bundle, unchanged bool, e
 // handshake, hot-swapped from the CP bundle with strict-parse + forward-only +
 // fail-static (a bad/rollback bundle keeps last-good; the live pool is never nilled
 // once set).
+//
+// Warm-start (EnableWarmStart): the last-good {generation, ca_id, ca_pem} is persisted to
+// disk after every apply, and on startup its generation is loaded as an anti-resurrection
+// FLOOR — after a restart-during-outage the manager rejects any bundle older than the
+// last-good generation, so a stale CP replica can't resurrect a CA the operator just
+// rotated out. The cached CA is DELIBERATELY NOT loaded into clientCAs: trust stays
+// CIDR-only until the first LIVE fetch supersedes the floor (persist-and-trust would
+// re-trust the rotated-out CA across the restart).
 type Manager struct {
 	clientCAs atomic.Pointer[x509.CertPool]
 	gen       atomic.Uint64
 	caID      atomic.Pointer[string]
+
+	// floor is the persisted last-good generation: a bundle below it is rejected
+	// (floor_rejected) so a restart can't regress to a rotated-out CA. 0 = no floor
+	// (cold start). Written once by EnableWarmStart before Run starts, then read only
+	// in apply (the single Run goroutine) — no concurrent access, so no atomic needed.
+	floor uint64
+	// cachePath is the warm-start file; "" disables persistence. Set by EnableWarmStart.
+	cachePath string
+	// lastGood is the most recent applied bundle, rewritten to disk on EVERY successful poll
+	// (incl. 304s) so the file's written_at tracks last CP CONTACT (liveness), not last CA
+	// change — otherwise a stable fleet's months-old cache would always exceed MAX_STALE and
+	// the floor would never load. Touched only in the single Run goroutine.
+	lastGood *cacheEntry
 }
 
 func NewManager() *Manager { return &Manager{} }
@@ -109,6 +131,97 @@ func NewManager() *Manager { return &Manager{} }
 // caller then requests-but-does-not-verify client certs so the cold-start window
 // degrades to CIDR-only rather than aborting edge handshakes).
 func (m *Manager) ClientCAs() *x509.CertPool { return m.clientCAs.Load() }
+
+// WarmStartFloor returns the persisted last-good generation loaded as the
+// anti-resurrection floor (0 = none). Read-only, for observability/tests.
+func (m *Manager) WarmStartFloor() uint64 { return m.floor }
+
+// cacheEntry is the on-disk warm-start record. ca_pem + ca_id are public (no
+// secret-at-rest concern); written_at bounds staleness.
+type cacheEntry struct {
+	Generation uint64 `json:"generation"`
+	CAID       string `json:"ca_id"`
+	CAPEM      string `json:"ca_pem"`
+	WrittenAt  int64  `json:"written_at"` // unix seconds
+}
+
+// EnableWarmStart wires the on-disk warm-start cache. Call ONCE before Run. It records the
+// cache path (Run rewrites it after every successful apply) and, if a cache exists and is
+// within maxStale, loads its generation as the anti-resurrection FLOOR: after a restart the
+// manager rejects any bundle older than the last-good generation, so a stale CP replica
+// can't resurrect a CA the operator just rotated out. It deliberately does NOT load the
+// cached CA into ClientCAs — trust stays CIDR-only until the first LIVE fetch supersedes the
+// floor. A missing / corrupt / too-stale / zero-generation cache is a quiet no-op
+// (cold-start, no floor). maxStale<=0 disables the age bound.
+func (m *Manager) EnableWarmStart(path string, maxStale time.Duration) {
+	m.cachePath = path
+	if path == "" {
+		return
+	}
+	e, err := readCache(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			// A corrupt/unreadable cache is non-fatal: cold-start with no floor (safe — we
+			// just lose the cross-restart anti-resurrection guard until the next apply).
+			slog.Warn("core: warm-start cache unreadable; cold-starting with no floor", "path", path, "error", err)
+		}
+		return
+	}
+	if maxStale > 0 {
+		if age := time.Since(time.Unix(e.WrittenAt, 0)); age > maxStale {
+			slog.Warn("core: warm-start cache too stale; discarding (cold-start, no floor)",
+				"path", path, "age", age.Round(time.Second), "max_stale", maxStale)
+			return
+		}
+	}
+	m.floor = e.Generation
+	metric.TrustWarmStart(true)
+	slog.Info("core: warm-start floor loaded — edge mTLS trust WITHHELD (CIDR-only) until a live fetch revalidates",
+		"floor_generation", e.Generation, "ca_id", e.CAID)
+}
+
+// readCache reads + validates the warm-start file. A zero generation is invalid (it would
+// be no floor at all) and is treated as a parse error so the caller cold-starts cleanly.
+func readCache(path string) (cacheEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cacheEntry{}, err
+	}
+	var e cacheEntry
+	if err := json.Unmarshal(data, &e); err != nil {
+		return cacheEntry{}, fmt.Errorf("parse warm-start cache: %w", err)
+	}
+	if e.Generation == 0 {
+		return cacheEntry{}, fmt.Errorf("warm-start cache has zero generation")
+	}
+	return e, nil
+}
+
+// writeCache persists e as the next restart's floor, always stamping written_at = now so
+// the file tracks last CP contact (liveness). Best-effort: any failure logs and is ignored
+// (a missing cache only loses the cross-restart guard, never breaks serving). The write is
+// atomic (temp + rename) so a crash mid-write can't leave a torn file. No-op when
+// persistence is disabled.
+func (m *Manager) writeCache(e cacheEntry) {
+	if m.cachePath == "" {
+		return
+	}
+	e.WrittenAt = time.Now().Unix()
+	data, err := json.Marshal(e)
+	if err != nil {
+		slog.Warn("core: warm-start cache marshal failed", "error", err)
+		return
+	}
+	tmp := m.cachePath + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		slog.Warn("core: warm-start cache write failed", "path", m.cachePath, "error", err)
+		return
+	}
+	if err := os.Rename(tmp, m.cachePath); err != nil {
+		slog.Warn("core: warm-start cache rename failed", "path", m.cachePath, "error", err)
+		_ = os.Remove(tmp)
+	}
+}
 
 // Generation / CAID expose the last applied bundle for observability.
 func (m *Manager) Generation() uint64 { return m.gen.Load() }
@@ -165,6 +278,7 @@ const (
 	resultParseRejected
 	resultEmptyRejected
 	resultRollbackRejected
+	resultFloorRejected
 )
 
 func (r applyResult) label() string {
@@ -177,6 +291,8 @@ func (r applyResult) label() string {
 		return "empty_rejected"
 	case resultRollbackRejected:
 		return "rollback_rejected"
+	case resultFloorRejected:
+		return "floor_rejected"
 	default:
 		return "unknown"
 	}
@@ -194,6 +310,13 @@ func (m *Manager) apply(b Bundle) (applyResult, error) {
 	}
 	if n == 0 {
 		return resultEmptyRejected, fmt.Errorf("trust bundle ca_pem has no certificates")
+	}
+	// Warm-start floor (anti-resurrection across restart): a bundle older than the persisted
+	// last-good generation is a stale/rolled-back CA — reject BEFORE the in-session
+	// forward-only check (this catches it even on the first post-restart apply, when cur==0).
+	// floor==0 (no cache) makes this a no-op.
+	if b.Generation < m.floor {
+		return resultFloorRejected, fmt.Errorf("warm-start floor: bundle generation %d < persisted floor %d (stale/rolled-back CA across restart)", b.Generation, m.floor)
 	}
 	cur := m.gen.Load()
 	if cur != 0 && b.Generation <= cur {
@@ -262,6 +385,11 @@ func (m *Manager) Run(ctx context.Context, c *Client, pollInterval time.Duration
 			continue
 		case unchanged:
 			backoff = time.Second
+			// A 304 is still successful CP contact: refresh the cache's liveness timestamp so
+			// MAX_STALE measures time-since-contact, not time-since-last-CA-change.
+			if m.lastGood != nil {
+				m.writeCache(*m.lastGood)
+			}
 			continue
 		default:
 			res, err := m.apply(b)
@@ -270,6 +398,11 @@ func (m *Manager) Run(ctx context.Context, c *Client, pollInterval time.Duration
 				slog.Warn("core: trust-bundle rejected; keeping last-good", "error", err)
 			} else {
 				metric.TrustBundleApplied(b.CAID, b.Generation)
+				// A live fetch revalidated trust: remember it, persist it as the next restart's
+				// floor, and flip out of the warm-start (CIDR-only) degraded state.
+				m.lastGood = &cacheEntry{Generation: b.Generation, CAID: b.CAID, CAPEM: string(b.CAPEM)}
+				m.writeCache(*m.lastGood)
+				metric.TrustWarmStart(false)
 				slog.Info("core: edge trust bundle applied", "generation", b.Generation, "ca_id", b.CAID)
 			}
 			backoff = time.Second

--- a/trust/trust.go
+++ b/trust/trust.go
@@ -118,10 +118,11 @@ type Manager struct {
 	floor uint64
 	// cachePath is the warm-start file; "" disables persistence. Set by EnableWarmStart.
 	cachePath string
-	// lastGood is the most recent applied bundle, rewritten to disk on EVERY successful poll
-	// (incl. 304s) so the file's written_at tracks last CP CONTACT (liveness), not last CA
-	// change — otherwise a stable fleet's months-old cache would always exceed MAX_STALE and
-	// the floor would never load. Touched only in the single Run goroutine.
+	// lastGood is the most recent applied bundle (or, before this session's first apply, the
+	// loaded warm-start entry — see EnableWarmStart), rewritten to disk on EVERY successful
+	// poll (incl. 304s) so the file's written_at tracks last CP CONTACT (liveness), not last
+	// CA change — otherwise a stable fleet's months-old cache would always exceed MAX_STALE
+	// and the floor would never load. Set before Run starts, then touched only in Run.
 	lastGood *cacheEntry
 }
 
@@ -175,6 +176,13 @@ func (m *Manager) EnableWarmStart(path string, maxStale time.Duration) {
 		}
 	}
 	m.floor = e.Generation
+	// Seed lastGood from the cache so the liveness timestamp is refreshed even on a 304 that
+	// arrives BEFORE this session's first apply. This grants NO trust — lastGood feeds only
+	// writeCache (never ClientCAs / gen) — it just keeps written_at tracking last CP contact
+	// so MAX_STALE stays meaningful regardless of poll ordering. (Today Run's first fetch is a
+	// non-watch GET so a pre-apply 304 can't occur; this removes the latent coupling.)
+	seed := e
+	m.lastGood = &seed
 	metric.TrustWarmStart(true)
 	slog.Info("core: warm-start floor loaded — edge mTLS trust WITHHELD (CIDR-only) until a live fetch revalidates",
 		"floor_generation", e.Generation, "ca_id", e.CAID)

--- a/trust/trust_test.go
+++ b/trust/trust_test.go
@@ -6,9 +6,11 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"math/big"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -152,6 +154,136 @@ func TestTrustBundleOverTLSEndToEnd(t *testing.T) {
 		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	}); err != nil {
 		t.Fatalf("edge leaf does not verify against the pulled trust bundle: %v", err)
+	}
+}
+
+// ---- warm-start cache ----
+
+// The full warm-start cycle: apply -> persist -> a fresh manager loads the floor ->
+// rejects a stale (rotated-out) bundle, ACCEPTS the revalidating equal generation (must
+// not brick), then resumes forward-only.
+func TestWarmStartFloorRoundTrip(t *testing.T) {
+	caPEM, _ := caPEMFor(t)
+	path := t.TempDir() + "/trust-cache.json"
+
+	// Manager A applies gen 7 and persists it.
+	a := NewManager()
+	a.cachePath = path
+	if _, err := a.apply(Bundle{Generation: 7, CAPEM: caPEM, CAID: "ca7"}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	a.writeCache(cacheEntry{Generation: 7, CAPEM: string(caPEM), CAID: "ca7"})
+
+	// Manager B (a "restart") loads the floor — but must NOT trust anything yet.
+	b := NewManager()
+	b.EnableWarmStart(path, time.Hour)
+	if b.WarmStartFloor() != 7 {
+		t.Fatalf("floor = %d, want 7", b.WarmStartFloor())
+	}
+	if b.ClientCAs() != nil {
+		t.Fatal("warm-start must NOT load ClientCAs from the cache (trust stays CIDR-only until revalidated)")
+	}
+
+	// A stale CP replica serving gen 6 (< floor) is rejected — anti-resurrection.
+	if res, err := b.apply(Bundle{Generation: 6, CAPEM: caPEM, CAID: "old"}); err == nil || res != resultFloorRejected {
+		t.Errorf("stale-below-floor: res=%v err=%v, want resultFloorRejected", res, err)
+	}
+	if b.ClientCAs() != nil {
+		t.Fatal("a floor-rejected bundle must not establish trust")
+	}
+
+	// The revalidating LIVE fetch at the SAME generation (7 == floor) MUST apply — the
+	// floor must not brick the current bundle.
+	if res, err := b.apply(Bundle{Generation: 7, CAPEM: caPEM, CAID: "ca7"}); err != nil || res != resultApplied {
+		t.Fatalf("revalidate at floor: res=%v err=%v, want resultApplied", res, err)
+	}
+	if b.ClientCAs() == nil || b.Generation() != 7 {
+		t.Fatal("revalidation must flip on mTLS trust (pool loaded, gen=7)")
+	}
+
+	// Forward-only resumes: replay of 7 is now a rollback, 8 advances.
+	if res, _ := b.apply(Bundle{Generation: 7, CAPEM: caPEM}); res != resultRollbackRejected {
+		t.Errorf("post-revalidation replay: res=%v, want resultRollbackRejected", res)
+	}
+	if res, err := b.apply(Bundle{Generation: 8, CAPEM: caPEM, CAID: "ca8"}); err != nil || res != resultApplied {
+		t.Errorf("forward apply: res=%v err=%v, want resultApplied", res, err)
+	}
+}
+
+// A cache older than maxStale is discarded (cold-start, no floor) so a long outage resyncs
+// cleanly rather than being pinned to an ancient floor.
+func TestWarmStartMaxStaleDiscards(t *testing.T) {
+	caPEM, _ := caPEMFor(t)
+	path := t.TempDir() + "/trust-cache.json"
+	stale := cacheEntry{Generation: 9, CAID: "x", CAPEM: string(caPEM), WrittenAt: time.Now().Add(-48 * time.Hour).Unix()}
+	data, _ := json.Marshal(stale)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m := NewManager()
+	m.EnableWarmStart(path, 24*time.Hour)
+	if m.WarmStartFloor() != 0 {
+		t.Errorf("a too-stale cache must be discarded (floor 0), got %d", m.WarmStartFloor())
+	}
+	// With no floor, an older generation now applies (cold-start semantics).
+	if res, err := m.apply(Bundle{Generation: 3, CAPEM: caPEM, CAID: "y"}); err != nil || res != resultApplied {
+		t.Errorf("post-discard apply: res=%v err=%v, want resultApplied", res, err)
+	}
+}
+
+// Missing / corrupt / zero-generation caches are quiet no-ops (cold-start, no floor) — never
+// fatal, never a panic.
+func TestWarmStartBadCacheIsSafeNoOp(t *testing.T) {
+	caPEM, _ := caPEMFor(t)
+	dir := t.TempDir()
+	cases := map[string][]byte{
+		"corrupt": []byte("{ not json"),
+		"zerogen": func() []byte { d, _ := json.Marshal(cacheEntry{Generation: 0, CAPEM: string(caPEM)}); return d }(),
+	}
+	for name, content := range cases {
+		p := dir + "/" + name + ".json"
+		if err := os.WriteFile(p, content, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		m := NewManager()
+		m.EnableWarmStart(p, time.Hour)
+		if m.WarmStartFloor() != 0 {
+			t.Errorf("%s: floor = %d, want 0 (cold-start)", name, m.WarmStartFloor())
+		}
+	}
+	// Missing file.
+	m := NewManager()
+	m.EnableWarmStart(dir+"/does-not-exist.json", time.Hour)
+	if m.WarmStartFloor() != 0 {
+		t.Errorf("missing cache: floor = %d, want 0", m.WarmStartFloor())
+	}
+	// Empty path disables persistence (no floor, writeCache is a no-op).
+	m2 := NewManager()
+	m2.EnableWarmStart("", time.Hour)
+	m2.writeCache(cacheEntry{Generation: 1, CAPEM: string(caPEM)}) // must not panic / write anywhere
+	if m2.WarmStartFloor() != 0 {
+		t.Error("empty path must leave no floor")
+	}
+}
+
+// writeCache is atomic + leaves no .tmp behind, and the re-read floor matches.
+func TestWarmStartWriteAtomic(t *testing.T) {
+	caPEM, _ := caPEMFor(t)
+	path := t.TempDir() + "/c.json"
+	m := NewManager()
+	m.cachePath = path
+	// writeCache always stamps written_at=now (liveness), even if the caller passes a stale
+	// timestamp — this is what makes the 304-refresh track last CP contact.
+	m.writeCache(cacheEntry{Generation: 42, CAPEM: string(caPEM), CAID: "z", WrittenAt: 1})
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Error("writeCache must not leave a .tmp file behind")
+	}
+	e, err := readCache(path)
+	if err != nil || e.Generation != 42 || e.CAID != "z" {
+		t.Fatalf("round-trip: entry=%+v err=%v", e, err)
+	}
+	if time.Since(time.Unix(e.WrittenAt, 0)) > time.Minute {
+		t.Errorf("writeCache must stamp a fresh written_at (liveness), got %d", e.WrittenAt)
 	}
 }
 

--- a/trust/trust_test.go
+++ b/trust/trust_test.go
@@ -183,6 +183,11 @@ func TestWarmStartFloorRoundTrip(t *testing.T) {
 	if b.ClientCAs() != nil {
 		t.Fatal("warm-start must NOT load ClientCAs from the cache (trust stays CIDR-only until revalidated)")
 	}
+	// lastGood is seeded from the cache so a 304 before the first apply still refreshes the
+	// liveness timestamp — but it grants NO trust (ClientCAs stayed nil above, floor unchanged).
+	if b.lastGood == nil || b.lastGood.Generation != 7 {
+		t.Fatalf("EnableWarmStart must seed lastGood from the cache for the liveness refresh, got %+v", b.lastGood)
+	}
 
 	// A stale CP replica serving gen 6 (< floor) is rejected — anti-resurrection.
 	if res, err := b.apply(Bundle{Generation: 6, CAPEM: caPEM, CAID: "old"}); err == nil || res != resultFloorRejected {


### PR DESCRIPTION
## Warm-start cache (EDGE-AUTOTRUST.md "Warm-start cache")

Implements the Phase-1 warm-start cache the recent completeness audit flagged as unbuilt. It closes a **restart-during-outage resurrection hole**.

### The hole
The core's forward-only generation check lives only in memory. On restart it resets to 0, so the first post-restart trust-bundle fetch is accepted unconditionally. If the CP is down and a **stale CP replica** is serving an older generation (e.g. a pre-rotation `OLD++NEW`, or pre-trim bundle), the restarted core accepts it — **resurrecting a CA the operator just rotated out** and re-trusting a compromised edge.

### The fix — a persisted generation FLOOR
- After **every** successful poll (apply *and* 304), persist `{generation, ca_id, ca_pem, written_at}` to `EDGE_TRUST_CP_CACHE_FILE` (public data; atomic temp+rename). `written_at` tracks last CP **contact**, not last CA change — so a stable fleet's floor doesn't expire between rotations.
- On startup, load the cached generation as an anti-rollback **floor**: `apply()` rejects any bundle below it (`trust_apply_total{result="floor_rejected"}`) — even on the first post-restart apply when the in-session generation is still 0.

### Confers NO trust until revalidated (the doc's key invariant)
The cached CA is **deliberately not loaded into `ClientCAs`**. Per-request trust keys on `r.TLS.VerifiedChains`, which stays empty until the first **live** apply populates the pool — so trust stays **CIDR-only** during the warm-start window and "flips on" mTLS only after a live fetch supersedes the floor. Bonus: a stale-CA handshake can never reject a NEW-leaf edge that re-minted during the rotation (handshake-safe).

### Bounds & safety
- `EDGE_TRUST_CP_MAX_STALE` (default `3600`s) bounds time-since-contact: a longer outage discards the floor and cold-starts (larger = safer vs. resurrection; smaller = recovers faster from a CP-side generation reset, e.g. a Secret rebuild).
- Missing / corrupt / zero-generation / too-stale cache ⇒ quiet no-op (cold-start, no floor) — never fatal.

### Observability
- `parapet_trust_warmstart_active` (0/1) — the alertable degraded state (running on an unrevalidated floor, mTLS withheld). This is the **handshake-safe realization** of the doc's `trust_source{file}`: when the cache grants no trust, no per-request decision is file-sourced, so the state is a gauge, not a per-request counter. (Noted in the doc.)
- `trust_apply_total{result="floor_rejected"}` — the anti-resurrection rejection signal.

### Tests
Full cycle (apply→persist→restart→floor loads), floor rejects a stale bundle, the revalidating **equal-generation** apply (must not brick), CIDR-only-until-revalidated, `MAX_STALE` discard, corrupt/missing/zero-gen safety, atomic write, liveness timestamp. Full suite green under `-race`; `gofmt`/`vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)