### PR TITLE
harden: verify-cache cache-bust defense + durable purge-state writes

### DIFF
--- a/edge/purge.go
+++ b/edge/purge.go
@@ -520,8 +520,9 @@ func clonePrefixMap(m map[string][]prefixRec) map[string][]prefixRec {
 }
 
 // atomicWriteFile writes data to path via a same-dir temp file with
-// write+fsync+close+rename, so a reader never sees a partial state file (matches
-// the disk cache's commit idiom).
+// write+fsync+close+rename, then fsyncs the parent directory so the rename itself
+// is durable — without the dir fsync a crash right after rename can lose the new
+// file, leaving stale/absent state (matches the disk cache's commit idiom).
 func atomicWriteFile(path string, data []byte) error {
 	dir := filepath.Dir(path)
 	f, err := os.CreateTemp(dir, ".purge-state-*.tmp")
@@ -547,7 +548,20 @@ func atomicWriteFile(path string, data []byte) error {
 		os.Remove(tmp)
 		return err
 	}
-	return nil
+	return fsyncDir(dir)
+}
+
+// fsyncDir flushes a directory entry so a rename into it survives a crash. A
+// failure to open/sync the dir is best-effort (some filesystems don't support it);
+// the rename already happened, so it is logged via the returned error but not fatal
+// to the in-memory state.
+func fsyncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
 }
 
 // --- keys ---

--- a/trust/trust.go
+++ b/trust/trust.go
@@ -390,17 +390,32 @@ func (m *Manager) VerifyClientCert(cs *tls.ConnectionState) bool {
 	})
 	ok := err == nil
 
+	// Cache only verified-OK results. An attacker can't mint a cert that chains to the
+	// edge CA, so a flood of distinct UNtrusted certs would otherwise fill the cache and
+	// evict the legit fleet's entries (cache-bust, forcing a re-verify of every real
+	// edge). Not caching false defeats that: an untrusted cert just re-verifies (a cheap
+	// fail) without touching the cache or the write lock. A stale-generation cached entry
+	// is still rejected by the read-path gen check above; the reset below drops stale
+	// entries on the first OK after a CA rotation.
+	if !ok {
+		return false
+	}
 	m.verifyMu.Lock()
 	if m.verifyGen != gen || m.verifyCache == nil {
 		m.verifyCache = make(map[string]bool, 64)
 		m.verifyGen = gen
 	}
 	if len(m.verifyCache) >= verifyCacheCap {
-		clear(m.verifyCache)
+		// Bounded: drop ONE arbitrary entry rather than wiping the whole cache, so a
+		// fleet larger than the cap can't cost every other edge a re-verify at once.
+		for k := range m.verifyCache {
+			delete(m.verifyCache, k)
+			break
+		}
 	}
-	m.verifyCache[key] = ok
+	m.verifyCache[key] = true
 	m.verifyMu.Unlock()
-	return ok
+	return true
 }
 
 // applyResult classifies an apply attempt so the caller can emit the right metric

