### PR TITLE
fix: small robustness — retry cancel, AllowRemote logging, WAF order

### DIFF
--- a/controller_waf.go
+++ b/controller_waf.go
@@ -154,7 +154,7 @@ func (ctrl *Controller) reloadWAFDebounced() {
 		}
 	}()
 
-	var globalDocs []string
+	var globalCMs []*v1.ConfigMap
 	zoneDocs := map[string][]string{}
 
 	ctrl.watchedConfigMaps.Range(func(_, value any) bool {
@@ -168,13 +168,30 @@ func (ctrl *Controller) reloadWAFDebounced() {
 					"configmap", cm.Namespace+"/"+cm.Name, "pod_namespace", ctrl.PodNamespace)
 				return true
 			}
-			globalDocs = append(globalDocs, sortedDataValues(cm.Data)...)
+			globalCMs = append(globalCMs, cm)
 		case wafRoleZone:
 			key := cm.Namespace + "/" + cm.Name
 			zoneDocs[key] = append(zoneDocs[key], sortedDataValues(cm.Data)...)
 		}
 		return true
 	})
+
+	// Concatenate global ConfigMaps in a deterministic namespace/name order. The
+	// sync.Map.Range above visits them in random order, so without this the
+	// concatenation order of multiple global ConfigMaps — and thus equal-priority
+	// rule precedence and the fingerprint below — would flip between reloads.
+	// (Zones don't need this: a zone key is one ConfigMap's namespace/name, so its
+	// docs come from a single ConfigMap.)
+	sort.Slice(globalCMs, func(i, j int) bool {
+		if globalCMs[i].Namespace != globalCMs[j].Namespace {
+			return globalCMs[i].Namespace < globalCMs[j].Namespace
+		}
+		return globalCMs[i].Name < globalCMs[j].Name
+	})
+	var globalDocs []string
+	for _, cm := range globalCMs {
+		globalDocs = append(globalDocs, sortedDataValues(cm.Data)...)
+	}
 
 	// global: recompile only when the rule input changed. The fingerprint is over
 	// the exact (sorted, deterministic) docs that feed SetRules, so an identical

--- a/controller_waf_test.go
+++ b/controller_waf_test.go
@@ -325,6 +325,44 @@ rules:
 	require.NotNil(t, ctrl.LookupZone("cust/delta"))
 }
 
+func TestReloadWAF_MultipleGlobalConfigMapsDeterministicOrder(t *testing.T) {
+	t.Parallel()
+
+	// Two global ConfigMaps in the controller namespace, each contributing one
+	// equal-priority rule. The concatenation order must follow namespace/name
+	// (waf-a before waf-b), not the random sync.Map.Range order — otherwise
+	// equal-priority precedence and the fingerprint would flip between reloads.
+	ctrl := newWAFController()
+	ctrl.watchedConfigMaps.Store("ctrl-ns/waf-a", wafCM("ctrl-ns", "waf-a", wafRoleGlobal, `
+rules:
+  - id: rule-a
+    expression: "true"
+    action: log
+`))
+	ctrl.watchedConfigMaps.Store("ctrl-ns/waf-b", wafCM("ctrl-ns", "waf-b", wafRoleGlobal, `
+rules:
+  - id: rule-b
+    expression: "true"
+    action: log
+`))
+
+	// Reload many times: the order must be stable and sorted on every pass. Before
+	// the deterministic sort, the random Range order flips this with high
+	// probability across this many iterations.
+	var firstFP string
+	for i := 0; i < 20; i++ {
+		ctrl.reloadWAFDebounced()
+		assert.Equal(t, []string{"rule-a", "rule-b"}, ctrl.globalWAF.Rules(),
+			"global rule order must be namespace/name-sorted and stable")
+		if i == 0 {
+			firstFP = ctrl.globalWAFFingerprint
+		} else {
+			assert.Equal(t, firstFP, ctrl.globalWAFFingerprint,
+				"a stable concatenation order keeps the fingerprint stable (no needless recompile)")
+		}
+	}
+}
+
 func TestReloadWAF_DisabledIsNoop(t *testing.T) {
 	t.Parallel()
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -256,10 +256,23 @@ func AllowRemote(ctx Context) {
 	xs := strings.Split(allowRemote, ",")
 	for _, x := range xs {
 		x = strings.TrimSpace(x)
-		_, allow, _ := net.ParseCIDR(x)
-		if allow != nil {
-			allowList = append(allowList, allow)
+		if x == "" {
+			continue
 		}
+		_, allow, err := net.ParseCIDR(x)
+		if err != nil {
+			slog.Error("plugin/AllowRemote: invalid CIDR, ignoring entry",
+				"ingress", ctx.ingressID(), "value", x, "error", err)
+			continue
+		}
+		allowList = append(allowList, allow)
+	}
+	if len(allowList) == 0 {
+		// Every entry was malformed: the block predicate below would 403 ALL
+		// traffic (except acme-challenge). Surface it so the outage is diagnosable
+		// instead of silently blackholing the ingress.
+		slog.Error("plugin/AllowRemote: no valid CIDRs parsed; this ingress will block all traffic",
+			"ingress", ctx.ingressID(), "annotation", allowRemote)
 	}
 
 	m := block.New(func(r *http.Request) bool {

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -1,6 +1,8 @@
 package plugin_test
 
 import (
+	"bytes"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -402,6 +404,44 @@ func TestAllowRemote(t *testing.T) {
 		assert.True(t, called)
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
+}
+
+func TestAllowRemoteAllInvalidCIDRsLogsAndBlocks(t *testing.T) {
+	// Not parallel: temporarily swaps the slog default to capture output. (Go runs
+	// non-parallel tests sequentially, so no concurrent slog user races the swap.)
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})))
+	defer slog.SetDefault(prev)
+
+	ctx := Context{
+		Middlewares: &parapet.Middlewares{},
+		Ingress: &networking.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "ing",
+				Annotations: map[string]string{
+					// a bare IP (no /mask) is rejected by net.ParseCIDR, so the whole
+					// allow-list ends up empty → the ingress would 403 all traffic.
+					"parapet.moonrhythm.io/allow-remote": "203.0.113.5",
+				},
+			},
+		},
+	}
+	AllowRemote(ctx)
+
+	logs := buf.String()
+	assert.Contains(t, logs, "invalid CIDR", "the malformed entry must be logged")
+	assert.Contains(t, logs, "block all traffic", "the total-block outcome must be surfaced")
+
+	// behavior is fail-closed: every non-acme request is forbidden
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "203.0.113.5:1234"
+	w := httptest.NewRecorder()
+	var called bool
+	ctx.ServeHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })).ServeHTTP(w, r)
+	assert.False(t, called)
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
 func TestStripPrefix(t *testing.T) {

--- a/retry.go
+++ b/retry.go
@@ -51,6 +51,7 @@ func retryMiddleware(h http.Handler) http.Handler {
 			r.Body = &trackBodyRead{ReadCloser: r.Body}
 		}
 
+	retryLoop:
 		for i := 0; i < maxRetry; i++ {
 			if tryServe(w, r) {
 				return
@@ -59,7 +60,10 @@ func retryMiddleware(h http.Handler) http.Handler {
 			select {
 			case <-time.After(backoffDuration(i)):
 			case <-ctx.Done():
-				break
+				// client gone / request canceled: stop retrying. A bare `break`
+				// here would only exit the select, not the loop, so the label is
+				// required to actually abort.
+				break retryLoop
 			}
 		}
 		http.Error(w, "Bad Gateway", http.StatusBadGateway)

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"errors"
 	"net"
 	"net/http"
@@ -44,6 +45,28 @@ func TestRetryMiddleware(t *testing.T) {
 		})))
 		assert.Equal(t, int32(1), calls.Load(), "a responded 503 is served once, not retried")
 		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	})
