### PR TITLE
feat(edge-trust): EDGE_TRUST_CP_INSECURE_HTTP opt-in for a plaintext trust channel

### DIFF
--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -171,12 +171,19 @@ too** — a truncated/garbled NEW block in the `OLD ++ NEW` overlap bundle must 
 rejected (keep last-good), never half-applied, so a bad NEW block blocks the rotation
 loudly rather than silently dropping NEW (which would 502 just-re-minted edges).
 
-**Deliberate inversion of `edge/cp.go`:** a missing/empty/unparseable
-`EDGE_TRUST_CP_CA`, or an `AppendCertsFromPEM` that adds **zero** certs, is a **FATAL
-startup error**; `InsecureSkipVerify` is never set; a non-`https://` endpoint is
-rejected fatally — **no plaintext analog ever**. `EDGE_TRUST_CP_CA` SHOULD be a
-dedicated single-purpose CA signing only the CP server cert; the client verifies the
-CP cert hostname against the endpoint host.
+**Deliberate inversion of `edge/cp.go`:** in the default (https) mode a
+missing/empty/unparseable `EDGE_TRUST_CP_CA`, or an `AppendCertsFromPEM` that adds
+**zero** certs, is a **FATAL startup error**, and `InsecureSkipVerify` is never set. A
+non-`https://` endpoint is rejected fatally **unless** `EDGE_TRUST_CP_INSECURE_HTTP=true`
+is explicitly set — a guarded opt-in (`trust.ClassifyEndpoint`) into a **PLAINTEXT
+`http://`** channel for transports that already provide mutual auth + encryption
+(mesh / tunnel / VPC). In that mode the integrity guarantee lives in the transport,
+not in-process, `EDGE_TRUST_CP_CA` is unused, and the choice is logged loudly; it is
+**off by default**. The forward-only / strict-parse / fail-static guards still apply,
+but they do **not** defend against a live MITM on a plaintext channel, so `https://`
+(terminate TLS at the mesh if needed) remains the recommendation. `EDGE_TRUST_CP_CA`
+SHOULD be a dedicated single-purpose CA signing only the CP server cert; the client
+verifies the CP cert hostname against the endpoint host.
 
 ### Freshness: long-poll, not bare poll
 
@@ -688,8 +695,9 @@ not Prometheus counters (a Pushgateway would be a new failure domain).
 |---|---|---|---|
 | `TRUST_PROXY` | core | `cloudflare` | **Unchanged** — the `cidrTrust` OR-branch. Never add edge egress CIDRs here. |
 | `CP_METRICS_LISTEN` | CP | `:9187` | Separate unauthenticated `/metrics` listener (serving process only); `""` disables. Restrict via NetworkPolicy. |
-| `EDGE_TRUST_CP_ENDPOINT` | core | `""` (off) | HTTPS base URL of the CP. Set ⇒ the core pulls `GET /v1/trust-bundle`. **MUST be `https://`** — non-https is fatal, no plaintext analog ever. |
-| `EDGE_TRUST_CP_CA` | core | `""` | PEM of the CA that signs the **CP server** cert → `RootCAs`. **Mandatory + fatal** if missing/empty/unparseable; no system-roots fallback, no skip-verify. Dedicated single-purpose CA; distinct from the edge CA in `ca_pem`. |
+| `EDGE_TRUST_CP_ENDPOINT` | core | `""` (off) | Base URL of the CP. Set ⇒ the core pulls `GET /v1/trust-bundle`. **`https://` by default** (non-https is fatal); `http://` is permitted only with `EDGE_TRUST_CP_INSECURE_HTTP=true`. |
+| `EDGE_TRUST_CP_INSECURE_HTTP` | core | `false` | Opt into a **PLAINTEXT `http://`** trust channel. Safe **only** on a transport that already provides mutual auth + encryption (mesh/tunnel/VPC) — the in-process server-TLS integrity guarantee is gone (a MITM could inject a forged CA and forge the whole fleet), so it is off by default, logged loudly, and `EDGE_TRUST_CP_CA` is unused. Prefer terminating TLS at the mesh and keeping `https://`. |
+| `EDGE_TRUST_CP_CA` | core | `""` | PEM of the CA that signs the **CP server** cert → `RootCAs`. **Mandatory + fatal** in https mode if missing/empty/unparseable; no system-roots fallback, no skip-verify. Unused when `EDGE_TRUST_CP_INSECURE_HTTP=true`. Dedicated single-purpose CA; distinct from the edge CA in `ca_pem`. |
 | `EDGE_TRUST_CP_WATCH_TIMEOUT` / `_POLL_INTERVAL` | core/CP | `30s` / `5m` | Long-poll ceiling; safety-net poll. The poll now bounds **CA-rotation** propagation only (not per-request revocation), so it may lengthen; keep the long-poll for fast rotation convergence. |
 | `EDGE_TRUST_CP_CACHE_FILE` / `_MAX_STALE` | core | `""` (off) / `3600` (s, =1h) | Warm-start cache. After every successful poll the core persists `{generation, ca_id, ca_pem, written_at}` (public; atomic temp+rename) and on startup loads its generation as an anti-rollback **floor** (a bundle below it ⇒ `trust_apply_total{result="floor_rejected"}`), so a restart-during-outage can't resurrect a rotated-out CA via a stale CP replica. It confers **NO trust** until a live fetch revalidates — the cached CA is **not** loaded into `ClientCAs`, so trust stays CIDR-only meanwhile (`trust_warmstart_active=1`) and flips to mTLS on the first live apply. `written_at` tracks last CP **contact** (refreshed on 304s too), so `_MAX_STALE` (seconds) bounds time-since-contact: a longer outage discards the floor and cold-starts (larger = safer vs. resurrection; smaller = recovers faster from a CP-side generation reset). |
 | `EDGE_TRUST_REQUIRE_SAN` | core | **forced false, deprecated** | CA-only is the only model; the per-request SAN check is removed. Setting `true` with CP-issuance is a **fatal config error**. Slated for removal. |

