### PR TITLE
perf/harden: zero-cost gates on the per-request path + consistent WAF snapshot

### DIFF
--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -200,7 +200,7 @@ func main() {
 	if !disableLog {
 		m.Use(logger.Stdout())
 	}
-	m.Use(state.Middleware())
+	m.Use(state.Middleware(!disableLog))
 	m.Use(metric.Requests(ctrl.IsKnownHost))
 	m.Use(compress.Gzip())
 	m.Use(compress.BrWithQuality(4))

--- a/edge/purge.go
+++ b/edge/purge.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/moonrhythm/parapet/pkg/cache"
@@ -105,6 +106,14 @@ type PurgeTable struct {
 	dirtyVer     uint64
 	persistMu    sync.Mutex
 	persistedVer uint64
+
+	// active is true once any purge has ever been stamped (or loaded from disk). The
+	// serving-path hook (InvalidatedAfter -> epochFor) reads it lock-free FIRST and
+	// returns 0 immediately when false — so an edge that caches but has never been
+	// issued a purge pays nothing per cache hit (no RLock, no urlKey hash, no scans).
+	// It only ever flips false->true (epochs and the global flush never revert), so a
+	// stale false read just costs one request the (eventually-consistent) miss.
+	active atomic.Bool
 }
 
 // prefixRec is one path-prefix purge for a host: the normalized prefix (trailing
@@ -176,6 +185,9 @@ func (t *PurgeTable) InvalidatedAfterMeta(m cache.Meta) int64 {
 // come from the request or the stored Meta; tags come from the stored Meta (the
 // origin's surrogate keys). Shared by the lookup hook and the reaper.
 func (t *PurgeTable) epochFor(host, uri string, tags []string) int64 {
+	if !t.active.Load() {
+		return 0 // no purge ever applied: skip the lock, the urlKey hash, and the scans
+	}
 	uk := urlKey(host, uri)
 	path := pathOf(uri)
 	t.mu.RLock()
@@ -315,6 +327,7 @@ func (t *PurgeTable) stamp() int64 {
 		n = t.highWater
 	}
 	t.highWater = n
+	t.active.Store(true) // a purge now exists; the serving-path gate must stop short-circuiting
 	return n
 }
 
@@ -456,6 +469,11 @@ func (t *PurgeTable) load() error {
 		if v > t.highWater {
 			t.highWater = v
 		}
+	}
+	// highWater > 0 ⇒ at least one purge was loaded ⇒ the serving-path gate must
+	// stop short-circuiting after a restart that reloaded persisted purge state.
+	if t.highWater > 0 {
+		t.active.Store(true)
 	}
 	return nil
 }

--- a/edge/purge_test.go
+++ b/edge/purge_test.go
@@ -233,6 +233,33 @@ func TestPurge_PrefixCapFold(t *testing.T) {
 	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://a.com/1"), "still invalidated via the global epoch")
 }
 
+func TestPurge_NoPurgeGate(t *testing.T) {
+	tbl, _ := NewPurgeTable("", 0)
+	// Before any purge: the serving-path gate short-circuits to 0 without locking.
+	assert.False(t, tbl.active.Load())
+	assert.EqualValues(t, 0, tbl.InvalidatedAfterMeta(cache.Meta{Host: "a.com", URI: "/x", Tags: []string{"t"}}))
+
+	fixedClock(tbl, 1000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeHost, Host: "a.com"}}, 1))
+	// After a purge: the gate opens and lookups resolve normally.
+	assert.True(t, tbl.active.Load())
+	assert.EqualValues(t, 1000, tbl.InvalidatedAfterMeta(cache.Meta{Host: "a.com", URI: "/x"}))
+	assert.EqualValues(t, 0, tbl.InvalidatedAfterMeta(cache.Meta{Host: "other.com", URI: "/x"}))
+}
+
+func TestPurge_GateActiveAfterReload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "purge-state")
+	t1, _ := NewPurgeTable(path, 0)
+	fixedClock(t1, 2000)
+	require.NoError(t, t1.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeHost, Host: "a.com"}}, 1))
+
+	// A reload of persisted purge state must re-open the gate (else lookups would
+	// short-circuit to 0 and silently under-invalidate after a restart).
+	t2, _ := NewPurgeTable(path, 0)
+	assert.True(t, t2.active.Load())
+	assert.EqualValues(t, 2000, t2.InvalidatedAfterMeta(cache.Meta{Host: "a.com", URI: "/x"}))
+}
+
 func TestPurge_TagScope(t *testing.T) {
 	tbl, _ := NewPurgeTable("", 0)
 	fixedClock(tbl, 1000)

--- a/edgecp/wafstore.go
+++ b/edgecp/wafstore.go
@@ -25,7 +25,7 @@ const (
 // set and `scoped()` filters it. Lock-free reads via atomic pointers; the three
 // inputs (global ConfigMaps, zone ConfigMaps, Ingresses) update independently.
 type WafStore struct {
-	mu       sync.Mutex
+	mu       sync.RWMutex // write-held by Set*/recompute; read-held by scoped for a consistent snapshot
 	global   atomic.Pointer[string]
 	zones    atomic.Pointer[map[string]string] // zoneKey -> rules YAML
 	hostZone atomic.Pointer[map[string]string] // lowercased host -> zoneKey
@@ -105,7 +105,19 @@ type scopedSnapshot struct {
 // scoped builds the response for an edge, including only host→zone entries whose
 // host the edge may serve (per `allow`) and the zones those entries reference.
 // Global is always included (it's the platform baseline, identical for all edges).
+//
+// It reads global/zones/hostZone/gen under the read lock so the four are a single
+// CONSISTENT snapshot of the store's state — without it, the four independent atomic
+// reads could straddle a concurrent SetZones/SetHostZone/recompute and return, e.g.,
+// a host→zone binding whose zone rules aren't in the (older) zones map, or a
+// generation that doesn't match the payload. (Cross-reloader eventual consistency
+// between the zone and ingress watches is inherent and corrected on the next poll;
+// parapet re-runs the WAF authoritatively regardless.) scoped runs per edge poll, so
+// the brief RLock is negligible.
 func (s *WafStore) scoped(allow func(host string) bool) scopedSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	allZones := *s.zones.Load()
 	allHostZone := *s.hostZone.Load()
 

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -28,7 +28,7 @@ func TestInjectStateIngress(t *testing.T) {
 			},
 		},
 	}
-	ctx.Use(state.Middleware())
+	ctx.Use(state.Middleware(true))
 	InjectStateIngress(ctx)
 
 	var called bool

--- a/state/state.go
+++ b/state/state.go
@@ -49,16 +49,21 @@ func NewContext(parent context.Context, s State) context.Context {
 	return context.WithValue(parent, ctxKey{}, s)
 }
 
-// Middleware injects empty state context to request and set all state values to logger
-func Middleware() parapet.Middleware {
+// Middleware injects a pooled per-request State into the context. When logEnabled is
+// true it also copies every state field into the request's access-log record on the
+// way out. With logging disabled the copy loop is skipped entirely — it would
+// otherwise iterate the map and walk the context chain via logger.Set on every
+// request for a log line that is never emitted, so a disabled access log pays nothing.
+func Middleware(logEnabled bool) parapet.Middleware {
 	return parapet.MiddlewareFunc(func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 			s := pool.Get().(State)
 			defer func() {
-				// inject state to log
-				for k, v := range s {
-					logger.Set(ctx, k, v) // TODO: implement log to reduce memory usage
+				if logEnabled {
+					for k, v := range s {
+						logger.Set(ctx, k, v)
+					}
 				}
 				putState(s)
 			}()

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -47,7 +47,7 @@ func TestMiddleware(t *testing.T) {
 
 	var called bool
 	var m parapet.Middlewares
-	m.Use(Middleware())
+	m.Use(Middleware(true))
 	m.Use(parapet.MiddlewareFunc(func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			s := Get(r.Context())
@@ -76,7 +76,7 @@ func TestMiddleware(t *testing.T) {
 // asserts the second request sees a clean slate.
 func TestMiddlewareDoesNotLeakStateBetweenRequests(t *testing.T) {
 	var m parapet.Middlewares
-	m.Use(Middleware())
+	m.Use(Middleware(false)) // exercise the disabled-log path (pooling must still recycle)
 
 	first := true
 	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Batch 3, from the serving-path perf audit (#2) plus one non-hot-path consistency fix (#1). Three behavior-preserving changes; the rest of both audits were verified low/false and intentionally not taken.

## P1 — edge: skip the purge lookup when nothing is purged
`PurgeTable.epochFor` ran on **every edge cache hit** — `RLock` + `sha256(host⊕uri)` + prefix/tag scans — even on an edge that caches but has never been issued a purge (the common case). Added an atomic `active` flag, set on the first stamp (and on reload of persisted purge state), checked **lock-free at the top** of `epochFor`: with no purge ever applied, the hook returns `0` with no lock, no hash, no scan. It only flips false→true, so a stale read costs one request the (already eventually-consistent) miss — never a wrong serve.

## P2 — controller: disabled access log pays nothing
`state.Middleware` copied every state field into the access-log record on the way out of **every request** (map iteration + a `logger.Set` context-chain walk per key) even when `DISABLE_LOG` suppresses the log. `Middleware(logEnabled bool)` now skips the copy loop entirely when logging is off (the `sync.Pool` recycle still runs). Honors the disabled-feature-zero-cost principle.

## W1 — edgecp: consistent WAF snapshot
`WafStore.scoped` read `global`/`zones`/`hostZone`/`gen` as four independent atomic loads, so a concurrent reload could yield a torn snapshot (a host→zone binding whose zone rules are absent, or a generation mismatched to the payload). It now reads them under a read lock (`mu` → `RWMutex`) for one consistent snapshot. Cross-reloader eventual consistency between the zone and ingress watches is inherent and self-heals on the next poll; parapet re-runs the WAF authoritatively regardless. `scoped` runs per edge poll, so the brief RLock is negligible.

## Intentionally NOT taken (verified low/false)
- route-table `host:port` concat alloc — proposed cache fix is infeasible (RRLB returns a different IP per call, by design).
- metric handle-cache RLock + `prometheus.Labels` alloc — already amortized to ~0 by the handle cache (cache-miss only).
- the long tail of micro-opts on amortized / inherent / correctly-zero-cost-when-disabled paths.

## Tests
New: no-purge gate + gate-active-after-reload (`edge`), disabled-log pool recycle (`state`). `gofmt`/`go vet` clean; `go test -race ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)