### PR TITLE
feat(edge-trust): optional EDGE_TRUST_CP_CA + ungated http:// endpoint

### DIFF
--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -171,19 +171,23 @@ too** — a truncated/garbled NEW block in the `OLD ++ NEW` overlap bundle must 
 rejected (keep last-good), never half-applied, so a bad NEW block blocks the rotation
 loudly rather than silently dropping NEW (which would 502 just-re-minted edges).
 
-**Deliberate inversion of `edge/cp.go`:** in the default (https) mode a
-missing/empty/unparseable `EDGE_TRUST_CP_CA`, or an `AppendCertsFromPEM` that adds
-**zero** certs, is a **FATAL startup error**, and `InsecureSkipVerify` is never set. A
-non-`https://` endpoint is rejected fatally **unless** `EDGE_TRUST_CP_INSECURE_HTTP=true`
-is explicitly set — a guarded opt-in (`trust.ClassifyEndpoint`) into a **PLAINTEXT
-`http://`** channel for transports that already provide mutual auth + encryption
-(mesh / tunnel / VPC). In that mode the integrity guarantee lives in the transport,
-not in-process, `EDGE_TRUST_CP_CA` is unused, and the choice is logged loudly; it is
-**off by default**. The forward-only / strict-parse / fail-static guards still apply,
-but they do **not** defend against a live MITM on a plaintext channel, so `https://`
-(terminate TLS at the mesh if needed) remains the recommendation. `EDGE_TRUST_CP_CA`
-SHOULD be a dedicated single-purpose CA signing only the CP server cert; the client
-verifies the CP cert hostname against the endpoint host.
+**`EDGE_TRUST_CP_ENDPOINT` scheme + CA (`trust.ClassifyEndpoint`):**
+
+- **`https://` (recommended):** verified server-TLS, `InsecureSkipVerify` never set. If
+  `EDGE_TRUST_CP_CA` is set it **pins** to that CA (an `AppendCertsFromPEM` that adds
+  **zero** certs is a **FATAL** error; a set-but-unreadable file is **FATAL** — no silent
+  downgrade). If `EDGE_TRUST_CP_CA` is **unset**, the CP cert is verified against the host's
+  **system trust store** (`NewSystemRootsClient`; the image ships `ca-certificates`) — real
+  verified TLS with hostname checks, but weaker than pinning (any system-trusted CA could
+  impersonate the CP), so a pinned, dedicated single-purpose CA remains the tightest option.
+- **`http://`:** a **PLAINTEXT** channel — the tokenless integrity guarantee then lives in
+  the transport, not in-process, `EDGE_TRUST_CP_CA` is unused, and the choice is **logged
+  loudly**. The forward-only / strict-parse / fail-static guards still apply, but they do
+  **not** defend against a live MITM on plaintext, so use `http://` **only** on a transport
+  that already provides mutual auth + encryption (mesh / tunnel / VPC) — otherwise keep
+  `https://` (terminate TLS at the mesh if needed). Any other scheme is a fatal error.
+
+In every mode the client verifies the CP cert hostname against the endpoint host.
 
 ### Freshness: long-poll, not bare poll
 
@@ -695,9 +699,8 @@ not Prometheus counters (a Pushgateway would be a new failure domain).
 |---|---|---|---|
 | `TRUST_PROXY` | core | `cloudflare` | **Unchanged** — the `cidrTrust` OR-branch. Never add edge egress CIDRs here. |
 | `CP_METRICS_LISTEN` | CP | `:9187` | Separate unauthenticated `/metrics` listener (serving process only); `""` disables. Restrict via NetworkPolicy. |