--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -244,21 +244,37 @@ func main() {
 	// to it — in addition to the static TRUST_PROXY CIDRs. See EDGE-AUTOTRUST.md.
 	var trustMgr *trust.Manager
 	if ep := config.String("EDGE_TRUST_CP_ENDPOINT"); ep != "" {
-		if !strings.HasPrefix(ep, "https://") {
-			slog.Error("EDGE_TRUST_CP_ENDPOINT must be https:// (the trust channel has no plaintext mode, ever)", "endpoint", ep)
-			os.Exit(1)
-		}
-		caPath := config.String("EDGE_TRUST_CP_CA")
-		caPEM, err := os.ReadFile(caPath)
+		mode, err := trust.ClassifyEndpoint(ep, config.Bool("EDGE_TRUST_CP_INSECURE_HTTP"))
 		if err != nil {
-			slog.Error("EDGE_TRUST_CP_CA must be set and readable — it is the mandatory server-TLS anchor that makes the tokenless trust channel safe", "path", caPath, "error", err)
+			slog.Error("EDGE_TRUST_CP_ENDPOINT rejected", "endpoint", ep, "error", err)
 			os.Exit(1)
 		}
-		tc, err := trust.NewClient(ep, caPEM)
-		if err != nil {
-			slog.Error("edge trust client", "error", err)
-			os.Exit(1)
+
+		var tc *trust.Client
+		switch mode {
+		case trust.ModeHTTPS:
+			caPath := config.String("EDGE_TRUST_CP_CA")
+			caPEM, err := os.ReadFile(caPath)
+			if err != nil {
+				slog.Error("EDGE_TRUST_CP_CA must be set and readable — it is the mandatory server-TLS anchor that makes the tokenless trust channel safe", "path", caPath, "error", err)
+				os.Exit(1)
+			}
+			tc, err = trust.NewClient(ep, caPEM)
+			if err != nil {
+				slog.Error("edge trust client", "error", err)
+				os.Exit(1)
+			}
+		case trust.ModeInsecureHTTP:
+			// Opt-in plaintext: only safe when the transport already provides mutual
+			// auth + encryption. The in-process server-TLS integrity guarantee is gone,
+			// so say so loudly (mirrors the CP's own plaintext-mode warning).
+			slog.Warn("edge trust: PLAINTEXT trust channel enabled (EDGE_TRUST_CP_INSECURE_HTTP) — the "+
+				"tokenless trust-bundle has NO on-wire integrity; a MITM can inject a forged CA and forge "+
+				"the ENTIRE edge fleet (spoof X-Forwarded-For, bypass WAF/rate-limits). Only run this on a "+
+				"transport that already provides mutual auth + encryption (mesh/tunnel/VPC).", "endpoint", ep)
+			tc = trust.NewInsecureHTTPClient(ep)
 		}
+
 		trustMgr = trust.NewManager()
 		// Warm-start cache (optional): persist the last-good bundle so a restart-during-outage
 		// can't resurrect a rotated-out CA via a stale CP replica. The cache seeds an

--- a/trust/trust.go
+++ b/trust/trust.go
@@ -11,12 +11,14 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -38,13 +40,67 @@ type bundleBody struct {
 	CAID       string `json:"ca_id"`
 }
 
-// Client is the tokenless HTTPS client to the control plane's GET /v1/trust-bundle.
-// Server-TLS verification is MANDATORY and non-skippable: it is the sole integrity
-// guarantee that justifies dropping the bearer token (a forged bundle would be a
-// trust-boundary takeover). NewClient fails if the CP server CA can't be loaded.
+// Client is the tokenless client to the control plane's GET /v1/trust-bundle.
+//
+// By default it is HTTPS with MANDATORY, non-skippable server-TLS verification: that
+// is the sole integrity guarantee that justifies dropping the bearer token (a forged
+// bundle would be a trust-boundary takeover). NewClient fails if the CP server CA
+// can't be loaded.
+//
+// NewInsecureHTTPClient builds a PLAINTEXT variant for transports that already provide
+// mutual auth + encryption (mesh/tunnel/VPC); it is gated behind
+// EDGE_TRUST_CP_INSECURE_HTTP and is never the default. See ClassifyEndpoint.
 type Client struct {
 	http *http.Client
 	base string
+}
+
+// EndpointMode is how the core dials EDGE_TRUST_CP_ENDPOINT, decided by ClassifyEndpoint.
+type EndpointMode int
+
+const (
+	// ModeHTTPS pulls the trust bundle over verified server-TLS — the default and
+	// only safe-by-default mode. EDGE_TRUST_CP_CA is mandatory and the CP cert is
+	// verified, because the bundle is tokenless and a forged ca_pem is a fleet-wide
+	// trust takeover.
+	ModeHTTPS EndpointMode = iota
+	// ModeInsecureHTTP pulls the trust bundle over PLAINTEXT http://. It exists only
+	// for transports that already provide mutual auth + encryption (mesh/tunnel/VPC)
+	// and must be explicitly opted into via EDGE_TRUST_CP_INSECURE_HTTP — the on-wire
+	// integrity guarantee then lives in the transport, not in-process.
+	ModeInsecureHTTP
+)
+
+// ClassifyEndpoint decides how to dial endpoint. https:// is always ModeHTTPS.
+// http:// is ModeInsecureHTTP only when allowHTTP (EDGE_TRUST_CP_INSECURE_HTTP) is
+// set; a plaintext trust channel without that explicit opt-in, or any other scheme,
+// is an error.
+func ClassifyEndpoint(endpoint string, allowHTTP bool) (EndpointMode, error) {
+	switch {
+	case strings.HasPrefix(endpoint, "https://"):
+		return ModeHTTPS, nil
+	case strings.HasPrefix(endpoint, "http://"):
+		if allowHTTP {
+			return ModeInsecureHTTP, nil
+		}
+		return 0, errors.New("EDGE_TRUST_CP_ENDPOINT is http:// but EDGE_TRUST_CP_INSECURE_HTTP is not set: " +
+			"the tokenless trust channel has no on-wire integrity over plaintext; only enable it on an " +
+			"already mutually-authenticated transport (mesh/tunnel/VPC)")
+	default:
+		return 0, errors.New("EDGE_TRUST_CP_ENDPOINT must be https:// (or http:// with EDGE_TRUST_CP_INSECURE_HTTP=true)")
+	}
+}
+
+// NewInsecureHTTPClient builds a PLAINTEXT trust client (no server-TLS, no CA). It is
+// only safe when the transport (mesh/tunnel/VPC) already provides mutual auth +
+// encryption; gated behind EDGE_TRUST_CP_INSECURE_HTTP, never the default. The
+// forward-only / strict-parse / fail-static guards in Manager still apply, but they do
+// NOT defend against a live MITM on a plaintext channel.
+func NewInsecureHTTPClient(base string) *Client {
+	return &Client{
+		base: base,
+		http: &http.Client{Timeout: 60 * time.Second},
+	}
 }
 
 // NewClient builds the client. caPEM (EDGE_TRUST_CP_CA) is the CA that signs the

--- a/trust/trust_test.go
+++ b/trust/trust_test.go
@@ -157,6 +157,63 @@ func TestTrustBundleOverTLSEndToEnd(t *testing.T) {
 	}
 }
 
+func TestClassifyEndpoint(t *testing.T) {
+	cases := []struct {
+		name      string
+		endpoint  string
+		allowHTTP bool
+		want      EndpointMode
+		wantErr   bool
+	}{
+		{"https without flag", "https://cp:8443", false, ModeHTTPS, false},
+		{"https ignores the flag (never downgraded)", "https://cp:8443", true, ModeHTTPS, false},
+		{"http without flag is rejected", "http://cp:8080", false, 0, true},
+		{"http with flag is plaintext", "http://cp:8080", true, ModeInsecureHTTP, false},
+		{"no scheme is rejected", "cp:8443", true, 0, true},
+		{"other scheme is rejected", "ftp://cp", true, 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ClassifyEndpoint(c.endpoint, c.allowHTTP)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q (allowHTTP=%v)", c.endpoint, c.allowHTTP)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Fatalf("mode = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// The opt-in plaintext client (EDGE_TRUST_CP_INSECURE_HTTP) pulls the bundle over
+// http:// with no server-TLS and no CA. Integrity is assumed to come from the
+// transport (mesh/tunnel); the plaintext test server stands in for it.
+func TestInsecureHTTPClientFetchesOverPlaintext(t *testing.T) {
+	caCertPEM, caKeyPEM := caPEMFor(t)
+	signer, _, err := edgecp.NewProvidedSigner(caCertPEM, caKeyPEM, time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := edgecp.NewServer(edgecp.NewCertStore(), edgecp.NewAuthz(nil)).WithSigner(signer, 1).Handler()
+	srv := httptest.NewServer(h) // PLAINTEXT http://, unlike NewTLSServer above
+	defer srv.Close()
+
+	c := NewInsecureHTTPClient(srv.URL)
+	b, unchanged, err := c.Fetch(0, false)
+	if err != nil || unchanged {
+		t.Fatalf("plaintext fetch: err=%v unchanged=%v", err, unchanged)
+	}
+	if b.CAID != signer.CAID() {
+		t.Errorf("ca_id mismatch: %q vs %q", b.CAID, signer.CAID())
+	}
+}
+
 // ---- warm-start cache ----
 
 // The full warm-start cycle: apply -> persist -> a fresh manager loads the floor ->


### PR DESCRIPTION
Adds a **guarded, off-by-default** opt-in to run the core's edge trust-bundle pull over plaintext `http://`, for deployments where the transport (service mesh / tunnel / VPC peering) already provides mutual auth + encryption.

## Why
The trust channel (`GET /v1/trust-bundle`) is **tokenless**, so the CP's server-TLS cert is its *only* integrity guarantee — over plain `http://`, a MITM could inject a forged `ca_pem` and, in the CA-only trust model, **forge the entire edge fleet** (spoof `X-Forwarded-For`, bypass IP WAF/rate-limits, poison GeoIP). That's why the core hard-rejected `http://`.

But the **CP already has this exact escape hatch** — it serves plaintext when `CP_TLS_CERT`/`CP_TLS_KEY` are unset, "for a trusted private network (tunnel/mesh/VPC) where the transport is already encrypted/authenticated," with a loud warning (`cmd/edge-controlplane/main.go:177-189`). This makes the **core symmetric**: when the wire is already mutually-authenticated, let the integrity guarantee live in the transport.

## What changed
- **`trust.ClassifyEndpoint(endpoint, allowHTTP)`** — `https://` → `ModeHTTPS` always (the flag never downgrades https); `http://` → `ModeInsecureHTTP` only when `allowHTTP`, else an error; any other scheme errors.
- **`trust.NewInsecureHTTPClient(base)`** — a plaintext client (no server-TLS, no CA).
- **`main.go`** — `EDGE_TRUST_CP_INSECURE_HTTP` gates the `http://` path; it's logged loudly and skips the now-irrelevant `EDGE_TRUST_CP_CA`.

**Default (flag unset) is byte-for-byte the old behavior** — `http://` is still fatal, `https://` still requires `EDGE_TRUST_CP_CA` with full verification.

## Security posture (called out in code + doc)
- **Off by default**, explicit opt-in, loud `WARN` on use.
- The forward-only / strict-parse / fail-static guards still apply, but they do **not** defend against a live MITM on plaintext — the flag's docs state it is only safe on an already mutually-authenticated transport.
- **`https://` (terminate TLS at the mesh if needed) remains the recommendation.** Contract updated in `EDGE-AUTOTRUST.md` (the "no plaintext analog ever" assertion + the env table).

## Tests (`go test -race`)
- `TestClassifyEndpoint` — `http://` rejected **without** the flag, accepted **with** it; `https://` never downgraded; bad schemes rejected.
- `TestInsecureHTTPClientFetchesOverPlaintext` — the plaintext client pulls a real trust bundle from an `httptest.NewServer` (http) and the `ca_id` matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)