### PR TITLE
fix: resolve named Service targetPort + reject unexposed backend ports

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -17,6 +17,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/moonrhythm/parapet-ingress-controller/cert"
@@ -276,7 +277,15 @@ func (ctrl *Controller) watchEndpoints(ctx context.Context) {
 	// set is (re)listed.
 	watchResource(ctx, ctrl.watchNamespace, "endpoints", k8s.WatchEndpoints,
 		&ctrl.watchedEndpoints,
-		ctrl.reloadSingleEndpoint,
+		func(ep *v1.Endpoints) {
+			ctrl.reloadSingleEndpoint(ep)
+			// Endpoints carry the numeric port a *named* Service targetPort resolves
+			// to, so a service whose named port wasn't resolvable at service-reload
+			// time (endpoints not yet present) converges once its endpoints arrive.
+			// Debounced, so high endpoint churn coalesces into at most one cheap
+			// port-table rebuild per window.
+			ctrl.reloadService()
+		},
 		ctrl.deleteSingleEndpoint,
 	)
 }
@@ -450,8 +459,14 @@ func (ctrl *Controller) reloadServiceDebounced() {
 
 		// build route target port
 		for _, p := range s.Spec.Ports {
+			target, ok := ctrl.resolveTargetPort(s, p)
+			if !ok {
+				// named targetPort not resolvable yet (no endpoints / no matching
+				// subset port); skip rather than route to ":0". It converges when the
+				// service's endpoints arrive (watchEndpoints triggers reloadService).
+				continue
+			}
 			addr := buildHostPort(s.Namespace, s.Name, int(p.Port))
-			target := strconv.Itoa(int(p.TargetPort.IntVal))
 			addrToPort[addr] = target
 		}
 
@@ -459,6 +474,38 @@ func (ctrl *Controller) reloadServiceDebounced() {
 	})
 
 	ctrl.routeTable.SetPortRoutes(addrToPort)
+}
+
+// resolveTargetPort returns the concrete numeric pod port (as a string) a
+// ServicePort routes to. A numeric targetPort is used directly. A *named*
+// targetPort (intstr.String) carries no number in the Service object, so it is
+// resolved from the service's Endpoints — matching the EndpointPort whose Name
+// equals this ServicePort's Name (Kubernetes keys EndpointPort.Name to
+// ServicePort.Name). Returns ok=false when a named port can't be resolved yet,
+// so the caller skips it instead of producing a dead ":0" route.
+func (ctrl *Controller) resolveTargetPort(s *v1.Service, p v1.ServicePort) (string, bool) {
+	if p.TargetPort.Type == intstr.Int {
+		if p.TargetPort.IntVal > 0 {
+			return strconv.Itoa(int(p.TargetPort.IntVal)), true
+		}
+		// An unset targetPort is normally defaulted to the service port by the
+		// apiserver; fall back to that identity mapping defensively.
+		return strconv.Itoa(int(p.Port)), true
+	}
+
+	v, ok := ctrl.watchedEndpoints.Load(s.Namespace + "/" + s.Name)
+	if !ok {
+		return "", false
+	}
+	ep := v.(*v1.Endpoints)
+	for _, ss := range ep.Subsets {
+		for _, epp := range ss.Ports {
+			if epp.Name == p.Name && epp.Port > 0 {
+				return strconv.Itoa(int(epp.Port)), true
+			}
+		}
+	}
+	return "", false
 }
 
 func (ctrl *Controller) reloadSecret() {
@@ -642,17 +689,20 @@ func getBackendConfig(backend *networking.IngressBackend, svc *v1.Service) (conf
 	// specifies port by number
 	config.PortNumber = int(backend.Service.Port.Number)
 
-	// find port name
-	// since port name is required in kubernetes, we can assume that port name is always available
+	// find the matching service port (for its name + appProtocol). A backend that
+	// references a numeric port the service does not expose must be reported as
+	// not-found (ok=false), mirroring the port-by-name branch — otherwise the
+	// caller registers a route whose Lookup always misses, silently 503-ing every
+	// request with no "port not found" log.
 	for _, p := range svc.Spec.Ports {
 		if p.Port == backend.Service.Port.Number {
 			config.PortName = p.Name
 			if p.AppProtocol != nil {
 				config.Protocol = *p.AppProtocol
 			}
+			ok = true
 		}
 	}
-	ok = true
 	return
 }
 

--- a/controller_reload_test.go
+++ b/controller_reload_test.go
@@ -170,6 +170,68 @@ func TestReloadServiceAndEndpoint(t *testing.T) {
 	assert.Empty(t, ctrl.routeTable.Lookup("missing.default.svc.cluster.local:80"))
 }
 
+func namedPortService(namespace, name, portName string, port int) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeClusterIP,
+			Ports: []v1.ServicePort{
+				// NAMED targetPort: no number lives in the Service object.
+				{Name: portName, Port: int32(port), TargetPort: intstr.FromString(portName)},
+			},
+		},
+	}
+}
+
+func endpointsNamedPort(namespace, name, ip, portName string, port int) *v1.Endpoints {
+	return &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Subsets: []v1.EndpointSubset{
+			{
+				Addresses: []v1.EndpointAddress{{IP: ip}},
+				Ports:     []v1.EndpointPort{{Name: portName, Port: int32(port)}},
+			},
+		},
+	}
+}
+
+func TestReloadServiceNamedTargetPort(t *testing.T) {
+	// A named targetPort ("http") carries no number in the Service; it must be
+	// resolved from the matching EndpointPort, not read as IntVal (which is 0 and
+	// would route every request to ":0" → dial failure → 503).
+	ctrl := New("", proxy.New())
+	ctrl.watchedServices.Store("default/web", namedPortService("default", "web", "http", 80))
+	ctrl.watchedEndpoints.Store("default/web", endpointsNamedPort("default", "web", "10.0.0.1", "http", 8080))
+
+	ctrl.reloadServiceDebounced()
+	ctrl.reloadEndpointDebounced()
+
+	assert.Equal(t, "10.0.0.1:8080",
+		ctrl.routeTable.Lookup("web.default.svc.cluster.local:80"),
+		"named targetPort resolves to the matching EndpointPort number")
+}
+
+func TestReloadServiceNamedTargetPortConvergesWhenEndpointsArrive(t *testing.T) {
+	// Service reloads before its endpoints exist: the named port can't resolve
+	// yet, so no dead ":0" route is produced (Lookup is empty, fail-fast 503). It
+	// converges once endpoints arrive and reloadService runs again (which the
+	// endpoint watch triggers in production).
+	ctrl := New("", proxy.New())
+	ctrl.watchedServices.Store("default/web", namedPortService("default", "web", "http", 80))
+
+	ctrl.reloadServiceDebounced()
+	assert.Empty(t, ctrl.routeTable.Lookup("web.default.svc.cluster.local:80"),
+		"unresolved named port must not create a ':0' route")
+
+	ctrl.watchedEndpoints.Store("default/web", endpointsNamedPort("default", "web", "10.0.0.2", "http", 9090))
+	ctrl.reloadServiceDebounced()  // endpoint watch triggers this in production
+	ctrl.reloadEndpointDebounced() // host routes (pod IPs)
+
+	assert.Equal(t, "10.0.0.2:9090",
+		ctrl.routeTable.Lookup("web.default.svc.cluster.local:80"),
+		"named port converges once endpoints arrive")
+}
+
 func TestReloadEndpointEmptySubsetIsNotRouted(t *testing.T) {
 	ctrl := New("", proxy.New())
 	ctrl.watchedServices.Store("default/web", clusterIPService("default", "web", 80, 8080))

--- a/controller_test.go
+++ b/controller_test.go
@@ -345,6 +345,41 @@ func TestGetBackendConfig(t *testing.T) {
 		assert.Equal(t, 8080, config.PortNumber)
 		assert.Equal(t, "h2c", config.Protocol)
 	})
