### PR TITLE
metric: re-key backend_* to Service

### DIFF
--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -194,8 +194,8 @@ func main() {
 	m.Use(host.StripPort())
 	m.Use(host.ToLower())
 	m.Use(metric.HostActiveTracker(ctrl.IsKnownHost))
-	m.Use(hostCountryRateLimit(ctrl.IsKnownHost))
-	m.Use(hostRateLimit(ctrl.IsKnownHost))
+	m.Use(hostCountryRateLimit())
+	m.Use(hostRateLimit())
 
 	if !disableLog {
 		m.Use(logger.Stdout())
@@ -424,7 +424,7 @@ func forwardGeoHeaders(country func(*http.Request) string, asn func(*http.Reques
 }
 
 // hostRateLimit protects from unresponsive upstreams by limit concurrent requests to the same host.
-func hostRateLimit(isKnownHost func(host string) bool) parapet.Middleware {
+func hostRateLimit() parapet.Middleware {
 	concurrentCapacity := config.Int("HOST_CONCURRENT_CAPACITY") // concurrent requests
 	concurrentSize := config.Int("HOST_CONCURRENT_SIZE")         // queue size
 
@@ -438,7 +438,6 @@ func hostRateLimit(isKnownHost func(host string) bool) parapet.Middleware {
 
 	exceededHandler := func(w http.ResponseWriter, r *http.Request, _ time.Duration) {
 		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
-		metric.HostRatelimitRequest(metric.HostLabel(r.Host, isKnownHost))
 		metric.RejectedRequest("host_limit")
 	}
 
@@ -469,7 +468,7 @@ func hostRateLimit(isKnownHost func(host string) bool) parapet.Middleware {
 }
 
 // hostCountryRateLimit protects from unresponsive upstreams by limit concurrent requests to the same host and country.
-func hostCountryRateLimit(isKnownHost func(host string) bool) parapet.Middleware {
+func hostCountryRateLimit() parapet.Middleware {
 	concurrentCapacity := config.Int("HOST_COUNTRY_CONCURRENT_CAPACITY") // concurrent requests
 	concurrentSize := config.Int("HOST_COUNTRY_CONCURRENT_SIZE")         // queue size
 	countryHeaderRaw := strings.TrimSpace(config.String("HOST_COUNTRY_HEADER"))
@@ -507,7 +506,6 @@ func hostCountryRateLimit(isKnownHost func(host string) bool) parapet.Middleware
 
 	exceededHandler := func(w http.ResponseWriter, r *http.Request, _ time.Duration) {
 		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
-		metric.HostRatelimitRequest(metric.HostLabel(r.Host, isKnownHost))
 		metric.RejectedRequest("host_limit")
 	}
 

--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -194,8 +194,8 @@ func main() {
 	m.Use(host.StripPort())
 	m.Use(host.ToLower())
 	m.Use(metric.HostActiveTracker(ctrl.IsKnownHost))
-	m.Use(hostCountryRateLimit())
-	m.Use(hostRateLimit())
+	m.Use(hostCountryRateLimit(ctrl.IsKnownHost))
+	m.Use(hostRateLimit(ctrl.IsKnownHost))
 
 	if !disableLog {
 		m.Use(logger.Stdout())
@@ -424,7 +424,7 @@ func forwardGeoHeaders(country func(*http.Request) string, asn func(*http.Reques
 }
 
 // hostRateLimit protects from unresponsive upstreams by limit concurrent requests to the same host.
-func hostRateLimit() parapet.Middleware {
+func hostRateLimit(isKnownHost func(host string) bool) parapet.Middleware {
 	concurrentCapacity := config.Int("HOST_CONCURRENT_CAPACITY") // concurrent requests
 	concurrentSize := config.Int("HOST_CONCURRENT_SIZE")         // queue size
 
@@ -438,6 +438,7 @@ func hostRateLimit() parapet.Middleware {
 
 	exceededHandler := func(w http.ResponseWriter, r *http.Request, _ time.Duration) {
 		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+		metric.HostRatelimitRequest(metric.HostLabel(r.Host, isKnownHost))
 		metric.RejectedRequest("host_limit")
 	}
 
@@ -468,7 +469,7 @@ func hostRateLimit() parapet.Middleware {
 }
 
 // hostCountryRateLimit protects from unresponsive upstreams by limit concurrent requests to the same host and country.
-func hostCountryRateLimit() parapet.Middleware {
+func hostCountryRateLimit(isKnownHost func(host string) bool) parapet.Middleware {
 	concurrentCapacity := config.Int("HOST_COUNTRY_CONCURRENT_CAPACITY") // concurrent requests
 	concurrentSize := config.Int("HOST_COUNTRY_CONCURRENT_SIZE")         // queue size
 	countryHeaderRaw := strings.TrimSpace(config.String("HOST_COUNTRY_HEADER"))
@@ -506,6 +507,7 @@ func hostCountryRateLimit() parapet.Middleware {
 
 	exceededHandler := func(w http.ResponseWriter, r *http.Request, _ time.Duration) {
 		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+		metric.HostRatelimitRequest(metric.HostLabel(r.Host, isKnownHost))
 		metric.RejectedRequest("host_limit")
 	}
 

--- a/metric/backendconns.go
+++ b/metric/backendconns.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const addrSizeHint = 300
+const backendSizeHint = 100
 
 type backendMetrics struct {
 	connections prometheus.Gauge
@@ -17,40 +17,55 @@ type backendMetrics struct {
 	writes      prometheus.Counter
 }
 
+// backendKey identifies the backend Service a connection belongs to. Keying on
+// the Service (not the dialed pod IP:port) keeps the series count bounded by the
+// number of Services — pods churn on every deploy/scale, and an addr-keyed
+// handle cache never evicts, so stale per-pod series would accumulate at 0/
+// constant for the life of the process. A pod address belongs to exactly one
+// Service, so attributing the connection to it at dial time is stable.
+type backendKey struct {
+	serviceType      string
+	serviceNamespace string
+	serviceName      string
+}
+
 type backendConnections struct {
 	connections *prometheus.GaugeVec
 	reads       *prometheus.CounterVec
 	writes      *prometheus.CounterVec
 
-	cache *cache[string, *backendMetrics] // keyed by addr
+	cache *cache[backendKey, *backendMetrics]
 }
 
 var _backendConnections backendConnections
 
 func init() {
+	labels := []string{"service_type", "service_namespace", "service_name"}
 	_backendConnections.connections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: prom.Namespace,
 		Name:      "backend_connections",
-	}, []string{"addr"})
+	}, labels)
 	_backendConnections.reads = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: prom.Namespace,
 		Name:      "backend_network_read_bytes",
-	}, []string{"addr"})
+	}, labels)
 	_backendConnections.writes = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: prom.Namespace,
 		Name:      "backend_network_write_bytes",
-	}, []string{"addr"})
-	_backendConnections.cache = newCache[string, *backendMetrics](addrSizeHint)
+	}, labels)
+	_backendConnections.cache = newCache[backendKey, *backendMetrics](backendSizeHint)
 
 	prom.Registry().MustRegister(_backendConnections.connections)
 	prom.Registry().MustRegister(_backendConnections.reads)
 	prom.Registry().MustRegister(_backendConnections.writes)
 }
 
-func (p *backendConnections) getM(addr string) *backendMetrics {
-	return p.cache.getOrCreate(addr, func() *backendMetrics {
+func (p *backendConnections) getM(key backendKey) *backendMetrics {
+	return p.cache.getOrCreate(key, func() *backendMetrics {
 		l := prometheus.Labels{
-			"addr": addr,
+			"service_type":      key.serviceType,
+			"service_namespace": key.serviceNamespace,
+			"service_name":      key.serviceName,
 		}
 		return &backendMetrics{
 			connections: p.connections.With(l),
@@ -60,9 +75,15 @@ func (p *backendConnections) getM(addr string) *backendMetrics {
 	})
 }
 
-// BackendConnections collects backend connection metrics
-func BackendConnections(conn net.Conn, addr string) net.Conn {
-	m := _backendConnections.getM(addr)
+// BackendConnections collects backend connection metrics, attributed to the
+// destination Service (serviceType/namespace/name) rather than the dialed pod
+// address — see backendKey for why.
+func BackendConnections(conn net.Conn, serviceType, serviceNamespace, serviceName string) net.Conn {
+	m := _backendConnections.getM(backendKey{
+		serviceType:      serviceType,
+		serviceNamespace: serviceNamespace,
+		serviceName:      serviceName,
+	})
 	trackConn := &trackBackendConn{
 		Conn: conn,
 		m:    m,

--- a/metric/host.go
+++ b/metric/host.go
@@ -13,13 +13,6 @@ import (
 const hostSizeHint = 100
 
 func init() {
-	_hostRatelimit.vec = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: prom.Namespace,
-		Name:      "host_ratelimit_requests",
-	}, []string{"host"})
-	_hostRatelimit.cache = newCache[string, prometheus.Counter](hostSizeHint)
-	prom.Registry().MustRegister(_hostRatelimit.vec)
-
 	_host.vec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: prom.Namespace,
 		Name:      "host_active_requests",
@@ -101,24 +94,4 @@ func kindLabel(h http.Header) string {
 // hosts the router doesn't serve.
 func HostActiveTracker(isKnownHost func(host string) bool) parapet.Middleware {
 	return promHostTracker{isKnownHost: isKnownHost}
-}
-
-var _hostRatelimit promHostRatelimit
-
-type promHostRatelimit struct {
-	vec   *prometheus.CounterVec
-	cache *cache[string, prometheus.Counter]
-}
-
-func (p *promHostRatelimit) Inc(host string) {
-	p.cache.getOrCreate(host, func() prometheus.Counter {
-		return p.vec.With(prometheus.Labels{
-			"host": host,
-		})
-	}).Inc()
-}
-
-// HostRatelimitRequest increments the host ratelimit counter
-func HostRatelimitRequest(host string) {
-	_hostRatelimit.Inc(host)
 }

--- a/metric/host.go
+++ b/metric/host.go
@@ -13,6 +13,13 @@ import (
 const hostSizeHint = 100
 
 func init() {
+	_hostRatelimit.vec = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "host_ratelimit_requests",
+	}, []string{"host"})
+	_hostRatelimit.cache = newCache[string, prometheus.Counter](hostSizeHint)
+	prom.Registry().MustRegister(_hostRatelimit.vec)
+
 	_host.vec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: prom.Namespace,
 		Name:      "host_active_requests",
@@ -94,4 +101,26 @@ func kindLabel(h http.Header) string {
 // hosts the router doesn't serve.
 func HostActiveTracker(isKnownHost func(host string) bool) parapet.Middleware {
 	return promHostTracker{isKnownHost: isKnownHost}
+}
+
+var _hostRatelimit promHostRatelimit
+
+type promHostRatelimit struct {
+	vec   *prometheus.CounterVec
+	cache *cache[string, prometheus.Counter]
+}
+
+func (p *promHostRatelimit) Inc(host string) {
+	p.cache.getOrCreate(host, func() prometheus.Counter {
+		return p.vec.With(prometheus.Labels{
+			"host": host,
+		})
+	}).Inc()
+}
+
+// HostRatelimitRequest increments the host ratelimit counter. Kept distinct from
+// the host-less rejected_requests{reason="host_limit"} aggregate: the per-host
+// breakdown is what tells you *which* host is being flooded during an attack.
+func HostRatelimitRequest(host string) {
+	_hostRatelimit.Inc(host)
 }

--- a/proxy/dialer.go
+++ b/proxy/dialer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/moonrhythm/parapet-ingress-controller/metric"
+	"github.com/moonrhythm/parapet-ingress-controller/state"
 )
 
 type dialer struct {
@@ -36,7 +37,12 @@ func (d *dialer) DialContext(ctx context.Context, network, addr string) (conn ne
 		return
 	}
 
-	conn = metric.BackendConnections(conn, addr)
+	// Attribute the connection to its destination Service, not the dialed pod
+	// address. The transport calls DialContext with the request context, so the
+	// route state stamped by makeHandler is available here; a pod addr maps to a
+	// single Service, so the attribution is stable across connection reuse.
+	s := state.Get(ctx)
+	conn = metric.BackendConnections(conn, s["serviceType"], s["namespace"], s["serviceName"])
 	return
 }
 


### PR DESCRIPTION
## Why

`backend_connections`, `backend_network_read_bytes`, and `backend_network_write_bytes` keyed on the dialed pod `IP:port`. Pods churn on every deploy/scale and the per-handle cache **never evicts**, so dead-pod series pile up at `0`/constant for the life of the process — the dominant source of stale-series growth. Per-pod-IP granularity is also rarely what you query; you almost always want per-Service.

Now keyed on `{service_type, service_namespace, service_name}` — bounded by the number of Services. The dialer reads the route state stamped by `makeHandler` (the transport calls `DialContext` with the request context). A pod address belongs to exactly one Service, so attribution stays stable across connection reuse.

> Note: this branch initially also dropped `host_ratelimit_requests` (redundant with `rejected_requests{reason="host_limit"}`), but that was reverted — the per-host breakdown is needed to see *which* host is being flooded during an attack.

## ⚠️ Breaking (metrics surface)

Dashboards/alerts querying `backend_*` by `addr` must switch to the `service_type` / `service_namespace` / `service_name` labels.

## Test

`gofmt -l`, `go vet ./...`, `go build ./...`, `go test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)