### PR TITLE
feat(edge-trust): let edge mTLS and Cloudflare AOP coexist on :443

### DIFF
--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -71,23 +71,28 @@ not a source IP.
    live `GetClientCertificate` callback. A client cert can only ride TLS, so edge
    trust is conferred **only on `:443`**; plaintext `:80` is never mTLS-trusted.
 
-4. **The core verifies it.** The `:443` `tls.Config` gets
-   `ClientAuth = tls.VerifyClientCertIfGiven` (the cert is optional — Cloudflare /
-   browsers present none) and a `ClientCAs` pool sourced from the trust-bundle
-   `ca_pem`. The stdlib populates `r.TLS.VerifiedChains` only after cryptographic
-   verification against `ClientCAs`; a presented-but-unverifiable cert aborts the
-   handshake.
+4. **The core verifies it — per request, not at the TLS layer.** The `:443`
+   `tls.Config` uses `ClientAuth = tls.RequestClientCert`: it *requests* a client cert
+   but **never verifies it during the handshake**, so a non-edge client cert never
+   aborts the connection. This is what lets the edge **and** another mTLS client that
+   hits `:443` directly (e.g. **Cloudflare Authenticated Origin Pulls**, whose cert
+   chains to Cloudflare's CA, not the edge CA) coexist on the same port — Cloudflare's
+   cert would otherwise fail `VerifyClientCertIfGiven` and break every Cloudflare
+   request. Verification is instead done per request by `trust.Manager.VerifyClientCert`
+   against the live edge-CA pool (`ca_pem`), with a per-generation memo cache.
 
 5. **The per-request trust predicate** (installed once; see [Core wiring](#core-wiring)):
 
    ```
    trust(r) := cidrTrust(r)                         // existing TRUST_PROXY (e.g. cloudflare)
-            OR len(r.TLS.VerifiedChains) > 0        // a chain cryptographically verified to the edge CA
+            OR trustMgr.VerifyClientCert(r.TLS)     // client cert chains to the edge CA (verified here)
    ```
 
-   The edge CA signs nothing but edge leaves, so a verified chain **is** the trust
-   grant — a single non-empty check, no SAN lookup, no allow-set, no operator-asserted
-   string set in the per-request path.
+   The edge CA signs nothing but edge leaves, so a chaining cert **is** the trust
+   grant — no SAN lookup, no allow-set, no operator-asserted string set in the
+   per-request path. A cert that doesn't chain (Cloudflare AOP, a browser, an attacker)
+   simply returns false and falls through to the CIDR branch; the handshake already
+   completed.
 
 ### Single source of truth (onboard in one place); the SAN is not load-bearing
 
@@ -139,18 +144,20 @@ Install **one** closure, assigned to **both** servers' `TrustProxy`:
 
 ```go
 trustProxy = func(r *http.Request) bool {
-    if cidrTrust != nil && cidrTrust(r) { return true }               // metric: cidr
-    if r.TLS == nil || len(r.TLS.VerifiedChains) == 0 { return false } // metric: none / not-:443
-    return true                                                        // verified chain to the edge CA == trust
+    if cidrTrust != nil && cidrTrust(r) { return true }   // metric: cidr
+    if trustMgr.VerifyClientCert(r.TLS) { return true }   // client cert chains to the edge CA
+    return false                                          // metric: none (incl. :80, no cert, Cloudflare AOP)
 }
 ```
 
-`sanAllowed`, the `requireSAN` branch, and `trustPol.Load()` are gone. Keep the `:80`
-`r.TLS == nil` short-circuit (CIDR-only on plaintext) and the `GetConfigForClient`
-hot-swap (`c.ClientCAs = clientCAs.Load()`, fresh per handshake, never nil) +
-startup self-test (asserts `GetCertificate` + `ClientCAs` +
-`ClientAuth == VerifyClientCertIfGiven`) **verbatim**. Only the *feed* into
-`clientCAs` changes; trust no longer reads any per-request map.
+`sanAllowed`, the `requireSAN` branch, and `trustPol.Load()` are gone. `:443` uses
+`ClientAuth = tls.RequestClientCert` (request-but-never-verify) so a non-edge client
+cert (Cloudflare Authenticated Origin Pulls) can't abort the handshake; the edge-CA
+chain check is done per request by `VerifyClientCert` (nil `r.TLS` / `:80` ⇒ false,
+i.e. CIDR-only on plaintext). The pool is no longer fed into the `tls.Config`'s
+`ClientCAs`; it lives in the manager for the per-request verify (memoized by leaf
+fingerprint per generation). Only the *feed* into the pool changes; trust still reads
+no per-request map.
 
 ### The trust pull (tokenless CP client)
 

--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -304,7 +304,11 @@ func main() {
 			src := metric.TrustSrcNone
 			if cidrTrust != nil && cidrTrust(r) {
 				src = metric.TrustSrcCIDR
-			} else if r.TLS != nil && len(r.TLS.VerifiedChains) > 0 {
+			} else if trustMgr.VerifyClientCert(r.TLS) {
+				// An edge client cert that chains to the live edge CA, verified per
+				// request. A non-edge client cert (e.g. Cloudflare Authenticated Origin
+				// Pulls) simply isn't trusted here — the handshake was never aborted for
+				// it — so it falls through to the CIDR branch above.
 				src = metric.TrustSrcVerifiedChain
 			}
 			metric.TrustSource(src)

--- a/trust/e2e_test.go
+++ b/trust/e2e_test.go
@@ -73,27 +73,27 @@ func TestAutoTrustEndToEnd(t *testing.T) {
 	edgeCert, _ := ccStore.GetClientCertificate(nil)
 
 	// (1) A request presenting the CP-issued edge cert is TRUSTED by the core
-	// (the core's per-request predicate keys on len(VerifiedChains) > 0).
-	if n := getVerifiedChains(t, coreURL, edgeCert); n == 0 {
-		t.Error("edge with a CP-issued cert should be trusted (verified chain), got 0")
+	// (VerifyClientCert chains it to the pulled edge CA).
+	if n := getTrust(t, coreURL, edgeCert); n == 0 {
+		t.Error("edge with a CP-issued cert should be trusted, got untrusted")
 	}
 
-	// (2) A request with NO client cert completes but is UNTRUSTED (0 chains) —
+	// (2) A request with NO client cert completes but is UNTRUSTED —
 	// Cloudflare-direct / browser traffic must still work, just CIDR-only.
-	if n := getVerifiedChains(t, coreURL, nil); n != 0 {
-		t.Errorf("no-cert request should be untrusted (0 chains), got %d", n)
+	if n := getTrust(t, coreURL, nil); n != 0 {
+		t.Errorf("no-cert request should be untrusted, got %d", n)
 	}
 
-	// (3) A leaf from a DIFFERENT (rogue) CA must NOT be trusted: the security
-	// property is "no verified chain", i.e. the core treats it as untrusted
-	// (CIDR-only). Go's VerifyClientCertIfGiven may either abort the handshake or
-	// (on TLS 1.3) accept the connection without a verified chain — both are safe,
-	// because the per-request predicate keys on len(VerifiedChains) > 0.
+	// (3) A leaf from a DIFFERENT (rogue) CA — the Cloudflare-AOP coexistence case:
+	// the handshake MUST complete (ClientAuth is RequestClientCert, never verified at
+	// the TLS layer) and the request is simply UNTRUSTED (VerifyClientCert false).
 	rogue := genRogueLeaf(t)
 	rn, rerr := tryGet(coreURL, rogue)
-	t.Logf("rogue cert: chains=%d err=%v (either 0-chains or a handshake error is acceptable)", rn, rerr)
-	if rerr == nil && rn > 0 {
-		t.Error("a rogue-CA client cert was TRUSTED (got a verified chain) — must never be")
+	if rerr != nil {
+		t.Errorf("a non-edge client cert must NOT abort the handshake (Cloudflare AOP coexistence), got: %v", rerr)
+	}
+	if rn != 0 {
+		t.Error("a rogue-CA client cert was TRUSTED — must never be")
 	}
 
 	// (4) Cold start: a core whose trust bundle hasn't loaded (nil pool) must
@@ -105,7 +105,7 @@ func TestAutoTrustEndToEnd(t *testing.T) {
 	if n, err := tryGet(coldURL, rogue); err != nil {
 		t.Errorf("cold-start must not abort a presented cert, got error: %v", err)
 	} else if n != 0 {
-		t.Errorf("cold-start must not verify (0 chains), got %d", n)
+		t.Errorf("cold-start must be untrusted, got %d", n)
 	}
 }
 
@@ -123,15 +123,16 @@ func pullInto(t *testing.T, c *Client, m *Manager) {
 }
 
 // startCore runs an http.Server whose TLS config is the core's real ServerTLSConfig
-// (built from the trust manager). The handler reports the number of verified client
-// chains the handshake produced. Returns the base URL and a closer.
+// (built from the trust manager). The handler reports the real per-request trust
+// decision — 1 if m.VerifyClientCert trusts the presented client cert, else 0 —
+// exactly as the core's TrustProxy predicate does. Returns the base URL and a closer.
 func startCore(t *testing.T, m *Manager) (string, func()) {
 	t.Helper()
 	serverCert := genServerCert(t)
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n := 0
-		if r.TLS != nil {
-			n = len(r.TLS.VerifiedChains)
+		if m.VerifyClientCert(r.TLS) {
+			n = 1
 		}
 		_, _ = io.WriteString(w, strconv.Itoa(n))
 	})
@@ -147,7 +148,7 @@ func startCore(t *testing.T, m *Manager) (string, func()) {
 	return "https://" + ln.Addr().String() + "/", func() { _ = srv.Close() }
 }
 
-func getVerifiedChains(t *testing.T, url string, clientCert *tls.Certificate) int {
+func getTrust(t *testing.T, url string, clientCert *tls.Certificate) int {
 	t.Helper()
 	n, err := tryGet(url, clientCert)
 	if err != nil {

--- a/trust/trust.go
+++ b/trust/trust.go
@@ -7,6 +7,7 @@ package trust
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -19,6 +20,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -150,8 +152,8 @@ func (c *Client) Fetch(sinceGen uint64, watch bool) (b Bundle, unchanged bool, e
 	}
 }
 
-// Manager holds the live edge-CA pool the core's :443 GetConfigForClient reads per
-// handshake, hot-swapped from the CP bundle with strict-parse + forward-only +
+// Manager holds the live edge-CA pool the core's :443 VerifyClientCert checks per
+// request, hot-swapped from the CP bundle with strict-parse + forward-only +
 // fail-static (a bad/rollback bundle keeps last-good; the live pool is never nilled
 // once set).
 //
@@ -180,7 +182,20 @@ type Manager struct {
 	// CA change — otherwise a stable fleet's months-old cache would always exceed MAX_STALE
 	// and the floor would never load. Set before Run starts, then touched only in Run.
 	lastGood *cacheEntry
+
+	// verifyCache memoizes VerifyClientCert results (leaf fingerprint -> chains-to-pool)
+	// for the current generation, so the edge fleet's repeated requests skip the
+	// per-request x509 chain build. Keyed alongside verifyGen: a pool swap (rotation)
+	// advances the generation and the next access starts a fresh generation's map.
+	// Bounded by clear-when-full so a flood of distinct client certs can't grow it.
+	verifyMu    sync.RWMutex
+	verifyGen   uint64
+	verifyCache map[string]bool
 }
+
+// verifyCacheCap bounds the per-generation VerifyClientCert memo; over it, the map is
+// cleared wholesale (cheap, results recompute) rather than evicted per entry.
+const verifyCacheCap = 4096
 
 func NewManager() *Manager { return &Manager{} }
 
@@ -296,41 +311,80 @@ func (m *Manager) CAID() string {
 	return ""
 }
 
-// ServerTLSConfig builds the core's :443 *tls.Config so it verifies an OPTIONAL
-// edge client cert against the live, hot-reloaded CA pool — CA-only trust. The SNI
-// server cert is unchanged: getCertificate (the controller's cert table) and the
-// self-signed fallback are served exactly as before. Per handshake, ClientCAs is
-// loaded fresh from the manager; before the bundle loads (pool nil) it
-// requests-but-does-not-verify (tls.RequestClientCert) so the cold-start window
-// degrades to CIDR-only rather than aborting edge handshakes. Once loaded it is
-// tls.VerifyClientCertIfGiven (no cert → fine; a presented cert must verify to the
-// edge CA, else the handshake aborts). A verified cert populates
-// r.TLS.VerifiedChains, which the per-request trust predicate keys on.
+// ServerTLSConfig builds the core's :443 *tls.Config. It REQUESTS an optional client
+// cert (tls.RequestClientCert) but NEVER verifies it at the TLS layer — so a client
+// cert that doesn't chain to the edge CA (e.g. Cloudflare Authenticated Origin Pulls)
+// can't abort the handshake. Edge trust is decided per request by VerifyClientCert
+// against the live edge-CA pool: a chaining cert is mTLS-trusted, anything else falls
+// through to CIDR, and the handshake always completes. The SNI server cert is
+// unchanged — getCertificate (the controller's cert table) and the self-signed
+// fallback are served exactly as before.
 func (m *Manager) ServerTLSConfig(
 	getCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error),
 	fallback []tls.Certificate,
 ) *tls.Config {
-	base := &tls.Config{
+	return &tls.Config{
 		MinVersion:     tls.VersionTLS12,
 		Certificates:   fallback,
 		GetCertificate: getCertificate,
 		ClientAuth:     tls.RequestClientCert,
 	}
-	base.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
-		c := &tls.Config{
-			MinVersion:     tls.VersionTLS12,
-			Certificates:   fallback,
-			GetCertificate: getCertificate,
-		}
-		if pool := m.ClientCAs(); pool != nil {
-			c.ClientCAs = pool
-			c.ClientAuth = tls.VerifyClientCertIfGiven
-		} else {
-			c.ClientAuth = tls.RequestClientCert
-		}
-		return c, nil
+}
+
+// VerifyClientCert reports whether the peer presented a client cert that chains to the
+// live edge-CA pool (CA-only trust) — the per-request replacement for the TLS-layer
+// VerifyClientCertIfGiven (see ServerTLSConfig). No cert, no loaded pool, or a cert
+// that doesn't chain (Cloudflare AOP, a browser, an attacker) all return false; the
+// caller then falls back to CIDR trust. A successful verify is memoized by leaf
+// fingerprint for the current generation, so the edge fleet's repeated requests skip
+// the x509 chain build; a pool swap (CA rotation) advances the generation and
+// re-verifies.
+func (m *Manager) VerifyClientCert(cs *tls.ConnectionState) bool {
+	if cs == nil || len(cs.PeerCertificates) == 0 {
+		return false
 	}
-	return base
+	pool := m.clientCAs.Load()
+	if pool == nil {
+		return false
+	}
+	// Read pool before generation: apply() Stores the pool before the generation, so
+	// pool-then-gen never yields (old pool, new gen) — at worst (new pool, old gen),
+	// which only caches under a stale generation that the next access re-verifies.
+	gen := m.gen.Load()
+	sum := sha256.Sum256(cs.PeerCertificates[0].Raw)
+	key := string(sum[:])
+
+	m.verifyMu.RLock()
+	if m.verifyGen == gen {
+		if v, ok := m.verifyCache[key]; ok {
+			m.verifyMu.RUnlock()
+			return v
+		}
+	}
+	m.verifyMu.RUnlock()
+
+	inter := x509.NewCertPool()
+	for _, c := range cs.PeerCertificates[1:] {
+		inter.AddCert(c)
+	}
+	_, err := cs.PeerCertificates[0].Verify(x509.VerifyOptions{
+		Roots:         pool,
+		Intermediates: inter,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	ok := err == nil
+
+	m.verifyMu.Lock()
+	if m.verifyGen != gen || m.verifyCache == nil {
+		m.verifyCache = make(map[string]bool, 64)
+		m.verifyGen = gen
+	}
+	if len(m.verifyCache) >= verifyCacheCap {
+		clear(m.verifyCache)
+	}
+	m.verifyCache[key] = ok
+	m.verifyMu.Unlock()
+	return ok
 }
 
 // applyResult classifies an apply attempt so the caller can emit the right metric

--- a/trust/trust_test.go
+++ b/trust/trust_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/json"
@@ -77,6 +78,79 @@ func TestManagerForwardOnlyAndFailStatic(t *testing.T) {
 	}
 	if m.Generation() != 6 || m.CAID() != "b" {
 		t.Error("forward apply did not take")
+	}
+}
+
+// TestVerifyClientCert is the Cloudflare-coexistence contract: only a client cert that
+// chains to the live edge CA confers mTLS trust; no cert / a foreign cert (Cloudflare
+// AOP) returns false (never aborts), and a CA rotation re-verifies (the per-generation
+// cache is invalidated).
+func TestVerifyClientCert(t *testing.T) {
+	caCertPEM, caKeyPEM := caPEMFor(t)
+	signer, _, err := edgecp.NewProvidedSigner(caCertPEM, caKeyPEM, time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafFor := func(sg *edgecp.Signer, id string) *x509.Certificate {
+		key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		chainPEM, _, _, err := sg.Sign(key.Public(), id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		block, _ := pem.Decode(chainPEM)
+		leaf, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return leaf
+	}
+	csFor := func(leaf *x509.Certificate) *tls.ConnectionState {
+		if leaf == nil {
+			return &tls.ConnectionState{}
+		}
+		return &tls.ConnectionState{PeerCertificates: []*x509.Certificate{leaf}}
+	}
+
+	m := NewManager()
+	edge := leafFor(signer, "edge-1")
+
+	// No bundle loaded yet → no mTLS trust (cold start degrades to CIDR-only).
+	if m.VerifyClientCert(csFor(edge)) {
+		t.Fatal("no loaded pool must not confer mTLS trust")
+	}
+
+	if _, err := m.apply(Bundle{Generation: 1, CAPEM: caCertPEM, CAID: "a"}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// Edge leaf verifies (second call exercises the memo cache).
+	if !m.VerifyClientCert(csFor(edge)) || !m.VerifyClientCert(csFor(edge)) {
+		t.Fatal("edge leaf must verify against the loaded edge CA")
+	}
+
+	// Absent client cert (nil and empty) → not trusted; never aborts.
+	if m.VerifyClientCert(nil) || m.VerifyClientCert(csFor(nil)) {
+		t.Fatal("absent client cert must not confer mTLS trust")
+	}
+
+	// A cert from a DIFFERENT CA (the Cloudflare-AOP case) → not trusted.
+	otherCertPEM, otherKeyPEM := caPEMFor(t)
+	otherSigner, _, _ := edgecp.NewProvidedSigner(otherCertPEM, otherKeyPEM, time.Hour, time.Minute)
+	other := leafFor(otherSigner, "intruder")
+	if m.VerifyClientCert(csFor(other)) {
+		t.Fatal("a cert not chaining to the edge CA must not be trusted")
+	}
+
+	// Rotate to the other CA: the cache is invalidated by the generation bump, so the
+	// old-CA leaf is now rejected and the other leaf accepted.
+	if _, err := m.apply(Bundle{Generation: 2, CAPEM: otherCertPEM, CAID: "b"}); err != nil {
+		t.Fatalf("rotate apply: %v", err)
+	}
+	if m.VerifyClientCert(csFor(edge)) {
+		t.Fatal("after rotating CAs, the old-CA leaf must no longer verify")
+	}
+	if !m.VerifyClientCert(csFor(other)) {
+		t.Fatal("the new-CA leaf must verify after rotation")
 	}
 }
 


### PR DESCRIPTION
Fixes the `http: TLS handshake error from <cf-ip>: tls: failed to verify certificate: x509: certificate signed by unknown authority` floods when both the parapet edge proxy **and** Cloudflare hit the core's `:443` directly.

## Root cause
With `EDGE_TRUST_CP_ENDPOINT` set, once a trust bundle loaded the core's `:443` escalated to `tls.VerifyClientCertIfGiven`, which requires **any** presented client cert to chain to the edge CA — else the handshake aborts. Cloudflare **Authenticated Origin Pulls** presents Cloudflare's cert (chains to Cloudflare's CA, not the edge CA), so every Cloudflare connection failed the handshake.

## Fix — decide edge trust per request, not at the TLS layer (no new env var)
- **`ServerTLSConfig`** now uses `tls.RequestClientCert` **always** — request a client cert but **never verify it during the handshake**, so a non-edge cert can't abort the connection. (`GetConfigForClient`/`ClientCAs`-on-the-config are gone.)
- **`Manager.VerifyClientCert(*tls.ConnectionState)`** verifies the presented leaf against the **live edge-CA pool** (with `ClientAuth` EKU). The `TrustProxy` predicate calls it instead of reading `r.TLS.VerifiedChains`.
- Result on the same port: **edge cert → verifies → mTLS-trusted; Cloudflare AOP / browser / attacker → not trusted → CIDR fallback**; the handshake always completes.
- Successful verifies are **memoized by leaf fingerprint per generation** (RWMutex + clear-when-full), so the edge fleet skips the per-request x509 chain build and a CA rotation re-verifies. Only un-forgeable verified leaves grow the positive set; the cap bounds a junk-cert flood.

The trust **decision** is unchanged (only an edge-CA chain confers mTLS trust); only the *failure mode* changes — a non-edge client cert now completes the handshake (untrusted) instead of aborting it. A valid edge cert behaves identically.

## Tests (`go test -race`)
- `TestVerifyClientCert` — edge leaf verifies; nil/empty and foreign-CA certs untrusted; a CA rotation invalidates the per-generation cache (old leaf rejected, new leaf accepted).
- `e2e_test.go` updated to assert trust via `VerifyClientCert` over a **real handshake**, and that a **rogue client cert does NOT abort the handshake** — the coexistence guarantee.

Verified: `gofmt` clean, `go vet` clean, `go build ./...` OK, `trust` + `cmd` pass `-race`. Contract updated in `EDGE-AUTOTRUST.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)