+
+	t.Run("Port Number not exposed by service returns ok=false", func(t *testing.T) {
+		// A numeric backend port the service does not expose must be reported as
+		// not-found, so the caller logs "port not found" and skips it instead of
+		// registering a dead route that silently 503s every request.
+		backend := networking.IngressBackend{
+			Service: &networking.IngressServiceBackend{
+				Name: "service",
+				Port: networking.ServiceBackendPort{Number: 9999},
+			},
+		}
+		service := v1.Service{
+			Spec: v1.ServiceSpec{
+				Ports: []v1.ServicePort{{Name: "http", Port: 8080}},
+			},
+		}
+		_, ok := getBackendConfig(&backend, &service)
+		assert.False(t, ok, "unexposed numeric port must not be reported as found")
+	})
+
+	t.Run("Port Name not exposed by service returns ok=false", func(t *testing.T) {
+		backend := networking.IngressBackend{
+			Service: &networking.IngressServiceBackend{
+				Name: "service",
+				Port: networking.ServiceBackendPort{Name: "missing"},
+			},
+		}
+		service := v1.Service{
+			Spec: v1.ServiceSpec{
+				Ports: []v1.ServicePort{{Name: "http", Port: 8080}},
+			},
+		}
+		_, ok := getBackendConfig(&backend, &service)
+		assert.False(t, ok)
+	})
 }
 
 func TestEndpointToRRLB(t *testing.T) {


### PR DESCRIPTION
Two service-port resolution correctness fixes from a core audit, with regression tests.

## 1. Named Service `targetPort` routes to `:0` → all traffic 503s — **HIGH** (`controller.go`)
`reloadServiceDebounced` read `p.TargetPort.IntVal` unconditionally. For a **named** targetPort (e.g. `targetPort: http`), `intstr.Type` is `String` and `IntVal` is `0`, so the route target became `svc.ns.svc.cluster.local:0`. The proxy dials `:0`, which always fails → dial error → the pod is marked bad and the request retried, all failing → client gets **503 for every request** to such a service. Named targetPorts are a common, valid manifest pattern (and were untested).

**Fix:** `resolveTargetPort` uses `IntVal` only for a numeric targetPort and resolves a **named** one from the service's Endpoints — the `EndpointPort` whose `Name` matches the `ServicePort` name (Kubernetes keys `EndpointPort.Name` to `ServicePort.Name`). An unresolved named port is **skipped** (fail-fast 503), not routed to `:0`. The endpoint watch now also triggers `reloadService`, so a named port **converges** once its endpoints arrive (e.g. service created before pods are ready).

## 2. `getBackendConfig` reported `ok` for a port the service doesn't expose — **LOW** (`controller.go`)
The port-by-number branch set `ok = true` unconditionally. A backend referencing a numeric port the service doesn't expose registered a route whose `Lookup` always misses → **silent 503 with no `"port not found"` log**. Now `ok = true` only when a service port actually matches, mirroring the port-by-name branch (which already did this).

## Tests
- `TestReloadServiceNamedTargetPort` / `…ConvergesWhenEndpointsArrive` — a named port resolves to the `EndpointPort` number (was `:0`), and converges when endpoints arrive after the service.
- `TestGetBackendConfig` — unexposed numeric and named ports both return `ok=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)