### PR TITLE
fix(proxy): stop dialer racing the recycled per-request state map

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -855,10 +855,21 @@ func (ctrl *Controller) makeHandler(ing *networking.Ingress, svc *v1.Service, co
 	if ctrl.proxy.AutoH2CEnabled() {
 		upstreamKey = svc.Namespace + "/" + svc.Name + ":" + strconv.Itoa(config.PortNumber)
 	}
+	// Immutable per-Service attribution for backend connection metrics. These are
+	// constant for this route, so build them once. They mirror the
+	// serviceType/serviceName/namespace state fields (still stamped below for the
+	// access log and per-request metrics, both read in the request goroutine) but
+	// are carried to the dialer in a context value that is never cleared or pooled.
+	// The dialer can run on a background goroutine that outlives the request, after
+	// the state map has been recycled, so it must not read the map — see
+	// proxy.WithBackendAttr.
+	serviceType := string(svc.Spec.Type)
+	serviceName := svc.Name
+	namespace := svc.Namespace
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s := state.Get(r.Context())
-		s["serviceType"] = string(svc.Spec.Type)
-		s["serviceName"] = svc.Name
+		s["serviceType"] = serviceType
+		s["serviceName"] = serviceName
 		if upstreamKey != "" { // auto-h2c negative-cache key (proxy reads it)
 			s["upstreamKey"] = upstreamKey
 		}
@@ -876,6 +887,8 @@ func (ctrl *Controller) makeHandler(ing *networking.Ingress, svc *v1.Service, co
 		r.URL.Host = target
 
 		s["serviceTarget"] = target
+
+		r = r.WithContext(proxy.WithBackendAttr(r.Context(), serviceType, namespace, serviceName))
 
 		ctrl.proxy.ServeHTTP(w, r)
 	})

--- a/proxy/attr.go
+++ b/proxy/attr.go
@@ -1,0 +1,42 @@
+package proxy
+
+import "context"
+
+// backendAttr is the immutable per-Service attribution the dialer stamps onto
+// connection metrics. It is carried in the request context (set by the route
+// handler via WithBackendAttr) rather than read from the pooled state map.
+//
+// Why not the state map: Go's transport may start a dial on a background
+// goroutine that races a fresh connection against an idle one
+// (startDialConnForLocked → dialConnFor). That dial runs DialContext with the
+// request's context, but it can outlive the originating request — by the time
+// it completes, state.Middleware's defer has already cleared the per-request
+// State and returned it to the sync.Pool, where another in-flight request may
+// have picked it up and started writing. Reading that map from the dial
+// goroutine is then a concurrent map read against a map write, which the
+// runtime turns into a fatal error. This value is never cleared or recycled, so
+// a late read is always safe and returns the correct Service labels.
+type backendAttr struct {
+	serviceType string
+	namespace   string
+	serviceName string
+}
+
+type backendAttrCtxKey struct{}
+
+// WithBackendAttr returns a child context carrying immutable backend
+// attribution (Service type / namespace / name) for connection metrics. The
+// route handler sets it before proxying; the dialer reads it when wrapping a
+// freshly dialed connection.
+func WithBackendAttr(ctx context.Context, serviceType, namespace, serviceName string) context.Context {
+	return context.WithValue(ctx, backendAttrCtxKey{}, backendAttr{
+		serviceType: serviceType,
+		namespace:   namespace,
+		serviceName: serviceName,
+	})
+}
+
+func backendAttrFromContext(ctx context.Context) backendAttr {
+	a, _ := ctx.Value(backendAttrCtxKey{}).(backendAttr)
+	return a
+}

--- a/proxy/dialer.go
+++ b/proxy/dialer.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/moonrhythm/parapet-ingress-controller/metric"
-	"github.com/moonrhythm/parapet-ingress-controller/state"
 )
 
 type dialer struct {
@@ -38,11 +37,15 @@ func (d *dialer) DialContext(ctx context.Context, network, addr string) (conn ne
 	}
 
 	// Attribute the connection to its destination Service, not the dialed pod
-	// address. The transport calls DialContext with the request context, so the
-	// route state stamped by makeHandler is available here; a pod addr maps to a
-	// single Service, so the attribution is stable across connection reuse.
-	s := state.Get(ctx)
-	conn = metric.BackendConnections(conn, s["serviceType"], s["namespace"], s["serviceName"])
+	// address; a pod addr maps to a single Service, so the attribution is stable
+	// across connection reuse. The labels come from an immutable context value
+	// (set by the route handler via WithBackendAttr), not the pooled state map:
+	// this dial can run on a background goroutine that outlives the request and
+	// reach here after the state map has been cleared and recycled, so reading
+	// that map would race a concurrent writer — see backendAttr for the full
+	// mechanism.
+	a := backendAttrFromContext(ctx)
+	conn = metric.BackendConnections(conn, a.serviceType, a.namespace, a.serviceName)
 	return
 }
 

