### PR TITLE
perf(edge): guard serve-all on-demand cert fetch (single-flight + neg-cache + cap)

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -208,6 +208,17 @@ handshake per new SNI. The CP's per-token authz is still the boundary — an SNI
 the token isn't allowed for `403`s and falls back to self-signed — so serve-all
 only truly serves "all" when the edge's token is authorized for all domains.
 
+The on-demand fetch blocks the handshake on a synchronous CP round trip, so three
+guards bound its blast radius (all serve-all only): concurrent handshakes for the
+**same** SNI collapse into one fetch via single-flight; a missing/denied SNI is
+**negative-cached** for `EDGE_ONDEMAND_NEG_TTL` (default 30s) so it isn't re-fetched
+on every handshake; and a **global cap** `EDGE_ONDEMAND_MAX_INFLIGHT` (default 32)
+limits concurrent fetches across distinct SNIs — over the cap a handshake self-signs
+immediately instead of queueing, so a flood of unknown SNIs can't exhaust handshake
+goroutines or hammer the CP. `parapet_edge_ondemand_cert_total{result}` counts the
+outcomes (`hit|miss|shed|suppressed`); a rising `shed`/`suppressed` rate signals a
+flood or a too-tight cap/TTL.
+
 ### Rotation ordering (the gotcha)
 
 The edge serves a cached cert. On rotation the new cert must reach the edge

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -146,6 +146,10 @@ func main() {
 		// On a handshake for an SNI not held, fetch it from the control plane (the
 		// handshake blocks on it); the CP's per-token authz still gates which SNIs
 		// resolve. The periodic refresh keeps on-demand domains rotated.
+		store.ConfigureOnDemand(
+			time.Duration(envInt64("EDGE_ONDEMAND_NEG_TTL", 30))*time.Second,
+			int(envInt64("EDGE_ONDEMAND_MAX_INFLIGHT", 32)),
+		)
 		store.SetOnDemand(func(sni string) { edge.RefreshCertOnce(cp, store, sni, remintCoord) })
 		slog.Info("edge: EDGE_DOMAINS empty — serving ALL domains (certs fetched on demand)")
 	} else {

--- a/edge/certstore.go
+++ b/edge/certstore.go
@@ -16,8 +16,22 @@ import (
 	"crypto/tls"
 	"sync"
 	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/singleflight"
 
 	"github.com/moonrhythm/parapet-ingress-controller/cert"
+)
+
+// On-demand (serve-all) fetch guards. A handshake for an unheld SNI blocks on a
+// synchronous control-plane round-trip, so an unguarded path lets a flood of
+// missing/denied SNIs tie up handshake goroutines and hammer the CP (each 404 is
+// re-fetched on every handshake). These defaults bound all three blast radii;
+// override via ConfigureOnDemand.
+const (
+	defaultOnDemandNegTTL      = 30 * time.Second // how long a missed SNI is suppressed
+	defaultOnDemandMaxInFlight = 32               // global cap on concurrent on-demand fetches
+	maxNegCacheEntries         = 4096             // bound the negative cache's own memory
 )
 
 // CertStore is the edge's in-memory, hot-swappable certificate store. It holds
@@ -42,6 +56,20 @@ type CertStore struct {
 	// control plane during the handshake. nil in pinned mode (a miss falls back
 	// to self-signed). Set via SetOnDemand.
 	onDemand func(sni string)
+
+	// On-demand fetch guards (serve-all only; dormant while onDemand is nil).
+	//   - sf collapses concurrent handshakes for the SAME SNI into one CP fetch
+	//     whose result (a populated table) every waiter then reads.
+	//   - sem caps concurrent fetches across DISTINCT SNIs: over the cap a handshake
+	//     self-signs immediately instead of queueing on the CP (flood shedding).
+	//   - miss is a short-TTL negative cache so a missing/denied SNI isn't re-fetched
+	//     on every handshake; cleared whenever Update lands a cert for the key.
+	sf     singleflight.Group
+	sem    chan struct{}
+	negTTL time.Duration
+
+	missMu sync.Mutex
+	miss   map[string]time.Time // SNI -> suppress-until
 }
 
 type cachedCert struct {
@@ -49,9 +77,29 @@ type cachedCert struct {
 	etag string
 }
 
-// NewCertStore returns an empty store.
+// NewCertStore returns an empty store with the on-demand guards at their defaults
+// (active only once SetOnDemand wires a fetcher).
 func NewCertStore() *CertStore {
-	return &CertStore{cache: map[string]cachedCert{}}
+	return &CertStore{
+		cache:  map[string]cachedCert{},
+		miss:   map[string]time.Time{},
+		sem:    make(chan struct{}, defaultOnDemandMaxInFlight),
+		negTTL: defaultOnDemandNegTTL,
+	}
+}
+
+// ConfigureOnDemand tunes the serve-all on-demand fetch guards. negTTL is how long a
+// missing/denied SNI is suppressed from re-fetching; maxInFlight caps concurrent
+// on-demand fetches (excess handshakes self-sign immediately rather than queueing on
+// the control plane). Non-positive values keep the current setting. Call once at
+// startup, before serving.
+func (s *CertStore) ConfigureOnDemand(negTTL time.Duration, maxInFlight int) {
+	if negTTL > 0 {
+		s.negTTL = negTTL
+	}
+	if maxInFlight > 0 {
+		s.sem = make(chan struct{}, maxInFlight)
+	}
 }
 
 // SetOnDemand enables serve-all mode: a handshake for an SNI not in the store
@@ -71,12 +119,99 @@ func (s *CertStore) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate
 		return c, nil
 	}
 	if s.onDemand != nil && hello.ServerName != "" {
-		s.onDemand(hello.ServerName)
+		s.fetchOnDemand(hello.ServerName)
 		if c, _ := s.table.Get(hello); c != nil {
 			return c, nil
 		}
 	}
 	return nil, nil // -> self-signed fallback (client sees "unknown authority")
+}
+
+// fetchOnDemand resolves a missing SNI through the control plane under three guards:
+// a negative cache (recently-missed SNIs short-circuit without a CP call), single-flight
+// (concurrent handshakes for the same SNI share one fetch), and a global in-flight cap
+// (excess distinct-SNI fetches shed to self-signed). On success the cert lands in the
+// table; GetCertificate re-reads it.
+func (s *CertStore) fetchOnDemand(sni string) {
+	if s.suppressed(sni) {
+		ondemand("suppressed")
+		return
+	}
+	// Single-flight: the leader fetches; followers for the same SNI block on it and then
+	// read the populated table. The leader's result is dropped once it returns, so a later
+	// handshake re-evaluates (gated by the negative cache).
+	_, _, _ = s.sf.Do(sni, func() (any, error) {
+		// Global cap: a flood of DISTINCT missing SNIs sheds here rather than queueing a
+		// blocking CP round-trip per handshake. Same-SNI load is already collapsed above,
+		// so one slot covers a herd.
+		select {
+		case s.sem <- struct{}{}:
+			defer func() { <-s.sem }()
+		default:
+			ondemand("shed")
+			return nil, nil
+		}
+		s.onDemand(sni)
+		if s.cached(sni) {
+			s.clearMiss(sni)
+			ondemand("hit")
+		} else {
+			s.recordMiss(sni)
+			ondemand("miss")
+		}
+		return nil, nil
+	})
+}
+
+// suppressed reports whether sni is within its negative-cache window, evicting the
+// entry lazily on expiry.
+func (s *CertStore) suppressed(sni string) bool {
+	s.missMu.Lock()
+	defer s.missMu.Unlock()
+	until, ok := s.miss[sni]
+	if !ok {
+		return false
+	}
+	if time.Now().After(until) {
+		delete(s.miss, sni)
+		return false
+	}
+	return true
+}
+
+// recordMiss negative-caches sni for negTTL. It is self-bounding: at the cap it first
+// sweeps expired entries, then drops the record rather than growing unboundedly (the
+// in-flight cap still bounds CP load, so a dropped record only forgoes the optimization).
+func (s *CertStore) recordMiss(sni string) {
+	s.missMu.Lock()
+	defer s.missMu.Unlock()
+	if len(s.miss) >= maxNegCacheEntries {
+		now := time.Now()
+		for k, until := range s.miss {
+			if now.After(until) {
+				delete(s.miss, k)
+			}
+		}
+		if len(s.miss) >= maxNegCacheEntries {
+			return
+		}
+	}
+	s.miss[sni] = time.Now().Add(s.negTTL)
+}
+
+// clearMiss drops any negative-cache entry for key (a cert is now available).
+func (s *CertStore) clearMiss(key string) {
+	s.missMu.Lock()
+	defer s.missMu.Unlock()
+	delete(s.miss, key)
+}
+
+// cached reports whether a cert is currently stored under fetch key.
+func (s *CertStore) cached(key string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.cache[key]
+	return ok
 }
 
 // Update installs/replaces the material for a fetch key and atomically rebuilds
