### PR TITLE
feat(edge): cache-purge reaper — proactive reclamation of invalidated entries

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -403,11 +403,14 @@ EDGE_CACHE_PURGE_POLL_INTERVAL   poll GET /v1/purges (default 10s; lower than th
                                  cert/WAF refresh — invalidation latency matters more)
 EDGE_CACHE_PURGE_MAX_RECORDS     per-map cap before a conservative fold-to-global
                                  (default 65536)
+EDGE_CACHE_PURGE_SWEEP_INTERVAL  reaper cadence: physically reclaim invalidated
+                                 entries off the serving path (default 300s)
 ```
 
-The purge feature is **implemented** (see "Purge / invalidation" below). There is
-no background reaper — the in-memory table is bounded by the count-cap fold above,
-and disk by the cache's LRU byte cap.
+The purge feature is **implemented** (see "Purge / invalidation" below). A
+background reaper (`EDGE_CACHE_PURGE_SWEEP_INTERVAL`) physically reclaims
+invalidated entries off the serving path; the in-memory record table is bounded by
+the count-cap fold, and disk by the cache's LRU byte cap.
 
 A fetch/IO error on the read path **fails static** (degrades to a cache miss →
 serve from origin), never erroring the client request. **Not yet:**
@@ -418,14 +421,12 @@ connection/byte/runtime metrics).
 
 ### Purge / invalidation
 
-> **Status: implemented** (edge `edge/purge.go` + `edge/purgerefresh.go`; control
-> plane `edgecp/purgestore.go` + `GET`/`POST /v1/purges`). The lookup gate is the
-> `parapet/pkg/cache` `Options.InvalidatedAfter` hook (added in **parapet
-> v0.17.0**), so this is a pure-Go feature with no Rust counterpart. One
-> deliberate deviation from the original sketch below: there is **no background
-> reaper** (the `Storage` interface exposes no enumeration), so eager disk reclaim
-> is left to the LRU byte cap and the in-memory table is bounded by a count-cap
-> fold instead — see "Bounding the table" below.
+> **Status: implemented** (edge `edge/purge.go` + `edge/purgerefresh.go` +
+> `edge/purgereaper.go`; control plane `edgecp/purgestore.go` + `GET`/`POST
+> /v1/purges`). The lookup gate is the `parapet/pkg/cache`
+> `Options.InvalidatedAfter` hook (parapet **v0.17.0**); the reaper uses
+> `Storage.Range` + the raw host/uri in `Meta` (parapet **v0.17.1**). Pure-Go
+> feature, no Rust counterpart.
 
 Invalidation is **pulled from the control plane**, exactly like cert and WAF
 distribution: an operator publishes a purge once at the control plane and every
@@ -485,17 +486,33 @@ Epochs are clamped **monotonic non-decreasing** (a new stamp is `>= highWater`, 
 largest epoch ever stamped, reloaded from disk on restart) so an NTP step back
 can't un-purge.
 
-**Bounding the table (no reaper).** The parapet `Storage` interface has no scan
-method, so there is no background reaper to physically delete invalidated files or
-retire records; correctness comes from the lazy gate and disk is bounded by the
-cache's LRU byte cap. The in-memory `host`/`url` maps are bounded by a **count-cap
-fold**: when a map exceeds `EDGE_CACHE_PURGE_MAX_RECORDS` it is folded into the
-`global` epoch (which `≥` every record it held) and cleared — this
-**over-invalidates (a coarser flush) but never under-invalidates**, and keeps
-memory finite. Because purges are operator-issued (not per request), the fold is
-essentially never hit in practice. (`PurgeTable.Sweep` can additionally retire
-records older than a retention window, but only when paired with a freshness cap —
-it is not auto-wired today.)
+**Reaping (entries).** The lazy gate alone reaps an entry only when it is next
+looked up, so after a broad purge with little traffic the dead bytes would linger
+until LRU pressure evicts them. A **background reaper** (`ReapOnce` / `RunReaper`,
+`EDGE_CACHE_PURGE_SWEEP_INTERVAL`, default 300s, jittered) closes that: it
+`Storage.Range`s over the cache and `Delete`s every entry whose `Meta.Created <=
+epochFor(Meta.Host, Meta.URI)` — using the raw host/uri parapet v0.17.1 stamps into
+`Meta` so all three scopes match off the serving path (an old entry with an empty
+`Host` matches the global scope only). Correctness never depends on the reaper —
+the gate already guarantees a purged entry is never served — so it deletes only in
+the **safe direction**: over-deleting a still-valid entry (e.g. a `Created` stamped
+low by a wall-clock step) merely costs a re-fetch, never a stale serve.
+
+**The reaper deliberately does NOT retire records.** Dropping a record is the one
+*under-invalidating* direction, and it can't be made safe against a backward
+wall-clock step: both `Meta.Created` (stamped by parapet at fill-commit) and any
+sweep marker are unclamped wall clocks, so a fill that commits with a regressed
+`Created` after the sweep walk could match a record the sweep then retired —
+leaving a purged entry servable. Since retirement is only an optimization over an
+already-safe bound, the table is bounded purely by the **count-cap fold** instead.
+
+The **count-cap fold** bounds the `host`/`url` maps unconditionally and safely: if
+a map exceeds `EDGE_CACHE_PURGE_MAX_RECORDS` it is folded into the `global` epoch
+(which `≥` every record it held, via the `highWater` monotonic clamp) and cleared —
+**over-invalidates (a coarser flush) but never under-invalidates**. Because purges
+are operator-issued (not per request), the maps stay small and the fold is
+essentially never hit in practice. Disk is additionally bounded by the cache's LRU
+byte cap regardless.
 
 **Distribution loop.** The control plane keeps a bounded append-only journal
 (`{seq, scope, host?, uri?}`, monotonic `seq`, `min_seq` = oldest retained,
@@ -638,8 +655,9 @@ needed. (The Rust **controller** implementation stays in `rust/`; only the Rust
 5. **Cache purge / invalidation** — CP purge journal + `GET`/`POST /v1/purges`,
    edge poll loop with a persisted cursor, lazy epoch invalidation (global / host /
    url) checked at lookup via the `parapet/pkg/cache` `InvalidatedAfter` hook.
-   In-memory table bounded by a count-cap fold; no background reaper (disk reclaim
-   left to the LRU byte cap). Scopes: exact-URL (all variants), whole-host,
+   A background reaper (`Storage.Range`) physically reclaims invalidated entries
+   off the serving path; the count-cap fold + LRU byte cap bound the rest. Scopes:
+   exact-URL (all variants), whole-host,
    flush-all. **(done)** See [Purge / invalidation](#purge--invalidation).
    Edge-only. Path-prefix and Cache-Tag purge are deferred (prefix needs a scan;
    tags must be recorded at admit time) — the epoch table extends to both later.

--- a/SPEC.md
+++ b/SPEC.md
@@ -165,12 +165,14 @@ invariants:
   `parapet/pkg/cache` `InvalidatedAfter` hook (parapet ≥ v0.17.0). Epochs use the
   **edge's own clock** at apply time (no trusted CP timestamp; the cursor makes
   apply idempotent, monotonic-clamped against an NTP step-back). Scopes: exact-URL
-  (all variants), whole-host, flush-all. The in-memory table is bounded by a
-  count-cap fold into the global epoch (over-invalidates, never under-); there is
-  no background reaper (the `Storage` interface has no enumeration), so disk reclaim
-  is left to the LRU byte cap. Issuing a purge needs `CP_PURGE_ADMIN_TOKEN` (a
-  stronger credential than the per-edge read tokens). Edge-only — no controller
-  mirror, no conformance obligation, **pure-Go (no Rust counterpart)**. See
+  (all variants), whole-host, flush-all. A background reaper
+  (`EDGE_CACHE_PURGE_SWEEP_INTERVAL`) physically reclaims invalidated entries off
+  the serving path, using `Storage.Range` + the raw host/uri in `Meta` (parapet ≥
+  v0.17.1); the in-memory record table is bounded by a count-cap fold into the
+  global epoch (over-invalidates, never under-), and disk by the cache's LRU byte
+  cap. Issuing a purge needs `CP_PURGE_ADMIN_TOKEN` (a stronger
+  credential than the per-edge read tokens). Edge-only — no controller mirror, no
+  conformance obligation, **pure-Go (no Rust counterpart)**. See
   [EDGE.md](EDGE.md#purge--invalidation).
 
 ## Configuration (environment variables)

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -198,6 +198,7 @@ func main() {
 	// memory (EDGE_CACHE_BACKEND=memory; bodies in RAM, lost on restart).
 	var respCache *cache.Cache
 	var purgeTable *edge.PurgeTable
+	var purgeStorage cache.Storage // the live backend, for the reaper's Range sweep
 	if envOr("EDGE_CACHE_ENABLED", "false") == "true" {
 		maxSize := envInt64("EDGE_CACHE_MAX_SIZE", 1<<30)
 		maxFile := envInt64("EDGE_CACHE_MAX_FILE_SIZE", 8<<20)
@@ -230,17 +231,23 @@ func main() {
 					slog.Warn("edge cache: purge state load failed; starting from a clean table", "error", err)
 				}
 				purgeTable = pt
+				purgeStorage = storage
 				opts.InvalidatedAfter = purgeTable.InvalidatedAfter
 			}
 			respCache = cache.New(storage, opts)
 		}
 	}
-	// Start the purge poll loop once (initial poll + ticker) when the table is live.
+	// Start the purge poll loop + reaper once when the table is live.
 	if purgeTable != nil {
 		purgeInterval := time.Duration(envInt64("EDGE_CACHE_PURGE_POLL_INTERVAL", 10)) * time.Second
 		edge.RefreshPurgeOnce(cp, purgeTable) // best-effort initial sync; fail-static
 		go edge.RunPurgeRefresh(ctx, cp, purgeTable, purgeInterval)
-		slog.Info("edge cache: purge polling enabled", "poll_interval", purgeInterval)
+		// The reaper physically reclaims invalidated entries off the serving path (the
+		// lazy lookup gate already guarantees correctness; this is just reclamation).
+		// Housekeeping cadence, jittered.
+		sweepInterval := time.Duration(envInt64("EDGE_CACHE_PURGE_SWEEP_INTERVAL", 300)) * time.Second
+		go edge.RunReaper(ctx, purgeStorage, purgeTable, sweepInterval)
+		slog.Info("edge cache: purge polling enabled", "poll_interval", purgeInterval, "sweep_interval", sweepInterval)
 	}
 
 	var getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error)

--- a/deploy/edge/edge.yaml
+++ b/deploy/edge/edge.yaml
@@ -114,15 +114,18 @@ spec:
             #   value: "8388608"
             # Cache purge / invalidation (on by default with the cache). The edge
             # polls the control plane's GET /v1/purges and reaps invalidated entries
-            # lazily at lookup. Needs CP_PURGE_ENABLED on the control plane; if the
-            # CP isn't distributing purges the edge fail-statics (a 404 is a quiet
-            # no-op). Disk backend persists the purge cursor under EDGE_CACHE_DIR.
+            # lazily at lookup, plus a background reaper (EDGE_CACHE_PURGE_SWEEP_INTERVAL)
+            # that reclaims them proactively. Needs CP_PURGE_ENABLED on the control
+            # plane; if the CP isn't distributing purges the edge fail-statics (a 404
+            # is a quiet no-op). Disk backend persists the purge cursor under EDGE_CACHE_DIR.
             # - name: EDGE_CACHE_PURGE_ENABLED       # "true" (default) | "false"
             #   value: "true"
             # - name: EDGE_CACHE_PURGE_POLL_INTERVAL # seconds between polls (default 10)
             #   value: "10"
             # - name: EDGE_CACHE_PURGE_MAX_RECORDS   # per-map cap before a conservative fold (default 65536)
             #   value: "65536"
+            # - name: EDGE_CACHE_PURGE_SWEEP_INTERVAL # reaper cadence: reclaim invalidated entries off the serving path (default 300s)
+            #   value: "300"
             # Prometheus metrics endpoint (connections / bytes / Go runtime). Set
             # "" to disable.
             - name: EDGE_METRICS_LISTEN

--- a/edge/metrics.go
+++ b/edge/metrics.go
@@ -132,11 +132,34 @@ var (
 		Name:      "edge_cache_purge_folds_total",
 		Help:      "Cumulative conservative cap-folds of the cache-purge table into the global epoch.",
 	}, []string{"edge_id"})
+
+	// edgePurgeReapSweeps counts completed reaper sweeps (each physically reclaims
+	// invalidated entries off the serving path).
+	edgePurgeReapSweeps = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_cache_purge_reap_sweeps_total",
+		Help:      "Completed cache-purge reaper sweeps.",
+	}, []string{"edge_id"})
+
+	// edgePurgeReapEntries counts entries the reaper physically deleted (cumulative).
+	edgePurgeReapEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_cache_purge_reap_entries_total",
+		Help:      "Cache entries physically reclaimed by the reaper (cumulative).",
+	}, []string{"edge_id"})
 )
 
 func init() {
 	prom.Registry().MustRegister(edgeClientCertCAID, edgeClientCertNotAfter, edgeClientCertLoaded, edgeRemint, edgeCPTargetCAID, edgeRefresh, edgeClientCertSignerFP, edgeCPActiveSignerFP, edgeOnDemand,
-		edgePurgePoll, edgePurgeEntries, edgePurgeCursor, edgePurgeRecords, edgePurgeFolds)
+		edgePurgePoll, edgePurgeEntries, edgePurgeCursor, edgePurgeRecords, edgePurgeFolds, edgePurgeReapSweeps, edgePurgeReapEntries)
+}
+
+// purgeReap records one completed reaper sweep and the entries it reclaimed.
+func purgeReap(reaped int) {
+	edgePurgeReapSweeps.WithLabelValues(edgeID).Inc()
+	if reaped > 0 {
+		edgePurgeReapEntries.WithLabelValues(edgeID).Add(float64(reaped))
+	}
 }
 
 // purgePoll counts one purge poll by result.

--- a/edge/purge.go
+++ b/edge/purge.go
@@ -123,9 +123,23 @@ func (t *PurgeTable) now() int64 {
 // is <= this value as stale. Host normalization mirrors cache.primaryHash
 // (lowercase + strip port) so the keys line up exactly. The stored Meta is unused.
 func (t *PurgeTable) InvalidatedAfter(r *http.Request, _ cache.Meta) int64 {
-	host := normHost(r.Host)
-	uk := urlKey(host, r.URL.RequestURI())
+	return t.epochFor(normHost(r.Host), r.URL.RequestURI())
+}
 
+// InvalidatedAfterMeta is the reaper's variant of InvalidatedAfter: it reads the
+// (already-normalized) host + uri from a stored entry's Meta instead of a live
+// request, so a sweep can match entries off the serving path. normHost is
+// idempotent on Meta.Host (the cache stamps it normalized); an old entry with an
+// empty Host matches only the global scope.
+func (t *PurgeTable) InvalidatedAfterMeta(m cache.Meta) int64 {
+	return t.epochFor(normHost(m.Host), m.URI)
+}
+
+// epochFor returns the invalidation epoch (unix nanos) applying to a normalized
+// host + uri: the max of the global, per-host, and per-url epochs. Shared by the
+// lookup hook and the reaper.
+func (t *PurgeTable) epochFor(host, uri string) int64 {
+	uk := urlKey(host, uri)
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	e := t.global
@@ -240,34 +254,6 @@ func (t *PurgeTable) enforceCapLocked() {
 	if folded {
 		t.global = t.highWater // highWater >= every epoch stamped, so it covers the dropped records
 		t.folds++
-	}
-}
-
-// Sweep drops host/url records older than retain, reclaiming memory for purges
-// whose effect is already covered by ordinary TTL expiry.
-//
-// SAFETY: this is sound only when retain >= the maximum freshness lifetime the
-// edge will cache (the EDGE_CACHE_MAX_TTL cap). A record at epoch T only stops
-// mattering once every entry created <= T is unservable; with the lazy gate (no
-// background reaper) the guarantee that "nothing created <= T is still fresh"
-// comes from TTL alone, i.e. after retain >= maxFreshness has elapsed. Calling it
-// with a shorter retain can drop a record while a long-max-age entry created
-// before it is still fresh, re-serving stale content. The count-cap fold
-// (enforceCapLocked) is the unconditional memory bound; Sweep is an optional
-// optimization gated on that TTL cap.
-func (t *PurgeTable) Sweep(retain time.Duration) {
-	cutoff := t.now() - retain.Nanoseconds()
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	for k, v := range t.url {
-		if v < cutoff {
-			delete(t.url, k)
-		}
-	}
-	for k, v := range t.host {
-		if v < cutoff {
-			delete(t.host, k)
-		}
 	}
 }
 

--- a/edge/purge_test.go
+++ b/edge/purge_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/moonrhythm/parapet/pkg/cache"
 	"github.com/stretchr/testify/assert"
@@ -148,21 +147,27 @@ func TestPurge_CapFoldBoundsMemory(t *testing.T) {
 	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://a.com/2"))
 }
 
+func TestPurge_InvalidatedAfterMetaMatchesRequest(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 0)
+	fixedClock(tbl, 4000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeURL, Host: "acme.com", URI: "/p?x=1"}}, 1))
+
+	// The reaper's Meta-based lookup must agree with the request-based hook for the
+	// same host+uri (Meta.Host is already normalized; normHost is idempotent).
+	m := cache.Meta{Host: "acme.com", URI: "/p?x=1"}
+	assert.EqualValues(t, 4000, tbl.InvalidatedAfterMeta(m))
+	assert.Equal(t, epochFor(tbl, "GET", "http://acme.com/p?x=1"), tbl.InvalidatedAfterMeta(m))
+	// A different uri doesn't match.
+	assert.EqualValues(t, 0, tbl.InvalidatedAfterMeta(cache.Meta{Host: "acme.com", URI: "/p?x=2"}))
+	// An empty-Host (old) entry matches only the global scope.
+	assert.EqualValues(t, 0, tbl.InvalidatedAfterMeta(cache.Meta{Host: "", URI: "/p?x=1"}))
+}
+
 func TestPurge_FlushAllRealignsCursorDown(t *testing.T) {
 	tbl, _ := NewPurgeTable("", 0)
 	require.NoError(t, tbl.Apply(nil, 500)) // cursor 500 (persisted against an old journal)
 	require.NoError(t, tbl.FlushAll(3))     // journal reset: realign the cursor DOWN to maxSeq
 	assert.EqualValues(t, 3, tbl.Cursor(), "a reset flush realigns the cursor down so it can't re-flush forever")
-}
-
-func TestPurge_SweepDropsOldRecords(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 0)
-	fixedClock(tbl, 1_000_000)
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeURL, Host: "a.com", URI: "/old"}}, 1))
-	// Advance the clock well past the record, then sweep with a short retention.
-	fixedClock(tbl, 1_000_000+int64(time.Hour))
-	tbl.Sweep(time.Minute)
-	assert.Zero(t, tbl.Stats().URLRecs, "record older than retention swept")
 }
 
 func TestPurge_PersistenceRoundTrip(t *testing.T) {

--- a/edge/purgereaper.go
+++ b/edge/purgereaper.go
@@ -1,0 +1,64 @@
+package edge
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/moonrhythm/parapet/pkg/cache"
+)
+
+// ReapOnce sweeps the cache storage once, PHYSICALLY deleting every entry the
+// purge table has invalidated (Meta.Created <= the entry's invalidation epoch).
+//
+// It complements the lazy lookup gate (PurgeTable.InvalidatedAfter): the gate
+// reaps an entry only when it is next looked up, so after a broad purge with
+// little subsequent traffic the now-dead bytes would linger until LRU pressure
+// evicts them. The reaper reclaims them proactively. Correctness never depends on
+// it — the gate already guarantees a purged entry is never served — it is purely
+// reclamation, and over-deleting a still-valid entry (e.g. a Created stamped low
+// by a wall-clock step) only costs a re-fetch, never a stale serve.
+//
+// The reaper deliberately does NOT retire purge records: that is the one
+// under-invalidating direction, and it cannot be made safe against a backward
+// wall-clock step between a purge and a later fill's commit (both Meta.Created and
+// the sweep marker are unclamped wall clocks). The in-memory table is instead
+// bounded by the monotonic, over-invalidating count-cap fold (enforceCapLocked) —
+// see PurgeTable. Purges are operator-issued, so the maps stay small regardless.
+func ReapOnce(storage cache.Storage, table *PurgeTable) {
+	var reaped int
+	storage.Range(func(key string, m cache.Meta) bool {
+		if m.Created <= table.InvalidatedAfterMeta(m) {
+			storage.Delete(key)
+			reaped++
+		}
+		return true
+	})
+	if reaped > 0 {
+		slog.Info("edge: cache reaper swept invalidated entries", "reaped", reaped)
+	}
+	purgeReap(reaped)
+	setPurgeMetrics(table.Stats())
+}
+
+// RunReaper runs the periodic cache reaper forever. The first tick is jittered by
+// [0,interval] to decorrelate the fleet. The cadence (EDGE_CACHE_PURGE_SWEEP_INTERVAL)
+// is independent of the purge poll — it is housekeeping, not latency-sensitive.
+func RunReaper(ctx context.Context, storage cache.Storage, table *PurgeTable, interval time.Duration) {
+	if interval <= 0 { // time.NewTicker panics on a non-positive interval
+		interval = 300 * time.Second
+	}
+	if !sleepCtx(ctx, fullJitter(interval)) {
+		return
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			ReapOnce(storage, table)
+		}
+	}
+}

--- a/edge/purgereaper_test.go
+++ b/edge/purgereaper_test.go
@@ -1,0 +1,80 @@
+package edge
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moonrhythm/parapet/pkg/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// putEntry seeds one entry into a cache.Storage with a known Meta (for reaper tests).
+func putEntry(t *testing.T, s cache.Storage, key string, m cache.Meta, body []byte) {
+	t.Helper()
+	m.Size = int64(len(body))
+	w, err := s.Writer(key)
+	require.NoError(t, err)
+	_, err = w.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, w.Commit(m))
+}
+
+func storageLen(s cache.Storage) int {
+	n := 0
+	s.Range(func(string, cache.Meta) bool { n++; return true })
+	return n
+}
+
+func TestReapOnce_DeletesInvalidatedKeepsOthers(t *testing.T) {
+	s := cache.NewMemory(1 << 20)
+	fresh := time.Now().Add(time.Hour).UnixNano()
+	putEntry(t, s, "aa01", cache.Meta{PrimaryHex: "aa01", Host: "acme.com", URI: "/a", Created: 100, FreshUntil: fresh}, []byte("x"))
+	putEntry(t, s, "bb02", cache.Meta{PrimaryHex: "bb02", Host: "other.com", URI: "/b", Created: 100, FreshUntil: fresh}, []byte("y"))
+	putEntry(t, s, "cc03", cache.Meta{PrimaryHex: "cc03", Host: "acme.com", URI: "/c", Created: 250, FreshUntil: fresh}, []byte("z")) // created AFTER the purge
+
+	tbl, _ := NewPurgeTable("", 0)
+	fixedClock(tbl, 200)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeHost, Host: "acme.com"}}, 1)) // host epoch 200
+
+	fixedClock(tbl, 300)
+	ReapOnce(s, tbl)
+
+	_, _, okA := s.Get("aa01")
+	assert.False(t, okA, "acme.com /a (created 100 <= 200) reaped")
+	_, _, okB := s.Get("bb02")
+	assert.True(t, okB, "other.com untouched (different host)")
+	_, _, okC := s.Get("cc03")
+	assert.True(t, okC, "acme.com /c (created 250 > 200) survives — not over-reaped")
+
+	// The reaper does NOT retire records (that direction is unsafe under a clock
+	// step); the host record stays and keeps gating future entries.
+	assert.EqualValues(t, 1, tbl.Stats().HostRecs, "record kept (retirement intentionally not done)")
+}
+
+func TestReapOnce_GlobalReapsAllIncludingEmptyHost(t *testing.T) {
+	s := cache.NewMemory(1 << 20)
+	fresh := time.Now().Add(time.Hour).UnixNano()
+	putEntry(t, s, "aa01", cache.Meta{PrimaryHex: "aa01", Host: "", URI: "/old", Created: 100, FreshUntil: fresh}, []byte("x")) // pre-v0.17.1 entry, no Host
+	putEntry(t, s, "bb02", cache.Meta{PrimaryHex: "bb02", Host: "a.com", URI: "/y", Created: 100, FreshUntil: fresh}, []byte("y"))
+
+	tbl, _ := NewPurgeTable("", 0)
+	fixedClock(tbl, 200)
+	require.NoError(t, tbl.FlushAll(1)) // global epoch 200
+
+	fixedClock(tbl, 300)
+	ReapOnce(s, tbl)
+
+	assert.Zero(t, storageLen(s), "flush-all reaps every entry, even one with an empty Host")
+	assert.Positive(t, epochFor(tbl, "GET", "http://anything.com/"), "global epoch kept (no retirement)")
+}
+
+func TestReapOnce_NoPurgesIsNoOp(t *testing.T) {
+	s := cache.NewMemory(1 << 20)
+	fresh := time.Now().Add(time.Hour).UnixNano()
+	putEntry(t, s, "aa01", cache.Meta{PrimaryHex: "aa01", Host: "a.com", URI: "/a", Created: 100, FreshUntil: fresh}, []byte("x"))
+
+	tbl, _ := NewPurgeTable("", 0)
+	ReapOnce(s, tbl)
+	assert.Equal(t, 1, storageLen(s), "nothing purged -> nothing reaped")
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/profiler v0.6.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.32.0
 	github.com/acoshift/configfile v1.9.0
-	github.com/moonrhythm/parapet v0.17.0
+	github.com/moonrhythm/parapet v0.17.1
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moonrhythm/parapet v0.17.0 h1:DjPwYVuFR5KNX17kU9I7um5+WAO+fE6Uu+/Vfj+Lwro=
-github.com/moonrhythm/parapet v0.17.0/go.mod h1:mfLCzU9zBm6vn05mnOgO0G8/+pArndciyLv3BYM9HJA=
+github.com/moonrhythm/parapet v0.17.1 h1:qV7+h3H1M9noRtnhFjBkGabeONfQxCoACaA8bdHZgOU=
+github.com/moonrhythm/parapet v0.17.1/go.mod h1:mfLCzU9zBm6vn05mnOgO0G8/+pArndciyLv3BYM9HJA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=


### PR DESCRIPTION
## What

Adds a **background reaper** that physically reclaims purged cache entries off the serving path, completing the edge cache-purge feature. The lazy `InvalidatedAfter` gate (shipped in #127) only reaps an entry on its *next lookup*, so after a broad purge with little subsequent traffic the now-dead bytes lingered until LRU pressure evicted them. The reaper reclaims them proactively.

Builds on **parapet v0.17.1** (`go.mod` bumped here), which added `Storage.Range` + raw `Host`/`URI` in `Meta` (moonrhythm/parapet#184).

## How it works

- `edge/purgereaper.go` — `ReapOnce` / `RunReaper`: `Storage.Range` over the cache, `Delete` every entry whose `Meta.Created <= epochFor(Meta.Host, Meta.URI)`. All three purge scopes match off the serving path via the host/uri parapet stamps into `Meta` (an old, pre-v0.17.1 entry with an empty `Host` matches the global scope only).
- `edge/purge.go` — shared `epochFor` + `InvalidatedAfterMeta` (the `Meta`-based variant of the lookup hook).
- Wired into `cmd/edge-proxy` — `EDGE_CACHE_PURGE_SWEEP_INTERVAL` (default 300s, jittered); 2 metrics (`edge_cache_purge_reap_sweeps_total`, `edge_cache_purge_reap_entries_total`).

**Safety:** the reaper deletes only in the *safe direction* — over-deleting a still-valid entry (e.g. a `Created` stamped low by a wall-clock step) merely costs a re-fetch, never a stale serve, because the lazy gate remains authoritative. Correctness never depends on the reaper.

## Review-shaped design (18-agent adversarial review)

The review caught the one direction that *isn't* safe and reshaped the design accordingly:

> An earlier `RetireBefore` (purge-record retirement) could **drop a purge record** while an in-flight fill committed with a backward-clock-stepped `Created <= ` that record's epoch *after* the sweep walk — leaving a purged entry servable (an under-invalidation).

Record retirement can't be made safe against a backward wall-clock step (both `Meta.Created` and any sweep marker are unclamped wall clocks), and it was only an optimization over the already-safe count-cap fold — so **retirement and the now-dead `Sweep` were removed**. The in-memory record table stays bounded by the monotonic, over-invalidating count-cap fold (never under-invalidates). The benign reaper-vs-refill TOCTOU is left as-is (documented best-effort `Storage.Range` contract). One finding correctly self-classified as a non-bug.

## Tests

New: reaper end-to-end (host-scoped reap, no over-reap of post-purge entries, flush-all reaps empty-`Host` entries, no-op when nothing purged), `InvalidatedAfterMeta` agreeing with the request hook, `Storage.Range` round-trips. `gofmt`/`go vet` clean, full build, `go test -race ./edge/ ./edgecp/` and the full suite pass.

## Config

`EDGE_CACHE_PURGE_SWEEP_INTERVAL` (default 300s). Edge-only; pure-Go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)