-| `EDGE_TRUST_CP_ENDPOINT` | core | `""` (off) | Base URL of the CP. Set ⇒ the core pulls `GET /v1/trust-bundle`. **`https://` by default** (non-https is fatal); `http://` is permitted only with `EDGE_TRUST_CP_INSECURE_HTTP=true`. |
-| `EDGE_TRUST_CP_INSECURE_HTTP` | core | `false` | Opt into a **PLAINTEXT `http://`** trust channel. Safe **only** on a transport that already provides mutual auth + encryption (mesh/tunnel/VPC) — the in-process server-TLS integrity guarantee is gone (a MITM could inject a forged CA and forge the whole fleet), so it is off by default, logged loudly, and `EDGE_TRUST_CP_CA` is unused. Prefer terminating TLS at the mesh and keeping `https://`. |
-| `EDGE_TRUST_CP_CA` | core | `""` | PEM of the CA that signs the **CP server** cert → `RootCAs`. **Mandatory + fatal** in https mode if missing/empty/unparseable; no system-roots fallback, no skip-verify. Unused when `EDGE_TRUST_CP_INSECURE_HTTP=true`. Dedicated single-purpose CA; distinct from the edge CA in `ca_pem`. |
+| `EDGE_TRUST_CP_ENDPOINT` | core | `""` (off) | Base URL of the CP. Set ⇒ the core pulls `GET /v1/trust-bundle`. `https://` = verified TLS (recommended); `http://` = **PLAINTEXT** (logged loudly; only safe on a mesh/tunnel/VPC transport that already provides mutual auth + encryption). Any other scheme is fatal. |
+| `EDGE_TRUST_CP_CA` | core | `""` | **Optional.** PEM of the CA that signs the **CP server** cert → pinned `RootCAs` (the tightest trust; a dedicated single-purpose CA, distinct from the edge CA in `ca_pem`). If **unset** (https mode), the CP cert is verified against the **system trust store** instead — weaker (any system-trusted CA could impersonate the CP), but still verified TLS with hostname checks. A set-but-unreadable file, or one yielding zero certs, is fatal (no silent downgrade); unused for `http://`. `InsecureSkipVerify` is never set. |
 | `EDGE_TRUST_CP_WATCH_TIMEOUT` / `_POLL_INTERVAL` | core/CP | `30s` / `5m` | Long-poll ceiling; safety-net poll. The poll now bounds **CA-rotation** propagation only (not per-request revocation), so it may lengthen; keep the long-poll for fast rotation convergence. |
 | `EDGE_TRUST_CP_CACHE_FILE` / `_MAX_STALE` | core | `""` (off) / `3600` (s, =1h) | Warm-start cache. After every successful poll the core persists `{generation, ca_id, ca_pem, written_at}` (public; atomic temp+rename) and on startup loads its generation as an anti-rollback **floor** (a bundle below it ⇒ `trust_apply_total{result="floor_rejected"}`), so a restart-during-outage can't resurrect a rotated-out CA via a stale CP replica. It confers **NO trust** until a live fetch revalidates — the cached CA is **not** loaded into `ClientCAs`, so trust stays CIDR-only meanwhile (`trust_warmstart_active=1`) and flips to mTLS on the first live apply. `written_at` tracks last CP **contact** (refreshed on 304s too), so `_MAX_STALE` (seconds) bounds time-since-contact: a longer outage discards the floor and cold-starts (larger = safer vs. resurrection; smaller = recovers faster from a CP-side generation reset). |
 | `EDGE_TRUST_REQUIRE_SAN` | core | **forced false, deprecated** | CA-only is the only model; the per-request SAN check is removed. Setting `true` with CP-issuance is a **fatal config error**. Slated for removal. |