@@ -99,6 +234,7 @@ func (s *CertStore) Update(key string, chainPEM, keyPEM []byte, etag string) boo
 	// Rebuild the SAN index from every cached cert and swap it in atomically.
 	s.table.Set(certs)
 	s.loaded.Store(true)
+	s.clearMiss(key) // a cert now exists for this key — lift any negative-cache suppression
 	return true
 }
 

--- a/edge/certstore_test.go
+++ b/edge/certstore_test.go
@@ -2,7 +2,10 @@ package edge
 
 import (
 	"crypto/tls"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -90,4 +93,79 @@ func TestCertStore_OnDemandFetchOnMiss(t *testing.T) {
 	assert.Equal(t, 1, calls)
 	// an SNI the on-demand fetch can't satisfy falls back (no panic / no error)
 	assert.False(t, get(s, "denied.com"))
+}
+
+func TestCertStore_OnDemandNegativeCacheSuppressesRepeat(t *testing.T) {
+	s := NewCertStore()
+	var calls int32
+	s.SetOnDemand(func(string) { atomic.AddInt32(&calls, 1) }) // never satisfies -> always a miss
+	for range 5 {
+		assert.False(t, get(s, "denied.com"))
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "missed SNI is fetched once, then negative-cached")
+}
+
+func TestCertStore_OnDemandNegativeCacheExpires(t *testing.T) {
+	s := NewCertStore()
+	s.ConfigureOnDemand(time.Millisecond, 0)
+	var calls int32
+	s.SetOnDemand(func(string) { atomic.AddInt32(&calls, 1) })
+	assert.False(t, get(s, "denied.com"))
+	time.Sleep(5 * time.Millisecond)
+	assert.False(t, get(s, "denied.com"))
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "re-fetched after the negative-cache TTL expires")
+}
+
+func TestCertStore_OnDemandUpdateLiftsSuppression(t *testing.T) {
+	s := NewCertStore()
+	var calls int32
+	deliver := false
+	s.SetOnDemand(func(sni string) {
+		atomic.AddInt32(&calls, 1)
+		if deliver {
+			c, k := genCertPEM(t, sni)
+			s.Update(sni, c, k, "")
+		}
+	})
+	assert.False(t, get(s, "lazy.com"), "first attempt misses and negative-caches")
+	// Even though the fetcher would now deliver, the negative cache short-circuits it.
+	deliver = true
+	assert.False(t, get(s, "lazy.com"), "still suppressed within the TTL window")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+	// A cert arriving by any path (here the periodic loop) clears the suppression.
+	c, k := genCertPEM(t, "lazy.com")
+	require.True(t, s.Update("lazy.com", c, k, ""))
+	assert.True(t, get(s, "lazy.com"), "served from the table once a cert lands")
+}
+
+func TestCertStore_OnDemandSingleFlightCollapsesConcurrent(t *testing.T) {
+	s := NewCertStore()
+	var calls int32
+	var once sync.Once
+	started := make(chan struct{})
+	release := make(chan struct{})
+	s.SetOnDemand(func(sni string) {
+		atomic.AddInt32(&calls, 1)
+		once.Do(func() { close(started) })
+		<-release // hold the leader so followers pile into single-flight
+		c, k := genCertPEM(t, sni)
+		s.Update(sni, c, k, "")
+	})
+
+	const n = 8
+	var wg sync.WaitGroup
+	results := make([]bool, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) { defer wg.Done(); results[i] = get(s, "lazy.com") }(i)
+	}
+	<-started
+	time.Sleep(20 * time.Millisecond) // give every goroutine time to join the in-flight fetch
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "concurrent same-SNI handshakes share one CP fetch")
+	for i := range results {
+		assert.True(t, results[i], "every waiter is served the fetched cert")
+	}
 }