--- a/trust/trust_test.go
+++ b/trust/trust_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -448,5 +449,104 @@ func TestNewClientRequiresCA(t *testing.T) {
 	}
 	if _, err := NewClient("https://cp:8443", []byte("not a cert")); err == nil {
 		t.Error("unparseable CA must be rejected")
+	}
+}
+
+func leafSignedBy(t *testing.T, sg *edgecp.Signer, id string) *x509.Certificate {
+	t.Helper()
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	chainPEM, _, _, err := sg.Sign(key.Public(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, _ := pem.Decode(chainPEM)
+	leaf, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return leaf
+}
+
+func csForLeaf(leaf *x509.Certificate) *tls.ConnectionState {
+	return &tls.ConnectionState{PeerCertificates: []*x509.Certificate{leaf}}
+}
+
+// TestVerifyClientCertUntrustedDoesNotBustCache is the M5 hardening: an attacker
+// can't mint a cert that chains to the edge CA, so a flood of distinct UNtrusted
+// certs must never enter the verify cache — otherwise they'd evict the legit
+// fleet's entries and force every real edge to re-verify (cache-bust).
+func TestVerifyClientCertUntrustedDoesNotBustCache(t *testing.T) {
+	caPEM, caKey := caPEMFor(t)
+	signer, _, err := edgecp.NewProvidedSigner(caPEM, caKey, time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherPEM, otherKey := caPEMFor(t)
+	otherSigner, _, _ := edgecp.NewProvidedSigner(otherPEM, otherKey, time.Hour, time.Minute)
+
+	m := NewManager()
+	if _, err := m.apply(Bundle{Generation: 1, CAPEM: caPEM, CAID: "a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	edge := leafSignedBy(t, signer, "edge-1")
+	if !m.VerifyClientCert(csForLeaf(edge)) {
+		t.Fatal("edge leaf must verify")
+	}
+	m.verifyMu.RLock()
+	n0 := len(m.verifyCache)
+	m.verifyMu.RUnlock()
+	if n0 != 1 {
+		t.Fatalf("trusted cert should be cached; cache len = %d", n0)
+	}
+
+	for i := 0; i < 200; i++ {
+		if m.VerifyClientCert(csForLeaf(leafSignedBy(t, otherSigner, "intruder-"+strconv.Itoa(i)))) {
+			t.Fatal("a cert not chaining to the edge CA must not be trusted")
+		}
+	}
+	m.verifyMu.RLock()
+	n1 := len(m.verifyCache)
+	m.verifyMu.RUnlock()
+	if n1 != 1 {
+		t.Fatalf("untrusted certs must never be cached; cache grew to %d (cache-bust)", n1)
+	}
+
+	if !m.VerifyClientCert(csForLeaf(edge)) {
+		t.Fatal("the trusted cert must still verify (served from cache)")
+	}
+}
+
+// TestVerifyClientCertEvictsOneAtCap: at the cap a new trusted cert drops ONE entry
+// rather than wiping the whole cache (so a fleet > cap doesn't force a fleet-wide
+// re-verify at once).
+func TestVerifyClientCertEvictsOneAtCap(t *testing.T) {
+	caPEM, caKey := caPEMFor(t)
+	signer, _, err := edgecp.NewProvidedSigner(caPEM, caKey, time.Hour, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := NewManager()
+	if _, err := m.apply(Bundle{Generation: 1, CAPEM: caPEM, CAID: "a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-fill to the cap for the live generation.
+	m.verifyMu.Lock()
+	m.verifyGen = m.gen.Load()
+	m.verifyCache = make(map[string]bool, verifyCacheCap)
+	for i := 0; i < verifyCacheCap; i++ {
+		m.verifyCache["k"+strconv.Itoa(i)] = true
+	}
+	m.verifyMu.Unlock()
+
+	if !m.VerifyClientCert(csForLeaf(leafSignedBy(t, signer, "edge-cap"))) {
+		t.Fatal("trusted cert must verify")
+	}
+	m.verifyMu.RLock()
+	n := len(m.verifyCache)
+	m.verifyMu.RUnlock()
+	if n != verifyCacheCap {
+		t.Fatalf("at cap, expected one eviction + one insert to keep len == %d, got %d", verifyCacheCap, n)
 	}
 }


### PR DESCRIPTION
Batch 2 of the hot-path hardening audit. Two fixes; three audit items verified and intentionally left as-is.

## M5 — DoS: VerifyClientCert cache-bust
The per-generation memo cached **both** verify outcomes and **wiped the whole map** at the cap. A client can present a client cert on the `:443` mTLS handshake (`RequestClientCert`), and an attacker without an edge-CA leaf can mint **unlimited distinct UNtrusted certs** — filling the cache and evicting the legit fleet's entries, forcing a re-verify of every real edge.

Fix: **cache only verified-OK results** (an attacker can't mint a cert that chains to the edge CA, so untrusted certs never enter the cache or take the write lock — they just re-verify, a cheap fail), and at the cap **evict one** entry instead of clearing the whole map. A stale-generation cached entry is still rejected by the read-path generation check; the reset still clears stale entries on the first OK after a CA rotation.

Adds the first cache-behavior tests for `VerifyClientCert` (the path had none): untrusted-flood-doesn't-bust + evict-one-at-cap, alongside the existing trust/reject/rotation contract test (which still passes — it never relied on caching `false`).

## L4 — durability: purge-state parent-dir fsync
`atomicWriteFile` fsync'd the temp file but not the containing directory, so a crash right after `rename` could lose the new state file. Added a parent-dir fsync after rename (matches the disk cache's commit idiom). The pre-existing failure mode was already conservative (lost state → flush-all on next poll); this makes the rename itself crash-durable.

## Verified, NOT changed (by reading the code)
- **M6** (route-table host/port "desync"): **not a bug.** `SetHostRoutes` (reloadEndpoint) and `SetPortRoutes` (reloadService) are independent debounced reloaders; `Lookup` requires **both** `okHost && okPort`, so the transient window is **fail-closed** (503 + retry, never wrong-tenant routing). Coupling them into one atomic swap isn't worth closing a sub-second rollout window the retry path already tolerates.
- **L5** (`ca_id` metric cardinality): **false positive** — `TrustBundleApplied` already does `Reset()`-then-`Set()`, keeping exactly one `ca_id` series across rotations.
- **L6** (edge `cp.go` 4 KiB error-body drain cap): **intentional bound** (don't read unbounded from a dependency); a rare >4 KiB error body just closes the conn (`defer Close`, no leak).

`gofmt`/`go vet` clean; `go test -race ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)