### PR TITLE
feat(edge): cache purge / invalidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea
+.claude/
 /parapet-ingress-controller

--- a/EDGE.md
+++ b/EDGE.md
@@ -5,8 +5,8 @@ runs the WAF, fronting the in-cluster parapet ingress controller. A small
 in-cluster **control plane** distributes, per edge, only the certificates (and
 private keys) and WAF rules for the domains that edge serves.
 
-> Status: **Phases 1–4 implemented** (cert distribution, WAF distribution + edge
-> global eval, zones at edge, disk response cache); Phase 5 (purge) is design only.
+> Status: **Phases 1–5 implemented** (cert distribution, WAF distribution + edge
+> global eval, zones at edge, disk response cache, cache purge / invalidation).
 > Both the control plane (`cmd/edge-controlplane`, reusing `cert`, `k8s`,
 > `wafrule`) and the **edge** (`cmd/edge-proxy` + `edge`, on the parapet
 > framework) are **Go**. They share **only a language-neutral HTTP/JSON contract**
@@ -161,17 +161,23 @@ GET /v1/waf           Authorization: Bearer <token>   [If-None-Match: "<etag>"]
        (ETag is over the *scoped* payload, so 304 revalidation is per-edge-correct)
 
 GET /v1/purges?since=<seq>   Authorization: Bearer <token>
-  200 {"entries":[{"seq":N,"scope":"url|host|all","host":"…","uri":"…"}],
-       "max_seq": N, "min_seq": M, "flush_required": false}
+  200 {"entries":[{"seq":N,"scope":"url|host|flush-all","host":"…","uri":"…"}],
+       "max_seq": N, "flush_required": false}
        entries        : journal entries with seq > since, SCOPED to the token's hosts
-       flush_required : true when since < min_seq (the edge fell behind / the journal
-                        was trimmed) → the edge does a lazy flush-all and jumps its
-                        cursor to max_seq. Conservative: never under-invalidates.
-  401 (no/invalid token)
+                        (flush-all reaches every edge; host/url only its allowed hosts)
+       flush_required : true when the edge's next-needed seq (since+1) was trimmed
+                        (it fell behind the retained window), OR when since > max_seq
+                        (its cursor is ahead of the CP's journal — a CP restart / fresh
+                        replica reset the in-memory journal). The edge does a lazy
+                        flush-all and realigns its cursor to max_seq. Conservative:
+                        never under-invalidates.
+  401 (no/invalid token)   404 (purge distribution disabled)
 
 POST /v1/purges       Authorization: Bearer <ADMIN token>   ← stronger cred than the read token
-  {"scope":"url|host|all", "host":"…", "uri":"…"}  → appends to the journal, returns {"seq":N}
-  401 (no/invalid admin token)  403 (host ∉ allowed(token))
+  {"scope":"url|host|flush-all", "host":"…", "uri":"…"}  → appends to the journal, returns {"seq":N}
+       (the admin token is NOT host-scoped — it may purge any host; per-host scoping is
+        applied on the read side, not at issue time)
+  401 (no/invalid admin token)  400 (invalid scope/host/uri)  404 (purge distribution disabled)
 
 GET /healthz          (no auth)
   200 always (liveness)
@@ -391,13 +397,17 @@ EDGE_CACHE_BACKEND       disk | memory (default disk)
 EDGE_CACHE_DIR           cache root, disk backend only (default /var/cache/parapet-edge)
 EDGE_CACHE_MAX_SIZE      total bytes cap, LRU-evicted (default 1073741824 = 1 GiB)
 EDGE_CACHE_MAX_FILE_SIZE per-object bytes cap (default 8388608 = 8 MiB)
+EDGE_CACHE_PURGE_ENABLED         poll for + apply cache purges (default true; needs
+                                 CP_PURGE_ENABLED on the control plane)
 EDGE_CACHE_PURGE_POLL_INTERVAL   poll GET /v1/purges (default 10s; lower than the
                                  cert/WAF refresh — invalidation latency matters more)
-EDGE_CACHE_PURGE_SWEEP_INTERVAL  background reaper cadence (default 300s)
+EDGE_CACHE_PURGE_MAX_RECORDS     per-map cap before a conservative fold-to-global
+                                 (default 65536)
 ```
 
-`EDGE_CACHE_PURGE_POLL_INTERVAL` / `EDGE_CACHE_PURGE_SWEEP_INTERVAL` belong to the
-**design-only** purge feature below and are **not read by any code yet**.
+The purge feature is **implemented** (see "Purge / invalidation" below). There is
+no background reaper — the in-memory table is bounded by the count-cap fold above,
+and disk by the cache's LRU byte cap.
 
 A fetch/IO error on the read path **fails static** (degrades to a cache miss →
 serve from origin), never erroring the client request. **Not yet:**
@@ -408,11 +418,14 @@ connection/byte/runtime metrics).
 
 ### Purge / invalidation
 
-> **Status: design only — not implemented** (in neither the edge nor the control
-> plane). The mechanism below was sketched against the former Rust/pingora cache;
-> the equivalent will be built in `parapet/pkg/cache` (lazy epochs checked in the
-> lookup gate + a background reaper) when Phase 5 lands. The CP `/v1/purges`
-> endpoints do not exist yet either.
+> **Status: implemented** (edge `edge/purge.go` + `edge/purgerefresh.go`; control
+> plane `edgecp/purgestore.go` + `GET`/`POST /v1/purges`). The lookup gate is the
+> `parapet/pkg/cache` `Options.InvalidatedAfter` hook (added in **parapet
+> v0.17.0**), so this is a pure-Go feature with no Rust counterpart. One
+> deliberate deviation from the original sketch below: there is **no background
+> reaper** (the `Storage` interface exposes no enumeration), so eager disk reclaim
+> is left to the LRU byte cap and the in-memory table is bounded by a count-cap
+> fold instead — see "Bounding the table" below.
 
 Invalidation is **pulled from the control plane**, exactly like cert and WAF
 distribution: an operator publishes a purge once at the control plane and every
@@ -420,69 +433,86 @@ sharded edge converges on its own timer. There is **no inbound purge port on the
 edge** (edges are out-of-cluster, often NAT'd), and the per-token host scoping is
 the same boundary that gates `/v1/certs` and `/v1/waf`. Three scopes are
 supported: **exact URL** (all `Vary` variants, both schemes, GET+HEAD),
-**whole host/zone**, and **flush-all**.
+**whole host**, and **flush-all**.
 
-**Why lazy epochs, not eager file deletion.** The on-disk filename is
-`combined()` = `hash(primary ⊕ variance)`, where `primary = hash("METHOD scheme
-uri")` and `variance` comes from `Vary`. So from a URL alone you **cannot
-enumerate its variants' filenames** — there's no index, and the hash mixes the
-two. `Storage::purge(CompactCacheKey)` needs the *exact* key (primary+variance),
-which an operator purging a URL doesn't have. But `lookup` receives the full
-`CacheKey` (namespace = host, primary *string* = `"GET https /a?x=1"`), so the
-edge can match a request against a coarse predicate at lookup time regardless of
-variance. That asymmetry is why purge is **lazy epoch invalidation** plus a
-background reaper, not synchronous deletes.
+**Why lazy epochs, not eager file deletion.** The cache stores each entry under
+`variantHash = hash(primaryHash ⊕ Vary-values)`, where `primaryHash =
+hash(host+method+scheme+uri)`. So from a URL alone you **cannot enumerate its
+variants' storage keys** — there's no index, and the hash mixes everything. But
+the cache's `InvalidatedAfter(r, Meta)` hook runs *at lookup* with the live
+request (host, uri) **and** the stored `Meta` (which carries `Created`, unix
+nanos). So the edge can match a request against a coarse predicate at lookup time
+regardless of variance, without ever naming the key. That asymmetry is why purge
+is **lazy epoch invalidation**, not synchronous deletes: a hit whose
+`Meta.Created <= invalidAfter` is reaped and served as a miss, exactly like a
+passed `FreshUntil`.
 
-**The invalidation table** (small, in-memory, persisted to
-`<EDGE_CACHE_DIR>/purge-state` with the same temp+fsync+rename as the cache):
-
-```
-global:  Option<SystemTime>
-host:    host                       → SystemTime    (lowercased host)
-url:     hash(host ⊕ uri)           → SystemTime    (uri = path+query; method/scheme-agnostic)
-cursor:  u64   (last journal seq applied — persisted in the SAME atomic write as the maps)
-```
-
-**Lookup gate**, added to `DiskCache::lookup` after decoding the sidecar:
+**The invalidation table** (`edge.PurgeTable`, in-memory, persisted to
+`<EDGE_CACHE_DIR>/purge-state` with the same temp+fsync+rename as the disk cache;
+the in-memory backend keeps no state):
 
 ```
-invalid_after = max(global, host[namespace], url[hash(namespace ⊕ uri_of(primary))])  // absent ⇒ epoch 0
-if meta.created() <= invalid_after { reap(.meta,.body) best-effort + notify eviction; return miss }
+global:  int64                       // flush-all epoch (unix nanos); 0 = never
+host:    host                → int64 // normalized host (lowercase, port-stripped)
+url:     hash(host ⊕ uri)    → int64 // uri = path+query; method/scheme-agnostic
+cursor:  uint64                      // last journal seq applied — persisted in the SAME atomic write as the maps
 ```
 
-Keying the `url` map on `host ⊕ uri` (not the full primary) is deliberate: one
-URL purge then covers **all methods, both schemes, and every `Vary` variant** —
-the operator's mental model of "purge `/a`". Issue cost is **O(1)** (no scan, no
-variance enumeration); the hot-path cost is one lock read + ≤3 map lookups + a
-timestamp compare, and only on cache lookups (so zero when caching is disabled).
+**Lookup gate** — `PurgeTable.InvalidatedAfter`, wired into `cache.Options`:
+
+```
+invalidAfter = max(global, host[normHost(r.Host)], url[hash(normHost ⊕ r.URL.RequestURI())])  // absent ⇒ 0
+// the cache then reaps + misses any hit with Meta.Created <= invalidAfter
+```
+
+Host normalization mirrors `cache.primaryHash` exactly (lowercase + strip port)
+so a purge key matches the stored key. Keying the `url` map on `host ⊕ uri` (not
+the full primary) is deliberate: one URL purge covers **all methods, both
+schemes, and every `Vary` variant** — the operator's mental model of "purge
+`/a`". Issue cost is **O(1)**; the hot-path cost is one `RLock` + ≤3 map lookups +
+a timestamp compare, and only on cache hits (so zero when caching is disabled, and
+nil-checked away entirely when purge is off).
 
 **Edge-clock epochs — no trusted CP timestamp.** An epoch is *"invalidate
 everything cached before this edge learned of the purge"* = the edge's own wall
-clock at first-apply. This removes any CP↔edge clock-skew dependency; the control
-plane only has to **deliver** the directive. Idempotency comes from the cursor,
-not the timestamp: the edge applies a journal `seq` only if `seq > cursor`, so an
-entry is applied exactly once and "now-at-apply" is never replayed. The one
-inherent gap — an in-flight miss whose origin fetch began before apply but commits
-just after — is the same race every CDN purge has; the next TTL expiry or purge
-covers it. (Clamp epochs to be monotonic non-decreasing so an NTP step back can't
-un-purge.)
+clock at apply. This removes any CP↔edge clock-skew dependency; the control plane
+only has to **deliver** the directive. Idempotency comes from the cursor, not the
+timestamp: the edge applies a journal `seq` only if `seq > cursor`, so an entry is
+applied exactly once and "now-at-apply" is never replayed. The one inherent gap —
+an in-flight miss whose origin fetch began before apply but commits just after —
+is the same race every CDN purge has; the next TTL expiry or purge covers it.
+Epochs are clamped **monotonic non-decreasing** (a new stamp is `>= highWater`, the
+largest epoch ever stamped, reloaded from disk on restart) so an NTP step back
+can't un-purge.
 
