### PR TITLE
harden: startup readiness, status-label cardinality, purge fsync off the lock

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -160,31 +160,93 @@ func (ctrl *Controller) Watch() {
 	}
 }
 
+// preloadResources lists every watched resource into the store before the first
+// reload. Each list is RETRIED until it succeeds (or ctx is cancelled): the very
+// next step (firstReload) flips the controller to Ready, so listing an empty store
+// because the API server was momentarily unreachable would make the pod report
+// healthy while serving 404 for every route. A legitimately empty namespace lists
+// successfully (no error) and proceeds immediately.
 func (ctrl *Controller) preloadResources(ctx context.Context) {
-	ingresses, _ := k8s.GetIngresses(ctx, ctrl.watchNamespace)
-	for _, i := range ingresses {
-		ctrl.watchedIngresses.Store(i.Namespace+"/"+i.Name, &i)
-	}
-
-	services, _ := k8s.GetServices(ctx, ctrl.watchNamespace)
-	for _, s := range services {
-		ctrl.watchedServices.Store(s.Namespace+"/"+s.Name, &s)
-	}
-
-	secrets, _ := k8s.GetSecrets(ctx, ctrl.watchNamespace)
-	for _, s := range secrets {
-		ctrl.watchedSecrets.Store(s.Namespace+"/"+s.Name, &s)
-	}
-
-	endpoints, _ := k8s.GetEndpoints(ctx, ctrl.watchNamespace)
-	for _, e := range endpoints {
-		ctrl.watchedEndpoints.Store(e.Namespace+"/"+e.Name, &e)
-	}
+	preloadList(ctx, "ingresses", func() error {
+		ingresses, err := k8s.GetIngresses(ctx, ctrl.watchNamespace)
+		if err != nil {
+			return err
+		}
+		for i := range ingresses {
+			ctrl.watchedIngresses.Store(ingresses[i].Namespace+"/"+ingresses[i].Name, &ingresses[i])
+		}
+		return nil
+	})
+	preloadList(ctx, "services", func() error {
+		services, err := k8s.GetServices(ctx, ctrl.watchNamespace)
+		if err != nil {
+			return err
+		}
+		for i := range services {
+			ctrl.watchedServices.Store(services[i].Namespace+"/"+services[i].Name, &services[i])
+		}
+		return nil
+	})
+	preloadList(ctx, "secrets", func() error {
+		secrets, err := k8s.GetSecrets(ctx, ctrl.watchNamespace)
+		if err != nil {
+			return err
+		}
+		for i := range secrets {
+			ctrl.watchedSecrets.Store(secrets[i].Namespace+"/"+secrets[i].Name, &secrets[i])
+		}
+		return nil
+	})
+	preloadList(ctx, "endpoints", func() error {
+		endpoints, err := k8s.GetEndpoints(ctx, ctrl.watchNamespace)
+		if err != nil {
+			return err
+		}
+		for i := range endpoints {
+			ctrl.watchedEndpoints.Store(endpoints[i].Namespace+"/"+endpoints[i].Name, &endpoints[i])
+		}
+		return nil
+	})
 
 	if ctrl.WAFConfig.Enabled {
-		configmaps, _ := k8s.GetConfigMaps(ctx, ctrl.watchNamespace, wafLabelKey)
-		for _, cm := range configmaps {
-			ctrl.watchedConfigMaps.Store(cm.Namespace+"/"+cm.Name, &cm)
+		preloadList(ctx, "configmaps", func() error {
+			configmaps, err := k8s.GetConfigMaps(ctx, ctrl.watchNamespace, wafLabelKey)
+			if err != nil {
+				return err
+			}
+			for i := range configmaps {
+				ctrl.watchedConfigMaps.Store(configmaps[i].Namespace+"/"+configmaps[i].Name, &configmaps[i])
+			}
+			return nil
+		})
+	}
+}
+
+// preloadList runs fn, retrying with capped exponential backoff on error until it
+// succeeds or ctx is cancelled. The controller stays NotReady (firstReload hasn't
+// run) for the duration, so a transient API-server outage at startup never lets it
+// serve traffic with an empty route table.
+func preloadList(ctx context.Context, name string, fn func() error) {
+	const (
+		baseBackoff = 500 * time.Millisecond
+		maxBackoff  = 10 * time.Second
+	)
+	backoff := baseBackoff
+	for {
+		if err := fn(); err == nil {
+			return
+		} else {
+			slog.Error("controller: preload failed; retrying (staying NotReady)", "resource", name, "error", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < maxBackoff {
+			if backoff *= 2; backoff > maxBackoff {
+				backoff = maxBackoff
+			}
 		}
 	}
 }

--- a/controller_test.go
+++ b/controller_test.go
@@ -1,13 +1,17 @@
 package controller
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/moonrhythm/parapet"
 	"github.com/stretchr/testify/assert"
@@ -542,4 +546,41 @@ func TestServeHandlerConcurrentWithReload(t *testing.T) {
 
 	wg.Wait()
 	assert.True(t, ctrl.IsKnownHost("example.com"), "served host stays known after the reload storm")
+}
+
+func TestPreloadListRetriesUntilSuccess(t *testing.T) {
+	// A transient API error must not let preload give up (which would flip the
+	// controller Ready with an empty route table); it retries until the list succeeds.
+	var calls int32
+	preloadList(context.Background(), "test", func() error {
+		if atomic.AddInt32(&calls, 1) < 2 {
+			return errors.New("api server down")
+		}
+		return nil
+	})
+	assert.EqualValues(t, 2, atomic.LoadInt32(&calls), "retried the failed list, then succeeded")
+}
+
+func TestPreloadListStopsOnContextCancel(t *testing.T) {
+	// A cancelled context must break the retry loop promptly (shutdown), even while
+	// the list keeps failing.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var calls int32
+	done := make(chan struct{})
+	go func() {
+		preloadList(ctx, "test", func() error {
+			atomic.AddInt32(&calls, 1)
+			return errors.New("always fails")
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("preloadList did not return on a cancelled context")
+	}
+	assert.EqualValues(t, 1, atomic.LoadInt32(&calls), "one attempt, then the cancelled ctx breaks the loop")
 }

--- a/edge/purge.go
+++ b/edge/purge.go
@@ -97,6 +97,14 @@ type PurgeTable struct {
 	path     string       // persistence file; "" disables persistence (e.g. memory backend)
 	maxRecs  int          // per-map record cap before a conservative fold-to-global
 	nowNanos func() int64 // injectable clock (unix nanos); nil => time.Now
+
+	// dirtyVer is bumped (under mu) for each persisted snapshot. persistMu serializes
+	// the actual file write OFF the mu critical section — so the fsync never blocks a
+	// serving-path InvalidatedAfter RLock — while persistedVer (under persistMu)
+	// drops a stale snapshot whose newer successor already landed.
+	dirtyVer     uint64
+	persistMu    sync.Mutex
+	persistedVer uint64
 }
 
 // prefixRec is one path-prefix purge for a host: the normalized prefix (trailing
@@ -205,7 +213,6 @@ func (t *PurgeTable) epochFor(host, uri string, tags []string) int64 {
 // from the durable cursor and re-applies idempotently.
 func (t *PurgeTable) Apply(entries []PurgeEntry, maxSeq uint64) error {
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	base := t.cursor
 	changed := false
 	for _, e := range entries {
@@ -220,12 +227,14 @@ func (t *PurgeTable) Apply(entries []PurgeEntry, maxSeq uint64) error {
 		changed = true
 	}
 	// Persist only on a real change, so an idle poll (no new entries, cursor
-	// unchanged) doesn't fsync — and the fsync-under-lock cost is paid only when an
-	// actual purge advances the state, not on every poll tick.
+	// unchanged) doesn't fsync.
 	if !changed {
+		t.mu.Unlock()
 		return nil
 	}
-	return t.saveLocked()
+	snap, ver := t.snapshotLocked()
+	t.mu.Unlock()
+	return t.persist(snap, ver)
 }
 
 // FlushAll bumps the global epoch (lazy flush-all), clears the host/url maps (now
@@ -238,14 +247,15 @@ func (t *PurgeTable) Apply(entries []PurgeEntry, maxSeq uint64) error {
 // leave the cursor stuck above the CP's journal and re-flush on every poll forever.
 func (t *PurgeTable) FlushAll(maxSeq uint64) error {
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	t.global = t.stamp()
 	t.host = map[string]int64{}
 	t.url = map[string]int64{}
 	t.prefix = map[string][]prefixRec{}
 	t.tag = map[string]int64{}
 	t.cursor = maxSeq
-	return t.saveLocked()
+	snap, ver := t.snapshotLocked()
+	t.mu.Unlock()
+	return t.persist(snap, ver)
 }
 
 // applyLocked applies one entry's effect. Caller holds t.mu.
@@ -450,24 +460,63 @@ func (t *PurgeTable) load() error {
 	return nil
 }
 
-// saveLocked atomically persists the current state. Caller holds t.mu. A "" path
-// is a no-op (persistence disabled).
-func (t *PurgeTable) saveLocked() error {
+// snapshotLocked captures an immutable, deep copy of the persistable state and a
+// monotonic version, so the caller can fsync it OUTSIDE t.mu (see persist) without
+// the live maps being mutated underneath the marshal. Caller holds t.mu. The copy
+// is O(records) — cheap (records are operator-issued, not per-request) and far less
+// than holding the lock across an fsync.
+func (t *PurgeTable) snapshotLocked() (persistState, uint64) {
+	t.dirtyVer++
+	return persistState{
+		Global: t.global,
+		Host:   cloneInt64Map(t.host),
+		URL:    cloneInt64Map(t.url),
+		Prefix: clonePrefixMap(t.prefix),
+		Tag:    cloneInt64Map(t.tag),
+		Cursor: t.cursor,
+	}, t.dirtyVer
+}
+
+// persist atomically writes a snapshot to disk WITHOUT holding t.mu (so the fsync
+// never blocks a serving-path InvalidatedAfter RLock). persistMu serializes writes
+// and persistedVer drops a stale snapshot whose newer successor already landed, so
+// an older Apply can never overwrite a newer one's state on disk. A "" path is a
+// no-op (in-memory backend). A write error is returned for logging; the in-memory
+// table is authoritative and the next change re-persists.
+func (t *PurgeTable) persist(snap persistState, ver uint64) error {
 	if t.path == "" {
 		return nil
 	}
-	data, err := json.Marshal(persistState{
-		Global: t.global,
-		Host:   t.host,
-		URL:    t.url,
-		Prefix: t.prefix,
-		Tag:    t.tag,
-		Cursor: t.cursor,
-	})
+	t.persistMu.Lock()
+	defer t.persistMu.Unlock()
+	if ver <= t.persistedVer {
+		return nil // a newer snapshot already won the race to disk
+	}
+	data, err := json.Marshal(snap)
 	if err != nil {
 		return err
 	}
-	return atomicWriteFile(t.path, data)
+	if err := atomicWriteFile(t.path, data); err != nil {
+		return err
+	}
+	t.persistedVer = ver
+	return nil
+}
+
+func cloneInt64Map(m map[string]int64) map[string]int64 {
+	out := make(map[string]int64, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func clonePrefixMap(m map[string][]prefixRec) map[string][]prefixRec {
+	out := make(map[string][]prefixRec, len(m))
+	for k, v := range m {
+		out[k] = append([]prefixRec(nil), v...) // prefixRec is a value type — copied by value
+	}
+	return out
 }
 
 // atomicWriteFile writes data to path via a same-dir temp file with

--- a/edge/purge_test.go
+++ b/edge/purge_test.go
@@ -266,6 +266,34 @@ func TestPurge_FlushAllRealignsCursorDown(t *testing.T) {
 	assert.EqualValues(t, 3, tbl.Cursor(), "a reset flush realigns the cursor down so it can't re-flush forever")
 }
 
+func TestPurge_PersistStaleVersionSkipped(t *testing.T) {
+	// persist() runs the fsync OFF the table lock and must drop a stale snapshot
+	// whose newer successor already landed, so an older Apply can't clobber a newer
+	// one's on-disk state.
+	path := filepath.Join(t.TempDir(), "purge-state")
+	tbl, err := NewPurgeTable(path, 0)
+	require.NoError(t, err)
+	fixedClock(tbl, 1000)
+
+	// Capture two ordered snapshots (newer = v2).
+	tbl.mu.Lock()
+	tbl.host["a.com"] = 100
+	snap1, ver1 := tbl.snapshotLocked()
+	tbl.host["b.com"] = 200
+	snap2, ver2 := tbl.snapshotLocked()
+	tbl.mu.Unlock()
+	require.Greater(t, ver2, ver1)
+
+	// Land the NEWER one first, then try the older — the older must be skipped.
+	require.NoError(t, tbl.persist(snap2, ver2))
+	require.NoError(t, tbl.persist(snap1, ver1))
+
+	reloaded, err := NewPurgeTable(path, 0)
+	require.NoError(t, err)
+	assert.EqualValues(t, 200, reloaded.InvalidatedAfterMeta(cache.Meta{Host: "b.com"}), "newer snapshot survived")
+	assert.EqualValues(t, 100, reloaded.InvalidatedAfterMeta(cache.Meta{Host: "a.com"}), "stale persist did not roll the file back")
+}
+
 func TestPurge_PersistenceRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "purge-state")
 

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -99,7 +99,7 @@ func TestPromRequestsIncCachesAndCounts(t *testing.T) {
 		serviceName: "svc",
 		serviceType: "ClusterIP",
 		method:      "GET",
-		status:      200,
+		status:      "200",
 	}
 
 	// the two 200 calls share one cache entry; a 404 adds a second
@@ -107,7 +107,7 @@ func TestPromRequestsIncCachesAndCounts(t *testing.T) {
 
 	_promRequests.cache.mu.RLock()
 	rm200 := _promRequests.cache.m[key]
-	key.status = 404
+	key.status = "404"
 	rm404 := _promRequests.cache.m[key]
 	_promRequests.cache.mu.RUnlock()
 
@@ -115,4 +115,43 @@ func TestPromRequestsIncCachesAndCounts(t *testing.T) {
 	assert.NotNil(t, rm200)
 	assert.NotNil(t, rm404)
 	assert.NotSame(t, rm200, rm404)
+}
+
+func TestStatusLabel(t *testing.T) {
+	assert.Equal(t, "100", statusLabel(100))
+	assert.Equal(t, "200", statusLabel(200))
+	assert.Equal(t, "599", statusLabel(599))
+	// out of the valid HTTP range -> collapsed
+	assert.Equal(t, "other", statusLabel(0))
+	assert.Equal(t, "other", statusLabel(99))
+	assert.Equal(t, "other", statusLabel(600))
+	assert.Equal(t, "other", statusLabel(12345))
+	assert.Equal(t, "other", statusLabel(-1))
+}
+
+func TestStatusLabelBoundsRequestCardinality(t *testing.T) {
+	// An upstream can write any int via WriteHeader. Without statusLabel, each
+	// distinct code mints a new handle-cache entry + permanent series; statusLabel
+	// must collapse out-of-range codes to one "other" series per (host, method).
+	const host = "status-card-test.example.com"
+	s := state.State{"namespace": "ns", "ingress": "ing", "serviceName": "svc", "serviceType": "ClusterIP"}
+	countEntries := func() int {
+		n := 0
+		_promRequests.cache.mu.RLock()
+		for k := range _promRequests.cache.m {
+			if k.host == host {
+				n++
+			}
+		}
+		_promRequests.cache.mu.RUnlock()
+		return n
+	}
+	start := time.Now()
+	r := httptest.NewRequest("GET", "http://"+host+"/x", nil)
+	r = r.WithContext(state.NewContext(r.Context(), s))
+	for code := 1000; code < 1500; code++ {
+		_promRequests.Inc(r, code, start)
+	}
+	assert.Equal(t, 1, countEntries(),
+		"500 distinct out-of-range status codes must collapse to a single 'other' series per (host,method)")
 }

--- a/metric/requests.go
+++ b/metric/requests.go
@@ -45,7 +45,7 @@ type requestKey struct {
 	serviceName string
 	serviceType string
 	method      string
-	status      int
+	status      string
 }
 
 // requestMetric bundles the counter and duration observer for one label set so
@@ -88,6 +88,18 @@ func methodLabel(method string) string {
 	}
 }
 
+// statusLabel bounds the response status label for the `requests` metric. An
+// upstream can write any int via WriteHeader, so labeling the counter — and keying
+// the handle cache — with the raw code lets a buggy/hostile backend mint unbounded
+// permanent series (the same OOM class methodLabel guards against). Valid HTTP
+// codes (100–599) pass through; anything else collapses to "other".
+func statusLabel(status int) string {
+	if status >= 100 && status <= 599 {
+		return strconv.Itoa(status)
+	}
+	return "other"
+}
+
 func (p *promRequests) Inc(r *http.Request, status int, start time.Time) {
 	duration := time.Since(start)
 
@@ -96,6 +108,7 @@ func (p *promRequests) Inc(r *http.Request, status int, start time.Time) {
 
 	host := HostLabel(r.Host, p.isKnownHost)
 	method := methodLabel(r.Method)
+	statusStr := statusLabel(status)
 
 	// Edge rejection: a tracked rejection status where the request never reached
 	// a backend (makeHandler sets serviceTarget only when it proxies). Counted in
@@ -112,7 +125,7 @@ func (p *promRequests) Inc(r *http.Request, status int, start time.Time) {
 		serviceName: s["serviceName"],
 		serviceType: s["serviceType"],
 		method:      method,
-		status:      status,
+		status:      statusStr,
 	}
 
 	rm := p.cache.getOrCreate(key, func() *requestMetric {
@@ -124,7 +137,7 @@ func (p *promRequests) Inc(r *http.Request, status int, start time.Time) {
 				"ingress_namespace": s["namespace"],
 				"service_type":      s["serviceType"],
 				"service_name":      s["serviceName"],
-				"status":            strconv.Itoa(status),
+				"status":            statusStr,
 			}),
 			observer: p.durations.With(prometheus.Labels{
 				"service_type":      s["serviceType"],


### PR DESCRIPTION
Batch 1 of the hot-path hardening audit — three adversarially-verified findings (each with a test). No new features; no behavior change on the happy path.

## M1 — availability: don't go Ready with an empty route table
`preloadResources` swallowed the initial list errors (`_, _ :=`) and `firstReload` then flipped the controller **Ready**. So a transient API-server outage at startup made the pod report healthy while serving **404 for every route** until the watches reconnected.

Each initial list now **retries with capped exponential backoff until it succeeds** (or ctx is cancelled). A legitimately empty namespace lists with no error and proceeds immediately; only a real API error retries, and the pod stays **NotReady** for the duration.

## M3 — metric DoS: bound the response-status label
The `requests` metric labeled — and cache-keyed — on the raw response status (`strconv.Itoa(status)`). An upstream can write any int via `WriteHeader`, so each distinct code minted a new permanent Prometheus series + handle-cache entry (the same OOM class `methodLabel` already guards against). Added `statusLabel()` collapsing non-`100..599` to `other`, applied to **both** the label and the cache key.

## M2 — hot-path perf: purge fsync off the table lock
`PurgeTable.Apply`/`FlushAll` held the table **write lock across the state-file fsync**, stalling every serving-path `InvalidatedAfter` RLock during a purge poll. The fsync now runs **off** the lock: the change is snapshotted (deep copy + monotonic version) under the lock, then persisted under a separate `persistMu` that **drops a stale snapshot whose newer successor already landed** — so an older `Apply` can never roll the on-disk state back.

## Not changed — audit false positive
Finding M4 ("missing `service_namespace` label → metric collision") was a **false positive**: `plugin.InjectStateIngress` (registered first in the chain) sets `s["namespace"]` on every proxied request; the auditor only inspected `makeHandler`. Verified, left as-is.

## Tests
`statusLabel` bounding + 500-distinct-code cardinality collapse; `preloadList` retry-until-success + stop-on-cancel; purge stale-snapshot-skip (older `persist` can't clobber a newer one). `gofmt`/`go vet` clean; `go test -race ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)