--- a/edge/metrics.go
+++ b/edge/metrics.go
@@ -79,10 +79,27 @@ var (
 		Name:      "edge_cp_active_signer_fp",
 		Help:      "CP active signing fp the edge last observed (value 1).",
 	}, []string{"sigfp", "edge_id"})
+
+	// edgeOnDemand counts serve-all on-demand cert resolutions by result. "hit"/"miss"/"shed"
+	// are per-CP-fetch (single-flight leader): hit landed a cert, miss got a 404/error and
+	// negative-cached it, shed bailed over the in-flight cap without touching the CP.
+	// "suppressed" is per-handshake — a negative-cache short-circuit — so it measures how
+	// much repeat-miss load the cache absorbs. A climbing shed/suppressed rate flags an
+	// SNI flood or a too-tight cap/TTL.
+	edgeOnDemand = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_ondemand_cert_total",
+		Help:      "Serve-all on-demand cert resolutions by result (hit|miss|shed|suppressed).",
+	}, []string{"result", "edge_id"})
 )
 
 func init() {
-	prom.Registry().MustRegister(edgeClientCertCAID, edgeClientCertNotAfter, edgeClientCertLoaded, edgeRemint, edgeCPTargetCAID, edgeRefresh, edgeClientCertSignerFP, edgeCPActiveSignerFP)
+	prom.Registry().MustRegister(edgeClientCertCAID, edgeClientCertNotAfter, edgeClientCertLoaded, edgeRemint, edgeCPTargetCAID, edgeRefresh, edgeClientCertSignerFP, edgeCPActiveSignerFP, edgeOnDemand)
+}
+
+// ondemand counts one on-demand cert resolution outcome.
+func ondemand(result string) {
+	edgeOnDemand.WithLabelValues(result, edgeID).Inc()
 }
 
 // edgeID is the process's logical identity, stamped on every metric. Defaults to

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/net v0.55.0
+	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.1
 	k8s.io/apimachinery v0.36.1