-**Background reaper** (reuses the startup-scan background-thread pattern, off the
-serving path) periodically applies the table to physically delete invalidated
-files, update the LRU accounting, and **retire** table records: once a full sweep
-completes *after* a record's timestamp, nothing older can remain, so the record is
-dropped. This is what bounds the `url` map (it holds only URLs purged within
-roughly one sweep interval) and reclaims disk; the lazy gate already guarantees
-correctness immediately, and the LRU byte cap holds regardless.
+**Bounding the table (no reaper).** The parapet `Storage` interface has no scan
+method, so there is no background reaper to physically delete invalidated files or
+retire records; correctness comes from the lazy gate and disk is bounded by the
+cache's LRU byte cap. The in-memory `host`/`url` maps are bounded by a **count-cap
+fold**: when a map exceeds `EDGE_CACHE_PURGE_MAX_RECORDS` it is folded into the
+`global` epoch (which `≥` every record it held) and cleared — this
+**over-invalidates (a coarser flush) but never under-invalidates**, and keeps
+memory finite. Because purges are operator-issued (not per request), the fold is
+essentially never hit in practice. (`PurgeTable.Sweep` can additionally retire
+records older than a retention window, but only when paired with a freshness cap —
+it is not auto-wired today.)
 
 **Distribution loop.** The control plane keeps a bounded append-only journal
-(`{seq, scope, host?, uri?}`, monotonic `seq`, `min_seq` = oldest retained). The
-edge polls `GET /v1/purges?since=<cursor>` on `EDGE_CACHE_PURGE_POLL_INTERVAL`; on
-`flush_required` it bumps the `global` epoch and sets `cursor = max_seq`, else it
-applies each new entry once and atomically persists `{maps, cursor}`. Purges are
-issued by an admin `POST /v1/purges` (a **stronger** credential than the per-edge
-read token); auto-sourcing a `host` purge on cert rotation or Ingress change is a
-natural later addition.
+(`{seq, scope, host?, uri?}`, monotonic `seq`, `min_seq` = oldest retained,
+`CP_PURGE_MAX_ENTRIES`). The edge polls `GET /v1/purges?since=<cursor>` on
+`EDGE_CACHE_PURGE_POLL_INTERVAL`; on `flush_required` it bumps the `global` epoch
+and realigns `cursor = max_seq`, else it applies each new entry once and (only on a
+real change) atomically persists `{maps, cursor}`. The CP returns `flush_required`
+both when the cursor fell behind the retained window (`since+1 < min_seq`) **and**
+when the cursor is *ahead* of the journal (`since > max_seq` — a CP restart or fresh
+replica reset the in-memory journal); the latter is the case where `cursor =
+max_seq` is a deliberate realign **down**, so a reset can't wedge the edge into
+flushing every poll. The CP scopes each edge's response by its token (flush-all
+reaches every edge; host/url entries only edges that may serve that host). Purges
+are issued by an admin
+`POST /v1/purges` gated by `CP_PURGE_ADMIN_TOKEN` (a **stronger** credential than
+the per-edge read token); auto-sourcing a `host` purge on cert rotation or Ingress
+change is a natural later addition.
 
 ## Ports & exposure
 
@@ -540,8 +570,9 @@ edge *can* be co-located, prefer keyless (recoverable in git history).
 | Cache read IO error | Degrades to a cache miss (**fail static**) → served from parapet. Never errors the client request. |
 | Cache dir unwritable | Cache init fails → caching disabled for the process (logged); the edge still proxies normally. |
 | `GET /v1/purges` unreachable | Edge keeps its applied epochs + cursor (**fail static**); retries with backoff. Pending purges are *delayed, not lost* — the journal+cursor catch up. Stale-serving window bounded by object TTL. |
-| Purge cursor gap (`since < min_seq`) | CP returns `flush_required` → edge bumps the global epoch (lazy flush-all) and jumps to `max_seq`. Conservative; never under-invalidates. |
-| `purge-state` lost/corrupt | Cursor resets to 0 → next poll is a gap → flush-all. Cursor + maps share **one atomic write** so they can't desync. |
+| Purge cursor gap (`since+1 < min_seq`, journal trimmed) | CP returns `flush_required` → edge bumps the global epoch (lazy flush-all) and realigns to `max_seq`. Conservative; never under-invalidates. |
+| CP restart / fresh replica (in-memory journal seq resets below the edge cursor, `since > max_seq`) | CP returns `flush_required` (the cursor-ahead-of-journal check) → edge flushes and realigns its cursor **down** to `max_seq`. The edge also independently flushes on `max_seq < cursor` as defense-in-depth against an older CP. Never silently under-invalidates. |
+| `purge-state` lost/corrupt | Cursor resets to 0 → next poll re-syncs (a trim gap or cursor-ahead → flush-all). Cursor + maps share **one atomic write** so they can't desync. |
 
 ## Conformance
 
@@ -606,8 +637,9 @@ needed. (The Rust **controller** implementation stays in `rust/`; only the Rust
    parapet-core equivalent).
 5. **Cache purge / invalidation** — CP purge journal + `GET`/`POST /v1/purges`,
    edge poll loop with a persisted cursor, lazy epoch invalidation (global / host /
-   url) checked at lookup, and a background reaper for disk reclaim. Scopes:
-   exact-URL (all variants), whole-host/zone, flush-all. **(design)** See
-   [Purge / invalidation](#purge--invalidation). Edge-only. Path-prefix and
-   Cache-Tag purge are deferred (prefix needs a scan; tags must be recorded at
-   admit time) — the epoch table extends to both later.
+   url) checked at lookup via the `parapet/pkg/cache` `InvalidatedAfter` hook.
+   In-memory table bounded by a count-cap fold; no background reaper (disk reclaim
+   left to the LRU byte cap). Scopes: exact-URL (all variants), whole-host,
+   flush-all. **(done)** See [Purge / invalidation](#purge--invalidation).
+   Edge-only. Path-prefix and Cache-Tag purge are deferred (prefix needs a scan;
+   tags must be recorded at admit time) — the epoch table extends to both later.

--- a/SPEC.md
+++ b/SPEC.md
@@ -158,15 +158,20 @@ invariants:
   cached only with a `Content-Length` within the per-object cap (chunked GETs pass
   through uncached, to never store a truncated body). See
   [EDGE.md](EDGE.md#response-cache-at-the-edge).
-- **Cache purge (edge-only, design)** — invalidation is **pulled** from the
-  control plane (`GET`/`POST /v1/purges`, a per-edge-scoped journal + cursor),
-  mirroring cert/WAF distribution; no inbound port on the edge. Lazy **epoch**
-  invalidation (global / host / url-keyed-on-`host⊕uri`) is checked at lookup.
-  Epochs use the **edge's own clock** at apply time (no trusted CP timestamp; the
-  cursor makes apply idempotent); a background reaper reclaims disk. Scopes:
-  exact-URL (all variants), whole-host/zone, flush-all. Edge-only — no controller
-  mirror, no conformance obligation. **Design only — not implemented** in either
-  the edge or the control plane. See [EDGE.md](EDGE.md#purge--invalidation).
+- **Cache purge (edge-only)** — invalidation is **pulled** from the control plane
+  (`GET`/`POST /v1/purges`, a per-edge-scoped journal + cursor), mirroring
+  cert/WAF distribution; no inbound port on the edge. Lazy **epoch** invalidation
+  (global / host / url-keyed-on-`host⊕uri`) is checked at lookup via the
+  `parapet/pkg/cache` `InvalidatedAfter` hook (parapet ≥ v0.17.0). Epochs use the
+  **edge's own clock** at apply time (no trusted CP timestamp; the cursor makes
+  apply idempotent, monotonic-clamped against an NTP step-back). Scopes: exact-URL
+  (all variants), whole-host, flush-all. The in-memory table is bounded by a
+  count-cap fold into the global epoch (over-invalidates, never under-); there is
+  no background reaper (the `Storage` interface has no enumeration), so disk reclaim
+  is left to the LRU byte cap. Issuing a purge needs `CP_PURGE_ADMIN_TOKEN` (a
+  stronger credential than the per-edge read tokens). Edge-only — no controller
+  mirror, no conformance obligation, **pure-Go (no Rust counterpart)**. See
+  [EDGE.md](EDGE.md#purge--invalidation).
 
 ## Configuration (environment variables)
 

--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -331,6 +331,21 @@ func main() {
 		slog.Info("edge control plane: WAF distribution enabled", "pod_namespace", podNamespace)
 	}
 
+	// Optional cache-purge distribution (GET/POST /v1/purges). The read side rides
+	// the per-edge bearer token (scoped to the edge's hosts); issuing a purge needs
+	// CP_PURGE_ADMIN_TOKEN — a stronger credential than the edges hold. Without that
+	// token, issuance is locked out, so refuse to enable an issue-less purge plane.
+	if os.Getenv("CP_PURGE_ENABLED") == "true" {
+		adminToken := os.Getenv("CP_PURGE_ADMIN_TOKEN")
+		if adminToken == "" {
+			slog.Error("CP_PURGE_ENABLED=true requires CP_PURGE_ADMIN_TOKEN (the credential that gates POST /v1/purges)")
+			os.Exit(1)
+		}
+		purgeStore := edgecp.NewPurgeStore(envInt("CP_PURGE_MAX_ENTRIES", 0))
+		server = server.WithPurge(purgeStore, adminToken)
+		slog.Info("edge control plane: cache-purge distribution enabled")
+	}
+
 	// Convergence /metrics on a SEPARATE, unauthenticated listener (never the
 	// token-gated API mux, so a scraper reaches it without the bearer token). Only the
 	// serving process reaches here — the run-once bootstrap/rotate Jobs os.Exit above.

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -196,10 +197,12 @@ func main() {
 	// backend is disk (default; survives restarts, bounded by on-disk bytes) or
 	// memory (EDGE_CACHE_BACKEND=memory; bodies in RAM, lost on restart).
 	var respCache *cache.Cache
+	var purgeTable *edge.PurgeTable
 	if envOr("EDGE_CACHE_ENABLED", "false") == "true" {
 		maxSize := envInt64("EDGE_CACHE_MAX_SIZE", 1<<30)
 		maxFile := envInt64("EDGE_CACHE_MAX_FILE_SIZE", 8<<20)
 		var storage cache.Storage
+		var purgeStatePath string // disk backend persists purge state alongside the cache
 		switch envOr("EDGE_CACHE_BACKEND", "disk") {
 		case "memory":
 			storage = cache.NewMemory(maxSize)
@@ -211,12 +214,33 @@ func main() {
 				slog.Error("edge cache: cannot init cache dir; caching disabled", "dir", dir, "error", err)
 			} else {
 				storage = d
+				purgeStatePath = filepath.Join(dir, "purge-state")
 				slog.Info("edge cache enabled (disk-backed)", "dir", dir, "max_size", maxSize, "max_file", maxFile)
 			}
 		}
 		if storage != nil {
-			respCache = cache.New(storage, cache.Options{MaxFileSize: maxFile})
+			opts := cache.Options{MaxFileSize: maxFile}
+			// Cache-purge: an invalidation table fed from the control plane gates each
+			// hit (parapet's Options.InvalidatedAfter). On by default with the cache; the
+			// poll loop fail-statics if the CP isn't distributing purges. The table
+			// persists alongside the disk cache (in-memory backend keeps no state).
+			if envOr("EDGE_CACHE_PURGE_ENABLED", "true") == "true" {
+				pt, err := edge.NewPurgeTable(purgeStatePath, int(envInt64("EDGE_CACHE_PURGE_MAX_RECORDS", 0)))
+				if err != nil {
+					slog.Warn("edge cache: purge state load failed; starting from a clean table", "error", err)
+				}
+				purgeTable = pt
+				opts.InvalidatedAfter = purgeTable.InvalidatedAfter
+			}
+			respCache = cache.New(storage, opts)
 		}
+	}
+	// Start the purge poll loop once (initial poll + ticker) when the table is live.
+	if purgeTable != nil {
+		purgeInterval := time.Duration(envInt64("EDGE_CACHE_PURGE_POLL_INTERVAL", 10)) * time.Second
+		edge.RefreshPurgeOnce(cp, purgeTable) // best-effort initial sync; fail-static
+		go edge.RunPurgeRefresh(ctx, cp, purgeTable, purgeInterval)
+		slog.Info("edge cache: purge polling enabled", "poll_interval", purgeInterval)
 	}
 
 	var getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error)

--- a/deploy/edge/controlplane.yaml
+++ b/deploy/edge/controlplane.yaml
@@ -49,6 +49,22 @@ spec:
             #   {"<token>": ["acme.com", "*.acme.com"], ...}
             - name: CP_TOKENS_FILE
               value: /tokens/tokens.json
+            # --- Cache purge / invalidation distribution ---
+            # Serve GET /v1/purges (per-edge bearer, scoped to the edge's hosts) and
+            # POST /v1/purges (issue a purge). Issuing REQUIRES CP_PURGE_ADMIN_TOKEN —
+            # a stronger credential than the per-edge read tokens — so keep it in its
+            # own Secret. Issue with:
+            #   curl -H "Authorization: Bearer $ADMIN" -d '{"scope":"url","host":"acme.com","uri":"/a"}' \
+            #     https://controlplane:8443/v1/purges
+            # - name: CP_PURGE_ENABLED
+            #   value: "true"
+            # - name: CP_PURGE_ADMIN_TOKEN
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: edge-controlplane-purge
+            #       key: admin-token
+            # - name: CP_PURGE_MAX_ENTRIES   # retained journal length (default 4096)
+            #   value: "4096"
             # --- Edge auto-trust: data-plane client-cert issuance ---
             # The CP signs short-lived edge client certs (POST /v1/edge-cert) and
             # serves the PUBLIC edge CA in the tokenless trust bundle

--- a/deploy/edge/edge.yaml
+++ b/deploy/edge/edge.yaml
@@ -112,6 +112,17 @@ spec:
             #   value: "1073741824"
             # - name: EDGE_CACHE_MAX_FILE_SIZE  # per-object bytes (default 8 MiB)
             #   value: "8388608"
+            # Cache purge / invalidation (on by default with the cache). The edge
+            # polls the control plane's GET /v1/purges and reaps invalidated entries
+            # lazily at lookup. Needs CP_PURGE_ENABLED on the control plane; if the
+            # CP isn't distributing purges the edge fail-statics (a 404 is a quiet
+            # no-op). Disk backend persists the purge cursor under EDGE_CACHE_DIR.
+            # - name: EDGE_CACHE_PURGE_ENABLED       # "true" (default) | "false"
+            #   value: "true"
+            # - name: EDGE_CACHE_PURGE_POLL_INTERVAL # seconds between polls (default 10)
+            #   value: "10"
+            # - name: EDGE_CACHE_PURGE_MAX_RECORDS   # per-map cap before a conservative fold (default 65536)
+            #   value: "65536"
             # Prometheus metrics endpoint (connections / bytes / Go runtime). Set
             # "" to disable.
             - name: EDGE_METRICS_LISTEN

--- a/edge/cp.go
+++ b/edge/cp.go
@@ -18,8 +18,9 @@ import (
 // OOM the edge during decode. Generous but finite (a cert+key is a few KiB; a
 // WAF ruleset bundle for many zones can be larger).
 const (
-	maxCertBody = 4 << 20  // 4 MiB
-	maxWafBody  = 64 << 20 // 64 MiB
+	maxCertBody  = 4 << 20  // 4 MiB
+	maxWafBody   = 64 << 20 // 64 MiB
+	maxPurgeBody = 16 << 20 // 16 MiB (a journal page of {seq,scope,host,uri} records)
 )
 
 // CpClient is the HTTPS client to the in-cluster control plane. It presents the
@@ -175,6 +176,58 @@ func (c *CpClient) FetchWaf(currentEtag string) (WafFetch, error) {
 		}, nil
 	default:
 		return WafFetch{}, fmt.Errorf("control plane returned %d for /v1/waf", resp.StatusCode)
+	}
+}
+
+// PurgeFetch is the outcome of a cache-purge poll.
+type PurgeFetch struct {
+	// Disabled is true on a 404 ("purge distribution disabled" at the CP): a clean,
+	// expected off-state the caller skips quietly (distinct from an unreachable CP).
+	Disabled bool
+	// FlushRequired is true when the edge's cursor fell behind the CP's retained
+	// journal — the edge bumps its global epoch (lazy flush-all) and jumps to MaxSeq.
+	FlushRequired bool
+	// Entries are the new purges (seq > the requested cursor), already scoped to this
+	// edge's allowed hosts by the CP.
+	Entries []PurgeEntry
+	// MaxSeq is the highest journal seq; the edge advances its cursor to it.
+	MaxSeq uint64
+}
+
+type purgeBody struct {
+	Entries       []PurgeEntry `json:"entries"`
+	MaxSeq        uint64       `json:"max_seq"`
+	FlushRequired bool         `json:"flush_required"`
+}
+
+// FetchPurges polls GET /v1/purges?since=<cursor> for cache-purge directives the
+// edge hasn't applied. A 404 returns Disabled=true (err nil) so the caller can skip
+// quietly when the CP isn't distributing purges; any other non-200 is an error the
+// caller handles fail-static (keeps its applied epochs + cursor). No ETag: the
+// since-cursor already makes the poll incremental and idempotent.
+func (c *CpClient) FetchPurges(since uint64) (PurgeFetch, error) {
+	u := c.base + "/v1/purges?since=" + strconv.FormatUint(since, 10)
+	resp, err := c.do(u, "")
+	if err != nil {
+		return PurgeFetch{}, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return PurgeFetch{Disabled: true}, nil
+	case http.StatusOK:
+		var body purgeBody
+		if err := json.NewDecoder(io.LimitReader(resp.Body, maxPurgeBody)).Decode(&body); err != nil {
+			return PurgeFetch{}, fmt.Errorf("decode: %w", err)
+		}
+		return PurgeFetch{
+			FlushRequired: body.FlushRequired,
+			Entries:       body.Entries,
+			MaxSeq:        body.MaxSeq,
+		}, nil
+	default:
+		return PurgeFetch{}, fmt.Errorf("control plane returned %d for /v1/purges", resp.StatusCode)
 	}
 }
 

--- a/edge/metrics.go
+++ b/edge/metrics.go
@@ -91,10 +91,71 @@ var (
 		Name:      "edge_ondemand_cert_total",
 		Help:      "Serve-all on-demand cert resolutions by result (hit|miss|shed|suppressed).",
 	}, []string{"result", "edge_id"})
