### PR TITLE
perf: lock-free routing snapshot + bound the client-controlled method label

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -38,17 +38,23 @@ const (
 	secretSizeHint   = 50
 )
 
+// routeState is the immutable routing snapshot swapped in on each ingress
+// reload: the live mux plus the set of hosts it serves. Bundling both behind one
+// atomic.Pointer lets the request path read them with a single lock-free load
+// instead of taking a per-request RWMutex. knownHosts bounds host-labeled metric
+// cardinality — a Host the router doesn't serve collapses to a sentinel label
+// instead of minting unbounded series under a random-Host flood.
+type routeState struct {
+	mux        *http.ServeMux
+	knownHosts map[string]struct{}
+}
+
 // Controller is the parapet ingress controller
 type Controller struct {
-	// mu is the mutex for mux
-	mu  sync.RWMutex
-	mux *http.ServeMux
-	// knownHosts is the set of hosts the current mux serves (the host part of
-	// each registered route). Guarded by mu and swapped atomically with mux on
-	// reload. Used to bound host-labeled metric cardinality: a Host the router
-	// doesn't serve collapses to a sentinel label instead of creating an
-	// unbounded number of series under a random-Host flood.
-	knownHosts map[string]struct{}
+	// routes is the current routing snapshot, swapped atomically on reload so the
+	// request path (ServeHandler, IsKnownHost) reads it lock-free. Never nil after
+	// New(); reloadIngressDebounced builds a fresh *routeState and Stores it.
+	routes atomic.Pointer[routeState]
 
 	// namespace to watch, or empty to watch all
 	watchNamespace string
@@ -104,6 +110,9 @@ type Controller struct {
 // New creates new ingress controller
 func New(watchNamespace string, proxy *proxy.Proxy) *Controller {
 	ctrl := &Controller{}
+	// Seed an empty routing snapshot so the request path never observes a nil
+	// pointer if a request lands before the first reload completes.
+	ctrl.routes.Store(&routeState{mux: http.NewServeMux(), knownHosts: map[string]struct{}{}})
 	ctrl.health = healthz.New()
 	ctrl.health.SetReady(false)
 	ctrl.watchNamespace = watchNamespace
@@ -124,11 +133,7 @@ func (ctrl *Controller) Use(m plugin.Plugin) {
 // ServeHandler implements parapet.Middleware
 func (ctrl *Controller) ServeHandler(_ http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctrl.mu.RLock()
-		mux := ctrl.mux
-		ctrl.mu.RUnlock()
-
-		mux.ServeHTTP(w, r)
+		ctrl.routes.Load().mux.ServeHTTP(w, r)
 	})
 }
 
@@ -401,11 +406,14 @@ func (ctrl *Controller) reloadIngressDebounced() {
 
 	mux := buildRoutes(routes)
 	knownHosts := buildKnownHosts(routes)
-	ctrl.mu.Lock()
-	ctrl.mux = mux
-	ctrl.knownHosts = knownHosts
-	ctrl.mu.Unlock()
+	ctrl.routes.Store(&routeState{mux: mux, knownHosts: knownHosts})
 	ctrl.reloadSecret()
+}
+
+// currentMux returns the live routing mux. Internal/test accessor for the
+// atomically-swapped route state.
+func (ctrl *Controller) currentMux() *http.ServeMux {
+	return ctrl.routes.Load().mux
 }
 
 // buildKnownHosts extracts the distinct host part (everything before the first
@@ -424,9 +432,7 @@ func buildKnownHosts(routes map[string]http.Handler) map[string]struct{} {
 // IsKnownHost reports whether the current routes serve host (already lowercased
 // and port-stripped by the upstream middleware, matching the registered keys).
 func (ctrl *Controller) IsKnownHost(host string) bool {
-	ctrl.mu.RLock()
-	_, ok := ctrl.knownHosts[host]
-	ctrl.mu.RUnlock()
+	_, ok := ctrl.routes.Load().knownHosts[host]
 	return ok
 }
 

--- a/controller_reload_test.go
+++ b/controller_reload_test.go
@@ -87,7 +87,7 @@ func TestReloadIngress(t *testing.T) {
 
 		ctrl.reloadIngressDebounced()
 
-		assert.Equal(t, "example.com/", matchedPattern(t, ctrl.mux, "example.com", "/"))
+		assert.Equal(t, "example.com/", matchedPattern(t, ctrl.currentMux(), "example.com", "/"))
 	})
 
 	t.Run("Prefix registers both exact and subtree", func(t *testing.T) {
@@ -98,8 +98,8 @@ func TestReloadIngress(t *testing.T) {
 
 		ctrl.reloadIngressDebounced()
 
-		assert.Equal(t, "example.com/app", matchedPattern(t, ctrl.mux, "example.com", "/app"))
-		assert.Equal(t, "example.com/app/", matchedPattern(t, ctrl.mux, "example.com", "/app/sub"))
+		assert.Equal(t, "example.com/app", matchedPattern(t, ctrl.currentMux(), "example.com", "/app"))
+		assert.Equal(t, "example.com/app/", matchedPattern(t, ctrl.currentMux(), "example.com", "/app/sub"))
 	})
 
 	t.Run("Exact registers single path", func(t *testing.T) {
@@ -110,9 +110,9 @@ func TestReloadIngress(t *testing.T) {
 
 		ctrl.reloadIngressDebounced()
 
-		assert.Equal(t, "example.com/app", matchedPattern(t, ctrl.mux, "example.com", "/app"))
+		assert.Equal(t, "example.com/app", matchedPattern(t, ctrl.currentMux(), "example.com", "/app"))
 		// Exact must not match the subtree
-		assert.Empty(t, matchedPattern(t, ctrl.mux, "example.com", "/app/sub"))
+		assert.Empty(t, matchedPattern(t, ctrl.currentMux(), "example.com", "/app/sub"))
 	})
 
 	t.Run("skips ingress with non-matching class", func(t *testing.T) {
@@ -124,7 +124,7 @@ func TestReloadIngress(t *testing.T) {
 
 		ctrl.reloadIngressDebounced()
 
-		assert.Empty(t, matchedPattern(t, ctrl.mux, "example.com", "/"))
+		assert.Empty(t, matchedPattern(t, ctrl.currentMux(), "example.com", "/"))
 	})
 
 	t.Run("skips path when backend service is missing", func(t *testing.T) {
@@ -135,7 +135,7 @@ func TestReloadIngress(t *testing.T) {
 
 		ctrl.reloadIngressDebounced()
 
-		assert.Empty(t, matchedPattern(t, ctrl.mux, "example.com", "/"))
+		assert.Empty(t, matchedPattern(t, ctrl.currentMux(), "example.com", "/"))
 	})
 
 	t.Run("recovers from a panicking plugin", func(t *testing.T) {

--- a/controller_test.go
+++ b/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/moonrhythm/parapet"
@@ -447,4 +448,63 @@ func BenchmarkBuildHostPortStringConcat(b *testing.B) {
 		r = name + "." + namespace + ".svc.cluster.local" + ":" + strconv.Itoa(port)
 	}
 	_ = r
+}
+
+// TestServeHandlerConcurrentWithReload exercises the lock-free routing snapshot:
+// the request path (ServeHandler + IsKnownHost) must read a consistent mux /
+// known-host set while reloadIngressDebounced concurrently swaps it. Run under
+// `go test -race`; a torn read or nil mux would trip the detector or panic.
+func TestServeHandlerConcurrentWithReload(t *testing.T) {
+	ctrl := New("", proxy.New())
+	ctrl.watchedServices.Store("default/web", clusterIPService("default", "web", 80, 8080))
+	ctrl.watchedIngresses.Store("default/ing",
+		ingressToService("default", "ing", "example.com", "/", networking.PathTypeImplementationSpecific, "web", 80))
+	ctrl.reloadIngressDebounced()
+
+	handler := ctrl.ServeHandler(nil)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// reloader: keep swapping the route state
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				ctrl.reloadIngressDebounced()
+			}
+		}
+	}()
+
+	// readers: serve requests and probe IsKnownHost against the live snapshot
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 500; j++ {
+				r := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+				w := httptest.NewRecorder()
+				handler.ServeHTTP(w, r)
+				_ = ctrl.IsKnownHost("example.com")
+			}
+		}()
+	}
+
+	// let the readers run, then stop the reloader
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// readers do bounded work; close stop once they're likely done
+		for i := 0; i < 4000; i++ {
+			ctrl.IsKnownHost("example.com")
+		}
+		close(stop)
+	}()
+
+	wg.Wait()
+	assert.True(t, ctrl.IsKnownHost("example.com"), "served host stays known after the reload storm")
 }

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -2,6 +2,7 @@ package metric
 
 import (
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -21,6 +22,58 @@ func TestHostGetMCaching(t *testing.T) {
 	d := _host.getM("other.example.com", "")
 	assert.NotSame(t, a, c)
 	assert.NotSame(t, a, d)
+}
+
+func TestMethodLabel(t *testing.T) {
+	// registered methods pass through unchanged
+	for _, m := range []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "CONNECT", "OPTIONS", "TRACE"} {
+		assert.Equal(t, m, methodLabel(m))
+	}
+	// anything else collapses to the bounded sentinel (case-sensitive: lower-case
+	// and arbitrary tokens are non-standard)
+	assert.Equal(t, "other", methodLabel(""))
+	assert.Equal(t, "other", methodLabel("get"))
+	assert.Equal(t, "other", methodLabel("FOOBAR"))
+	assert.Equal(t, "other", methodLabel("PROPFIND"))
+}
+
+func TestMethodLabelBoundsRequestCardinality(t *testing.T) {
+	// A client can send unbounded distinct (but syntactically valid) HTTP method
+	// tokens to a host the router serves. Without methodLabel, each one mints a
+	// new handle-cache entry and a permanent Prometheus series. methodLabel must
+	// collapse them all to one "other" series per (host, status).
+	const host = "method-card-test.example.com"
+	s := state.State{
+		"namespace":   "ns",
+		"ingress":     "ing",
+		"serviceName": "svc",
+		"serviceType": "ClusterIP",
+	}
+
+	countEntries := func() int {
+		n := 0
+		_promRequests.cache.mu.RLock()
+		for k := range _promRequests.cache.m {
+			if k.host == host {
+				n++
+			}
+		}
+		_promRequests.cache.mu.RUnlock()
+		return n
+	}
+
+	start := time.Now()
+	for i := 0; i < 500; i++ {
+		// httptest.NewRequest parses the request line through http.ReadRequest, so
+		// these go through the same method-validation path a real client hits.
+		method := "M" + strconv.Itoa(i)
+		r := httptest.NewRequest(method, "http://"+host+"/x", nil)
+		r = r.WithContext(state.NewContext(r.Context(), s))
+		_promRequests.Inc(r, 200, start)
+	}
+
+	assert.Equal(t, 1, countEntries(),
+		"500 distinct method tokens must collapse to a single 'other' series per (host,status)")
 }
 
 func TestPromRequestsIncCachesAndCounts(t *testing.T) {

--- a/metric/requests.go
+++ b/metric/requests.go
@@ -69,6 +69,25 @@ func init() {
 	prom.Registry().MustRegister(_promRequests.vec, _promRequests.durations)
 }
 
+// methodLabel collapses the client-controlled request method to a bounded label
+// set for the `requests` metric. net/http admits any RFC7230 token as a method
+// (it only rejects invalid token characters), so labeling the counter — and
+// keying the handle cache — with the raw method lets a client mint unbounded
+// permanent series, and grow the cache, by sending random method tokens to a
+// host the router serves (the same OOM class host/upgrade are sanitized
+// against). Only the registered HTTP methods pass through; anything else
+// collapses to "other".
+func methodLabel(method string) string {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodConnect,
+		http.MethodOptions, http.MethodTrace:
+		return method
+	default:
+		return "other"
+	}
+}
+
 func (p *promRequests) Inc(r *http.Request, status int, start time.Time) {
 	duration := time.Since(start)
 
@@ -76,6 +95,7 @@ func (p *promRequests) Inc(r *http.Request, status int, start time.Time) {
 	s := state.Get(ctx)
 
 	host := HostLabel(r.Host, p.isKnownHost)
+	method := methodLabel(r.Method)
 
 	// Edge rejection: a tracked rejection status where the request never reached
 	// a backend (makeHandler sets serviceTarget only when it proxies). Counted in
@@ -91,7 +111,7 @@ func (p *promRequests) Inc(r *http.Request, status int, start time.Time) {
 		ingress:     s["ingress"],
 		serviceName: s["serviceName"],
 		serviceType: s["serviceType"],
-		method:      r.Method,
+		method:      method,
 		status:      status,
 	}
 
@@ -99,7 +119,7 @@ func (p *promRequests) Inc(r *http.Request, status int, start time.Time) {
 		return &requestMetric{
 			counter: p.vec.With(prometheus.Labels{
 				"host":              host,
-				"method":            r.Method,
+				"method":            method,
 				"ingress_name":      s["ingress"],
 				"ingress_namespace": s["namespace"],
 				"service_type":      s["serviceType"],


### PR DESCRIPTION
Two request-hot-path improvements from a core audit, each with a `-race` regression test.

## 1. Lock-free routing snapshot (`controller.go`)
Every served request took `ctrl.mu.RLock` to read the mux in `ServeHandler`, **plus** `IsKnownHost` took it again — and `IsKnownHost` runs **twice per request** (once in the host-active gauge middleware, once in the `requests` metric), more on reject paths. Under high RPS across many cores, the shared `RWMutex` reader-count cacheline is needless contention.

**Fix:** replace `mu` + `mux` + `knownHosts` with a single `atomic.Pointer[routeState]` (mux + known-host set bundled), swapped on each reload. The request path now reads both with one lock-free `Load()`. `New()` seeds an empty snapshot so a request arriving before the first reload can't nil-deref.

## 2. Bound the client-controlled method label (`metric/requests.go`)
The `requests` counter labels and the handle-cache key included `r.Method` verbatim. `net/http` accepts **any RFC-7230 token** as a method (it only rejects invalid token chars), so a client hitting a host the router serves with a stream of random method tokens mints **unbounded permanent Prometheus series** and grows the handle cache without bound — the exact OOM class `host`/`upgrade` are already sanitized against.

**Fix:** `methodLabel()` collapses anything outside the registered HTTP methods to `"other"`.

## Tests
- `TestServeHandlerConcurrentWithReload` — concurrent `ServeHTTP` + `IsKnownHost` while reloads swap the snapshot; clean under `-race`.
- `TestMethodLabel` / `TestMethodLabelBoundsRequestCardinality` — 500 distinct method tokens collapse to a single series (was 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)