### PR TITLE
fix(trust): treat same-generation bundle as unchanged, not a noisy rollback

### DIFF
--- a/trust/trust.go
+++ b/trust/trust.go
@@ -343,6 +343,7 @@ const (
 	resultEmptyRejected
 	resultRollbackRejected
 	resultFloorRejected
+	resultUnchanged
 )
 
 func (r applyResult) label() string {
@@ -357,6 +358,8 @@ func (r applyResult) label() string {
 		return "rollback_rejected"
 	case resultFloorRejected:
 		return "floor_rejected"
+	case resultUnchanged:
+		return "unchanged"
 	default:
 		return "unknown"
 	}
@@ -383,8 +386,15 @@ func (m *Manager) apply(b Bundle) (applyResult, error) {
 		return resultFloorRejected, fmt.Errorf("warm-start floor: bundle generation %d < persisted floor %d (stale/rolled-back CA across restart)", b.Generation, m.floor)
 	}
 	cur := m.gen.Load()
-	if cur != 0 && b.Generation <= cur {
-		return resultRollbackRejected, fmt.Errorf("rollback: bundle generation %d <= current %d", b.Generation, cur)
+	if cur != 0 && b.Generation == cur {
+		// Same generation as the live bundle: a benign replay, not a rollback. The
+		// safety-net plain-GET poll re-fetches the current bundle in steady state (and
+		// some CP long-poll implementations return the current bundle instead of a
+		// 304), so this happens routinely and must NOT warn.
+		return resultUnchanged, fmt.Errorf("unchanged: bundle generation %d == current %d", b.Generation, cur)
+	}
+	if cur != 0 && b.Generation < cur {
+		return resultRollbackRejected, fmt.Errorf("rollback: bundle generation %d < current %d", b.Generation, cur)
 	}
 	m.clientCAs.Store(pool)
 	m.gen.Store(b.Generation)
@@ -458,7 +468,15 @@ func (m *Manager) Run(ctx context.Context, c *Client, pollInterval time.Duration
 		default:
 			res, err := m.apply(b)
 			metric.TrustApply(res.label())
-			if err != nil {
+			if res == resultUnchanged {
+				// Same generation re-fetched: successful CP contact, nothing changed.
+				// Refresh the liveness timestamp (like a 304) and stay quiet — this is
+				// not a rollback.
+				slog.Debug("core: trust-bundle unchanged (same generation)", "generation", b.Generation)
+				if m.lastGood != nil {
+					m.writeCache(*m.lastGood)
+				}
+			} else if err != nil {
 				slog.Warn("core: trust-bundle rejected; keeping last-good", "error", err)
 			} else {
 				metric.TrustBundleApplied(b.CAID, b.Generation)

--- a/trust/trust_test.go
+++ b/trust/trust_test.go
@@ -51,12 +51,13 @@ func TestManagerForwardOnlyAndFailStatic(t *testing.T) {
 		t.Fatal("first apply did not take")
 	}
 
-	// Rollback (lower) and replay (equal) are rejected; the live pool is unchanged.
+	// A lower generation is rejected (rollback) and an equal one is a no-op
+	// (unchanged); neither is applied, so the live pool stays put.
 	if _, err := m.apply(Bundle{Generation: 3, CAPEM: caPEM}); err == nil {
-		t.Error("rollback to lower generation must be rejected")
+		t.Error("rollback to lower generation must not apply")
 	}
 	if _, err := m.apply(Bundle{Generation: 5, CAPEM: caPEM}); err == nil {
-		t.Error("replay of equal generation must be rejected")
+		t.Error("replay of equal generation must not apply")
 	}
 	if m.Generation() != 5 {
 		t.Error("a rejected bundle must not change generation")
@@ -90,8 +91,13 @@ func TestApplyResultEnum(t *testing.T) {
 	if res, err := m.apply(Bundle{Generation: 5, CAPEM: caPEM, CAID: "a"}); err != nil || res != resultApplied {
 		t.Fatalf("apply: res=%v err=%v, want resultApplied", res, err)
 	}
-	if res, err := m.apply(Bundle{Generation: 5, CAPEM: caPEM}); err == nil || res != resultRollbackRejected {
-		t.Errorf("replay: res=%v err=%v, want resultRollbackRejected", res, err)
+	// Equal generation is a benign replay → resultUnchanged (NOT a rollback, so it
+	// won't WARN); a strictly-lower generation is the real rollback.
+	if res, err := m.apply(Bundle{Generation: 5, CAPEM: caPEM}); err == nil || res != resultUnchanged {
+		t.Errorf("replay (equal gen): res=%v err=%v, want resultUnchanged", res, err)
+	}
+	if res, err := m.apply(Bundle{Generation: 4, CAPEM: caPEM}); err == nil || res != resultRollbackRejected {
+		t.Errorf("rollback (lower gen): res=%v err=%v, want resultRollbackRejected", res, err)
 	}
 	// No CERTIFICATE block at all → empty_rejected.
 	if res, err := m.apply(Bundle{Generation: 6, CAPEM: []byte("garbage")}); err == nil || res != resultEmptyRejected {
@@ -263,9 +269,9 @@ func TestWarmStartFloorRoundTrip(t *testing.T) {
 		t.Fatal("revalidation must flip on mTLS trust (pool loaded, gen=7)")
 	}
 
-	// Forward-only resumes: replay of 7 is now a rollback, 8 advances.
-	if res, _ := b.apply(Bundle{Generation: 7, CAPEM: caPEM}); res != resultRollbackRejected {
-		t.Errorf("post-revalidation replay: res=%v, want resultRollbackRejected", res)
+	// Forward-only resumes: replay of 7 is a no-op (unchanged), 8 advances.
+	if res, _ := b.apply(Bundle{Generation: 7, CAPEM: caPEM}); res != resultUnchanged {
+		t.Errorf("post-revalidation replay: res=%v, want resultUnchanged", res)
 	}
 	if res, err := b.apply(Bundle{Generation: 8, CAPEM: caPEM, CAID: "ca8"}); err != nil || res != resultApplied {
 		t.Errorf("forward apply: res=%v err=%v, want resultApplied", res, err)


### PR DESCRIPTION
Silences the repeated WARN you're seeing:

```
WARN core: trust-bundle rejected; keeping last-good
  error="rollback: bundle generation 1780648505736863020 <= current 1780648505736863020"
```

## Cause
`apply()` rejected **any** bundle with `generation <= current` as a *rollback*, and `Run` logged it at `WARN`. But `generation == current` is a **benign replay**, not a rollback — the safety-net plain-`GET` poll re-fetches the current bundle in steady state (and some CP long-poll implementations return the current bundle instead of a `304`), so this fires routinely with nothing actually wrong.

## Fix
Split the comparison:
- `generation == current` → new **`resultUnchanged`** (metric label `"unchanged"`); `Run` logs at **`Debug`** and refreshes the liveness timestamp like a `304`. No WARN.
- `generation < current` → still **`resultRollbackRejected`** + `WARN` (the real anti-rollback signal).

The `rollback_rejected` metric is no longer inflated by benign replays, so it stays meaningful for alerting.

## Tests (`go test -race`)
- `TestApplyResultEnum` — equal-gen → `resultUnchanged`, strictly-lower-gen → `resultRollbackRejected`.
- `TestWarmStartFloorRoundTrip` — post-revalidation equal-gen replay now expects `resultUnchanged`.

Verified `gofmt`/`vet`/`build` clean and the `trust` package passes `-race`.

> Note: the *underlying* reason your CP returns a same-generation 200 (instead of a `304` from the `?watch=1&since=` long-poll) may be worth a look CP-side — but it's harmless, and this stops the log spam regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)