+
+	// --- cache-purge (edge-only) ---
+
+	// edgePurgePoll counts purge polls by result: ok (entries applied/none),
+	// flush (cursor-gap flush-all), disabled (CP not distributing), error (fetch failed).
+	edgePurgePoll = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_cache_purge_poll_total",
+		Help:      "Cache-purge polls by result (ok|flush|disabled|error).",
+	}, []string{"result", "edge_id"})
+
+	// edgePurgeEntries counts purge entries applied (cumulative).
+	edgePurgeEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_cache_purge_entries_total",
+		Help:      "Cache-purge journal entries applied by the edge (cumulative).",
+	}, []string{"edge_id"})
+
+	// edgePurgeCursor is the last journal seq the edge has applied.
+	edgePurgeCursor = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_cache_purge_cursor",
+		Help:      "Last cache-purge journal seq applied by the edge.",
+	}, []string{"edge_id"})
+
+	// edgePurgeRecords is the current in-memory record count per scope map (host|url),
+	// so an operator can watch the table stay bounded.
+	edgePurgeRecords = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_cache_purge_records",
+		Help:      "Current cache-purge invalidation-table records, by scope map (host|url).",
+	}, []string{"scope", "edge_id"})
+
+	// edgePurgeFolds is the cumulative count of conservative cap-folds (a map
+	// exceeded its cap and was folded into the global epoch). A climbing value flags
+	// an undersized cap or an unusually large purge volume.
+	edgePurgeFolds = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_cache_purge_folds_total",
+		Help:      "Cumulative conservative cap-folds of the cache-purge table into the global epoch.",
+	}, []string{"edge_id"})
 )
 
 func init() {
-	prom.Registry().MustRegister(edgeClientCertCAID, edgeClientCertNotAfter, edgeClientCertLoaded, edgeRemint, edgeCPTargetCAID, edgeRefresh, edgeClientCertSignerFP, edgeCPActiveSignerFP, edgeOnDemand)
+	prom.Registry().MustRegister(edgeClientCertCAID, edgeClientCertNotAfter, edgeClientCertLoaded, edgeRemint, edgeCPTargetCAID, edgeRefresh, edgeClientCertSignerFP, edgeCPActiveSignerFP, edgeOnDemand,
+		edgePurgePoll, edgePurgeEntries, edgePurgeCursor, edgePurgeRecords, edgePurgeFolds)
+}
+
+// purgePoll counts one purge poll by result.
+func purgePoll(result string) { edgePurgePoll.WithLabelValues(result, edgeID).Inc() }
+
+// purgePollApplied adds n to the applied-entries counter (no-op for n<=0).
+func purgePollApplied(n int) {
+	if n > 0 {
+		edgePurgeEntries.WithLabelValues(edgeID).Add(float64(n))
+	}
+}
+
+// setPurgeMetrics reflects the table's current state into the gauges (cursor, per-map
+// record counts, cap-folds).
+func setPurgeMetrics(st PurgeStats) {
+	edgePurgeCursor.WithLabelValues(edgeID).Set(float64(st.Cursor))
+	edgePurgeRecords.WithLabelValues("host", edgeID).Set(float64(st.HostRecs))
+	edgePurgeRecords.WithLabelValues("url", edgeID).Set(float64(st.URLRecs))
+	edgePurgeFolds.WithLabelValues(edgeID).Set(float64(st.Folds))
 }
 
 // ondemand counts one on-demand cert resolution outcome.

