### PR TITLE
feat(edge): cache purge — path-prefix + cache-tag scopes

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -161,10 +161,11 @@ GET /v1/waf           Authorization: Bearer <token>   [If-None-Match: "<etag>"]
        (ETag is over the *scoped* payload, so 304 revalidation is per-edge-correct)
 
 GET /v1/purges?since=<seq>   Authorization: Bearer <token>
-  200 {"entries":[{"seq":N,"scope":"url|host|flush-all","host":"…","uri":"…"}],
+  200 {"entries":[{"seq":N,"scope":"url|host|prefix|flush-all","host":"…","uri":"…"}],
        "max_seq": N, "flush_required": false}
        entries        : journal entries with seq > since, SCOPED to the token's hosts
-                        (flush-all reaches every edge; host/url only its allowed hosts)
+                        (flush-all reaches every edge; host/url/prefix only its allowed hosts;
+                        for scope=prefix, uri is the path prefix)
        flush_required : true when the edge's next-needed seq (since+1) was trimmed
                         (it fell behind the retained window), OR when since > max_seq
                         (its cursor is ahead of the CP's journal — a CP restart / fresh
@@ -174,7 +175,11 @@ GET /v1/purges?since=<seq>   Authorization: Bearer <token>
   401 (no/invalid token)   404 (purge distribution disabled)
 
 POST /v1/purges       Authorization: Bearer <ADMIN token>   ← stronger cred than the read token
-  {"scope":"url|host|flush-all", "host":"…", "uri":"…"}  → appends to the journal, returns {"seq":N}
+  {"scope":"url|host|prefix|flush-all", "host":"…", "uri":"…"}  → appends to the journal, returns {"seq":N}
+       (scope=prefix: uri is the path prefix, e.g. "/blog"; path-only, boundary-aware.
+        url+prefix: uri MUST be a rooted "/..." path in the SAME percent-encoded form the
+        request carries — the cache keys on the raw request-uri, so "/café" must be sent
+        as "/caf%C3%A9". A non-"/" uri is rejected 400.)
        (the admin token is NOT host-scoped — it may purge any host; per-host scoping is
         applied on the read side, not at issue time)
   401 (no/invalid admin token)  400 (invalid scope/host/uri)  404 (purge distribution disabled)
@@ -432,9 +437,10 @@ Invalidation is **pulled from the control plane**, exactly like cert and WAF
 distribution: an operator publishes a purge once at the control plane and every
 sharded edge converges on its own timer. There is **no inbound purge port on the
 edge** (edges are out-of-cluster, often NAT'd), and the per-token host scoping is
-the same boundary that gates `/v1/certs` and `/v1/waf`. Three scopes are
-supported: **exact URL** (all `Vary` variants, both schemes, GET+HEAD),
-**whole host**, and **flush-all**.
+the same boundary that gates `/v1/certs` and `/v1/waf`. Four scopes are supported:
+**exact URL** (all `Vary` variants, both schemes, GET+HEAD), **path prefix**
+(every URL under a path on a host — path-only, boundary-aware: `/blog` covers
+`/blog` and `/blog/x` but not `/blogger`), **whole host**, and **flush-all**.
 
 **Why lazy epochs, not eager file deletion.** The cache stores each entry under
 `variantHash = hash(primaryHash ⊕ Vary-values)`, where `primaryHash =
@@ -654,10 +660,11 @@ needed. (The Rust **controller** implementation stays in `rust/`; only the Rust
    parapet-core equivalent).
 5. **Cache purge / invalidation** — CP purge journal + `GET`/`POST /v1/purges`,
    edge poll loop with a persisted cursor, lazy epoch invalidation (global / host /
-   url) checked at lookup via the `parapet/pkg/cache` `InvalidatedAfter` hook.
-   A background reaper (`Storage.Range`) physically reclaims invalidated entries
-   off the serving path; the count-cap fold + LRU byte cap bound the rest. Scopes:
-   exact-URL (all variants), whole-host,
-   flush-all. **(done)** See [Purge / invalidation](#purge--invalidation).
-   Edge-only. Path-prefix and Cache-Tag purge are deferred (prefix needs a scan;
-   tags must be recorded at admit time) — the epoch table extends to both later.
+   url / path-prefix) checked at lookup via the `parapet/pkg/cache`
+   `InvalidatedAfter` hook. A background reaper (`Storage.Range`) physically
+   reclaims invalidated entries off the serving path; the count-cap fold + LRU byte
+   cap bound the rest. Scopes: exact-URL (all variants), path-prefix (boundary-aware,
+   path-only), whole-host, flush-all. **(done)** See
+   [Purge / invalidation](#purge--invalidation). Edge-only. Cache-Tag (surrogate-key)
+   purge is deferred — it needs response tags recorded at admit time (a parapet
+   `Meta.Tags` addition); the epoch table extends to it later.

--- a/EDGE.md
+++ b/EDGE.md
@@ -161,11 +161,12 @@ GET /v1/waf           Authorization: Bearer <token>   [If-None-Match: "<etag>"]
        (ETag is over the *scoped* payload, so 304 revalidation is per-edge-correct)
 
 GET /v1/purges?since=<seq>   Authorization: Bearer <token>
-  200 {"entries":[{"seq":N,"scope":"url|host|prefix|flush-all","host":"…","uri":"…"}],
+  200 {"entries":[{"seq":N,"scope":"url|host|prefix|tag|flush-all","host":"…","uri":"…","tag":"…"}],
        "max_seq": N, "flush_required": false}
        entries        : journal entries with seq > since, SCOPED to the token's hosts
-                        (flush-all reaches every edge; host/url/prefix only its allowed hosts;
-                        for scope=prefix, uri is the path prefix)
+                        (flush-all and tag reach every edge; host/url/prefix only its
+                        allowed hosts; scope=prefix uri is the path prefix; scope=tag
+                        carries a surrogate key in tag, no host)
        flush_required : true when the edge's next-needed seq (since+1) was trimmed
                         (it fell behind the retained window), OR when since > max_seq
                         (its cursor is ahead of the CP's journal — a CP restart / fresh
@@ -175,11 +176,16 @@ GET /v1/purges?since=<seq>   Authorization: Bearer <token>
   401 (no/invalid token)   404 (purge distribution disabled)
 
 POST /v1/purges       Authorization: Bearer <ADMIN token>   ← stronger cred than the read token
-  {"scope":"url|host|prefix|flush-all", "host":"…", "uri":"…"}  → appends to the journal, returns {"seq":N}
+  {"scope":"url|host|prefix|tag|flush-all", "host":"…", "uri":"…", "tag":"…"}  → appends, returns {"seq":N}
        (scope=prefix: uri is the path prefix, e.g. "/blog"; path-only, boundary-aware.
         url+prefix: uri MUST be a rooted "/..." path in the SAME percent-encoded form the
         request carries — the cache keys on the raw request-uri, so "/café" must be sent
-        as "/caf%C3%A9". A non-"/" uri is rejected 400.)
+        as "/caf%C3%A9". A non-"/" uri is rejected 400.
+        scope=tag: tag is a surrogate key from the origin's Cache-Tag response header,
+        host-independent — distributed to every edge, which invalidates any entry whose
+        stored Cache-Tag set contains it. tag is required. NOTE: tag names are
+        broadcast fleet-wide (not host-gated like url/host/prefix), so they are a
+        shared cross-tenant namespace — do not encode secrets in Cache-Tag values.)
        (the admin token is NOT host-scoped — it may purge any host; per-host scoping is
         applied on the read side, not at issue time)
   401 (no/invalid admin token)  400 (invalid scope/host/uri)  404 (purge distribution disabled)
@@ -430,17 +436,22 @@ connection/byte/runtime metrics).
 > `edge/purgereaper.go`; control plane `edgecp/purgestore.go` + `GET`/`POST
 > /v1/purges`). The lookup gate is the `parapet/pkg/cache`
 > `Options.InvalidatedAfter` hook (parapet **v0.17.0**); the reaper uses
-> `Storage.Range` + the raw host/uri in `Meta` (parapet **v0.17.1**). Pure-Go
-> feature, no Rust counterpart.
+> `Storage.Range` + the raw host/uri in `Meta` (parapet **v0.17.1**); tag scope
+> uses the surrogate keys in `Meta.Tags` (parapet **v0.17.2**). Pure-Go feature,
+> no Rust counterpart.
 
 Invalidation is **pulled from the control plane**, exactly like cert and WAF
 distribution: an operator publishes a purge once at the control plane and every
 sharded edge converges on its own timer. There is **no inbound purge port on the
 edge** (edges are out-of-cluster, often NAT'd), and the per-token host scoping is
-the same boundary that gates `/v1/certs` and `/v1/waf`. Four scopes are supported:
+the same boundary that gates `/v1/certs` and `/v1/waf`. Five scopes are supported:
 **exact URL** (all `Vary` variants, both schemes, GET+HEAD), **path prefix**
 (every URL under a path on a host — path-only, boundary-aware: `/blog` covers
-`/blog` and `/blog/x` but not `/blogger`), **whole host**, and **flush-all**.
+`/blog` and `/blog/x` but not `/blogger`), **whole host**, **tag** (every cached
+response carrying a surrogate key from the origin's `Cache-Tag` header — content
+identity, host-independent), and **flush-all**. Host/url/prefix are host-scoped
+(an edge gets only purges for hosts it serves); tag and flush-all reach every edge,
+which then matches each entry's own tags / created-time.
 
 **Why lazy epochs, not eager file deletion.** The cache stores each entry under
 `variantHash = hash(primaryHash ⊕ Vary-values)`, where `primaryHash =
@@ -497,8 +508,8 @@ looked up, so after a broad purge with little traffic the dead bytes would linge
 until LRU pressure evicts them. A **background reaper** (`ReapOnce` / `RunReaper`,
 `EDGE_CACHE_PURGE_SWEEP_INTERVAL`, default 300s, jittered) closes that: it
 `Storage.Range`s over the cache and `Delete`s every entry whose `Meta.Created <=
-epochFor(Meta.Host, Meta.URI)` — using the raw host/uri parapet v0.17.1 stamps into
-`Meta` so all three scopes match off the serving path (an old entry with an empty
+epochFor(Meta.Host, Meta.URI, Meta.Tags)` — using the host/uri/tags parapet stamps
+into `Meta` so every scope matches off the serving path (an old entry with an empty
 `Host` matches the global scope only). Correctness never depends on the reaper —
 the gate already guarantees a purged entry is never served — so it deletes only in
 the **safe direction**: over-deleting a still-valid entry (e.g. a `Created` stamped
@@ -660,11 +671,10 @@ needed. (The Rust **controller** implementation stays in `rust/`; only the Rust
    parapet-core equivalent).
 5. **Cache purge / invalidation** — CP purge journal + `GET`/`POST /v1/purges`,
    edge poll loop with a persisted cursor, lazy epoch invalidation (global / host /
-   url / path-prefix) checked at lookup via the `parapet/pkg/cache`
+   url / path-prefix / tag) checked at lookup via the `parapet/pkg/cache`
    `InvalidatedAfter` hook. A background reaper (`Storage.Range`) physically
    reclaims invalidated entries off the serving path; the count-cap fold + LRU byte
    cap bound the rest. Scopes: exact-URL (all variants), path-prefix (boundary-aware,
-   path-only), whole-host, flush-all. **(done)** See
-   [Purge / invalidation](#purge--invalidation). Edge-only. Cache-Tag (surrogate-key)
-   purge is deferred — it needs response tags recorded at admit time (a parapet
-   `Meta.Tags` addition); the epoch table extends to it later.
+   path-only), whole-host, tag (surrogate keys from the origin's `Cache-Tag` header,
+   via parapet `Meta.Tags`, host-independent), flush-all. **(done)** See
+   [Purge / invalidation](#purge--invalidation). Edge-only.

--- a/SPEC.md
+++ b/SPEC.md
@@ -161,15 +161,17 @@ invariants:
 - **Cache purge (edge-only)** — invalidation is **pulled** from the control plane
   (`GET`/`POST /v1/purges`, a per-edge-scoped journal + cursor), mirroring
   cert/WAF distribution; no inbound port on the edge. Lazy **epoch** invalidation
-  (global / host / url-keyed-on-`host⊕uri`) is checked at lookup via the
-  `parapet/pkg/cache` `InvalidatedAfter` hook (parapet ≥ v0.17.0). Epochs use the
-  **edge's own clock** at apply time (no trusted CP timestamp; the cursor makes
-  apply idempotent, monotonic-clamped against an NTP step-back). Scopes: exact-URL
-  (all variants), path-prefix (boundary-aware, path-only), whole-host, flush-all. A
+  (global / host / url-keyed-on-`host⊕uri` / path-prefix / tag) is checked at
+  lookup via the `parapet/pkg/cache` `InvalidatedAfter` hook (parapet ≥ v0.17.0).
+  Epochs use the **edge's own clock** at apply time (no trusted CP timestamp; the
+  cursor makes apply idempotent, monotonic-clamped against an NTP step-back).
+  Scopes: exact-URL (all variants), path-prefix (boundary-aware, path-only),
+  whole-host, tag (surrogate keys from the origin's `Cache-Tag` header via parapet
+  `Meta.Tags`, host-independent — distributed to every edge), flush-all. A
   background reaper
   (`EDGE_CACHE_PURGE_SWEEP_INTERVAL`) physically reclaims invalidated entries off
-  the serving path, using `Storage.Range` + the raw host/uri in `Meta` (parapet ≥
-  v0.17.1); the in-memory record table is bounded by a count-cap fold into the
+  the serving path, using `Storage.Range` + the host/uri/tags in `Meta` (parapet ≥
+  v0.17.2); the in-memory record table is bounded by a count-cap fold into the
   global epoch (over-invalidates, never under-), and disk by the cache's LRU byte
   cap. Issuing a purge needs `CP_PURGE_ADMIN_TOKEN` (a stronger
   credential than the per-edge read tokens). Edge-only — no controller mirror, no

--- a/SPEC.md
+++ b/SPEC.md
@@ -165,7 +165,8 @@ invariants:
   `parapet/pkg/cache` `InvalidatedAfter` hook (parapet ≥ v0.17.0). Epochs use the
   **edge's own clock** at apply time (no trusted CP timestamp; the cursor makes
   apply idempotent, monotonic-clamped against an NTP step-back). Scopes: exact-URL
-  (all variants), whole-host, flush-all. A background reaper
+  (all variants), path-prefix (boundary-aware, path-only), whole-host, flush-all. A
+  background reaper
   (`EDGE_CACHE_PURGE_SWEEP_INTERVAL`) physically reclaims invalidated entries off
   the serving path, using `Storage.Range` + the raw host/uri in `Meta` (parapet ≥
   v0.17.1); the in-memory record table is bounded by a count-cap fold into the

--- a/deploy/edge/controlplane.yaml
+++ b/deploy/edge/controlplane.yaml
@@ -53,9 +53,12 @@ spec:
             # Serve GET /v1/purges (per-edge bearer, scoped to the edge's hosts) and
             # POST /v1/purges (issue a purge). Issuing REQUIRES CP_PURGE_ADMIN_TOKEN —
             # a stronger credential than the per-edge read tokens — so keep it in its
-            # own Secret. Issue with:
+            # own Secret. Scopes: url / prefix / host / tag / flush-all. Issue with:
             #   curl -H "Authorization: Bearer $ADMIN" -d '{"scope":"url","host":"acme.com","uri":"/a"}' \
             #     https://controlplane:8443/v1/purges
+            #   {"scope":"prefix","host":"acme.com","uri":"/blog"}   # everything under /blog
+            #   {"scope":"tag","tag":"product-42"}                   # by origin Cache-Tag, all hosts
+            #   {"scope":"host","host":"acme.com"} / {"scope":"flush-all"}
             # - name: CP_PURGE_ENABLED
             #   value: "true"
             # - name: CP_PURGE_ADMIN_TOKEN

--- a/edge/metrics.go
+++ b/edge/metrics.go
@@ -116,12 +116,12 @@ var (
 		Help:      "Last cache-purge journal seq applied by the edge.",
 	}, []string{"edge_id"})
 
-	// edgePurgeRecords is the current in-memory record count per scope map (host|url),
-	// so an operator can watch the table stay bounded.
+	// edgePurgeRecords is the current in-memory record count per scope map
+	// (host|url|prefix), so an operator can watch the table stay bounded.
 	edgePurgeRecords = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: prom.Namespace,
 		Name:      "edge_cache_purge_records",
-		Help:      "Current cache-purge invalidation-table records, by scope map (host|url).",
+		Help:      "Current cache-purge invalidation-table records, by scope map (host|url|prefix).",
 	}, []string{"scope", "edge_id"})
 
 	// edgePurgeFolds is the cumulative count of conservative cap-folds (a map
@@ -178,6 +178,7 @@ func setPurgeMetrics(st PurgeStats) {
 	edgePurgeCursor.WithLabelValues(edgeID).Set(float64(st.Cursor))
 	edgePurgeRecords.WithLabelValues("host", edgeID).Set(float64(st.HostRecs))
 	edgePurgeRecords.WithLabelValues("url", edgeID).Set(float64(st.URLRecs))
+	edgePurgeRecords.WithLabelValues("prefix", edgeID).Set(float64(st.PrefixRecs))
 	edgePurgeFolds.WithLabelValues(edgeID).Set(float64(st.Folds))
 }
 

--- a/edge/metrics.go
+++ b/edge/metrics.go
@@ -117,11 +117,11 @@ var (
 	}, []string{"edge_id"})
 
 	// edgePurgeRecords is the current in-memory record count per scope map
-	// (host|url|prefix), so an operator can watch the table stay bounded.
+	// (host|url|prefix|tag), so an operator can watch the table stay bounded.
 	edgePurgeRecords = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: prom.Namespace,
 		Name:      "edge_cache_purge_records",
-		Help:      "Current cache-purge invalidation-table records, by scope map (host|url|prefix).",
+		Help:      "Current cache-purge invalidation-table records, by scope map (host|url|prefix|tag).",
 	}, []string{"scope", "edge_id"})
 
 	// edgePurgeFolds is the cumulative count of conservative cap-folds (a map
@@ -179,6 +179,7 @@ func setPurgeMetrics(st PurgeStats) {
 	edgePurgeRecords.WithLabelValues("host", edgeID).Set(float64(st.HostRecs))
 	edgePurgeRecords.WithLabelValues("url", edgeID).Set(float64(st.URLRecs))
 	edgePurgeRecords.WithLabelValues("prefix", edgeID).Set(float64(st.PrefixRecs))
+	edgePurgeRecords.WithLabelValues("tag", edgeID).Set(float64(st.TagRecs))
 	edgePurgeFolds.WithLabelValues(edgeID).Set(float64(st.Folds))
 }
 

--- a/edge/purge.go
+++ b/edge/purge.go
@@ -30,18 +30,22 @@ const (
 	// ScopePrefix invalidates every URL under a path prefix on a host (path-only,
 	// boundary-aware; query strings ignored). The prefix travels in the URI field.
 	ScopePrefix Scope = "prefix"
+	// ScopeTag invalidates every cached response carrying a surrogate key (from the
+	// origin's Cache-Tag header), across all hosts. The tag travels in the Tag field.
+	ScopeTag Scope = "tag"
 )
 
 // PurgeEntry is one journal record as distributed by the control plane and applied
 // by the edge. Seq is the monotonic journal sequence (idempotency cursor); Host is
 // required for host/url/prefix scopes; URI carries the exact path+query for url
-// scope and the path prefix for prefix scope. It is also the JSON wire shape
-// returned by GET /v1/purges.
+// scope and the path prefix for prefix scope; Tag carries the surrogate key for tag
+// scope (host-independent). It is also the JSON wire shape returned by GET /v1/purges.
 type PurgeEntry struct {
 	Seq   uint64 `json:"seq"`
 	Scope Scope  `json:"scope"`
 	Host  string `json:"host,omitempty"`
 	URI   string `json:"uri,omitempty"`
+	Tag   string `json:"tag,omitempty"`
 }
 
 // PurgeTable is the edge's cache-invalidation state: a small, in-memory table of
@@ -65,6 +69,9 @@ type PurgeEntry struct {
 //     /blog matches /blog and /blog/x but not /blogger; query strings ignored).
 //     A linear scan of the host's prefix records, so it is O(prefixes-for-host) at
 //     lookup rather than O(1); the record count is bounded by the cap-fold.
+//   - tag     — every cached response carrying a surrogate key (the origin's
+//     Cache-Tag header, stored in Meta.Tags); host-independent, matched against the
+//     entry's own tags at lookup (O(tags-on-entry), a small bounded set).
 //
 // The table persists {global, host, url, prefix, cursor} to a single file with an
 // atomic temp+fsync+rename, so maps and cursor can never desync. It is safe for
@@ -75,6 +82,7 @@ type PurgeTable struct {
 	host   map[string]int64       // normalized host    -> epoch
 	url    map[string]int64       // hash(host ⊕ uri)   -> epoch
 	prefix map[string][]prefixRec // normalized host    -> path-prefix records
+	tag    map[string]int64       // surrogate key      -> epoch (host-independent)
 	cursor uint64                 // last journal seq applied (idempotency)
 
 	// highWater is the largest epoch ever stamped. Every new stamp is clamped to be
@@ -120,6 +128,7 @@ func NewPurgeTable(path string, maxRecords int) (*PurgeTable, error) {
 		host:    map[string]int64{},
 		url:     map[string]int64{},
 		prefix:  map[string][]prefixRec{},
+		tag:     map[string]int64{},
 		path:    path,
 		maxRecs: maxRecords,
 	}
@@ -136,12 +145,13 @@ func (t *PurgeTable) now() int64 {
 }
 
 // InvalidatedAfter is the parapet/pkg/cache Options.InvalidatedAfter hook. It
-// returns the invalidation epoch (unix nanos) applying to r: the max of the
-// global, per-host, and per-url epochs. The cache treats a hit whose Meta.Created
-// is <= this value as stale. Host normalization mirrors cache.primaryHash
-// (lowercase + strip port) so the keys line up exactly. The stored Meta is unused.
-func (t *PurgeTable) InvalidatedAfter(r *http.Request, _ cache.Meta) int64 {
-	return t.epochFor(normHost(r.Host), r.URL.RequestURI())
+// returns the invalidation epoch (unix nanos) applying to r: the max of the global,
+// per-host, per-url, per-prefix, and per-tag epochs. The cache treats a hit whose
+// Meta.Created is <= this value as stale. Host normalization mirrors
+// cache.primaryHash (lowercase + strip port) so the keys line up exactly. The
+// stored entry's surrogate keys (m.Tags) are folded in for tag-scoped purges.
+func (t *PurgeTable) InvalidatedAfter(r *http.Request, m cache.Meta) int64 {
+	return t.epochFor(normHost(r.Host), r.URL.RequestURI(), m.Tags)
 }
 
 // InvalidatedAfterMeta is the reaper's variant of InvalidatedAfter: it reads the
@@ -150,13 +160,14 @@ func (t *PurgeTable) InvalidatedAfter(r *http.Request, _ cache.Meta) int64 {
 // idempotent on Meta.Host (the cache stamps it normalized); an old entry with an
 // empty Host matches only the global scope.
 func (t *PurgeTable) InvalidatedAfterMeta(m cache.Meta) int64 {
-	return t.epochFor(normHost(m.Host), m.URI)
+	return t.epochFor(normHost(m.Host), m.URI, m.Tags)
 }
 
-// epochFor returns the invalidation epoch (unix nanos) applying to a normalized
-// host + uri: the max of the global, per-host, and per-url epochs. Shared by the
-// lookup hook and the reaper.
-func (t *PurgeTable) epochFor(host, uri string) int64 {
+// epochFor returns the invalidation epoch (unix nanos) applying to an entry: the
+// max of the global, per-host, per-url, per-prefix, and per-tag epochs. host+uri
+// come from the request or the stored Meta; tags come from the stored Meta (the
+// origin's surrogate keys). Shared by the lookup hook and the reaper.
+func (t *PurgeTable) epochFor(host, uri string, tags []string) int64 {
 	uk := urlKey(host, uri)
 	path := pathOf(uri)
 	t.mu.RLock()
@@ -173,6 +184,12 @@ func (t *PurgeTable) epochFor(host, uri string) int64 {
 	for _, p := range t.prefix[host] {
 		if p.Epoch > e && matchPrefix(path, p.Prefix) {
 			e = p.Epoch
+		}
+	}
+	// Tag scope: each surrogate key the entry carries (host-independent).
+	for _, tg := range tags {
+		if v := t.tag[tg]; v > e {
+			e = v
 		}
 	}
 	return e
@@ -226,6 +243,7 @@ func (t *PurgeTable) FlushAll(maxSeq uint64) error {
 	t.host = map[string]int64{}
 	t.url = map[string]int64{}
 	t.prefix = map[string][]prefixRec{}
+	t.tag = map[string]int64{}
 	t.cursor = maxSeq
 	return t.saveLocked()
 }
@@ -239,6 +257,7 @@ func (t *PurgeTable) applyLocked(e PurgeEntry) {
 		t.host = map[string]int64{}
 		t.url = map[string]int64{}
 		t.prefix = map[string][]prefixRec{}
+		t.tag = map[string]int64{}
 	case ScopeHost:
 		if h := normHost(e.Host); h != "" {
 			t.host[h] = t.stamp()
@@ -252,6 +271,11 @@ func (t *PurgeTable) applyLocked(e PurgeEntry) {
 	case ScopePrefix:
 		if h := normHost(e.Host); h != "" {
 			t.applyPrefixLocked(h, normalizePrefix(e.URI), t.stamp())
+			t.enforceCapLocked()
+		}
+	case ScopeTag:
+		if e.Tag != "" {
+			t.tag[e.Tag] = t.stamp()
 			t.enforceCapLocked()
 		}
 	}
@@ -303,6 +327,10 @@ func (t *PurgeTable) enforceCapLocked() {
 		t.prefix = map[string][]prefixRec{}
 		folded = true
 	}
+	if len(t.tag) > t.maxRecs {
+		t.tag = map[string]int64{}
+		folded = true
+	}
 	if folded {
 		t.global = t.highWater // highWater >= every epoch stamped, so it covers the dropped records
 		t.folds++
@@ -332,6 +360,7 @@ type PurgeStats struct {
 	HostRecs   int
 	URLRecs    int
 	PrefixRecs int
+	TagRecs    int
 	Folds      uint64
 }
 
@@ -345,6 +374,7 @@ func (t *PurgeTable) Stats() PurgeStats {
 		HostRecs:   len(t.host),
 		URLRecs:    len(t.url),
 		PrefixRecs: t.prefixCount(),
+		TagRecs:    len(t.tag),
 		Folds:      t.folds,
 	}
 }
@@ -358,6 +388,7 @@ type persistState struct {
 	Host   map[string]int64       `json:"host"`
 	URL    map[string]int64       `json:"url"`
 	Prefix map[string][]prefixRec `json:"prefix,omitempty"`
+	Tag    map[string]int64       `json:"tag,omitempty"`
 	Cursor uint64                 `json:"cursor"`
 }
 
@@ -388,6 +419,9 @@ func (t *PurgeTable) load() error {
 	if st.Prefix != nil {
 		t.prefix = st.Prefix
 	}
+	if st.Tag != nil {
+		t.tag = st.Tag
+	}
 	t.global = st.Global
 	t.cursor = st.Cursor
 	t.highWater = st.Global
@@ -408,6 +442,11 @@ func (t *PurgeTable) load() error {
 			}
 		}
 	}
+	for _, v := range t.tag {
+		if v > t.highWater {
+			t.highWater = v
+		}
+	}
 	return nil
 }
 
@@ -422,6 +461,7 @@ func (t *PurgeTable) saveLocked() error {
 		Host:   t.host,
 		URL:    t.url,
 		Prefix: t.prefix,
+		Tag:    t.tag,
 		Cursor: t.cursor,
 	})
 	if err != nil {

--- a/edge/purge.go
+++ b/edge/purge.go
@@ -27,12 +27,16 @@ const (
 	ScopeHost Scope = "host"
 	// ScopeURL invalidates one URL (all methods, schemes, and Vary variants).
 	ScopeURL Scope = "url"
+	// ScopePrefix invalidates every URL under a path prefix on a host (path-only,
+	// boundary-aware; query strings ignored). The prefix travels in the URI field.
+	ScopePrefix Scope = "prefix"
 )
 
 // PurgeEntry is one journal record as distributed by the control plane and applied
 // by the edge. Seq is the monotonic journal sequence (idempotency cursor); Host is
-// required for host/url scopes; URI (path+query) is required for url scope. It is
-// also the JSON wire shape returned by GET /v1/purges.
+// required for host/url/prefix scopes; URI carries the exact path+query for url
+// scope and the path prefix for prefix scope. It is also the JSON wire shape
+// returned by GET /v1/purges.
 type PurgeEntry struct {
 	Seq   uint64 `json:"seq"`
 	Scope Scope  `json:"scope"`
@@ -50,23 +54,28 @@ type PurgeEntry struct {
 // passed FreshUntil. Correctness is immediate (a purged entry can never be
 // served); the storage backend's LRU byte cap reclaims disk regardless.
 //
-// Three scopes, checked as a max at lookup so a URL is also covered by its host's
-// purge and by a global flush:
+// Scopes, checked as a max at lookup so a URL is also covered by its host's purge,
+// a matching path prefix, and a global flush:
 //   - global  — flush-all (one epoch)
 //   - host    — every URL under a host (keyed by normalized host)
 //   - url     — one URL across all methods, schemes, and Vary variants (keyed by
 //     hash(host ⊕ uri), so a single purge of /a covers GET+HEAD, http+https, and
 //     every cached variant)
+//   - prefix  — every URL under a path prefix on a host (path-only, boundary-aware:
+//     /blog matches /blog and /blog/x but not /blogger; query strings ignored).
+//     A linear scan of the host's prefix records, so it is O(prefixes-for-host) at
+//     lookup rather than O(1); the record count is bounded by the cap-fold.
 //
-// The table persists {global, host, url, cursor} to a single file with an atomic
-// temp+fsync+rename, so maps and cursor can never desync. It is safe for
+// The table persists {global, host, url, prefix, cursor} to a single file with an
+// atomic temp+fsync+rename, so maps and cursor can never desync. It is safe for
 // concurrent use.
 type PurgeTable struct {
 	mu     sync.RWMutex
-	global int64            // flush-all epoch (unix nanos); 0 = never flushed
-	host   map[string]int64 // normalized host    -> epoch
-	url    map[string]int64 // hash(host ⊕ uri)   -> epoch
-	cursor uint64           // last journal seq applied (idempotency)
+	global int64                  // flush-all epoch (unix nanos); 0 = never flushed
+	host   map[string]int64       // normalized host    -> epoch
+	url    map[string]int64       // hash(host ⊕ uri)   -> epoch
+	prefix map[string][]prefixRec // normalized host    -> path-prefix records
+	cursor uint64                 // last journal seq applied (idempotency)
 
 	// highWater is the largest epoch ever stamped. Every new stamp is clamped to be
 	// >= highWater so a wall-clock step back (NTP correction) can never lower an
@@ -80,6 +89,14 @@ type PurgeTable struct {
 	path     string       // persistence file; "" disables persistence (e.g. memory backend)
 	maxRecs  int          // per-map record cap before a conservative fold-to-global
 	nowNanos func() int64 // injectable clock (unix nanos); nil => time.Now
+}
+
+// prefixRec is one path-prefix purge for a host: the normalized prefix (trailing
+// slash trimmed; "" means the whole host, i.e. a "/" purge) and its epoch. Exported
+// fields so it round-trips through the persisted JSON.
+type prefixRec struct {
+	Prefix string `json:"prefix"`
+	Epoch  int64  `json:"epoch"`
 }
 
 // defaultMaxPurgeRecords bounds each of the host/url maps. Purge records are
@@ -102,6 +119,7 @@ func NewPurgeTable(path string, maxRecords int) (*PurgeTable, error) {
 	t := &PurgeTable{
 		host:    map[string]int64{},
 		url:     map[string]int64{},
+		prefix:  map[string][]prefixRec{},
 		path:    path,
 		maxRecs: maxRecords,
 	}
@@ -140,6 +158,7 @@ func (t *PurgeTable) InvalidatedAfterMeta(m cache.Meta) int64 {
 // lookup hook and the reaper.
 func (t *PurgeTable) epochFor(host, uri string) int64 {
 	uk := urlKey(host, uri)
+	path := pathOf(uri)
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	e := t.global
@@ -148,6 +167,13 @@ func (t *PurgeTable) epochFor(host, uri string) int64 {
 	}
 	if v := t.url[uk]; v > e {
 		e = v
+	}
+	// Prefix scope: linear scan of this host's prefix records (epoch check first so
+	// the string match is skipped once a higher epoch is already found).
+	for _, p := range t.prefix[host] {
+		if p.Epoch > e && matchPrefix(path, p.Prefix) {
+			e = p.Epoch
+		}
 	}
 	return e
 }
@@ -199,6 +225,7 @@ func (t *PurgeTable) FlushAll(maxSeq uint64) error {
 	t.global = t.stamp()
 	t.host = map[string]int64{}
 	t.url = map[string]int64{}
+	t.prefix = map[string][]prefixRec{}
 	t.cursor = maxSeq
 	return t.saveLocked()
 }
@@ -208,10 +235,10 @@ func (t *PurgeTable) applyLocked(e PurgeEntry) {
 	switch e.Scope {
 	case ScopeFlushAll:
 		t.global = t.stamp()
-		// global at >= every existing host/url epoch makes them redundant; drop to
-		// reclaim memory.
+		// global at >= every existing record makes them redundant; drop to reclaim memory.
 		t.host = map[string]int64{}
 		t.url = map[string]int64{}
+		t.prefix = map[string][]prefixRec{}
 	case ScopeHost:
 		if h := normHost(e.Host); h != "" {
 			t.host[h] = t.stamp()
@@ -222,7 +249,28 @@ func (t *PurgeTable) applyLocked(e PurgeEntry) {
 			t.url[urlKey(h, e.URI)] = t.stamp()
 			t.enforceCapLocked()
 		}
+	case ScopePrefix:
+		if h := normHost(e.Host); h != "" {
+			t.applyPrefixLocked(h, normalizePrefix(e.URI), t.stamp())
+			t.enforceCapLocked()
+		}
 	}
+}
+
+// applyPrefixLocked stamps (or refreshes) a host's path-prefix record. A repeat of
+// the same prefix updates its epoch in place (monotonic, so always upward); a new
+// prefix is appended. Caller holds t.mu.
+func (t *PurgeTable) applyPrefixLocked(host, prefix string, epoch int64) {
+	recs := t.prefix[host]
+	for i := range recs {
+		if recs[i].Prefix == prefix {
+			if epoch > recs[i].Epoch {
+				recs[i].Epoch = epoch
+			}
+			return
+		}
+	}
+	t.prefix[host] = append(recs, prefixRec{Prefix: prefix, Epoch: epoch})
 }
 
 // stamp returns a fresh epoch, clamped to be monotonic non-decreasing (>=
@@ -251,10 +299,23 @@ func (t *PurgeTable) enforceCapLocked() {
 		t.host = map[string]int64{}
 		folded = true
 	}
+	if t.prefixCount() > t.maxRecs {
+		t.prefix = map[string][]prefixRec{}
+		folded = true
+	}
 	if folded {
 		t.global = t.highWater // highWater >= every epoch stamped, so it covers the dropped records
 		t.folds++
 	}
+}
+
+// prefixCount totals the prefix records across hosts. Caller holds t.mu.
+func (t *PurgeTable) prefixCount() int {
+	n := 0
+	for _, recs := range t.prefix {
+		n += len(recs)
+	}
+	return n
 }
 
 // Cursor returns the last journal seq applied (for building the poll request).
@@ -266,11 +327,12 @@ func (t *PurgeTable) Cursor() uint64 {
 
 // PurgeStats is a snapshot of the table for metrics/diagnostics.
 type PurgeStats struct {
-	Cursor   uint64
-	Global   int64
-	HostRecs int
-	URLRecs  int
-	Folds    uint64
+	Cursor     uint64
+	Global     int64
+	HostRecs   int
+	URLRecs    int
+	PrefixRecs int
+	Folds      uint64
 }
 
 // Stats returns a concurrent-safe snapshot.
@@ -278,11 +340,12 @@ func (t *PurgeTable) Stats() PurgeStats {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return PurgeStats{
-		Cursor:   t.cursor,
-		Global:   t.global,
-		HostRecs: len(t.host),
-		URLRecs:  len(t.url),
-		Folds:    t.folds,
+		Cursor:     t.cursor,
+		Global:     t.global,
+		HostRecs:   len(t.host),
+		URLRecs:    len(t.url),
+		PrefixRecs: t.prefixCount(),
+		Folds:      t.folds,
 	}
 }
 
@@ -291,10 +354,11 @@ func (t *PurgeTable) Stats() PurgeStats {
 // persistState is the on-disk shape. Maps + cursor share one atomic write so they
 // can never desync.
 type persistState struct {
-	Global int64            `json:"global"`
-	Host   map[string]int64 `json:"host"`
-	URL    map[string]int64 `json:"url"`
-	Cursor uint64           `json:"cursor"`
+	Global int64                  `json:"global"`
+	Host   map[string]int64       `json:"host"`
+	URL    map[string]int64       `json:"url"`
+	Prefix map[string][]prefixRec `json:"prefix,omitempty"`
+	Cursor uint64                 `json:"cursor"`
 }
 
 // load reads persisted state into the table. A missing file is a clean start. Any
@@ -321,6 +385,9 @@ func (t *PurgeTable) load() error {
 	if st.URL != nil {
 		t.url = st.URL
 	}
+	if st.Prefix != nil {
+		t.prefix = st.Prefix
+	}
 	t.global = st.Global
 	t.cursor = st.Cursor
 	t.highWater = st.Global
@@ -332,6 +399,13 @@ func (t *PurgeTable) load() error {
 	for _, v := range t.url {
 		if v > t.highWater {
 			t.highWater = v
+		}
+	}
+	for _, recs := range t.prefix {
+		for _, p := range recs {
+			if p.Epoch > t.highWater {
+				t.highWater = p.Epoch
+			}
 		}
 	}
 	return nil
@@ -347,6 +421,7 @@ func (t *PurgeTable) saveLocked() error {
 		Global: t.global,
 		Host:   t.host,
 		URL:    t.url,
+		Prefix: t.prefix,
 		Cursor: t.cursor,
 	})
 	if err != nil {
@@ -405,4 +480,31 @@ func normHost(host string) string {
 func urlKey(host, uri string) string {
 	sum := sha256.Sum256([]byte(host + "\n" + uri))
 	return hex.EncodeToString(sum[:16])
+}
+
+// pathOf returns the path portion of a request-uri (everything before the first
+// '?'). Prefix purges match on the path only, so a query string never affects
+// whether an entry is covered.
+func pathOf(uri string) string {
+	if i := strings.IndexByte(uri, '?'); i >= 0 {
+		return uri[:i]
+	}
+	return uri
+}
+
+// normalizePrefix trims a single trailing slash so "/blog" and "/blog/" purge the
+// same section; "/" normalizes to "" (the whole-host prefix). The normalized form
+// is what matchPrefix compares against.
+func normalizePrefix(p string) string {
+	return strings.TrimRight(p, "/")
+}
+
+// matchPrefix reports whether path is covered by the normalized prefix pre, on a
+// path boundary: pre "/blog" matches "/blog" and "/blog/x" but NOT "/blogger". An
+// empty pre (from a "/" purge) matches every path.
+func matchPrefix(path, pre string) bool {
+	if pre == "" {
+		return true
+	}
+	return path == pre || strings.HasPrefix(path, pre+"/")
 }

--- a/edge/purge_test.go
+++ b/edge/purge_test.go
@@ -120,13 +120,15 @@ func TestPurge_FlushAllClearsAndSupersedes(t *testing.T) {
 	require.NoError(t, tbl.Apply([]PurgeEntry{
 		{Seq: 1, Scope: ScopeURL, Host: "a.com", URI: "/x"},
 		{Seq: 2, Scope: ScopeHost, Host: "b.com"},
-	}, 2))
+		{Seq: 3, Scope: ScopePrefix, Host: "c.com", URI: "/blog"},
+	}, 3))
 	fixedClock(tbl, 5000)
-	require.NoError(t, tbl.FlushAll(3))
+	require.NoError(t, tbl.FlushAll(4))
 
 	st := tbl.Stats()
 	assert.Zero(t, st.HostRecs, "host map cleared on flush")
 	assert.Zero(t, st.URLRecs, "url map cleared on flush")
+	assert.Zero(t, st.PrefixRecs, "prefix map cleared on flush")
 	assert.EqualValues(t, 5000, epochFor(tbl, "GET", "http://anything.com/q"))
 }
 
@@ -161,6 +163,72 @@ func TestPurge_InvalidatedAfterMetaMatchesRequest(t *testing.T) {
 	assert.EqualValues(t, 0, tbl.InvalidatedAfterMeta(cache.Meta{Host: "acme.com", URI: "/p?x=2"}))
 	// An empty-Host (old) entry matches only the global scope.
 	assert.EqualValues(t, 0, tbl.InvalidatedAfterMeta(cache.Meta{Host: "", URI: "/p?x=1"}))
+}
+
+func TestPurge_PrefixScope(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 0)
+	fixedClock(tbl, 1000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopePrefix, Host: "acme.com", URI: "/blog"}}, 1))
+
+	// Covered: the prefix itself, anything under it, and any query variant (path-only).
+	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://acme.com/blog"))
+	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://acme.com/blog/post-1"))
+	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://acme.com/blog/post-1?utm=x"))
+	// Not covered: boundary (/blogger), a sibling path, or another host.
+	assert.EqualValues(t, 0, epochFor(tbl, "GET", "http://acme.com/blogger"), "path boundary respected")
+	assert.EqualValues(t, 0, epochFor(tbl, "GET", "http://acme.com/about"))
+	assert.EqualValues(t, 0, epochFor(tbl, "GET", "http://other.com/blog/x"), "prefix is host-scoped")
+}
+
+func TestPurge_PrefixNormalizationAndRoot(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 0)
+	fixedClock(tbl, 2000)
+	// Trailing slash is normalized away: "/docs/" purges the same section as "/docs".
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopePrefix, Host: "a.com", URI: "/docs/"}}, 1))
+	assert.EqualValues(t, 2000, epochFor(tbl, "GET", "http://a.com/docs"))
+	assert.EqualValues(t, 2000, epochFor(tbl, "GET", "http://a.com/docs/intro"))
+	assert.EqualValues(t, 0, epochFor(tbl, "GET", "http://a.com/docsource"))
+
+	// "/" is the whole-host prefix.
+	fixedClock(tbl, 3000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 2, Scope: ScopePrefix, Host: "b.com", URI: "/"}}, 2))
+	assert.EqualValues(t, 3000, epochFor(tbl, "GET", "http://b.com/anything/here"))
+}
+
+func TestPurge_PrefixRepeatUpdatesEpochInPlace(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 0)
+	fixedClock(tbl, 1000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopePrefix, Host: "a.com", URI: "/x"}}, 1))
+	fixedClock(tbl, 5000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 2, Scope: ScopePrefix, Host: "a.com", URI: "/x"}}, 2))
+	assert.EqualValues(t, 1, tbl.Stats().PrefixRecs, "same prefix updates in place, no duplicate record")
+	assert.EqualValues(t, 5000, epochFor(tbl, "GET", "http://a.com/x/y"), "epoch advanced to the latest purge")
+}
+
+func TestPurge_PrefixPersistenceRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "purge-state")
+	t1, err := NewPurgeTable(path, 0)
+	require.NoError(t, err)
+	fixedClock(t1, 4000)
+	require.NoError(t, t1.Apply([]PurgeEntry{{Seq: 1, Scope: ScopePrefix, Host: "a.com", URI: "/sec"}}, 1))
+
+	t2, err := NewPurgeTable(path, 0)
+	require.NoError(t, err)
+	assert.EqualValues(t, 4000, epochFor(t2, "GET", "http://a.com/sec/page"), "prefix record survives reload")
+	assert.EqualValues(t, 1, t2.Stats().PrefixRecs)
+}
+
+func TestPurge_PrefixCapFold(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 2) // tiny cap
+	fixedClock(tbl, 1000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{
+		{Seq: 1, Scope: ScopePrefix, Host: "a.com", URI: "/1"},
+		{Seq: 2, Scope: ScopePrefix, Host: "a.com", URI: "/2"},
+		{Seq: 3, Scope: ScopePrefix, Host: "a.com", URI: "/3"}, // overflow -> fold to global
+	}, 3))
+	assert.Zero(t, tbl.Stats().PrefixRecs, "overflowing prefix records folded into global")
+	assert.EqualValues(t, 1, tbl.Stats().Folds)
+	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://a.com/1"), "still invalidated via the global epoch")
 }
 
 func TestPurge_FlushAllRealignsCursorDown(t *testing.T) {

--- a/edge/purge_test.go
+++ b/edge/purge_test.go
@@ -121,14 +121,16 @@ func TestPurge_FlushAllClearsAndSupersedes(t *testing.T) {
 		{Seq: 1, Scope: ScopeURL, Host: "a.com", URI: "/x"},
 		{Seq: 2, Scope: ScopeHost, Host: "b.com"},
 		{Seq: 3, Scope: ScopePrefix, Host: "c.com", URI: "/blog"},
-	}, 3))
+		{Seq: 4, Scope: ScopeTag, Tag: "t1"},
+	}, 4))
 	fixedClock(tbl, 5000)
-	require.NoError(t, tbl.FlushAll(4))
+	require.NoError(t, tbl.FlushAll(5))
 
 	st := tbl.Stats()
 	assert.Zero(t, st.HostRecs, "host map cleared on flush")
 	assert.Zero(t, st.URLRecs, "url map cleared on flush")
 	assert.Zero(t, st.PrefixRecs, "prefix map cleared on flush")
+	assert.Zero(t, st.TagRecs, "tag map cleared on flush")
 	assert.EqualValues(t, 5000, epochFor(tbl, "GET", "http://anything.com/q"))
 }
 
@@ -229,6 +231,32 @@ func TestPurge_PrefixCapFold(t *testing.T) {
 	assert.Zero(t, tbl.Stats().PrefixRecs, "overflowing prefix records folded into global")
 	assert.EqualValues(t, 1, tbl.Stats().Folds)
 	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://a.com/1"), "still invalidated via the global epoch")
+}
+
+func TestPurge_TagScope(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 0)
+	fixedClock(tbl, 1000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeTag, Tag: "product-42"}}, 1))
+
+	// Any entry carrying the surrogate key is invalidated, regardless of host/url.
+	assert.EqualValues(t, 1000, tbl.InvalidatedAfterMeta(cache.Meta{Host: "shop.com", URI: "/p", Tags: []string{"product-42"}}))
+	assert.EqualValues(t, 1000, tbl.InvalidatedAfterMeta(cache.Meta{Host: "other.com", URI: "/x", Tags: []string{"a", "product-42"}}))
+	// Entries without the tag are untouched.
+	assert.EqualValues(t, 0, tbl.InvalidatedAfterMeta(cache.Meta{Host: "shop.com", URI: "/p", Tags: []string{"category-shoes"}}))
+	assert.EqualValues(t, 0, tbl.InvalidatedAfterMeta(cache.Meta{Host: "shop.com", URI: "/p"}))
+}
+
+func TestPurge_TagPersistenceRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "purge-state")
+	t1, err := NewPurgeTable(path, 0)
+	require.NoError(t, err)
+	fixedClock(t1, 6000)
+	require.NoError(t, t1.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeTag, Tag: "sku-7"}}, 1))
+
+	t2, err := NewPurgeTable(path, 0)
+	require.NoError(t, err)
+	assert.EqualValues(t, 6000, t2.InvalidatedAfterMeta(cache.Meta{Tags: []string{"sku-7"}}), "tag record survives reload")
+	assert.EqualValues(t, 1, t2.Stats().TagRecs)
 }
 
 func TestPurge_FlushAllRealignsCursorDown(t *testing.T) {

--- a/edge/purgereaper_test.go
+++ b/edge/purgereaper_test.go
@@ -88,6 +88,28 @@ func TestReapOnce_PrefixReaps(t *testing.T) {
 	assert.True(t, okB, "/about untouched (outside the prefix)")
 }
 
+func TestReapOnce_TagReaps(t *testing.T) {
+	s := cache.NewMemory(1 << 20)
+	fresh := time.Now().Add(time.Hour).UnixNano()
+	putEntry(t, s, "aa01", cache.Meta{PrimaryHex: "aa01", Host: "shop.com", URI: "/p1", Tags: []string{"product-42"}, Created: 100, FreshUntil: fresh}, []byte("x"))
+	putEntry(t, s, "bb02", cache.Meta{PrimaryHex: "bb02", Host: "blog.com", URI: "/post", Tags: []string{"product-42"}, Created: 100, FreshUntil: fresh}, []byte("y")) // different host, same tag
+	putEntry(t, s, "cc03", cache.Meta{PrimaryHex: "cc03", Host: "shop.com", URI: "/p2", Tags: []string{"product-99"}, Created: 100, FreshUntil: fresh}, []byte("z"))
+
+	tbl, _ := NewPurgeTable("", 0)
+	fixedClock(tbl, 200)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeTag, Tag: "product-42"}}, 1))
+
+	fixedClock(tbl, 300)
+	ReapOnce(s, tbl)
+
+	_, _, okA := s.Get("aa01")
+	assert.False(t, okA, "tagged product-42 reaped (shop.com)")
+	_, _, okB := s.Get("bb02")
+	assert.False(t, okB, "tagged product-42 reaped across hosts (blog.com)")
+	_, _, okC := s.Get("cc03")
+	assert.True(t, okC, "product-99 untouched")
+}
+
 func TestReapOnce_NoPurgesIsNoOp(t *testing.T) {
 	s := cache.NewMemory(1 << 20)
 	fresh := time.Now().Add(time.Hour).UnixNano()

--- a/edge/purgereaper_test.go
+++ b/edge/purgereaper_test.go
@@ -69,6 +69,25 @@ func TestReapOnce_GlobalReapsAllIncludingEmptyHost(t *testing.T) {
 	assert.Positive(t, epochFor(tbl, "GET", "http://anything.com/"), "global epoch kept (no retirement)")
 }
 
+func TestReapOnce_PrefixReaps(t *testing.T) {
+	s := cache.NewMemory(1 << 20)
+	fresh := time.Now().Add(time.Hour).UnixNano()
+	putEntry(t, s, "aa01", cache.Meta{PrimaryHex: "aa01", Host: "acme.com", URI: "/blog/p1", Created: 100, FreshUntil: fresh}, []byte("x"))
+	putEntry(t, s, "bb02", cache.Meta{PrimaryHex: "bb02", Host: "acme.com", URI: "/about", Created: 100, FreshUntil: fresh}, []byte("y"))
+
+	tbl, _ := NewPurgeTable("", 0)
+	fixedClock(tbl, 200)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopePrefix, Host: "acme.com", URI: "/blog"}}, 1))
+
+	fixedClock(tbl, 300)
+	ReapOnce(s, tbl)
+
+	_, _, okA := s.Get("aa01")
+	assert.False(t, okA, "/blog/p1 reaped by the /blog prefix purge")
+	_, _, okB := s.Get("bb02")
+	assert.True(t, okB, "/about untouched (outside the prefix)")
+}
+
 func TestReapOnce_NoPurgesIsNoOp(t *testing.T) {
 	s := cache.NewMemory(1 << 20)
 	fresh := time.Now().Add(time.Hour).UnixNano()

--- a/edgecp/purgeserver_test.go
+++ b/edgecp/purgeserver_test.go
@@ -99,6 +99,22 @@ func TestPurgeAPI_GetScopedToAllowedHosts(t *testing.T) {
 	}
 }
 
+func TestPurgeAPI_PrefixPostThenGet(t *testing.T) {
+	srv, _ := purgeTestServer(t)
+	h := srv.Handler()
+
+	rec := do(t, h, "POST", "/v1/purges", "admin-secret", `{"scope":"prefix","host":"acme.com","uri":"/blog"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = do(t, h, "GET", "/v1/purges?since=0", "edge-tok", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got PurgeSince
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Entries, 1)
+	assert.Equal(t, "prefix", got.Entries[0].Scope)
+	assert.Equal(t, "/blog", got.Entries[0].URI)
+}
+
 func TestPurgeAPI_PostInvalidScopeIs400(t *testing.T) {
 	srv, _ := purgeTestServer(t)
 	h := srv.Handler()

--- a/edgecp/purgeserver_test.go
+++ b/edgecp/purgeserver_test.go
@@ -84,9 +84,9 @@ func TestPurgeAPI_PostThenGetRoundTrip(t *testing.T) {
 func TestPurgeAPI_GetScopedToAllowedHosts(t *testing.T) {
 	srv, store := purgeTestServer(t)
 	h := srv.Handler()
-	_, _ = store.Add(purgeScopeHost, "acme.com", "")  // edge allowed
-	_, _ = store.Add(purgeScopeHost, "other.com", "") // edge NOT allowed
-	_, _ = store.Add(purgeScopeFlushAll, "", "")      // everyone
+	_, _ = store.Add(purgeScopeHost, "acme.com", "", "")  // edge allowed
+	_, _ = store.Add(purgeScopeHost, "other.com", "", "") // edge NOT allowed
+	_, _ = store.Add(purgeScopeFlushAll, "", "", "")      // everyone
 
 	rec := do(t, h, "GET", "/v1/purges?since=0", "edge-tok", "")
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -113,6 +113,23 @@ func TestPurgeAPI_PrefixPostThenGet(t *testing.T) {
 	require.Len(t, got.Entries, 1)
 	assert.Equal(t, "prefix", got.Entries[0].Scope)
 	assert.Equal(t, "/blog", got.Entries[0].URI)
+}
+
+func TestPurgeAPI_TagPostReachesEvenUnscopedEdge(t *testing.T) {
+	srv, _ := purgeTestServer(t) // edge-tok serves only acme.com
+	h := srv.Handler()
+
+	rec := do(t, h, "POST", "/v1/purges", "admin-secret", `{"scope":"tag","tag":"product-42"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// The tag purge has no host, yet the acme.com-only edge still receives it.
+	rec = do(t, h, "GET", "/v1/purges?since=0", "edge-tok", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got PurgeSince
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Entries, 1)
+	assert.Equal(t, "tag", got.Entries[0].Scope)
+	assert.Equal(t, "product-42", got.Entries[0].Tag)
 }
 
 func TestPurgeAPI_PostInvalidScopeIs400(t *testing.T) {

--- a/edgecp/purgestore.go
+++ b/edgecp/purgestore.go
@@ -13,6 +13,7 @@ const (
 	purgeScopeHost     = "host"
 	purgeScopeURL      = "url"
 	purgeScopePrefix   = "prefix"
+	purgeScopeTag      = "tag"
 )
 
 // defaultPurgeJournalMax bounds the in-memory journal. Purges are operator-issued
@@ -23,12 +24,14 @@ const (
 const defaultPurgeJournalMax = 4096
 
 // purgeRecord is one journal entry. host is normalized (lowercased, port-stripped);
-// uri is the request-uri (path+query) verbatim from the operator.
+// uri is the request-uri (path+query, or path prefix) verbatim from the operator;
+// tag is a surrogate key (tag scope, host-independent).
 type purgeRecord struct {
 	seq   uint64
 	scope string
 	host  string
 	uri   string
+	tag   string
 }
 
 // PurgeEntryDTO is the JSON wire shape of one purge entry (matches edge.PurgeEntry).
@@ -37,6 +40,7 @@ type PurgeEntryDTO struct {
 	Scope string `json:"scope"`
 	Host  string `json:"host,omitempty"`
 	URI   string `json:"uri,omitempty"`
+	Tag   string `json:"tag,omitempty"`
 }
 
 // PurgeSince is the GET /v1/purges response: the entries an edge hasn't applied yet
@@ -73,23 +77,24 @@ func NewPurgeStore(maxEntries int) *PurgeStore {
 }
 
 // Add appends a purge and returns its seq. scope must be one of flush-all / host /
-// url / prefix. host is required (and normalized) for host/url/prefix; uri is
+// url / prefix / tag. host is required (and normalized) for host/url/prefix; uri is
 // required for url (the exact on-the-wire path+query) and prefix (the path prefix),
 // and MUST start with "/" so it can match a request path (a request-uri always
-// does) — a no-leading-slash value would silently match nothing. uri must be in
-// the same percent-encoded form the request carries (the cache keys on the raw
-// RequestURI). A bad scope/host/uri returns (0, false) so the handler can 400.
-func (s *PurgeStore) Add(scope, host, uri string) (uint64, bool) {
+// does) — a no-leading-slash value would silently match nothing; uri must be in the
+// same percent-encoded form the request carries (the cache keys on the raw
+// RequestURI). tag is required for tag scope (a surrogate key, host-independent). A
+// bad scope/host/uri/tag returns (0, false) so the handler can 400.
+func (s *PurgeStore) Add(scope, host, uri, tag string) (uint64, bool) {
 	scope = strings.TrimSpace(scope)
 	switch scope {
 	case purgeScopeFlushAll:
-		host, uri = "", ""
+		host, uri, tag = "", "", ""
 	case purgeScopeHost:
 		host = normHostCP(host)
 		if host == "" {
 			return 0, false
 		}
-		uri = ""
+		uri, tag = "", ""
 	case purgeScopeURL, purgeScopePrefix:
 		// url: uri is the exact path+query; prefix: uri is the path prefix. Both must
 		// be a rooted path ("/..."), else they'd never match a real request path —
@@ -99,6 +104,18 @@ func (s *PurgeStore) Add(scope, host, uri string) (uint64, bool) {
 		if host == "" || !strings.HasPrefix(uri, "/") {
 			return 0, false
 		}
+		tag = ""
+	case purgeScopeTag:
+		// tag is a surrogate key, host-independent — distributed to every edge, which
+		// then matches it against each entry's own Cache-Tag set. NOTE: unlike
+		// host/url/prefix (host-gated by Since's allow), tag names are broadcast
+		// fleet-wide, so they are a SHARED, cross-tenant-visible namespace — operators
+		// must not encode secrets in Cache-Tag values.
+		tag = strings.TrimSpace(tag)
+		if tag == "" {
+			return 0, false
+		}
+		host, uri = "", ""
 	default:
 		return 0, false
 	}
@@ -106,7 +123,7 @@ func (s *PurgeStore) Add(scope, host, uri string) (uint64, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.lastSeq++
-	s.entries = append(s.entries, purgeRecord{seq: s.lastSeq, scope: scope, host: host, uri: uri})
+	s.entries = append(s.entries, purgeRecord{seq: s.lastSeq, scope: scope, host: host, uri: uri, tag: tag})
 	if len(s.entries) > s.maxKeep {
 		// Trim oldest; re-slice into a fresh backing array so the dropped records
 		// are reclaimed rather than pinned by the slice header.
@@ -119,10 +136,10 @@ func (s *PurgeStore) Add(scope, host, uri string) (uint64, bool) {
 }
 
 // Since returns the purges an edge with cursor `since` hasn't applied: entries with
-// seq > since, filtered to flush-all (affects every edge) plus host/url/prefix
-// entries whose host the edge may serve (per allow). FlushRequired is set when the edge's
-// next-needed seq was already trimmed (since+1 < minSeq) — the edge then bumps its
-// global epoch and jumps to MaxSeq.
+// seq > since, filtered to flush-all and tag (both host-independent, so they reach
+// every edge) plus host/url/prefix entries whose host the edge may serve (per
+// allow). FlushRequired is set when the edge's next-needed seq was already trimmed
+// (since+1 < minSeq) — the edge then bumps its global epoch and jumps to MaxSeq.
 func (s *PurgeStore) Since(since uint64, allow func(host string) bool) PurgeSince {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -147,10 +164,12 @@ func (s *PurgeStore) Since(since uint64, allow func(host string) bool) PurgeSinc
 		if e.seq <= since {
 			continue
 		}
-		if e.scope != purgeScopeFlushAll && !allow(e.host) {
+		// flush-all and tag are host-independent (every edge); host/url/prefix are
+		// gated by the token's hosts.
+		if e.scope != purgeScopeFlushAll && e.scope != purgeScopeTag && !allow(e.host) {
 			continue
 		}
-		res.Entries = append(res.Entries, PurgeEntryDTO{Seq: e.seq, Scope: e.scope, Host: e.host, URI: e.uri})
+		res.Entries = append(res.Entries, PurgeEntryDTO{Seq: e.seq, Scope: e.scope, Host: e.host, URI: e.uri, Tag: e.tag})
 	}
 	return res
 }

--- a/edgecp/purgestore.go
+++ b/edgecp/purgestore.go
@@ -12,6 +12,7 @@ const (
 	purgeScopeFlushAll = "flush-all"
 	purgeScopeHost     = "host"
 	purgeScopeURL      = "url"
+	purgeScopePrefix   = "prefix"
 )
 
 // defaultPurgeJournalMax bounds the in-memory journal. Purges are operator-issued
@@ -72,8 +73,12 @@ func NewPurgeStore(maxEntries int) *PurgeStore {
 }
 
 // Add appends a purge and returns its seq. scope must be one of flush-all / host /
-// url; host is required for host+url (normalized here), uri for url. A bad
-// scope/host/uri returns (0, false) so the handler can 400.
+// url / prefix. host is required (and normalized) for host/url/prefix; uri is
+// required for url (the exact on-the-wire path+query) and prefix (the path prefix),
+// and MUST start with "/" so it can match a request path (a request-uri always
+// does) — a no-leading-slash value would silently match nothing. uri must be in
+// the same percent-encoded form the request carries (the cache keys on the raw
+// RequestURI). A bad scope/host/uri returns (0, false) so the handler can 400.
 func (s *PurgeStore) Add(scope, host, uri string) (uint64, bool) {
 	scope = strings.TrimSpace(scope)
 	switch scope {
@@ -85,9 +90,13 @@ func (s *PurgeStore) Add(scope, host, uri string) (uint64, bool) {
 			return 0, false
 		}
 		uri = ""
-	case purgeScopeURL:
+	case purgeScopeURL, purgeScopePrefix:
+		// url: uri is the exact path+query; prefix: uri is the path prefix. Both must
+		// be a rooted path ("/..."), else they'd never match a real request path —
+		// reject so a typo surfaces as a 400 instead of a silent no-op purge.
 		host = normHostCP(host)
-		if host == "" || uri == "" {
+		uri = strings.TrimSpace(uri)
+		if host == "" || !strings.HasPrefix(uri, "/") {
 			return 0, false
 		}
 	default:
@@ -110,8 +119,8 @@ func (s *PurgeStore) Add(scope, host, uri string) (uint64, bool) {
 }
 
 // Since returns the purges an edge with cursor `since` hasn't applied: entries with
-// seq > since, filtered to flush-all (affects every edge) plus host/url entries
-// whose host the edge may serve (per allow). FlushRequired is set when the edge's
+// seq > since, filtered to flush-all (affects every edge) plus host/url/prefix
+// entries whose host the edge may serve (per allow). FlushRequired is set when the edge's
 // next-needed seq was already trimmed (since+1 < minSeq) — the edge then bumps its
 // global epoch and jumps to MaxSeq.
 func (s *PurgeStore) Since(since uint64, allow func(host string) bool) PurgeSince {

--- a/edgecp/purgestore_test.go
+++ b/edgecp/purgestore_test.go
@@ -129,13 +129,44 @@ func TestPurgeStore_MaxUint64SinceFlushesNotPanics(t *testing.T) {
 	assert.True(t, res.FlushRequired)
 }
 
+func TestPurgeStore_PrefixTrimsWhitespaceAndStores(t *testing.T) {
+	s := NewPurgeStore(0)
+	// Surrounding whitespace is trimmed; a rooted path is accepted and stored clean
+	// (else the edge's normalizePrefix, which only trims a trailing slash, would keep
+	// the spaces and the prefix would silently match nothing).
+	_, ok := s.Add(purgeScopePrefix, "a.com", "  /blog  ")
+	require.True(t, ok)
+	res := s.Since(0, allowAll)
+	require.Len(t, res.Entries, 1)
+	assert.Equal(t, "/blog", res.Entries[0].URI, "prefix trimmed to a clean rooted path")
+}
+
+func TestPurgeStore_PrefixScopedByHost(t *testing.T) {
+	s := NewPurgeStore(0)
+	_, ok := s.Add(purgeScopePrefix, "a.com", "/blog")
+	require.True(t, ok)
+	_, ok = s.Add(purgeScopePrefix, "other.com", "/x")
+	require.True(t, ok)
+
+	// An edge allowed only a.com gets a.com's prefix purge, never other.com's.
+	res := s.Since(0, func(h string) bool { return h == "a.com" })
+	require.Len(t, res.Entries, 1)
+	assert.Equal(t, purgeScopePrefix, res.Entries[0].Scope)
+	assert.Equal(t, "a.com", res.Entries[0].Host)
+	assert.Equal(t, "/blog", res.Entries[0].URI)
+}
+
 func TestPurgeStore_InvalidInputsRejected(t *testing.T) {
 	s := NewPurgeStore(0)
 	cases := []struct{ scope, host, uri string }{
 		{"bogus", "a.com", "/x"},
-		{purgeScopeHost, "", ""},     // host scope needs a host
-		{purgeScopeURL, "a.com", ""}, // url scope needs a uri
-		{purgeScopeURL, "", "/x"},    // url scope needs a host
+		{purgeScopeHost, "", ""},            // host scope needs a host
+		{purgeScopeURL, "a.com", ""},        // url scope needs a uri
+		{purgeScopeURL, "", "/x"},           // url scope needs a host
+		{purgeScopeURL, "a.com", "blog"},    // url uri must be a rooted "/..." path
+		{purgeScopePrefix, "a.com", ""},     // prefix scope needs a prefix path
+		{purgeScopePrefix, "", "/x"},        // prefix scope needs a host
+		{purgeScopePrefix, "a.com", "blog"}, // prefix must be a rooted "/..." path (typo guard)
 	}
 	for _, c := range cases {
 		_, ok := s.Add(c.scope, c.host, c.uri)

--- a/edgecp/purgestore_test.go
+++ b/edgecp/purgestore_test.go
@@ -12,11 +12,11 @@ func allowNone(string) bool { return false }
 
 func TestPurgeStore_AddAndSinceFromZero(t *testing.T) {
 	s := NewPurgeStore(0)
-	seq1, ok := s.Add(purgeScopeURL, "acme.com", "/a")
+	seq1, ok := s.Add(purgeScopeURL, "acme.com", "/a", "")
 	require.True(t, ok)
-	seq2, ok := s.Add(purgeScopeHost, "acme.com", "")
+	seq2, ok := s.Add(purgeScopeHost, "acme.com", "", "")
 	require.True(t, ok)
-	seq3, ok := s.Add(purgeScopeFlushAll, "", "")
+	seq3, ok := s.Add(purgeScopeFlushAll, "", "", "")
 	require.True(t, ok)
 	assert.EqualValues(t, 1, seq1)
 	assert.EqualValues(t, 2, seq2)
@@ -32,9 +32,9 @@ func TestPurgeStore_AddAndSinceFromZero(t *testing.T) {
 
 func TestPurgeStore_SinceIncremental(t *testing.T) {
 	s := NewPurgeStore(0)
-	_, _ = s.Add(purgeScopeURL, "a.com", "/1")
-	_, _ = s.Add(purgeScopeURL, "a.com", "/2")
-	_, _ = s.Add(purgeScopeURL, "a.com", "/3")
+	_, _ = s.Add(purgeScopeURL, "a.com", "/1", "")
+	_, _ = s.Add(purgeScopeURL, "a.com", "/2", "")
+	_, _ = s.Add(purgeScopeURL, "a.com", "/3", "")
 
 	res := s.Since(2, allowAll)
 	require.Len(t, res.Entries, 1, "only entries with seq > cursor")
@@ -52,9 +52,9 @@ func TestPurgeStore_EmptyJournalNoGap(t *testing.T) {
 
 func TestPurgeStore_ScopingByHost(t *testing.T) {
 	s := NewPurgeStore(0)
-	_, _ = s.Add(purgeScopeHost, "a.com", "")
-	_, _ = s.Add(purgeScopeHost, "b.com", "")
-	_, _ = s.Add(purgeScopeFlushAll, "", "")
+	_, _ = s.Add(purgeScopeHost, "a.com", "", "")
+	_, _ = s.Add(purgeScopeHost, "b.com", "", "")
+	_, _ = s.Add(purgeScopeFlushAll, "", "", "")
 
 	// An edge allowed only a.com sees its host entry + the flush-all, not b.com.
 	allowA := func(h string) bool { return h == "a.com" }
@@ -71,8 +71,8 @@ func TestPurgeStore_ScopingByHost(t *testing.T) {
 
 func TestPurgeStore_FlushAllAlwaysDeliveredEvenToDenyAll(t *testing.T) {
 	s := NewPurgeStore(0)
-	_, _ = s.Add(purgeScopeHost, "a.com", "")
-	_, _ = s.Add(purgeScopeFlushAll, "", "")
+	_, _ = s.Add(purgeScopeHost, "a.com", "", "")
+	_, _ = s.Add(purgeScopeFlushAll, "", "", "")
 	res := s.Since(0, allowNone)
 	require.Len(t, res.Entries, 1)
 	assert.Equal(t, purgeScopeFlushAll, res.Entries[0].Scope)
@@ -81,7 +81,7 @@ func TestPurgeStore_FlushAllAlwaysDeliveredEvenToDenyAll(t *testing.T) {
 func TestPurgeStore_GapTriggersFlushRequired(t *testing.T) {
 	s := NewPurgeStore(2) // retain only the 2 newest
 	for i := 0; i < 5; i++ {
-		_, ok := s.Add(purgeScopeURL, "a.com", "/x")
+		_, ok := s.Add(purgeScopeURL, "a.com", "/x", "")
 		require.True(t, ok)
 	}
 	// Retained seqs are {4,5}; minSeq=4. An edge at cursor 1 needs seq 2 (trimmed) → gap.
@@ -109,7 +109,7 @@ func TestPurgeStore_CursorAheadOfJournalFlushes(t *testing.T) {
 
 	// After the restart the CP issues a few purges; the edge cursor is still ahead.
 	for i := 0; i < 3; i++ {
-		_, _ = s.Add(purgeScopeURL, "a.com", "/x")
+		_, _ = s.Add(purgeScopeURL, "a.com", "/x", "")
 	}
 	res = s.Since(500, allowAll)
 	assert.True(t, res.FlushRequired, "cursor still ahead of lastSeq=3 must flush")
@@ -124,7 +124,7 @@ func TestPurgeStore_CursorAheadOfJournalFlushes(t *testing.T) {
 
 func TestPurgeStore_MaxUint64SinceFlushesNotPanics(t *testing.T) {
 	s := NewPurgeStore(0)
-	_, _ = s.Add(purgeScopeURL, "a.com", "/x")
+	_, _ = s.Add(purgeScopeURL, "a.com", "/x", "")
 	res := s.Since(^uint64(0), allowAll) // would overflow since+1; cursor-ahead catches it first
 	assert.True(t, res.FlushRequired)
 }
@@ -134,7 +134,7 @@ func TestPurgeStore_PrefixTrimsWhitespaceAndStores(t *testing.T) {
 	// Surrounding whitespace is trimmed; a rooted path is accepted and stored clean
 	// (else the edge's normalizePrefix, which only trims a trailing slash, would keep
 	// the spaces and the prefix would silently match nothing).
-	_, ok := s.Add(purgeScopePrefix, "a.com", "  /blog  ")
+	_, ok := s.Add(purgeScopePrefix, "a.com", "  /blog  ", "")
 	require.True(t, ok)
 	res := s.Since(0, allowAll)
 	require.Len(t, res.Entries, 1)
@@ -143,9 +143,9 @@ func TestPurgeStore_PrefixTrimsWhitespaceAndStores(t *testing.T) {
 
 func TestPurgeStore_PrefixScopedByHost(t *testing.T) {
 	s := NewPurgeStore(0)
-	_, ok := s.Add(purgeScopePrefix, "a.com", "/blog")
+	_, ok := s.Add(purgeScopePrefix, "a.com", "/blog", "")
 	require.True(t, ok)
-	_, ok = s.Add(purgeScopePrefix, "other.com", "/x")
+	_, ok = s.Add(purgeScopePrefix, "other.com", "/x", "")
 	require.True(t, ok)
 
 	// An edge allowed only a.com gets a.com's prefix purge, never other.com's.
@@ -154,6 +154,30 @@ func TestPurgeStore_PrefixScopedByHost(t *testing.T) {
 	assert.Equal(t, purgeScopePrefix, res.Entries[0].Scope)
 	assert.Equal(t, "a.com", res.Entries[0].Host)
 	assert.Equal(t, "/blog", res.Entries[0].URI)
+}
+
+func TestPurgeStore_TagDeliveredToAllEdges(t *testing.T) {
+	s := NewPurgeStore(0)
+	_, ok := s.Add(purgeScopeTag, "", "", "product-42")
+	require.True(t, ok)
+	// A tag purge is host-independent — it reaches even a deny-all edge (which then
+	// matches it against each entry's own Cache-Tag set).
+	res := s.Since(0, allowNone)
+	require.Len(t, res.Entries, 1)
+	assert.Equal(t, purgeScopeTag, res.Entries[0].Scope)
+	assert.Equal(t, "product-42", res.Entries[0].Tag)
+	assert.Empty(t, res.Entries[0].Host, "tag entry carries no host")
+}
+
+func TestPurgeStore_TagRequiresTag(t *testing.T) {
+	s := NewPurgeStore(0)
+	_, ok := s.Add(purgeScopeTag, "", "", "")
+	assert.False(t, ok, "tag scope needs a tag")
+	_, ok = s.Add(purgeScopeTag, "", "", "  ")
+	assert.False(t, ok, "blank tag rejected")
+	_, ok = s.Add(purgeScopeTag, "", "", " sku-1 ")
+	require.True(t, ok)
+	assert.Equal(t, "sku-1", s.Since(0, allowNone).Entries[0].Tag, "tag trimmed")
 }
 
 func TestPurgeStore_InvalidInputsRejected(t *testing.T) {
@@ -169,7 +193,7 @@ func TestPurgeStore_InvalidInputsRejected(t *testing.T) {
 		{purgeScopePrefix, "a.com", "blog"}, // prefix must be a rooted "/..." path (typo guard)
 	}
 	for _, c := range cases {
-		_, ok := s.Add(c.scope, c.host, c.uri)
+		_, ok := s.Add(c.scope, c.host, c.uri, "")
 		assert.False(t, ok, "scope=%q host=%q uri=%q should be rejected", c.scope, c.host, c.uri)
 	}
 	// Nothing was journaled.
@@ -178,7 +202,7 @@ func TestPurgeStore_InvalidInputsRejected(t *testing.T) {
 
 func TestPurgeStore_HostNormalized(t *testing.T) {
 	s := NewPurgeStore(0)
-	_, ok := s.Add(purgeScopeHost, "  ACME.com:443 ", "")
+	_, ok := s.Add(purgeScopeHost, "  ACME.com:443 ", "", "")
 	require.True(t, ok)
 	res := s.Since(0, allowAll)
 	require.Len(t, res.Entries, 1)

--- a/edgecp/server.go
+++ b/edgecp/server.go
@@ -369,14 +369,15 @@ func (s *Server) handlePurgeAdmin(w http.ResponseWriter, r *http.Request) {
 		Scope string `json:"scope"`
 		Host  string `json:"host"`
 		URI   string `json:"uri"`
+		Tag   string `json:"tag"`
 	}
 	if err := json.NewDecoder(io.LimitReader(r.Body, 64<<10)).Decode(&body); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
-	seq, ok := s.purge.Add(body.Scope, body.Host, body.URI)
+	seq, ok := s.purge.Add(body.Scope, body.Host, body.URI, body.Tag)
 	if !ok {
-		http.Error(w, "invalid scope/host/uri (scope must be flush-all|host|url|prefix; host required for host/url/prefix; uri required for url, and the path prefix for prefix)", http.StatusBadRequest)
+		http.Error(w, "invalid scope/host/uri/tag (scope must be flush-all|host|url|prefix|tag; host required for host/url/prefix; uri (rooted /path) required for url and prefix; tag required for tag)", http.StatusBadRequest)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/edgecp/server.go
+++ b/edgecp/server.go
@@ -376,7 +376,7 @@ func (s *Server) handlePurgeAdmin(w http.ResponseWriter, r *http.Request) {
 	}
 	seq, ok := s.purge.Add(body.Scope, body.Host, body.URI)
 	if !ok {
-		http.Error(w, "invalid scope/host/uri (scope must be flush-all|host|url; host required for host/url; uri required for url)", http.StatusBadRequest)
+		http.Error(w, "invalid scope/host/uri (scope must be flush-all|host|url|prefix; host required for host/url/prefix; uri required for url, and the path prefix for prefix)", http.StatusBadRequest)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/profiler v0.6.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.32.0
 	github.com/acoshift/configfile v1.9.0
-	github.com/moonrhythm/parapet v0.17.1
+	github.com/moonrhythm/parapet v0.17.2
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moonrhythm/parapet v0.17.1 h1:qV7+h3H1M9noRtnhFjBkGabeONfQxCoACaA8bdHZgOU=
-github.com/moonrhythm/parapet v0.17.1/go.mod h1:mfLCzU9zBm6vn05mnOgO0G8/+pArndciyLv3BYM9HJA=
+github.com/moonrhythm/parapet v0.17.2 h1:dXLEhjY1iDk50XQS9M7WSKepTv/nPUoCxqu61CcwDZo=
+github.com/moonrhythm/parapet v0.17.2/go.mod h1:mfLCzU9zBm6vn05mnOgO0G8/+pArndciyLv3BYM9HJA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=


### PR DESCRIPTION
## What

Adds the final two cache-purge scopes on top of the shipped url / host / flush-all (#127) and reaper (#128), completing the edge purge feature:

- **`prefix`** — invalidate every URL under a path prefix on a host (e.g. `/blog` covers `/blog` and `/blog/x`). Path-only, boundary-aware (`/blog` ≠ `/blogger`), query-agnostic. Edge-only — no parapet change.
- **`tag`** — invalidate every cached response carrying a surrogate key from the origin's **`Cache-Tag`** response header. Content-identity invalidation across hosts/URLs (the canonical CDN model). Requires **parapet v0.17.2** (`Meta.Tags`), which `go.mod` is bumped to.

Two commits: `feat(edge): path-prefix cache-purge scope` and `feat(edge): cache-tag (surrogate-key) purge scope`.

## How

- `edge/purge.go`: `epochFor(host, uri, tags)` folds in a boundary-aware path-prefix scan and a per-tag lookup; `InvalidatedAfter(r, m)` and the reaper's `InvalidatedAfterMeta(m)` both pass `m.Tags` (the cache hook already receives the stored `Meta`). New `prefix`/`tag` maps; cap-fold, `FlushAll`, persistence, `highWater`, and metrics all extended.
- `edgecp`: `prefix` (host-gated) and `tag` scopes on `POST`/`GET /v1/purges`. Tag is **host-independent** — delivered to every edge (like flush-all), which filters by actual `Meta.Tags` membership; host/url/prefix stay host-gated. `Add` validates a rooted `/...` uri for url+prefix (rejecting silent-no-op typos) and a non-empty tag.
- The reaper reclaims prefix- and tag-matched entries for free via `Meta`.

## Reviewed (adversarial, before commit)

- **prefix** (19 agents): fixed a real footgun — a non-rooted uri (operator typo `blog`) was accepted but matched nothing; `Add` now 400s it (for url too). Also fixed `FlushAll` not clearing the prefix map, and documented the percent-encoded-uri requirement.
- **tag** (7 agents): both findings doc-only — documented that tag names broadcast fleet-wide (a shared, non-secret namespace; only the opaque label crosses, never content) and corrected a stale doc comment.

## Tests

57 purge tests across `edge/` + `edgecp/` (prefix boundary/normalization/`/`-root/cap/persistence/no-leading-slash-reject; tag gate/cross-host reap/persistence/flush/all-edges-delivery/validation; plus reaper coverage for both). `gofmt`/`go vet` clean, full build, `go test -race ./edge/ ./edgecp/` and the full suite pass.

## Config

No new env vars. Scopes are selected per `POST /v1/purges` body; `tag` uses the `tag` field, `prefix` reuses `uri`. Edge-only; pure-Go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)