### PR TITLE
fix: serialize WAF reload + resync watch store on reconnect

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -75,8 +75,14 @@ type Controller struct {
 
 	// WAF rule-input fingerprints from the last reload, used to skip recompiling
 	// CEL rulesets whose effective input (the sorted concatenated rule YAML) is
-	// byte-for-byte unchanged. Only ever read/written from reloadWAFDebounced,
-	// which the debounce serializes, so they need no lock.
+	// byte-for-byte unchanged. These are read/written only from reloadWAFDebounced,
+	// but the debounce does NOT guarantee single-flight execution (a timer-fired
+	// run executes in its own goroutine without the debounce lock, and an
+	// already-fired Timer.Stop is a no-op), so two reloadWAFDebounced passes can
+	// overlap under rapid ConfigMap churn when one pass outlives the debounce
+	// window. wafReloadMu serializes the whole pass so the fingerprint string and
+	// map are never raced (a concurrent map read/write is an unrecoverable fatal).
+	wafReloadMu          sync.Mutex
 	globalWAFFingerprint string
 	zoneFingerprints     map[string]string
 
@@ -195,6 +201,12 @@ func (ctrl *Controller) firstReload() {
 // metav1.Object constraint gives access to the object's namespace and name.
 // onDelete receives the deleted object so a caller can reload incrementally
 // (e.g. drop just that one host) instead of rebuilding from the whole store.
+//
+// On every watch re-establishment it relists via listFn and reconciles store
+// (resyncStore), then runs onResync — recovering any event dropped in the gap
+// between one watch closing and the next opening (the bare Watch carries no
+// resourceVersion and never replays history, so a missed Deleted would otherwise
+// leave a stale entry — and stale route — forever).
 func watchResource[T any, PT interface {
 	*T
 	metav1.Object
@@ -202,9 +214,11 @@ func watchResource[T any, PT interface {
 	ctx context.Context,
 	namespace, name string,
 	watchFn func(ctx context.Context, namespace string) (watch.Interface, error),
+	listFn func(ctx context.Context, namespace string) ([]T, error),
 	store *sync.Map,
 	onUpsert func(obj PT),
 	onDelete func(obj PT),
+	onResync func(),
 ) {
 	for {
 		w, err := watchFn(ctx, namespace)
@@ -235,14 +249,69 @@ func watchResource[T any, PT interface {
 
 		w.Stop()
 		slog.Info("restart " + name + " watcher")
+
+		// The watch just ended; reconcile against the authoritative list before
+		// reconnecting so anything dropped in the gap (e.g. a 410 Gone / watch-cache
+		// compaction) self-heals instead of lingering forever.
+		resyncStore[T, PT](ctx, namespace, name, listFn, store, onResync)
+	}
+}
+
+// resyncStore relists the authoritative set via listFn and reconciles store to
+// it: every listed object is stored, and any store key absent from the list is
+// deleted (a missed Deleted). It then runs onResync to rebuild routing from the
+// reconciled store. This needs no extra locking: each store is written only by
+// its single watch goroutine, and resyncStore runs in that goroutine while the
+// watch is stopped.
+func resyncStore[T any, PT interface {
+	*T
+	metav1.Object
+}](
+	ctx context.Context,
+	namespace, name string,
+	listFn func(ctx context.Context, namespace string) ([]T, error),
+	store *sync.Map,
+	onResync func(),
+) {
+	if listFn == nil {
+		return
+	}
+	items, err := listFn(ctx, namespace)
+	if err != nil {
+		slog.Error("can not relist "+name+" for resync", "error", err)
+		return
+	}
+
+	present := make(map[string]struct{}, len(items))
+	for i := range items {
+		obj := PT(&items[i])
+		key := obj.GetNamespace() + "/" + obj.GetName()
+		present[key] = struct{}{}
+		store.Store(key, obj)
+	}
+
+	var removed int
+	store.Range(func(k, _ any) bool {
+		key := k.(string)
+		if _, ok := present[key]; !ok {
+			store.Delete(key)
+			removed++
+		}
+		return true
+	})
+
+	slog.Info("resync "+name, "listed", len(items), "removed_stale", removed)
+	if onResync != nil {
+		onResync()
 	}
 }
 
 func (ctrl *Controller) watchIngresses(ctx context.Context) {
-	watchResource(ctx, ctrl.watchNamespace, "ingresses", k8s.WatchIngresses,
+	watchResource(ctx, ctrl.watchNamespace, "ingresses", k8s.WatchIngresses, k8s.GetIngresses,
 		&ctrl.watchedIngresses,
 		func(_ *networking.Ingress) { ctrl.reloadIngress() },
 		func(_ *networking.Ingress) { ctrl.reloadIngress() },
+		ctrl.reloadIngress,
 	)
 }
 
@@ -253,18 +322,20 @@ func (ctrl *Controller) watchServices(ctx context.Context) {
 		ctrl.reloadService()
 		ctrl.reloadIngress()
 	}
-	watchResource(ctx, ctrl.watchNamespace, "services", k8s.WatchServices,
+	watchResource(ctx, ctrl.watchNamespace, "services", k8s.WatchServices, k8s.GetServices,
 		&ctrl.watchedServices,
 		func(_ *v1.Service) { reload() },
 		func(_ *v1.Service) { reload() },
+		reload,
 	)
 }
 
 func (ctrl *Controller) watchSecrets(ctx context.Context) {
-	watchResource(ctx, ctrl.watchNamespace, "secrets", k8s.WatchSecrets,
+	watchResource(ctx, ctrl.watchNamespace, "secrets", k8s.WatchSecrets, k8s.GetSecrets,
 		&ctrl.watchedSecrets,
 		func(_ *v1.Secret) { ctrl.reloadSecret() },
 		func(_ *v1.Secret) { ctrl.reloadSecret() },
+		ctrl.reloadSecret,
 	)
 }
 
@@ -274,10 +345,12 @@ func (ctrl *Controller) watchEndpoints(ctx context.Context) {
 	// the whole endpoint table. The full rebuild (reloadEndpointDebounced) is
 	// reserved for the initial sync / resync in firstReload, where the entire
 	// set is (re)listed.
-	watchResource(ctx, ctrl.watchNamespace, "endpoints", k8s.WatchEndpoints,
+	watchResource(ctx, ctrl.watchNamespace, "endpoints", k8s.WatchEndpoints, k8s.GetEndpoints,
 		&ctrl.watchedEndpoints,
 		ctrl.reloadSingleEndpoint,
 		ctrl.deleteSingleEndpoint,
+		// resync: rebuild the full host-route table from the reconciled store.
+		ctrl.reloadEndpointDebounced,
 	)
 }
 

--- a/controller_waf.go
+++ b/controller_waf.go
@@ -117,10 +117,14 @@ func (ctrl *Controller) watchConfigMaps(ctx context.Context) {
 	watchFn := func(ctx context.Context, namespace string) (watch.Interface, error) {
 		return k8s.WatchConfigMaps(ctx, namespace, wafLabelKey)
 	}
-	watchResource(ctx, ctrl.watchNamespace, "configmaps", watchFn,
+	listFn := func(ctx context.Context, namespace string) ([]v1.ConfigMap, error) {
+		return k8s.GetConfigMaps(ctx, namespace, wafLabelKey)
+	}
+	watchResource(ctx, ctrl.watchNamespace, "configmaps", watchFn, listFn,
 		&ctrl.watchedConfigMaps,
 		func(_ *v1.ConfigMap) { ctrl.reloadWAF() },
 		func(_ *v1.ConfigMap) { ctrl.reloadWAF() },
+		ctrl.reloadWAF,
 	)
 }
 
@@ -137,6 +141,12 @@ func (ctrl *Controller) reloadWAFDebounced() {
 		return
 	}
 	slog.Info("reload waf")
+
+	// Serialize the whole pass: the debounce can fire two reloadWAFDebounced
+	// goroutines concurrently (see wafReloadMu), and the fingerprint string + map
+	// below are a read-modify-write that must be atomic across the pass.
+	ctrl.wafReloadMu.Lock()
+	defer ctrl.wafReloadMu.Unlock()
 
 	defer func() {
 		if err := recover(); err != nil {

--- a/controller_waf_test.go
+++ b/controller_waf_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -277,6 +278,51 @@ rules:
 	ctrl.reloadWAFDebounced()
 	assert.NotEqual(t, fp1, ctrl.globalWAFFingerprint, "changed global input advances the fingerprint")
 	assert.Equal(t, []string{"block-bots"}, ctrl.globalWAF.Rules())
+}
+
+func TestReloadWAF_ConcurrentReloadsRaceFree(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newWAFController()
+
+	// Seed a global ruleset plus several zones so each pass read-modify-writes
+	// both globalWAFFingerprint (string) and the zoneFingerprints map.
+	ctrl.watchedConfigMaps.Store("ctrl-ns/waf-global", wafCM("ctrl-ns", "waf-global", wafRoleGlobal, `
+rules:
+  - id: block-scanners
+    expression: request.user_agent.contains("sqlmap")
+    action: block
+`))
+	for _, z := range []string{"acme", "beta", "gamma", "delta"} {
+		ctrl.watchedConfigMaps.Store("cust/"+z, wafCM("cust", z, wafRoleZone, `
+rules:
+  - id: block-admin
+    expression: request.path.startsWith("/admin")
+    action: block
+`))
+	}
+
+	// The debounce does not guarantee single-flight execution, so two
+	// reloadWAFDebounced passes can overlap. Drive that directly: without
+	// wafReloadMu this trips `go test -race` on globalWAFFingerprint /
+	// zoneFingerprints (and can fatal on a concurrent map read+write).
+	const workers = 6
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				ctrl.reloadWAFDebounced()
+			}
+		}()
+	}
+	wg.Wait()
+
+	// State stays consistent after the concurrent storm.
+	assert.Equal(t, []string{"block-scanners"}, ctrl.globalWAF.Rules())
+	require.NotNil(t, ctrl.LookupZone("cust/acme"))
+	require.NotNil(t, ctrl.LookupZone("cust/delta"))
 }
 
 func TestReloadWAF_DisabledIsNoop(t *testing.T) {

--- a/controller_watch_test.go
+++ b/controller_watch_test.go
@@ -28,9 +28,11 @@ func TestWatchResource(t *testing.T) {
 	go watchResource[v1.Service](
 		context.Background(), "", "services",
 		func(context.Context, string) (watch.Interface, error) { return w, nil },
+		func(context.Context, string) ([]v1.Service, error) { return nil, nil },
 		&store,
 		func(_ *v1.Service) { upserts.Add(1) },
 		func(_ *v1.Service) { deletes.Add(1) },
+		func() {},
 	)
 
 	svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "web"}}
@@ -57,4 +59,49 @@ func TestWatchResource(t *testing.T) {
 	// the ignored Pod event never produced a callback or store entry
 	assert.Equal(t, int32(1), upserts.Load())
 	assert.Equal(t, int32(1), deletes.Load())
+}
+
+// When a watch ends, watchResource relists and reconciles the store before
+// reconnecting. This recovers from a Deleted event dropped in the watch gap: the
+// stale store entry (which would otherwise route traffic to a vanished backend
+// forever) is removed, and onResync fires to rebuild routing.
+func TestWatchResourceResyncReconcilesStore(t *testing.T) {
+	var store sync.Map
+	// "default/stale" is in the store but NOT in the authoritative list — i.e. a
+	// missed Deleted. "default/web" is the live object the list returns.
+	store.Store("default/stale", &v1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "stale"}})
+
+	listFn := func(context.Context, string) ([]v1.Service, error) {
+		return []v1.Service{
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "web"}},
+		}, nil
+	}
+
+	// First watch hands back an already-closed channel so the event loop exits
+	// immediately and triggers the resync; subsequent watches block forever so the
+	// resync runs exactly once.
+	var calls atomic.Int32
+	watchFn := func(context.Context, string) (watch.Interface, error) {
+		if calls.Add(1) == 1 {
+			closed := make(chan watch.Event)
+			close(closed)
+			return &fakeWatcher{ch: closed}, nil
+		}
+		return &fakeWatcher{ch: make(chan watch.Event)}, nil
+	}
+
+	var resyncs atomic.Int32
+	go watchResource[v1.Service](
+		context.Background(), "", "services",
+		watchFn, listFn, &store,
+		func(*v1.Service) {}, func(*v1.Service) {},
+		func() { resyncs.Add(1) },
+	)
+
+	assert.Eventually(t, func() bool {
+		_, staleOK := store.Load("default/stale")
+		_, webOK := store.Load("default/web")
+		return !staleOK && webOK && resyncs.Load() >= 1
+	}, 2*time.Second, time.Millisecond,
+		"resync must drop the stale entry, keep the listed one, and fire onResync")
 }


### PR DESCRIPTION
Two control-loop robustness fixes surfaced by a core audit of the Go implementation. Both ship with regression tests that fail against the pre-fix code (`go test -race`).

## 1. WAF reload data race — **HIGH** (`controller_waf.go`)
`reloadWAFDebounced` read-modify-writes `globalWAFFingerprint` (string) and `zoneFingerprints` (map) on the assumption that *"the debounce serializes us, so no lock"*. **That assumption is false.** `debounce.Call()` schedules the work via `time.AfterFunc`, which runs the callback in its **own goroutine without the debounce lock**, and `Timer.Stop()` on an already-fired timer is a no-op. So under rapid WAF ConfigMap churn, if one reload pass outlives the 300 ms window, the next timer fires a **second concurrent** `reloadWAFDebounced`.

A concurrent map read+write is an **unrecoverable Go fatal** (`fatal error: concurrent map read and map write`) — the `defer recover()` in the reload can't catch it — so the whole controller crashes, taking ingress down for every tenant.

**Fix:** a dedicated `ctrl.wafReloadMu` wraps the whole reload pass (the fingerprint read-modify-write must be atomic across the pass, so locking individual fields isn't enough).

## 2. Missed watch `Deleted` leaves a stale route forever — **MEDIUM** (`controller.go`)
The watch loops use a bare `Watch` with no `resourceVersion`, which never replays history. An event dropped in the gap between one watch closing and the next opening (a `410 Gone`, watch-cache compaction, or a mid-event connection drop) is lost. A missed `Deleted` leaves a stale entry — and a **stale route that sends traffic to a vanished backend** — until the process restarts.

**Fix:** relist-on-reconnect. `watchResource` now takes a `listFn` + `onResync`; after the watch ends it relists the authoritative set and reconciles the store (`resyncStore`: store present, delete absent), then rebuilds routing. It's **race-free** — each store has a single writer goroutine and the resync runs in it while the watch is stopped — and it fires *exactly* when needed, since the conditions that drop events are the same ones that close the watch.

## Tests
- `TestReloadWAF_ConcurrentReloadsRaceFree` — drives concurrent reloads; trips `-race` without `wafReloadMu`.
- `TestWatchResourceResyncReconcilesStore` — a stale store entry absent from the relist is dropped and `onResync` fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)