--- a/edge/purge.go
+++ b/edge/purge.go
@@ -1,0 +1,411 @@
+package edge
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/moonrhythm/parapet/pkg/cache"
+)
+
+// Scope is a purge's breadth.
+type Scope string
+
+const (
+	// ScopeFlushAll invalidates everything cached at the apply instant.
+	ScopeFlushAll Scope = "flush-all"
+	// ScopeHost invalidates every URL under one host.
+	ScopeHost Scope = "host"
+	// ScopeURL invalidates one URL (all methods, schemes, and Vary variants).
+	ScopeURL Scope = "url"
+)
+
+// PurgeEntry is one journal record as distributed by the control plane and applied
+// by the edge. Seq is the monotonic journal sequence (idempotency cursor); Host is
+// required for host/url scopes; URI (path+query) is required for url scope. It is
+// also the JSON wire shape returned by GET /v1/purges.
+type PurgeEntry struct {
+	Seq   uint64 `json:"seq"`
+	Scope Scope  `json:"scope"`
+	Host  string `json:"host,omitempty"`
+	URI   string `json:"uri,omitempty"`
+}
+
+// PurgeTable is the edge's cache-invalidation state: a small, in-memory table of
+// "everything cached at or before epoch T is invalid", consulted at cache-lookup
+// time via InvalidatedAfter (the parapet/pkg/cache Options.InvalidatedAfter hook).
+//
+// It implements LAZY epoch invalidation: issuing a purge is O(1) (one map write
+// stamping the edge's own wall clock), and an invalidated entry is physically
+// reaped only on its NEXT lookup — exactly when the hook reports it stale, like a
+// passed FreshUntil. Correctness is immediate (a purged entry can never be
+// served); the storage backend's LRU byte cap reclaims disk regardless.
+//
+// Three scopes, checked as a max at lookup so a URL is also covered by its host's
+// purge and by a global flush:
+//   - global  — flush-all (one epoch)
+//   - host    — every URL under a host (keyed by normalized host)
+//   - url     — one URL across all methods, schemes, and Vary variants (keyed by
+//     hash(host ⊕ uri), so a single purge of /a covers GET+HEAD, http+https, and
+//     every cached variant)
+//
+// The table persists {global, host, url, cursor} to a single file with an atomic
+// temp+fsync+rename, so maps and cursor can never desync. It is safe for
+// concurrent use.
+type PurgeTable struct {
+	mu     sync.RWMutex
+	global int64            // flush-all epoch (unix nanos); 0 = never flushed
+	host   map[string]int64 // normalized host    -> epoch
+	url    map[string]int64 // hash(host ⊕ uri)   -> epoch
+	cursor uint64           // last journal seq applied (idempotency)
+
+	// highWater is the largest epoch ever stamped. Every new stamp is clamped to be
+	// >= highWater so a wall-clock step back (NTP correction) can never lower an
+	// epoch and "un-purge" entries — purges are monotonic non-decreasing.
+	highWater int64
+
+	// folds counts conservative cap-folds (a map exceeded maxRecords and was folded
+	// into the global epoch). Surfaced via Stats for metrics.
+	folds uint64
+
+	path     string       // persistence file; "" disables persistence (e.g. memory backend)
+	maxRecs  int          // per-map record cap before a conservative fold-to-global
+	nowNanos func() int64 // injectable clock (unix nanos); nil => time.Now
+}
+
+// defaultMaxPurgeRecords bounds each of the host/url maps. Purge records are
+// created by operator-issued purges (not per request), so this is generous; on
+// overflow the map folds into the global epoch (conservative over-invalidation,
+// never under-invalidation), keeping memory finite without a reaper.
+const defaultMaxPurgeRecords = 1 << 16
+
+// NewPurgeTable builds the table, loading any persisted state from path. A path of
+// "" disables persistence (the table lives only in memory). maxRecords <= 0 uses
+// defaultMaxPurgeRecords. A missing state file is a clean first start (cursor 0); a
+// corrupt/unreadable one resets to an empty table (cursor 0) so the next poll
+// gaps and the control plane returns flush_required — conservative, never a silent
+// under-invalidation. The load outcome is returned for logging; the table is
+// always usable.
+func NewPurgeTable(path string, maxRecords int) (*PurgeTable, error) {
+	if maxRecords <= 0 {
+		maxRecords = defaultMaxPurgeRecords
+	}
+	t := &PurgeTable{
+		host:    map[string]int64{},
+		url:     map[string]int64{},
+		path:    path,
+		maxRecs: maxRecords,
+	}
+	err := t.load()
+	return t, err
+}
+
+// now returns the current unix-nano clock (injectable for tests).
+func (t *PurgeTable) now() int64 {
+	if t.nowNanos != nil {
+		return t.nowNanos()
+	}
+	return time.Now().UnixNano()
+}
+
+// InvalidatedAfter is the parapet/pkg/cache Options.InvalidatedAfter hook. It
+// returns the invalidation epoch (unix nanos) applying to r: the max of the
+// global, per-host, and per-url epochs. The cache treats a hit whose Meta.Created
+// is <= this value as stale. Host normalization mirrors cache.primaryHash
+// (lowercase + strip port) so the keys line up exactly. The stored Meta is unused.
+func (t *PurgeTable) InvalidatedAfter(r *http.Request, _ cache.Meta) int64 {
+	host := normHost(r.Host)
+	uk := urlKey(host, r.URL.RequestURI())
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	e := t.global
+	if v := t.host[host]; v > e {
+		e = v
+	}
+	if v := t.url[uk]; v > e {
+		e = v
+	}
+	return e
+}
+
+// Apply applies a batch of journal entries (only those with Seq > the pre-batch
+// cursor, so re-delivered entries are idempotent), advances the cursor to maxSeq
+// (covering empty batches and gaps within the retained range), and atomically
+// persists the new state. Entry order is irrelevant — epochs clamp monotonically
+// and the cursor is set from maxSeq. A persist failure is returned for logging but
+// the in-memory state is already updated (and is the source of truth for serving);
+// the next successful persist catches up, and a crash before then just re-polls
+// from the durable cursor and re-applies idempotently.
+func (t *PurgeTable) Apply(entries []PurgeEntry, maxSeq uint64) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	base := t.cursor
+	for _, e := range entries {
+		if e.Seq <= base {
+			continue // already applied in an earlier poll
+		}
+		t.applyLocked(e)
+	}
+	if maxSeq > t.cursor {
+		t.cursor = maxSeq
+	}
+	return t.saveLocked()
+}
+
+// FlushAll bumps the global epoch (lazy flush-all), clears the host/url maps (now
+// redundant — global supersedes any record <= it), advances the cursor to maxSeq,
+// and persists. Used on the control plane's flush_required signal (a cursor gap)
+// and for an explicit flush-all purge.
+func (t *PurgeTable) FlushAll(maxSeq uint64) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.global = t.stamp()
+	t.host = map[string]int64{}
+	t.url = map[string]int64{}
+	if maxSeq > t.cursor {
+		t.cursor = maxSeq
+	}
+	return t.saveLocked()
+}
+
+// applyLocked applies one entry's effect. Caller holds t.mu.
+func (t *PurgeTable) applyLocked(e PurgeEntry) {
+	switch e.Scope {
+	case ScopeFlushAll:
+		t.global = t.stamp()
+		// global at >= every existing host/url epoch makes them redundant; drop to
+		// reclaim memory.
+		t.host = map[string]int64{}
+		t.url = map[string]int64{}
+	case ScopeHost:
+		if h := normHost(e.Host); h != "" {
+			t.host[h] = t.stamp()
+			t.enforceCapLocked()
+		}
+	case ScopeURL:
+		if h := normHost(e.Host); h != "" {
+			t.url[urlKey(h, e.URI)] = t.stamp()
+			t.enforceCapLocked()
+		}
+	}
+}
+
+// stamp returns a fresh epoch, clamped to be monotonic non-decreasing (>=
+// highWater) so a wall-clock step back can't un-purge. Caller holds t.mu.
+func (t *PurgeTable) stamp() int64 {
+	n := t.now()
+	if n < t.highWater {
+		n = t.highWater
+	}
+	t.highWater = n
+	return n
+}
+
+// enforceCapLocked keeps each map within maxRecs by folding an overflowing map
+// into the global epoch: global jumps to highWater (covering every record purged
+// so far) and the map is cleared. This over-invalidates (a coarser flush) but
+// NEVER under-invalidates, and bounds memory without a background reaper. Caller
+// holds t.mu.
+func (t *PurgeTable) enforceCapLocked() {
+	folded := false
+	if len(t.url) > t.maxRecs {
+		t.url = map[string]int64{}
+		folded = true
+	}
+	if len(t.host) > t.maxRecs {
+		t.host = map[string]int64{}
+		folded = true
+	}
+	if folded {
+		t.global = t.highWater // highWater >= every epoch stamped, so it covers the dropped records
+		t.folds++
+	}
+}
+
+// Sweep drops host/url records older than retain, reclaiming memory for purges
+// whose effect is already covered by ordinary TTL expiry.
+//
+// SAFETY: this is sound only when retain >= the maximum freshness lifetime the
+// edge will cache (the EDGE_CACHE_MAX_TTL cap). A record at epoch T only stops
+// mattering once every entry created <= T is unservable; with the lazy gate (no
+// background reaper) the guarantee that "nothing created <= T is still fresh"
+// comes from TTL alone, i.e. after retain >= maxFreshness has elapsed. Calling it
+// with a shorter retain can drop a record while a long-max-age entry created
+// before it is still fresh, re-serving stale content. The count-cap fold
+// (enforceCapLocked) is the unconditional memory bound; Sweep is an optional
+// optimization gated on that TTL cap.
+func (t *PurgeTable) Sweep(retain time.Duration) {
+	cutoff := t.now() - retain.Nanoseconds()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for k, v := range t.url {
+		if v < cutoff {
+			delete(t.url, k)
+		}
+	}
+	for k, v := range t.host {
+		if v < cutoff {
+			delete(t.host, k)
+		}
+	}
+}
+
+// Cursor returns the last journal seq applied (for building the poll request).
+func (t *PurgeTable) Cursor() uint64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.cursor
+}
+
+// PurgeStats is a snapshot of the table for metrics/diagnostics.
+type PurgeStats struct {
+	Cursor   uint64
+	Global   int64
+	HostRecs int
+	URLRecs  int
+	Folds    uint64
+}
+
+// Stats returns a concurrent-safe snapshot.
+func (t *PurgeTable) Stats() PurgeStats {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return PurgeStats{
+		Cursor:   t.cursor,
+		Global:   t.global,
+		HostRecs: len(t.host),
+		URLRecs:  len(t.url),
+		Folds:    t.folds,
+	}
+}
+
+// --- persistence ---
+
+// persistState is the on-disk shape. Maps + cursor share one atomic write so they
+// can never desync.
+type persistState struct {
+	Global int64            `json:"global"`
+	Host   map[string]int64 `json:"host"`
+	URL    map[string]int64 `json:"url"`
+	Cursor uint64           `json:"cursor"`
+}
+
+// load reads persisted state into the table. A missing file is a clean start. Any
+// other error (unreadable / corrupt JSON) leaves the table empty (cursor 0) and is
+// returned for logging — the next poll gaps and the CP responds flush_required.
+func (t *PurgeTable) load() error {
+	if t.path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(t.path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	var st persistState
+	if err := json.Unmarshal(data, &st); err != nil {
+		return err // table stays empty; conservative re-sync on next poll
+	}
+	if st.Host != nil {
+		t.host = st.Host
+	}
+	if st.URL != nil {
+		t.url = st.URL
+	}
+	t.global = st.Global
+	t.cursor = st.Cursor
+	t.highWater = st.Global
+	for _, v := range t.host {
+		if v > t.highWater {
+			t.highWater = v
+		}
+	}
+	for _, v := range t.url {
+		if v > t.highWater {
+			t.highWater = v
+		}
+	}
+	return nil
+}
+
+// saveLocked atomically persists the current state. Caller holds t.mu. A "" path
+// is a no-op (persistence disabled).
+func (t *PurgeTable) saveLocked() error {
+	if t.path == "" {
+		return nil
+	}
+	data, err := json.Marshal(persistState{
+		Global: t.global,
+		Host:   t.host,
+		URL:    t.url,
+		Cursor: t.cursor,
+	})
+	if err != nil {
+		return err
+	}
+	return atomicWriteFile(t.path, data)
+}
+
+// atomicWriteFile writes data to path via a same-dir temp file with
+// write+fsync+close+rename, so a reader never sees a partial state file (matches
+// the disk cache's commit idiom).
+func atomicWriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, ".purge-state-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// --- keys ---
+
+// normHost lowercases and strips the port from a host, mirroring
+// cache.primaryHash exactly so a purge key matches the cache's stored key. It does
+// NOT strip a trailing dot (neither does the cache).
+func normHost(host string) string {
+	h := strings.ToLower(host)
+	if hh, _, err := net.SplitHostPort(h); err == nil {
+		h = hh
+	}
+	return h
+}
+
+// urlKey is the per-url map key: hash(host ⊕ uri). uri is the request-uri
+// (path+query). Hashing host⊕uri (not method/scheme) makes one url purge cover
+// GET+HEAD, http+https, and every Vary variant at once.
+func urlKey(host, uri string) string {
+	sum := sha256.Sum256([]byte(host + "\n" + uri))
+	return hex.EncodeToString(sum[:16])
+}

--- a/edge/purge.go
+++ b/edge/purge.go
@@ -150,31 +150,42 @@ func (t *PurgeTable) Apply(entries []PurgeEntry, maxSeq uint64) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	base := t.cursor
+	changed := false
 	for _, e := range entries {
 		if e.Seq <= base {
 			continue // already applied in an earlier poll
 		}
 		t.applyLocked(e)
+		changed = true
 	}
 	if maxSeq > t.cursor {
 		t.cursor = maxSeq
+		changed = true
+	}
+	// Persist only on a real change, so an idle poll (no new entries, cursor
+	// unchanged) doesn't fsync — and the fsync-under-lock cost is paid only when an
+	// actual purge advances the state, not on every poll tick.
+	if !changed {
+		return nil
 	}
 	return t.saveLocked()
 }
 
 // FlushAll bumps the global epoch (lazy flush-all), clears the host/url maps (now
-// redundant — global supersedes any record <= it), advances the cursor to maxSeq,
-// and persists. Used on the control plane's flush_required signal (a cursor gap)
-// and for an explicit flush-all purge.
+// redundant — global supersedes any record <= it), sets the cursor to maxSeq, and
+// persists. Used on the control plane's flush_required signal — both a cursor gap
+// (maxSeq >= cursor: advance) and a journal reset where the CP's seq fell below the
+// edge's cursor (maxSeq < cursor: realign DOWN). The cursor is set unconditionally
+// (the one place a regression is safe: the flush just invalidated everything, so
+// re-fetching from the new, lower maxSeq is idempotent) — otherwise a reset would
+// leave the cursor stuck above the CP's journal and re-flush on every poll forever.
 func (t *PurgeTable) FlushAll(maxSeq uint64) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.global = t.stamp()
 	t.host = map[string]int64{}
 	t.url = map[string]int64{}
-	if maxSeq > t.cursor {
-		t.cursor = maxSeq
-	}
+	t.cursor = maxSeq
 	return t.saveLocked()
 }
 