--- a/proxy/dialer_test.go
+++ b/proxy/dialer_test.go
@@ -1,0 +1,103 @@
+package proxy
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet-ingress-controller/state"
+)
+
+func TestBackendAttrRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithBackendAttr(context.Background(), "ClusterIP", "ns", "svc")
+	a := backendAttrFromContext(ctx)
+	assert.Equal(t, "ClusterIP", a.serviceType)
+	assert.Equal(t, "ns", a.namespace)
+	assert.Equal(t, "svc", a.serviceName)
+
+	// Absent value yields a zero attribution, not a panic.
+	assert.Equal(t, backendAttr{}, backendAttrFromContext(context.Background()))
+}
+
+// TestDialContextDoesNotRaceRecycledState reproduces the dialer crash fixed by
+// carrying backend attribution in an immutable context value.
+//
+// The transport may run DialContext on a background goroutine (it races a fresh
+// dial against an idle connection) that outlives the originating request. By the
+// time it reaches the attribution read, state.Middleware has cleared the pooled
+// per-request State and another request may already be writing to it. The old
+// dialer read those labels from that map, so the late read raced the writer —
+// "fatal error: concurrent map read and map write". The fix reads an immutable
+// value instead, so the dial goroutine never touches the recyclable map.
+//
+// A single writer goroutine continuously stamps then clears the shared map (so
+// writer-vs-writer never races); many concurrent dialers exercise the read path.
+// Run with -race: the pre-fix dialer trips the detector here, the fixed one does
+// not.
+func TestDialContextDoesNotRaceRecycledState(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			c.Close()
+		}
+	}()
+	addr := ln.Addr().String()
+
+	d := newDialer()
+
+	// The same shape state.Middleware injects: a pooled map reachable from the
+	// dial context, and (in the fixed code) the immutable attribution beside it.
+	s := state.State{}
+	ctx := state.NewContext(context.Background(), s)
+	ctx = WithBackendAttr(ctx, "ClusterIP", "ns", "svc")
+
+	stop := make(chan struct{})
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				// putState clears the map; the next request re-stamps it.
+				s["serviceType"] = "ClusterIP"
+				s["namespace"] = "ns"
+				s["serviceName"] = "svc"
+				clear(s)
+			}
+		}
+	}()
+
+	const dialers = 8
+	const dialsPerGoroutine = 400
+	var wg sync.WaitGroup
+	for i := 0; i < dialers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < dialsPerGoroutine; j++ {
+				conn, err := d.DialContext(ctx, "tcp", addr)
+				if err == nil {
+					conn.Close()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	close(stop)
+	<-writerDone
+}


### PR DESCRIPTION
## The crash

```
fatal error: concurrent map read and map write

goroutine ... [running]:
proxy.(*dialer).DialContext(...)
        proxy/dialer.go:45 ...
created by net/http.(*Transport).startDialConnForLocked
        net/http.(*Transport).dialConnFor
```

A live process-killing bug on `main`, introduced in #126.

## Root cause

`dialer.DialContext` attributed backend connection metrics by reading
`serviceType`/`namespace`/`serviceName` from the **pooled per-request
`state.State` map**:

```go
s := state.Get(ctx)
conn = metric.BackendConnections(conn, s["serviceType"], s["namespace"], s["serviceName"])
```

That map is explicitly **not concurrency-safe**. `state.Middleware` clears it
(`clear(s)` — a map write) and returns it to a `sync.Pool` on request
completion, where another in-flight request picks it up and writes new keys.

Go's transport may run `DialContext` on a **background goroutine that outlives
the request** — it races a fresh dial against an idle connection
(`startDialConnForLocked → dialConnFor`, exactly the stack trace above). When
the idle conn wins, the originating request returns and recycles its state map
while the orphaned dial goroutine is still executing `DialContext` and reading
those keys. **Concurrent map read (dialer) vs. map write (clear/recycle/re-stamp)
→ `fatal error: concurrent map read and map write`**, which crashes the whole
process.

## Fix

Carry the attribution in an **immutable context value** (`proxy.WithBackendAttr`,
built once per route in `makeHandler`) instead of the pooled map. The value is
never cleared or reused, so a late dial-goroutine read is always safe and
returns the correct Service labels — the same labels #126 introduced, with the
Service-keyed metric series intact.

The `serviceType`/`serviceName`/`namespace` **state fields stay** — they're read
by the access log and the per-request metrics, both in the request goroutine
(safe). Only the *escaping* reader, the dialer, moves off the map.

## Validation

- New `-race` reproducer `proxy/dialer_test.go` drives concurrent `DialContext`
  calls against a single writer recycling the shared state map. It trips
  `fatal error: concurrent map read and map write` on the **old** code and
  passes on the fix (verified by temporarily reverting the dialer).
- `go test -race ./...` — all green.
- `gofmt -l` clean, `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)