--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -244,7 +244,7 @@ func main() {
 	// to it — in addition to the static TRUST_PROXY CIDRs. See EDGE-AUTOTRUST.md.
 	var trustMgr *trust.Manager
 	if ep := config.String("EDGE_TRUST_CP_ENDPOINT"); ep != "" {
-		mode, err := trust.ClassifyEndpoint(ep, config.Bool("EDGE_TRUST_CP_INSECURE_HTTP"))
+		mode, err := trust.ClassifyEndpoint(ep)
 		if err != nil {
 			slog.Error("EDGE_TRUST_CP_ENDPOINT rejected", "endpoint", ep, "error", err)
 			os.Exit(1)
@@ -253,24 +253,36 @@ func main() {
 		var tc *trust.Client
 		switch mode {
 		case trust.ModeHTTPS:
-			caPath := config.String("EDGE_TRUST_CP_CA")
-			caPEM, err := os.ReadFile(caPath)
-			if err != nil {
-				slog.Error("EDGE_TRUST_CP_CA must be set and readable — it is the mandatory server-TLS anchor that makes the tokenless trust channel safe", "path", caPath, "error", err)
-				os.Exit(1)
-			}
-			tc, err = trust.NewClient(ep, caPEM)
-			if err != nil {
-				slog.Error("edge trust client", "error", err)
-				os.Exit(1)
+			if caPath := config.String("EDGE_TRUST_CP_CA"); caPath != "" {
+				// Pinned CA: trust only this CA for the CP server cert (tightest).
+				caPEM, err := os.ReadFile(caPath)
+				if err != nil {
+					// Explicitly set but unreadable is a misconfiguration — don't silently
+					// downgrade to system roots; stay fatal.
+					slog.Error("EDGE_TRUST_CP_CA is set but not readable", "path", caPath, "error", err)
+					os.Exit(1)
+				}
+				tc, err = trust.NewClient(ep, caPEM)
+				if err != nil {
+					slog.Error("edge trust client", "error", err)
+					os.Exit(1)
+				}
+			} else {
+				// No pinned CA: verify the CP server cert against the host's system trust
+				// store (the image ships ca-certificates). Real verified TLS with hostname
+				// checks — weaker than pinning (any system-trusted CA could impersonate the
+				// CP), so set EDGE_TRUST_CP_CA for the tightest trust on this tokenless
+				// channel.
+				slog.Info("edge trust: EDGE_TRUST_CP_CA unset — verifying the CP server cert against the system trust store", "endpoint", ep)
+				tc = trust.NewSystemRootsClient(ep)
 			}
 		case trust.ModeInsecureHTTP:
-			// Opt-in plaintext: only safe when the transport already provides mutual
-			// auth + encryption. The in-process server-TLS integrity guarantee is gone,
-			// so say so loudly (mirrors the CP's own plaintext-mode warning).
-			slog.Warn("edge trust: PLAINTEXT trust channel enabled (EDGE_TRUST_CP_INSECURE_HTTP) — the "+
-				"tokenless trust-bundle has NO on-wire integrity; a MITM can inject a forged CA and forge "+
-				"the ENTIRE edge fleet (spoof X-Forwarded-For, bypass WAF/rate-limits). Only run this on a "+
+			// http:// endpoint: plaintext, no in-process integrity guarantee, so say so
+			// loudly (mirrors the CP's own plaintext-mode warning). Only safe when the
+			// transport already provides mutual auth + encryption.
+			slog.Warn("edge trust: PLAINTEXT trust channel (http:// endpoint) — the tokenless "+
+				"trust-bundle has NO on-wire integrity; a MITM can inject a forged CA and forge the "+
+				"ENTIRE edge fleet (spoof X-Forwarded-For, bypass WAF/rate-limits). Only run this on a "+
 				"transport that already provides mutual auth + encryption (mesh/tunnel/VPC).", "endpoint", ep)
 			tc = trust.NewInsecureHTTPClient(ep)
 		}

--- a/trust/trust.go
+++ b/trust/trust.go
@@ -47,9 +47,10 @@ type bundleBody struct {
 // bundle would be a trust-boundary takeover). NewClient fails if the CP server CA
 // can't be loaded.
 //
-// NewInsecureHTTPClient builds a PLAINTEXT variant for transports that already provide
-// mutual auth + encryption (mesh/tunnel/VPC); it is gated behind
-// EDGE_TRUST_CP_INSECURE_HTTP and is never the default. See ClassifyEndpoint.
+// NewSystemRootsClient verifies the CP server cert against the system trust store
+// (used when EDGE_TRUST_CP_CA is unset); NewInsecureHTTPClient is a PLAINTEXT variant
+// for transports that already provide mutual auth + encryption (http:// endpoints).
+// See ClassifyEndpoint.
 type Client struct {
 	http *http.Client
 	base string
@@ -59,47 +60,62 @@ type Client struct {
 type EndpointMode int
 
 const (
-	// ModeHTTPS pulls the trust bundle over verified server-TLS — the default and
-	// only safe-by-default mode. EDGE_TRUST_CP_CA is mandatory and the CP cert is
-	// verified, because the bundle is tokenless and a forged ca_pem is a fleet-wide
-	// trust takeover.
+	// ModeHTTPS pulls the trust bundle over verified server-TLS (the recommended
+	// mode), because the bundle is tokenless and a forged ca_pem is a fleet-wide
+	// trust takeover. EDGE_TRUST_CP_CA pins a single CA; if it is unset the CP cert
+	// is verified against the system trust store instead (NewSystemRootsClient).
 	ModeHTTPS EndpointMode = iota
-	// ModeInsecureHTTP pulls the trust bundle over PLAINTEXT http://. It exists only
-	// for transports that already provide mutual auth + encryption (mesh/tunnel/VPC)
-	// and must be explicitly opted into via EDGE_TRUST_CP_INSECURE_HTTP — the on-wire
-	// integrity guarantee then lives in the transport, not in-process.
+	// ModeInsecureHTTP pulls the trust bundle over PLAINTEXT http://. The tokenless
+	// channel then has no in-process integrity guarantee, so it is only safe on a
+	// transport that already provides mutual auth + encryption (mesh/tunnel/VPC); the
+	// core logs a loud warning when it is used.
 	ModeInsecureHTTP
 )
 
-// ClassifyEndpoint decides how to dial endpoint. https:// is always ModeHTTPS.
-// http:// is ModeInsecureHTTP only when allowHTTP (EDGE_TRUST_CP_INSECURE_HTTP) is
-// set; a plaintext trust channel without that explicit opt-in, or any other scheme,
-// is an error.
-func ClassifyEndpoint(endpoint string, allowHTTP bool) (EndpointMode, error) {
+// ClassifyEndpoint decides how to dial endpoint by scheme: https:// ⇒ ModeHTTPS
+// (verified TLS — pinned CA or system roots), http:// ⇒ ModeInsecureHTTP (plaintext;
+// the caller warns). Any other scheme, or none, is an error.
+func ClassifyEndpoint(endpoint string) (EndpointMode, error) {
 	switch {
 	case strings.HasPrefix(endpoint, "https://"):
 		return ModeHTTPS, nil
 	case strings.HasPrefix(endpoint, "http://"):
-		if allowHTTP {
-			return ModeInsecureHTTP, nil
-		}
-		return 0, errors.New("EDGE_TRUST_CP_ENDPOINT is http:// but EDGE_TRUST_CP_INSECURE_HTTP is not set: " +
-			"the tokenless trust channel has no on-wire integrity over plaintext; only enable it on an " +
-			"already mutually-authenticated transport (mesh/tunnel/VPC)")
+		return ModeInsecureHTTP, nil
 	default:
-		return 0, errors.New("EDGE_TRUST_CP_ENDPOINT must be https:// (or http:// with EDGE_TRUST_CP_INSECURE_HTTP=true)")
+		return 0, errors.New("EDGE_TRUST_CP_ENDPOINT must be http:// or https://")
 	}
 }
 
-// NewInsecureHTTPClient builds a PLAINTEXT trust client (no server-TLS, no CA). It is
-// only safe when the transport (mesh/tunnel/VPC) already provides mutual auth +
-// encryption; gated behind EDGE_TRUST_CP_INSECURE_HTTP, never the default. The
-// forward-only / strict-parse / fail-static guards in Manager still apply, but they do
-// NOT defend against a live MITM on a plaintext channel.
+// NewInsecureHTTPClient builds a PLAINTEXT trust client (no server-TLS, no CA), used
+// when EDGE_TRUST_CP_ENDPOINT is http://. It is only safe when the transport
+// (mesh/tunnel/VPC) already provides mutual auth + encryption; the core logs a loud
+// warning on use. The forward-only / strict-parse / fail-static guards in Manager still
+// apply, but they do NOT defend against a live MITM on a plaintext channel.
 func NewInsecureHTTPClient(base string) *Client {
 	return &Client{
 		base: base,
 		http: &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+// NewSystemRootsClient builds an HTTPS trust client that verifies the CP server cert
+// against the host's system root store (RootCAs nil ⇒ system roots) with hostname
+// verification ON — InsecureSkipVerify is never set. Used when EDGE_TRUST_CP_CA is
+// unset and the CP serves a publicly/corp-trusted cert already in the trust store. It
+// is WEAKER than NewClient's pin-to-one-CA (any of the system-trusted CAs could
+// impersonate the CP), so a pinned EDGE_TRUST_CP_CA remains the tightest option for
+// this tokenless channel.
+func NewSystemRootsClient(base string) *Client {
+	return &Client{
+		base: base,
+		http: &http.Client{
+			Timeout: 60 * time.Second,
+			Transport: &http.Transport{
+				// RootCAs nil ⇒ the host's system root store; verification + hostname
+				// checks stay on (no InsecureSkipVerify).
+				TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+			},
+		},
 	}
 }
 

--- a/trust/trust_test.go
+++ b/trust/trust_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"math/big"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
@@ -159,25 +160,22 @@ func TestTrustBundleOverTLSEndToEnd(t *testing.T) {
 
 func TestClassifyEndpoint(t *testing.T) {
 	cases := []struct {
-		name      string
-		endpoint  string
-		allowHTTP bool
-		want      EndpointMode
-		wantErr   bool
+		name     string
+		endpoint string
+		want     EndpointMode
+		wantErr  bool
 	}{
-		{"https without flag", "https://cp:8443", false, ModeHTTPS, false},
-		{"https ignores the flag (never downgraded)", "https://cp:8443", true, ModeHTTPS, false},
-		{"http without flag is rejected", "http://cp:8080", false, 0, true},
-		{"http with flag is plaintext", "http://cp:8080", true, ModeInsecureHTTP, false},
-		{"no scheme is rejected", "cp:8443", true, 0, true},
-		{"other scheme is rejected", "ftp://cp", true, 0, true},
+		{"https is verified TLS", "https://cp:8443", ModeHTTPS, false},
+		{"http is plaintext (no flag needed)", "http://cp:8080", ModeInsecureHTTP, false},
+		{"no scheme is rejected", "cp:8443", 0, true},
+		{"other scheme is rejected", "ftp://cp", 0, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got, err := ClassifyEndpoint(c.endpoint, c.allowHTTP)
+			got, err := ClassifyEndpoint(c.endpoint)
 			if c.wantErr {
 				if err == nil {
-					t.Fatalf("expected error for %q (allowHTTP=%v)", c.endpoint, c.allowHTTP)
+					t.Fatalf("expected error for %q", c.endpoint)
 				}
 				return
 			}
@@ -191,9 +189,22 @@ func TestClassifyEndpoint(t *testing.T) {
 	}
 }
 
-// The opt-in plaintext client (EDGE_TRUST_CP_INSECURE_HTTP) pulls the bundle over
-// http:// with no server-TLS and no CA. Integrity is assumed to come from the
-// transport (mesh/tunnel); the plaintext test server stands in for it.
+// EDGE_TRUST_CP_CA unset falls back to the system trust store, but verification stays
+// ON (no InsecureSkipVerify): a CP cert not anchored in the system store is rejected,
+// unlike a pinned NewClient handed that cert as its CA.
+func TestSystemRootsClientVerifiesAndRejectsUntrusted(t *testing.T) {
+	srv := httptest.NewTLSServer(http.NotFoundHandler()) // self-signed, not in system roots
+	defer srv.Close()
+
+	c := NewSystemRootsClient(srv.URL)
+	if _, _, err := c.Fetch(0, false); err == nil {
+		t.Fatal("system-roots client must reject a CP cert not anchored in the system trust store")
+	}
+}
+
+// The plaintext client pulls the bundle over an http:// endpoint with no server-TLS
+// and no CA — the http:// use-case. Integrity is assumed to come from the transport
+// (mesh/tunnel); the plaintext test server stands in for it.
 func TestInsecureHTTPClientFetchesOverPlaintext(t *testing.T) {
 	caCertPEM, caKeyPEM := caPEMFor(t)
 	signer, _, err := edgecp.NewProvidedSigner(caCertPEM, caKeyPEM, time.Hour, time.Minute)


### PR DESCRIPTION
Relaxes two requirements on the core's edge trust-bundle pull, per maintainer request. Both ship with `-race` tests.

## 1. `EDGE_TRUST_CP_CA` is now optional (https mode)
- **Set** → pin to that CA (unchanged; the tightest trust). A set-but-**unreadable** path, or one yielding **zero** certs, stays **fatal** — no silent downgrade.
- **Unset** → verify the CP server cert against the host's **system trust store** (`trust.NewSystemRootsClient`; the image ships `ca-certificates`). Real verified TLS with hostname checks; `InsecureSkipVerify` is never set.

So if your CP already serves a publicly/corp-trusted cert, you can drop `EDGE_TRUST_CP_CA` entirely. It's **weaker than pinning** (any of the system-trusted CAs could impersonate the CP), so a pinned dedicated CA remains the recommended tightest option — logged at startup when the system-roots path is taken.

## 2. `http://` endpoints no longer need a flag
The `EDGE_TRUST_CP_INSECURE_HTTP` gate from #114 is **removed**. `ClassifyEndpoint` now maps `http://` → `ModeInsecureHTTP` directly, so:
```
EDGE_TRUST_CP_ENDPOINT=http://edge-controlplane:8080   # works, no extra flag
```
The plaintext path is still **logged loudly at runtime** (no on-wire integrity; only safe on a transport that already provides mutual auth + encryption — mesh/tunnel/VPC). The forward-only / strict-parse / fail-static guards still apply but do **not** defend against a live MITM on plaintext.

## Tests
- `TestClassifyEndpoint` — `https://` → `ModeHTTPS`, `http://` → `ModeInsecureHTTP` (no flag), other/no scheme → error.
- `TestInsecureHTTPClientFetchesOverPlaintext` — the `http://` use-case pulls a real bundle over plaintext.
- `TestSystemRootsClientVerifiesAndRejectsUntrusted` — the no-CA path still **verifies** (rejects a cert not anchored in the system store, proving no `InsecureSkipVerify`).

Contract updated in `EDGE-AUTOTRUST.md` (env table + the trust-pull section).

> Note: this supersedes the gating decision in #114 (which is already merged) — the `EDGE_TRUST_CP_INSECURE_HTTP` env var is retired. The security caveats are unchanged and still documented; only the gate is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)