--- a/edge/purge_test.go
+++ b/edge/purge_test.go
@@ -1,0 +1,200 @@
+package edge
+
+import (
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/moonrhythm/parapet/pkg/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// epochFor is the table's hook applied to a synthetic request for method/url.
+func epochFor(t *PurgeTable, method, rawurl string) int64 {
+	return t.InvalidatedAfter(httptest.NewRequest(method, rawurl, nil), cache.Meta{})
+}
+
+// fixedClock pins the table's clock for deterministic epochs.
+func fixedClock(t *PurgeTable, nanos int64) {
+	t.nowNanos = func() int64 { return nanos }
+}
+
+func TestPurge_ScopesAndMax(t *testing.T) {
+	tbl, err := NewPurgeTable("", 0)
+	require.NoError(t, err)
+	fixedClock(tbl, 1000)
+
+	// url scope: only the exact url is invalidated.
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeURL, Host: "acme.com", URI: "/a"}}, 1))
+	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://acme.com/a"))
+	assert.EqualValues(t, 0, epochFor(tbl, "GET", "http://acme.com/b"), "sibling url untouched")
+
+	// host scope: every url under the host. A later epoch wins via max.
+	fixedClock(tbl, 2000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 2, Scope: ScopeHost, Host: "acme.com"}}, 2))
+	assert.EqualValues(t, 2000, epochFor(tbl, "GET", "http://acme.com/b"))
+	assert.EqualValues(t, 2000, epochFor(tbl, "GET", "http://acme.com/a"), "host epoch > url epoch wins")
+	assert.EqualValues(t, 0, epochFor(tbl, "GET", "http://other.com/a"), "other host untouched")
+
+	// global scope: everything.
+	fixedClock(tbl, 3000)
+	require.NoError(t, tbl.FlushAll(3))
+	assert.EqualValues(t, 3000, epochFor(tbl, "GET", "http://other.com/a"))
+}
+
+func TestPurge_URLCoversMethodSchemeVariant(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 0)
+	fixedClock(tbl, 7000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeURL, Host: "acme.com", URI: "/p?x=1"}}, 1))
+
+	// Same host+uri, regardless of method/scheme, resolves to the same key.
+	assert.EqualValues(t, 7000, epochFor(tbl, "GET", "http://acme.com/p?x=1"))
+	assert.EqualValues(t, 7000, epochFor(tbl, "HEAD", "http://acme.com/p?x=1"))
+	assert.EqualValues(t, 7000, epochFor(tbl, "GET", "https://acme.com/p?x=1"))
+	// Different query is a different url.
+	assert.EqualValues(t, 0, epochFor(tbl, "GET", "http://acme.com/p?x=2"))
+}
+
+func TestPurge_HostNormalizationMatchesCacheKey(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 0)
+	fixedClock(tbl, 5000)
+	// Purge issued with mixed case + port; lookups with other case/port must match.
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeHost, Host: "ACME.com:443"}}, 1))
+	assert.EqualValues(t, 5000, epochFor(tbl, "GET", "http://acme.com/x"))
+	assert.EqualValues(t, 5000, epochFor(tbl, "GET", "http://Acme.COM:8443/x"))
+}
+
+func TestPurge_MonotonicClampOnClockStepBack(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 0)
+	fixedClock(tbl, 10_000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeHost, Host: "a.com"}}, 1))
+	assert.EqualValues(t, 10_000, epochFor(tbl, "GET", "http://a.com/"))
+
+	// Clock steps back; a new purge must not get a lower epoch.
+	fixedClock(tbl, 9_000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 2, Scope: ScopeHost, Host: "b.com"}}, 2))
+	assert.EqualValues(t, 10_000, epochFor(tbl, "GET", "http://b.com/"), "clamped to highWater, not the stepped-back clock")
+
+	// A flush after a step-back is also clamped.
+	fixedClock(tbl, 8_000)
+	require.NoError(t, tbl.FlushAll(3))
+	assert.GreaterOrEqual(t, epochFor(tbl, "GET", "http://c.com/"), int64(10_000))
+}
+
+func TestPurge_ApplyIdempotentByCursor(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 0)
+	fixedClock(tbl, 1000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{
+		{Seq: 1, Scope: ScopeURL, Host: "a.com", URI: "/x"},
+		{Seq: 2, Scope: ScopeURL, Host: "a.com", URI: "/y"},
+	}, 2))
+	assert.EqualValues(t, 2, tbl.Cursor())
+
+	// Re-deliver seq 1-2 plus a new seq 3 with a later clock; only seq 3 applies.
+	fixedClock(tbl, 9000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{
+		{Seq: 1, Scope: ScopeURL, Host: "a.com", URI: "/x"},
+		{Seq: 2, Scope: ScopeURL, Host: "a.com", URI: "/y"},
+		{Seq: 3, Scope: ScopeURL, Host: "a.com", URI: "/z"},
+	}, 3))
+	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://a.com/x"), "already-applied entry not re-stamped")
+	assert.EqualValues(t, 9000, epochFor(tbl, "GET", "http://a.com/z"), "new entry applied")
+	assert.EqualValues(t, 3, tbl.Cursor())
+}
+
+func TestPurge_ApplyAdvancesCursorOnGap(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 0)
+	// An empty batch with a higher maxSeq still advances the cursor.
+	require.NoError(t, tbl.Apply(nil, 42))
+	assert.EqualValues(t, 42, tbl.Cursor())
+	// Cursor never regresses.
+	require.NoError(t, tbl.Apply(nil, 10))
+	assert.EqualValues(t, 42, tbl.Cursor())
+}
+
+func TestPurge_FlushAllClearsAndSupersedes(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 0)
+	fixedClock(tbl, 1000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{
+		{Seq: 1, Scope: ScopeURL, Host: "a.com", URI: "/x"},
+		{Seq: 2, Scope: ScopeHost, Host: "b.com"},
+	}, 2))
+	fixedClock(tbl, 5000)
+	require.NoError(t, tbl.FlushAll(3))
+
+	st := tbl.Stats()
+	assert.Zero(t, st.HostRecs, "host map cleared on flush")
+	assert.Zero(t, st.URLRecs, "url map cleared on flush")
+	assert.EqualValues(t, 5000, epochFor(tbl, "GET", "http://anything.com/q"))
+}
+
+func TestPurge_CapFoldBoundsMemory(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 2) // tiny cap to force a fold
+	fixedClock(tbl, 1000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{
+		{Seq: 1, Scope: ScopeURL, Host: "a.com", URI: "/1"},
+		{Seq: 2, Scope: ScopeURL, Host: "a.com", URI: "/2"},
+		{Seq: 3, Scope: ScopeURL, Host: "a.com", URI: "/3"}, // overflow -> fold
+	}, 3))
+
+	st := tbl.Stats()
+	assert.Zero(t, st.URLRecs, "overflowing url map folded to global")
+	assert.EqualValues(t, 1, st.Folds)
+	// Conservative: the folded urls are still invalidated (via the global epoch).
+	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://a.com/1"))
+	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://a.com/2"))
+}
+
+func TestPurge_SweepDropsOldRecords(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 0)
+	fixedClock(tbl, 1_000_000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeURL, Host: "a.com", URI: "/old"}}, 1))
+	// Advance the clock well past the record, then sweep with a short retention.
+	fixedClock(tbl, 1_000_000+int64(time.Hour))
+	tbl.Sweep(time.Minute)
+	assert.Zero(t, tbl.Stats().URLRecs, "record older than retention swept")
+}
+
+func TestPurge_PersistenceRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "purge-state")
+
+	t1, err := NewPurgeTable(path, 0)
+	require.NoError(t, err)
+	fixedClock(t1, 5000)
+	require.NoError(t, t1.Apply([]PurgeEntry{
+		{Seq: 7, Scope: ScopeHost, Host: "a.com"},
+		{Seq: 8, Scope: ScopeURL, Host: "b.com", URI: "/p"},
+	}, 8))
+
+	// Reopen: state + cursor + highWater survive.
+	t2, err := NewPurgeTable(path, 0)
+	require.NoError(t, err)
+	assert.EqualValues(t, 8, t2.Cursor())
+	assert.EqualValues(t, 5000, epochFor(t2, "GET", "http://a.com/anything"))
+	assert.EqualValues(t, 5000, epochFor(t2, "GET", "http://b.com/p"))
+
+	// highWater restored: a purge under a stepped-back clock still clamps up.
+	fixedClock(t2, 1)
+	require.NoError(t, t2.Apply([]PurgeEntry{{Seq: 9, Scope: ScopeHost, Host: "c.com"}}, 9))
+	assert.EqualValues(t, 5000, epochFor(t2, "GET", "http://c.com/"), "highWater reloaded")
+}
+
+func TestPurge_CorruptStateResetsToEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "purge-state")
+	require.NoError(t, os.WriteFile(path, []byte("{not json"), 0o644))
+
+	tbl, err := NewPurgeTable(path, 0)
+	require.Error(t, err, "corrupt state is surfaced for logging")
+	assert.EqualValues(t, 0, tbl.Cursor(), "reset to a clean table (next poll gaps -> flush)")
+	assert.EqualValues(t, 0, epochFor(tbl, "GET", "http://a.com/"))
+}
+
+func TestPurge_MissingStateIsCleanStart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist")
+	tbl, err := NewPurgeTable(path, 0)
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, tbl.Cursor())
+}

--- a/edge/purge_test.go
+++ b/edge/purge_test.go
@@ -148,6 +148,13 @@ func TestPurge_CapFoldBoundsMemory(t *testing.T) {
 	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://a.com/2"))
 }
 
+func TestPurge_FlushAllRealignsCursorDown(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 0)
+	require.NoError(t, tbl.Apply(nil, 500)) // cursor 500 (persisted against an old journal)
+	require.NoError(t, tbl.FlushAll(3))     // journal reset: realign the cursor DOWN to maxSeq
+	assert.EqualValues(t, 3, tbl.Cursor(), "a reset flush realigns the cursor down so it can't re-flush forever")
+}
+
 func TestPurge_SweepDropsOldRecords(t *testing.T) {
 	tbl, _ := NewPurgeTable("", 0)
 	fixedClock(tbl, 1_000_000)

--- a/edge/purgerefresh.go
+++ b/edge/purgerefresh.go
@@ -1,0 +1,72 @@
+package edge
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// RefreshPurgeOnce polls the control plane for cache-purge directives and applies
+// them to the table. Fail-static: a fetch error keeps the table's applied epochs +
+// cursor untouched (pending purges are delayed, not lost — the journal+cursor catch
+// up on the next poll). A flush_required (the edge fell behind the CP's retained
+// journal) bumps the global epoch and jumps the cursor; otherwise new entries are
+// applied idempotently. A 404 (purge distribution disabled at the CP) is a quiet
+// no-op.
+func RefreshPurgeOnce(cp *CpClient, table *PurgeTable) {
+	res, err := cp.FetchPurges(table.Cursor())
+	switch {
+	case err != nil:
+		slog.Warn("edge: purge poll failed; keeping applied epochs", "error", err)
+		purgePoll("error")
+		return
+	case res.Disabled:
+		// CP isn't distributing purges; nothing to do.
+		purgePoll("disabled")
+		return
+	case res.FlushRequired || res.MaxSeq < table.Cursor():
+		// FlushRequired: the CP signalled a gap or a journal reset (our cursor is ahead
+		// of its lastSeq). The MaxSeq < cursor guard is defense-in-depth for an OLDER CP
+		// that predates the cursor-ahead-of-journal check (independent edge/CP rollout) —
+		// it would otherwise return flush_required=false on a reset and silently
+		// under-invalidate. FlushAll realigns the cursor (down, if needed) to MaxSeq.
+		if err := table.FlushAll(res.MaxSeq); err != nil {
+			slog.Warn("edge: purge state persist failed after flush; in-memory state applied", "error", err)
+		}
+		slog.Info("edge: cache purge flush-all", "max_seq", res.MaxSeq, "flush_required", res.FlushRequired)
+		purgePoll("flush")
+	default:
+		if len(res.Entries) > 0 {
+			slog.Info("edge: cache purges applied", "count", len(res.Entries), "max_seq", res.MaxSeq)
+		}
+		if err := table.Apply(res.Entries, res.MaxSeq); err != nil {
+			slog.Warn("edge: purge state persist failed; in-memory state applied", "error", err)
+		}
+		purgePollApplied(len(res.Entries))
+		purgePoll("ok")
+	}
+	setPurgeMetrics(table.Stats())
+}
+
+// RunPurgeRefresh runs the periodic cache-purge poll forever. The first tick is
+// jittered by [0,interval] to decorrelate the fleet's poll instants. The cadence is
+// independent of (and typically faster than) the cert/WAF refresh, since purge
+// latency is operator-facing. Fail-static.
+func RunPurgeRefresh(ctx context.Context, cp *CpClient, table *PurgeTable, interval time.Duration) {
+	if interval <= 0 { // time.NewTicker panics on a non-positive interval
+		interval = 10 * time.Second
+	}
+	if !sleepCtx(ctx, fullJitter(interval)) {
+		return
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			RefreshPurgeOnce(cp, table)
+		}
+	}
+}