@@ -74,7 +75,6 @@ require (
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect


### PR DESCRIPTION
## Problem

The serve-all on-demand cert path (`CertStore.GetCertificate` → `RefreshCertOnce` → `cp.FetchCert`) blocked the TLS handshake on a **synchronous control-plane round trip with no dedup, no memory, and no bound**:

- A **404 was never remembered** — every handshake for a missing/denied SNI re-hit the CP.
- **No single-flight** — N concurrent handshakes for the same SNI fired N concurrent CP calls (this also hurt the legit cold-start 200 path).
- **No global bound** — an attacker spraying *distinct* random SNIs got one blocking CP call per handshake, tying up handshake goroutines and amplifying load on the control plane.

## Fix — three layered guards in `CertStore` (same shape as `proxy/autoh2c.go`)

1. **Single-flight** (`golang.org/x/sync/singleflight`) — concurrent handshakes for the *same* SNI collapse into one CP fetch; followers wait and all read the populated table.
2. **Negative cache** — a missing/denied SNI is suppressed for `EDGE_ONDEMAND_NEG_TTL` (default 30s), self-bounded at 4096 entries (lazy + cap-triggered eviction), cleared whenever `Update` lands a cert (so the periodic loop succeeding later lifts it).
3. **Global in-flight cap** — `EDGE_ONDEMAND_MAX_INFLIGHT` (default 32) bounds concurrent fetches across *distinct* SNIs; over the cap a handshake self-signs immediately instead of queueing. This is what caps a unique-SNI flood and makes the negative-cache bound safe.

Composition: the semaphore is acquired *inside* the single-flight leader, so a same-SNI herd consumes one slot, not N.

## Observability

New `parapet_edge_ondemand_cert_total{result}` counter — `hit|miss|shed` per CP-fetch, `suppressed` per-handshake. A rising `shed`/`suppressed` rate flags an SNI flood or too-tight cap/TTL.

## Scope / safety

- **Pinned mode is untouched** — `onDemand` is nil, so all guards are dormant.
- Defaults are active even without env config; serve-all wiring lives in `cmd/edge-proxy/main.go`.

## Tests

`edge/certstore_test.go` adds 4 tests (suppress-repeat, TTL-expiry, Update-lifts-suppression, single-flight-collapse). `go test -race ./...`, `gofmt -l`, `go vet ./...` all clean.

## Follow-up (out of scope)

The on-demand fetch still uses the CP client's 30s `http.Client.Timeout`, so a leader fetch to a hung CP can block its waiters up to 30s. A shorter per-fetch context deadline would tighten handshake latency under a degraded CP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)