+
+	t.Run("a canceled context aborts the retry loop immediately", func(t *testing.T) {
+		// Once the request context is canceled (client disconnected), the loop must
+		// stop retrying — the ctx.Done() case must break the *loop*, not just the
+		// select. The handler keeps emitting a retryable dial error, so a bare
+		// `break` would burn through all maxRetry attempts; the labeled break stops
+		// after the first.
+		var calls atomic.Int32
+		ctx, cancel := context.WithCancel(context.Background())
+		h := retryMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			calls.Add(1)
+			cancel() // disconnect mid-attempt
+			panic(error(dialErr))
+		}))
+		r := httptest.NewRequest(http.MethodGet, "http://svc/", nil).WithContext(ctx)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		assert.Equal(t, int32(1), calls.Load(),
+			"canceled context must abort the loop after one attempt, not retry")
+		assert.Equal(t, http.StatusBadGateway, w.Code)
 	})
 
 	t.Run("does NOT retry a non-connection panic", func(t *testing.T) {


### PR DESCRIPTION
Three low-severity but real robustness fixes from a core audit, each with a regression test.

## 1. `retry.go` — `break` doesn't exit the retry loop on cancellation
The retry backoff `select` used a bare `break` in the `ctx.Done()` case, which only exits the `select`, not the enclosing `for` loop — so a canceled request context didn't actually short-circuit retries. Fixed with a labeled `break retryLoop`. (Impact is small in practice — the transport short-circuits a canceled context before dialing — but the cancellation fast-path was dead code.)

## 2. `plugin/AllowRemote` — silent total block on bad CIDRs
Invalid CIDRs were discarded with `_`. An all-invalid `allow-remote` annotation (e.g. a bare IP `203.0.113.5` with no `/mask`, which `net.ParseCIDR` rejects) leaves an **empty allow-list**, so the `block` predicate **403s all traffic** (except acme-challenge) — with **no log**, making the outage undiagnosable. Now each malformed entry is logged, and the total-block outcome is logged explicitly.

## 3. WAF reload — nondeterministic global ConfigMap order
Multiple global WAF ConfigMaps were concatenated in `sync.Map.Range` order, which is randomized. So with two global ConfigMaps of equal priority, rule precedence — and the recompile fingerprint — could **flip between reloads**. Now global ConfigMaps are sorted by namespace/name before concatenation. (Zones are unaffected: a zone key is a single ConfigMap.)

## Tests
- `retry_test.go` — a canceled context aborts after one attempt, not `maxRetry`.
- `plugin_test.go` — an all-invalid `allow-remote` logs and fails closed.
- `controller_waf_test.go` — global rule order is stable/sorted across 20 reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)