--- a/edge/purgerefresh_test.go
+++ b/edge/purgerefresh_test.go
@@ -1,0 +1,122 @@
+package edge
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchPurges200ParsesPayloadAndSendsCursor(t *testing.T) {
+	var gotSince, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/purges", r.URL.Path)
+		gotSince = r.URL.Query().Get("since")
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"entries":[{"seq":3,"scope":"url","host":"acme.com","uri":"/a"},{"seq":4,"scope":"host","host":"acme.com"}],"max_seq":4,"flush_required":false}`))
+	}))
+	defer srv.Close()
+
+	cp, _ := NewCpClient(srv.URL, "tok-9", nil)
+	res, err := cp.FetchPurges(2)
+	require.NoError(t, err)
+	assert.False(t, res.Disabled)
+	assert.False(t, res.FlushRequired)
+	assert.EqualValues(t, 4, res.MaxSeq)
+	require.Len(t, res.Entries, 2)
+	assert.Equal(t, ScopeURL, res.Entries[0].Scope)
+	assert.Equal(t, "/a", res.Entries[0].URI)
+	assert.Equal(t, "2", gotSince)
+	assert.Equal(t, "Bearer tok-9", gotAuth)
+}
+
+func TestFetchPurges404IsDisabledNotError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	cp, _ := NewCpClient(srv.URL, "t", nil)
+	res, err := cp.FetchPurges(0)
+	require.NoError(t, err, "404 is a clean disabled state, not an error")
+	assert.True(t, res.Disabled)
+}
+
+func TestFetchPurgesFlushRequired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"entries":[],"max_seq":99,"flush_required":true}`))
+	}))
+	defer srv.Close()
+	cp, _ := NewCpClient(srv.URL, "t", nil)
+	res, err := cp.FetchPurges(1)
+	require.NoError(t, err)
+	assert.True(t, res.FlushRequired)
+	assert.EqualValues(t, 99, res.MaxSeq)
+}
+
+func TestFetchPurgesNon200IsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	cp, _ := NewCpClient(srv.URL, "t", nil)
+	_, err := cp.FetchPurges(0)
+	assert.Error(t, err, "5xx is a fail-static error")
+}
+
+func TestRefreshPurgeOnce_AppliesAndAdvancesCursor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"entries":[{"seq":1,"scope":"url","host":"acme.com","uri":"/x"}],"max_seq":1,"flush_required":false}`))
+	}))
+	defer srv.Close()
+	cp, _ := NewCpClient(srv.URL, "t", nil)
+	tbl, _ := NewPurgeTable("", 0)
+
+	RefreshPurgeOnce(cp, tbl)
+	assert.EqualValues(t, 1, tbl.Cursor())
+	assert.Positive(t, epochFor(tbl, "GET", "http://acme.com/x"), "purged url has a non-zero invalidation epoch")
+}
+
+func TestRefreshPurgeOnce_FlushRequiredBumpsGlobal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"entries":[],"max_seq":50,"flush_required":true}`))
+	}))
+	defer srv.Close()
+	cp, _ := NewCpClient(srv.URL, "t", nil)
+	tbl, _ := NewPurgeTable("", 0)
+
+	RefreshPurgeOnce(cp, tbl)
+	assert.EqualValues(t, 50, tbl.Cursor())
+	assert.Positive(t, epochFor(tbl, "GET", "http://anything.com/q"), "flush-all sets a global epoch")
+}
+
+func TestRefreshPurgeOnce_MaxSeqBelowCursorForcesFlush(t *testing.T) {
+	// Defense-in-depth for an OLD CP that doesn't set flush_required on a journal reset
+	// but reports a max_seq below our cursor: the edge must still flush + realign.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"entries":[],"max_seq":3,"flush_required":false}`))
+	}))
+	defer srv.Close()
+	cp, _ := NewCpClient(srv.URL, "t", nil)
+	tbl, _ := NewPurgeTable("", 0)
+	require.NoError(t, tbl.Apply(nil, 500)) // cursor 500, ahead of the reset journal
+
+	RefreshPurgeOnce(cp, tbl)
+	assert.EqualValues(t, 3, tbl.Cursor(), "defense-in-depth flush realigns the cursor down")
+	assert.Positive(t, epochFor(tbl, "GET", "http://x.com/y"), "flush bumped the global epoch")
+}
+
+func TestRefreshPurgeOnce_FetchErrorIsFailStatic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	cp, _ := NewCpClient(srv.URL, "t", nil)
+	tbl, _ := NewPurgeTable("", 0)
+	// Seed a cursor so we can prove it isn't disturbed by a failed poll.
+	require.NoError(t, tbl.Apply(nil, 7))
+
+	RefreshPurgeOnce(cp, tbl)
+	assert.EqualValues(t, 7, tbl.Cursor(), "a failed poll keeps the cursor (fail-static)")
+}

--- a/edgecp/metrics.go
+++ b/edgecp/metrics.go
@@ -165,10 +165,27 @@ var (
 
 	rotationOverlapSince  atomic.Int64 // unix nanos the CP first observed phase=overlap; 0 = not in overlap
 	rotationStuckDeadline atomic.Int64 // nanos; 0 disables the stuck gauge (always 0)
+
+	// purgeIssued counts cache purges accepted on POST /v1/purges by scope. scope is
+	// bounded to {flush-all, host, url} (invalid scopes are 400'd before this).
+	purgeIssued = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_cache_purge_issued_total",
+		Help:      "Cache purges accepted on POST /v1/purges, by scope (flush-all|host|url).",
+	}, []string{"scope"})
+
+	// purgeJournalSize is the current retained purge-journal length (bounded by
+	// CP_PURGE_MAX_ENTRIES). It tracks how much poll lag the journal can absorb
+	// before an edge gets flush_required.
+	purgeJournalSize = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_cache_purge_journal_entries",
+		Help:      "Current number of retained entries in the cache-purge journal.",
+	})
 )
 
 func init() {
-	prom.Registry().MustRegister(signerFingerprint, signerGeneration, signerBundleCerts, signerLoaded, targetCAID, signerFloored, signerRVUnparsed, registryTotal, authzGeneration, activeSignerFP, signerActiveFlipFailed, issuedUnderSigner, tokenDisabledNoRotation, rotationStuck)
+	prom.Registry().MustRegister(signerFingerprint, signerGeneration, signerBundleCerts, signerLoaded, targetCAID, signerFloored, signerRVUnparsed, registryTotal, authzGeneration, activeSignerFP, signerActiveFlipFailed, issuedUnderSigner, tokenDisabledNoRotation, rotationStuck, purgeIssued, purgeJournalSize)
 }
 
 // SetRotationStuckDeadline configures the overlap-stuck threshold (call once at startup).

