### PR TITLE
ci: make PR image builds manual-only via workflow_dispatch

### DIFF
--- a/.github/workflows/edge-build.yaml
+++ b/.github/workflows/edge-build.yaml
@@ -21,17 +21,9 @@ on:
       - 'Dockerfile.edge-controlplane'
       - 'deploy/edge/**'
       - '.github/workflows/edge-build.yaml'
-  # Also build + push on PRs (tagged with the PR's commit SHA) so a PR image can
-  # be deployed/tested before merge. Same-repo PRs only (needs registry creds).
-  pull_request:
-    paths:
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'Dockerfile.edge'
-      - 'Dockerfile.edge-controlplane'
-      - 'deploy/edge/**'
-      - '.github/workflows/edge-build.yaml'
+  # PRs do NOT build automatically. To build a PR image (tagged with the head
+  # commit SHA) before merge, manually run this workflow from the Actions tab
+  # and pick the PR's branch. Same-repo branches only (needs registry creds).
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -9,15 +9,9 @@ on:
     - 'go.sum'
     - 'Dockerfile'
     - '.github/workflows/go-build.yaml'
-  # Also build + push on PRs (tagged with the PR's commit SHA) so a PR image can
-  # be deployed/tested before merge. Same-repo PRs only (needs registry creds).
-  pull_request:
-    paths:
-    - '**/*.go'
-    - 'go.mod'
-    - 'go.sum'
-    - 'Dockerfile'
-    - '.github/workflows/go-build.yaml'
+  # PRs do NOT build automatically. To build a PR image (tagged with the head
+  # commit SHA) before merge, manually run this workflow from the Actions tab
+  # and pick the PR's branch. Same-repo branches only (needs registry creds).
   workflow_dispatch: {}
 jobs:
   build:


### PR DESCRIPTION
## What

Removes the `pull_request` trigger from both image-build workflows so PRs no longer build + push Docker images on every push:

- **Go Build** (`go-build.yaml`) — controller image
- **edge-build** (`edge-build.yaml`) — edge proxy + control-plane images

## Why

The PR builds fired automatically on every PR push, pushing images tagged with the head SHA each time. This makes PR image builds opt-in instead.

## How to build a PR image now

Run the relevant workflow manually via `workflow_dispatch`: **Actions → (Go Build | edge-build) → Run workflow**, and pick the PR's branch. Images are tagged with that branch's head commit SHA, same as before. (Same-repo branches only — registry creds aren't exposed to forks.)

Builds on push to `main` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)