--- a/edgecp/purgeserver_test.go
+++ b/edgecp/purgeserver_test.go
@@ -1,0 +1,123 @@
+package edgecp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// purgeTestServer builds a Server with one edge token (scoped to acme.com) and an
+// admin token, purge enabled.
+func purgeTestServer(t *testing.T) (*Server, *PurgeStore) {
+	t.Helper()
+	authz := NewAuthz(map[string][]string{"edge-tok": {"acme.com"}})
+	store := NewPurgeStore(0)
+	srv := NewServer(NewCertStore(), authz).WithPurge(store, "admin-secret")
+	return srv, store
+}
+
+func do(t *testing.T, h http.Handler, method, target, auth, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body != "" {
+		r = httptest.NewRequest(method, target, strings.NewReader(body))
+	} else {
+		r = httptest.NewRequest(method, target, nil)
+	}
+	if auth != "" {
+		r.Header.Set("Authorization", "Bearer "+auth)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, r)
+	return rec
+}
+
+func TestPurgeAPI_DisabledIs404(t *testing.T) {
+	srv := NewServer(NewCertStore(), NewAuthz(map[string][]string{"edge-tok": {"acme.com"}}))
+	h := srv.Handler()
+	assert.Equal(t, http.StatusNotFound, do(t, h, "GET", "/v1/purges", "edge-tok", "").Code)
+	assert.Equal(t, http.StatusNotFound, do(t, h, "POST", "/v1/purges", "admin-secret", `{"scope":"flush-all"}`).Code)
+}
+
+func TestPurgeAPI_GetRequiresKnownToken(t *testing.T) {
+	srv, _ := purgeTestServer(t)
+	h := srv.Handler()
+	assert.Equal(t, http.StatusUnauthorized, do(t, h, "GET", "/v1/purges", "", "").Code)
+	assert.Equal(t, http.StatusUnauthorized, do(t, h, "GET", "/v1/purges", "bogus", "").Code)
+	assert.Equal(t, http.StatusOK, do(t, h, "GET", "/v1/purges", "edge-tok", "").Code)
+}
+
+func TestPurgeAPI_PostRequiresAdminToken(t *testing.T) {
+	srv, _ := purgeTestServer(t)
+	h := srv.Handler()
+	// An edge read token must NOT be able to issue a purge.
+	assert.Equal(t, http.StatusUnauthorized, do(t, h, "POST", "/v1/purges", "edge-tok", `{"scope":"flush-all"}`).Code)
+	assert.Equal(t, http.StatusUnauthorized, do(t, h, "POST", "/v1/purges", "", `{"scope":"flush-all"}`).Code)
+	assert.Equal(t, http.StatusOK, do(t, h, "POST", "/v1/purges", "admin-secret", `{"scope":"flush-all"}`).Code)
+}
+
+func TestPurgeAPI_PostThenGetRoundTrip(t *testing.T) {
+	srv, _ := purgeTestServer(t)
+	h := srv.Handler()
+
+	rec := do(t, h, "POST", "/v1/purges", "admin-secret", `{"scope":"url","host":"acme.com","uri":"/p"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var issued map[string]uint64
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &issued))
+	assert.EqualValues(t, 1, issued["seq"])
+
+	rec = do(t, h, "GET", "/v1/purges?since=0", "edge-tok", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got PurgeSince
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Entries, 1)
+	assert.Equal(t, "url", got.Entries[0].Scope)
+	assert.Equal(t, "/p", got.Entries[0].URI)
+	assert.EqualValues(t, 1, got.MaxSeq)
+}
+
+func TestPurgeAPI_GetScopedToAllowedHosts(t *testing.T) {
+	srv, store := purgeTestServer(t)
+	h := srv.Handler()
+	_, _ = store.Add(purgeScopeHost, "acme.com", "")  // edge allowed
+	_, _ = store.Add(purgeScopeHost, "other.com", "") // edge NOT allowed
+	_, _ = store.Add(purgeScopeFlushAll, "", "")      // everyone
+
+	rec := do(t, h, "GET", "/v1/purges?since=0", "edge-tok", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got PurgeSince
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	// acme.com host + flush-all, but never other.com.
+	require.Len(t, got.Entries, 2)
+	for _, e := range got.Entries {
+		assert.NotEqual(t, "other.com", e.Host)
+	}
+}
+
+func TestPurgeAPI_PostInvalidScopeIs400(t *testing.T) {
+	srv, _ := purgeTestServer(t)
+	h := srv.Handler()
+	assert.Equal(t, http.StatusBadRequest, do(t, h, "POST", "/v1/purges", "admin-secret", `{"scope":"nope"}`).Code)
+	assert.Equal(t, http.StatusBadRequest, do(t, h, "POST", "/v1/purges", "admin-secret", `{"scope":"host"}`).Code) // missing host
+	assert.Equal(t, http.StatusBadRequest, do(t, h, "POST", "/v1/purges", "admin-secret", `not json`).Code)
+}
+
+func TestPurgeAPI_GetInvalidSinceIs400(t *testing.T) {
+	srv, _ := purgeTestServer(t)
+	h := srv.Handler()
+	assert.Equal(t, http.StatusBadRequest, do(t, h, "GET", "/v1/purges?since=abc", "edge-tok", "").Code)
+}
+
+func TestPurgeAPI_EmptyAdminTokenLocksOut(t *testing.T) {
+	// WithPurge given an empty admin token: POST can never authenticate.
+	authz := NewAuthz(map[string][]string{"edge-tok": {"acme.com"}})
+	srv := NewServer(NewCertStore(), authz).WithPurge(NewPurgeStore(0), "")
+	h := srv.Handler()
+	assert.Equal(t, http.StatusUnauthorized, do(t, h, "POST", "/v1/purges", "", `{"scope":"flush-all"}`).Code)
+	assert.Equal(t, http.StatusUnauthorized, do(t, h, "POST", "/v1/purges", "anything", `{"scope":"flush-all"}`).Code)
+}

--- a/edgecp/purgestore.go
+++ b/edgecp/purgestore.go
@@ -1,0 +1,158 @@
+package edgecp
+
+import (
+	"net"
+	"strings"
+	"sync"
+)
+
+// Purge scope values on the wire. These MUST match the edge's edge.Scope strings
+// (the two packages share only this JSON contract, never code).
+const (
+	purgeScopeFlushAll = "flush-all"
+	purgeScopeHost     = "host"
+	purgeScopeURL      = "url"
+)
+
+// defaultPurgeJournalMax bounds the in-memory journal. Purges are operator-issued
+// (not per request), so a few thousand retained entries covers any realistic poll
+// lag; older entries are trimmed and an edge that fell behind the retained window
+// gets a flush_required (lazy flush-all) on its next poll — conservative, never an
+// under-invalidation.
+const defaultPurgeJournalMax = 4096
+
+// purgeRecord is one journal entry. host is normalized (lowercased, port-stripped);
+// uri is the request-uri (path+query) verbatim from the operator.
+type purgeRecord struct {
+	seq   uint64
+	scope string
+	host  string
+	uri   string
+}
+
+// PurgeEntryDTO is the JSON wire shape of one purge entry (matches edge.PurgeEntry).
+type PurgeEntryDTO struct {
+	Seq   uint64 `json:"seq"`
+	Scope string `json:"scope"`
+	Host  string `json:"host,omitempty"`
+	URI   string `json:"uri,omitempty"`
+}
+
+// PurgeSince is the GET /v1/purges response: the entries an edge hasn't applied yet
+// (scoped to its allowed hosts), the highest journal seq, and a flush_required flag
+// set when the edge's cursor fell behind the retained window (a gap).
+type PurgeSince struct {
+	Entries       []PurgeEntryDTO `json:"entries"`
+	MaxSeq        uint64          `json:"max_seq"`
+	FlushRequired bool            `json:"flush_required"`
+}
+
+// PurgeStore is the control plane's bounded append-only purge journal. An admin
+// appends purges via Add (monotonic seq); each edge polls Since(cursor) to converge
+// on its own timer, exactly like cert/WAF distribution. There is no per-edge state
+// here — the cursor lives on the edge — so it is replica-friendly only in the sense
+// that a single CP instance owns the journal; multiple CP replicas would each keep
+// an independent journal (acceptable: an edge polling a different replica that lacks
+// a recent entry simply gets flush_required on the gap, which over-invalidates
+// safely). It is safe for concurrent use.
+type PurgeStore struct {
+	mu      sync.Mutex
+	entries []purgeRecord
+	lastSeq uint64 // highest seq issued (0 = none yet)
+	minSeq  uint64 // smallest retained seq (1 when empty)
+	maxKeep int
+}
+
+// NewPurgeStore builds the journal. maxEntries <= 0 uses defaultPurgeJournalMax.
+func NewPurgeStore(maxEntries int) *PurgeStore {
+	if maxEntries <= 0 {
+		maxEntries = defaultPurgeJournalMax
+	}
+	return &PurgeStore{minSeq: 1, maxKeep: maxEntries}
+}
+
+// Add appends a purge and returns its seq. scope must be one of flush-all / host /
+// url; host is required for host+url (normalized here), uri for url. A bad
+// scope/host/uri returns (0, false) so the handler can 400.
+func (s *PurgeStore) Add(scope, host, uri string) (uint64, bool) {
+	scope = strings.TrimSpace(scope)
+	switch scope {
+	case purgeScopeFlushAll:
+		host, uri = "", ""
+	case purgeScopeHost:
+		host = normHostCP(host)
+		if host == "" {
+			return 0, false
+		}
+		uri = ""
+	case purgeScopeURL:
+		host = normHostCP(host)
+		if host == "" || uri == "" {
+			return 0, false
+		}
+	default:
+		return 0, false
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastSeq++
+	s.entries = append(s.entries, purgeRecord{seq: s.lastSeq, scope: scope, host: host, uri: uri})
+	if len(s.entries) > s.maxKeep {
+		// Trim oldest; re-slice into a fresh backing array so the dropped records
+		// are reclaimed rather than pinned by the slice header.
+		s.entries = append([]purgeRecord(nil), s.entries[len(s.entries)-s.maxKeep:]...)
+	}
+	s.minSeq = s.entries[0].seq
+	purgeIssued.WithLabelValues(scope).Inc()
+	purgeJournalSize.Set(float64(len(s.entries)))
+	return s.lastSeq, true
+}
+
+// Since returns the purges an edge with cursor `since` hasn't applied: entries with
+// seq > since, filtered to flush-all (affects every edge) plus host/url entries
+// whose host the edge may serve (per allow). FlushRequired is set when the edge's
+// next-needed seq was already trimmed (since+1 < minSeq) — the edge then bumps its
+// global epoch and jumps to MaxSeq.
+func (s *PurgeStore) Since(since uint64, allow func(host string) bool) PurgeSince {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	res := PurgeSince{MaxSeq: s.lastSeq}
+	// Cursor ahead of the journal (since > lastSeq): the edge has applied a seq this
+	// CP never issued, which means the journal was reset under it — a CP restart or a
+	// fresh/lagging replica (the store is in-memory, so seq restarts at 0). Without
+	// this, the post-reset seqs (1,2,3…) would all be <= the edge's stale cursor and
+	// silently skipped — an indefinite UNDER-invalidation. flush-all so the edge
+	// re-syncs and realigns its cursor down to MaxSeq. (Also subsumes the since=MaxUint64
+	// overflow case, since MaxUint64 > lastSeq.)
+	if since > s.lastSeq {
+		res.FlushRequired = true
+		return res
+	}
+	// Gap below the retained window: the edge's next-needed seq (since+1) was trimmed.
+	if since+1 < s.minSeq {
+		res.FlushRequired = true
+		return res
+	}
+	for _, e := range s.entries {
+		if e.seq <= since {
+			continue
+		}
+		if e.scope != purgeScopeFlushAll && !allow(e.host) {
+			continue
+		}
+		res.Entries = append(res.Entries, PurgeEntryDTO{Seq: e.seq, Scope: e.scope, Host: e.host, URI: e.uri})
+	}
+	return res
+}
+
+// normHostCP lowercases and strips the port from a host, mirroring the edge's
+// normHost (and cache.primaryHash) so a purge key matches the edge's stored key. It
+// also trims surrounding whitespace from operator input.
+func normHostCP(host string) string {
+	h := strings.ToLower(strings.TrimSpace(host))
+	if hh, _, err := net.SplitHostPort(h); err == nil {
+		h = hh
+	}
+	return h
+}

--- a/edgecp/purgestore_test.go
+++ b/edgecp/purgestore_test.go
@@ -1,0 +1,155 @@
+package edgecp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func allowAll(string) bool  { return true }
+func allowNone(string) bool { return false }
+
+func TestPurgeStore_AddAndSinceFromZero(t *testing.T) {
+	s := NewPurgeStore(0)
+	seq1, ok := s.Add(purgeScopeURL, "acme.com", "/a")
+	require.True(t, ok)
+	seq2, ok := s.Add(purgeScopeHost, "acme.com", "")
+	require.True(t, ok)
+	seq3, ok := s.Add(purgeScopeFlushAll, "", "")
+	require.True(t, ok)
+	assert.EqualValues(t, 1, seq1)
+	assert.EqualValues(t, 2, seq2)
+	assert.EqualValues(t, 3, seq3)
+
+	res := s.Since(0, allowAll)
+	assert.False(t, res.FlushRequired)
+	assert.EqualValues(t, 3, res.MaxSeq)
+	require.Len(t, res.Entries, 3)
+	assert.Equal(t, purgeScopeURL, res.Entries[0].Scope)
+	assert.Equal(t, "/a", res.Entries[0].URI)
+}
+
+func TestPurgeStore_SinceIncremental(t *testing.T) {
+	s := NewPurgeStore(0)
+	_, _ = s.Add(purgeScopeURL, "a.com", "/1")
+	_, _ = s.Add(purgeScopeURL, "a.com", "/2")
+	_, _ = s.Add(purgeScopeURL, "a.com", "/3")
+
+	res := s.Since(2, allowAll)
+	require.Len(t, res.Entries, 1, "only entries with seq > cursor")
+	assert.EqualValues(t, 3, res.Entries[0].Seq)
+	assert.EqualValues(t, 3, res.MaxSeq)
+}
+
+func TestPurgeStore_EmptyJournalNoGap(t *testing.T) {
+	s := NewPurgeStore(0)
+	res := s.Since(0, allowAll)
+	assert.False(t, res.FlushRequired)
+	assert.Empty(t, res.Entries)
+	assert.EqualValues(t, 0, res.MaxSeq)
+}
+
+func TestPurgeStore_ScopingByHost(t *testing.T) {
+	s := NewPurgeStore(0)
+	_, _ = s.Add(purgeScopeHost, "a.com", "")
+	_, _ = s.Add(purgeScopeHost, "b.com", "")
+	_, _ = s.Add(purgeScopeFlushAll, "", "")
+
+	// An edge allowed only a.com sees its host entry + the flush-all, not b.com.
+	allowA := func(h string) bool { return h == "a.com" }
+	res := s.Since(0, allowA)
+	require.Len(t, res.Entries, 2)
+	scopes := map[string]string{}
+	for _, e := range res.Entries {
+		scopes[e.Scope] = e.Host
+	}
+	assert.Equal(t, "a.com", scopes[purgeScopeHost])
+	_, hasFlush := scopes[purgeScopeFlushAll]
+	assert.True(t, hasFlush, "flush-all reaches every edge regardless of host scope")
+}
+
+func TestPurgeStore_FlushAllAlwaysDeliveredEvenToDenyAll(t *testing.T) {
+	s := NewPurgeStore(0)
+	_, _ = s.Add(purgeScopeHost, "a.com", "")
+	_, _ = s.Add(purgeScopeFlushAll, "", "")
+	res := s.Since(0, allowNone)
+	require.Len(t, res.Entries, 1)
+	assert.Equal(t, purgeScopeFlushAll, res.Entries[0].Scope)
+}
+
+func TestPurgeStore_GapTriggersFlushRequired(t *testing.T) {
+	s := NewPurgeStore(2) // retain only the 2 newest
+	for i := 0; i < 5; i++ {
+		_, ok := s.Add(purgeScopeURL, "a.com", "/x")
+		require.True(t, ok)
+	}
+	// Retained seqs are {4,5}; minSeq=4. An edge at cursor 1 needs seq 2 (trimmed) → gap.
+	res := s.Since(1, allowAll)
+	assert.True(t, res.FlushRequired)
+	assert.EqualValues(t, 5, res.MaxSeq)
+	assert.Empty(t, res.Entries)
+
+	// An edge at cursor 4 is within the window → incremental, no flush.
+	res = s.Since(4, allowAll)
+	assert.False(t, res.FlushRequired)
+	require.Len(t, res.Entries, 1)
+	assert.EqualValues(t, 5, res.Entries[0].Seq)
+}
+
+func TestPurgeStore_CursorAheadOfJournalFlushes(t *testing.T) {
+	// Simulates a CP restart / fresh replica: the in-memory journal seq is low (or
+	// zero) while an edge polls with a cursor it persisted against the older journal.
+	// Without the cursor-ahead check, post-reset seqs (1,2,3…) would be <= the edge
+	// cursor and silently dropped — an under-invalidation. The CP must flush instead.
+	s := NewPurgeStore(0)
+	res := s.Since(500, allowAll)
+	assert.True(t, res.FlushRequired, "cursor ahead of an empty journal must flush")
+	assert.EqualValues(t, 0, res.MaxSeq)
+
+	// After the restart the CP issues a few purges; the edge cursor is still ahead.
+	for i := 0; i < 3; i++ {
+		_, _ = s.Add(purgeScopeURL, "a.com", "/x")
+	}
+	res = s.Since(500, allowAll)
+	assert.True(t, res.FlushRequired, "cursor still ahead of lastSeq=3 must flush")
+	assert.EqualValues(t, 3, res.MaxSeq)
+
+	// Once the edge has realigned (cursor <= lastSeq), it polls incrementally again.
+	res = s.Since(2, allowAll)
+	assert.False(t, res.FlushRequired)
+	require.Len(t, res.Entries, 1)
+	assert.EqualValues(t, 3, res.Entries[0].Seq)
+}
+
+func TestPurgeStore_MaxUint64SinceFlushesNotPanics(t *testing.T) {
+	s := NewPurgeStore(0)
+	_, _ = s.Add(purgeScopeURL, "a.com", "/x")
+	res := s.Since(^uint64(0), allowAll) // would overflow since+1; cursor-ahead catches it first
+	assert.True(t, res.FlushRequired)
+}
+
+func TestPurgeStore_InvalidInputsRejected(t *testing.T) {
+	s := NewPurgeStore(0)
+	cases := []struct{ scope, host, uri string }{
+		{"bogus", "a.com", "/x"},
+		{purgeScopeHost, "", ""},     // host scope needs a host
+		{purgeScopeURL, "a.com", ""}, // url scope needs a uri
+		{purgeScopeURL, "", "/x"},    // url scope needs a host
+	}
+	for _, c := range cases {
+		_, ok := s.Add(c.scope, c.host, c.uri)
+		assert.False(t, ok, "scope=%q host=%q uri=%q should be rejected", c.scope, c.host, c.uri)
+	}
+	// Nothing was journaled.
+	assert.EqualValues(t, 0, s.Since(0, allowAll).MaxSeq)
+}
+
+func TestPurgeStore_HostNormalized(t *testing.T) {
+	s := NewPurgeStore(0)
+	_, ok := s.Add(purgeScopeHost, "  ACME.com:443 ", "")
+	require.True(t, ok)
+	res := s.Since(0, allowAll)
+	require.Len(t, res.Entries, 1)
+	assert.Equal(t, "acme.com", res.Entries[0].Host, "host lowercased, port-stripped, trimmed")
+}

--- a/edgecp/server.go
+++ b/edgecp/server.go
@@ -1,8 +1,11 @@
 package edgecp
 
 import (
+	"crypto/subtle"
 	"encoding/json"
+	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -17,6 +20,12 @@ type Server struct {
 	certs *CertStore
 	authz *Authz
 	waf   *WafStore // optional (nil = WAF distribution disabled, /v1/waf → 404)
+
+	// purge is the optional cache-purge journal (nil = purge distribution disabled,
+	// /v1/purges → 404). purgeAdminToken gates POST /v1/purges — a STRONGER credential
+	// than the per-edge read tokens (an edge can read its purges but not issue them).
+	purge           *PurgeStore
+	purgeAdminToken string
 
 	// signerState is the (signer, generation) snapshot, replaced WHOLESALE by
 	// SetSigner so a reader Loads both halves coherently (never a torn signer-from-A
@@ -97,6 +106,16 @@ func (s *Server) WithWAF(waf *WafStore) *Server {
 	return s
 }
 
+// WithPurge enables cache-purge distribution: GET /v1/purges (per-edge bearer,
+// scoped) and POST /v1/purges (gated by adminToken). An empty adminToken leaves
+// POST locked out (every issue attempt 401s) — read distribution still works.
+// Returns the server for chaining.
+func (s *Server) WithPurge(store *PurgeStore, adminToken string) *Server {
+	s.purge = store
+	s.purgeAdminToken = adminToken
+	return s
+}
+
 // WithSigner enables data-plane client-cert issuance and trust distribution at the
 // given trust-bundle generation. Returns the server for chaining.
 func (s *Server) WithSigner(sg *Signer, generation uint64) *Server {
@@ -161,6 +180,8 @@ func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /v1/certs", s.handleCert)
 	mux.HandleFunc("GET /v1/waf", s.handleWAF)
+	mux.HandleFunc("GET /v1/purges", s.handlePurges)
+	mux.HandleFunc("POST /v1/purges", s.handlePurgeAdmin)
 	mux.HandleFunc("POST /v1/edge-cert", s.handleEdgeCert)
 	mux.HandleFunc("GET /v1/trust-bundle", s.handleTrustBundle)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
@@ -299,6 +320,67 @@ func (s *Server) handleWAF(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = w.Write(body)
+}
+
+// handlePurges serves the cache-purge entries an edge hasn't applied yet
+// (GET /v1/purges?since=<cursor>), scoped to the edge's allowed hosts and
+// authorized by the per-edge bearer token. flush-all entries reach every edge;
+// host/url entries only the edges that may serve that host.
+func (s *Server) handlePurges(w http.ResponseWriter, r *http.Request) {
+	token, ok := bearer(r)
+	if !ok || !s.authz.Known(token) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if s.purge == nil {
+		http.Error(w, "purge distribution disabled", http.StatusNotFound)
+		return
+	}
+	var since uint64
+	if v := r.URL.Query().Get("since"); v != "" {
+		n, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			http.Error(w, "invalid since parameter", http.StatusBadRequest)
+			return
+		}
+		since = n
+	}
+	res := s.purge.Since(since, func(host string) bool { return s.authz.Allowed(token, host) })
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(res)
+}
+
+// handlePurgeAdmin issues a cache purge (POST /v1/purges), gated by the purge admin
+// token — a STRONGER credential than the per-edge read tokens. The body is
+// {scope, host?, uri?}; scope is flush-all / host / url.
+func (s *Server) handlePurgeAdmin(w http.ResponseWriter, r *http.Request) {
+	if s.purge == nil {
+		http.Error(w, "purge distribution disabled", http.StatusNotFound)
+		return
+	}
+	// Constant-time compare against the admin token; an empty configured token locks
+	// POST out entirely (no token can ever match).
+	tok, ok := bearer(r)
+	if !ok || s.purgeAdminToken == "" || subtle.ConstantTimeCompare([]byte(tok), []byte(s.purgeAdminToken)) != 1 {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	var body struct {
+		Scope string `json:"scope"`
+		Host  string `json:"host"`
+		URI   string `json:"uri"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 64<<10)).Decode(&body); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	seq, ok := s.purge.Add(body.Scope, body.Host, body.URI)
+	if !ok {
+		http.Error(w, "invalid scope/host/uri (scope must be flush-all|host|url; host required for host/url; uri required for url)", http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]uint64{"seq": seq})
 }
 
 // bearer extracts the token from an "Authorization: Bearer <token>" header.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/profiler v0.6.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.32.0
 	github.com/acoshift/configfile v1.9.0
-	github.com/moonrhythm/parapet v0.16.1-0.20260601131239-6c3d8c3c542f
+	github.com/moonrhythm/parapet v0.17.0
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moonrhythm/parapet v0.16.1-0.20260601131239-6c3d8c3c542f h1:6h8hEl8YKVCB6zGpvgXeu2XrnWOZLfL0xCJrbT9NKCI=
-github.com/moonrhythm/parapet v0.16.1-0.20260601131239-6c3d8c3c542f/go.mod h1:mfLCzU9zBm6vn05mnOgO0G8/+pArndciyLv3BYM9HJA=
+github.com/moonrhythm/parapet v0.17.0 h1:DjPwYVuFR5KNX17kU9I7um5+WAO+fE6Uu+/Vfj+Lwro=
+github.com/moonrhythm/parapet v0.17.0/go.mod h1:mfLCzU9zBm6vn05mnOgO0G8/+pArndciyLv3BYM9HJA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=


### PR DESCRIPTION
## What

Implements **edge cache purge / invalidation** (EDGE.md Phase 5) — the one piece that made the edge response cache operationally incomplete: until now, a stale or poisoned cache entry could only be cleared by waiting out the TTL or restarting the edge.

Invalidation is **pulled from the control plane**, exactly like cert/WAF distribution: an operator publishes a purge once at the CP, and every sharded edge converges on its own timer. No inbound port on the edge. Three scopes: **exact-URL** (covers all methods, both schemes, every `Vary` variant), **whole-host**, and **flush-all**.

Depends on **parapet v0.17.0** (`go.mod` bumped here), which adds the `cache.Options.InvalidatedAfter` lookup-gate hook (moonrhythm/parapet#183).

## How it works

- **Lookup gate** — `PurgeTable.InvalidatedAfter(r, Meta)` returns `max(global, host[h], url[hash(h⊕uri)])`; the cache reaps + misses any hit with `Meta.Created <= epoch`, exactly like a passed `FreshUntil`. Host normalization mirrors `cache.primaryHash` so keys match. O(1) issue cost; one `RLock` + ≤3 map reads on the hot path, and only on hits.
- **Edge-clock epochs** — the edge stamps its own wall clock at apply (no trusted CP timestamp), clamped monotonic non-decreasing so an NTP step-back can't un-purge. Idempotency comes from the journal cursor.
- **Distribution** — CP keeps a bounded append-only journal; the edge polls `GET /v1/purges?since=<cursor>` (default 10s), fail-static. Issuing is `POST /v1/purges` gated by `CP_PURGE_ADMIN_TOKEN` (a stronger credential than the per-edge read tokens; constant-time compared). The CP scopes each edge's response by its token.
- **Bounded without a reaper** — the parapet `Storage` interface has no enumeration, so there's no background reaper; the in-memory table is bounded by a count-cap fold into the global epoch (over-invalidates, never under-), and disk by the cache's LRU byte cap. Purge state persists alongside the disk cache via one atomic temp+fsync+rename (maps + cursor can't desync).

## Commits

1. `chore(deps)`: bump parapet to v0.17.0 (the `InvalidatedAfter` hook)
2. `feat(edge)`: Phase 1 — the `PurgeTable` invalidation table
3. `feat(edge)`: Phases 2-4 — distribution, endpoints, wiring, docs (+ review fixes)

## Review

Ran an 8-dimension adversarial review (52 agents, two independent verifier lenses per finding) before opening this. It caught a **real high-severity correctness bug**, now fixed with tests:

> **CP journal seq reset silently under-invalidated.** The CP journal is in-memory, so a CP **restart or fresh replica** reset `lastSeq` to 0 while disk-backed edges kept a higher persisted cursor. `flush_required` could never fire (`since+1 < minSeq` is unreachable when `minSeq=1`), so post-reset purges (seq 1,2,3…) were `<= cursor` and silently skipped — an **indefinite under-invalidation** breaking the documented "never under-invalidates" invariant.

Fixed with three coordinated changes (the naive fix would wedge the edge into flushing every poll): CP flushes on `since > lastSeq`; edge `FlushAll` realigns the cursor **down** to `max_seq` (safe — everything was just invalidated); edge `max_seq < cursor` defense-in-depth for an un-upgraded CP during independent rollout. The review also drove a persist-on-change perf fix and corrections to a pre-existing EDGE.md wire-contract table.

## Tests

39 purge-specific tests across `edge/` and `edgecp/` (table scopes, monotonic clamp, idempotency, gap→flush, **cursor-ahead-of-journal reset**, persistence round-trip + corrupt/missing reset, CP journal scoping, endpoint auth + admin-token lockout). `gofmt`/`go vet` clean, full repo builds, `go test -race ./...` passes.

## Config

Edge: `EDGE_CACHE_PURGE_ENABLED` (default true), `EDGE_CACHE_PURGE_POLL_INTERVAL` (10s), `EDGE_CACHE_PURGE_MAX_RECORDS` (65536).
CP: `CP_PURGE_ENABLED`, `CP_PURGE_ADMIN_TOKEN` (required to enable), `CP_PURGE_MAX_ENTRIES` (4096).

Edge-only — no controller mirror, no conformance obligation, pure-Go (no Rust counterpart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)