### PR TITLE
fix(trust): advertise edge-CA in CertificateRequest to stop browser cert prompt

### DIFF
--- a/EDGE-AUTOTRUST.md
+++ b/EDGE-AUTOTRUST.md
@@ -74,7 +74,15 @@ not a source IP.
 4. **The core verifies it — per request, not at the TLS layer.** The `:443`
    `tls.Config` uses `ClientAuth = tls.RequestClientCert`: it *requests* a client cert
    but **never verifies it during the handshake**, so a non-edge client cert never
-   aborts the connection. This is what lets the edge **and** another mTLS client that
+   aborts the connection. The request is resolved **per handshake**
+   (`GetConfigForClient`) against the live edge-CA pool: it advertises the edge-CA
+   subjects (`ClientCAs`) so a browser hitting `:443` directly filters them out and is
+   **not** shown a certificate-selection prompt (Chromium/Safari — see
+   `trust.Manager.ServerTLSConfig`; Firefox filters weakly), and **before any CA loads it
+   requests no client cert at all**, so a cold-start handshake never prompts. Advertising
+   `ClientCAs` does **not** enable TLS-layer verification (that would need
+   `VerifyClientCertIfGiven`) — it only populates the advertised CA list. This is what
+   lets the edge **and** another mTLS client that
    hits `:443` directly (e.g. **Cloudflare Authenticated Origin Pulls**, whose cert
    chains to Cloudflare's CA, not the edge CA) coexist on the same port — Cloudflare's
    cert would otherwise fail `VerifyClientCertIfGiven` and break every Cloudflare
@@ -154,10 +162,14 @@ trustProxy = func(r *http.Request) bool {
 `ClientAuth = tls.RequestClientCert` (request-but-never-verify) so a non-edge client
 cert (Cloudflare Authenticated Origin Pulls) can't abort the handshake; the edge-CA
 chain check is done per request by `VerifyClientCert` (nil `r.TLS` / `:80` ⇒ false,
-i.e. CIDR-only on plaintext). The pool is no longer fed into the `tls.Config`'s
-`ClientCAs`; it lives in the manager for the per-request verify (memoized by leaf
-fingerprint per generation). Only the *feed* into the pool changes; trust still reads
-no per-request map.
+i.e. CIDR-only on plaintext). The pool **is** advertised into the `tls.Config`'s
+`ClientCAs` — but only as the `CertificateRequest`'s acceptable-CA list (resolved per
+handshake via `GetConfigForClient`), so a directly-connecting browser filters it out and
+is never shown a cert-selection prompt. It is **not** used for TLS-layer verification:
+under `RequestClientCert` Go never verifies against `ClientCAs`, so the authoritative
+edge-CA chain check still happens per request in the manager (memoized by leaf
+fingerprint per generation), and before any CA loads the core requests no client cert at
+all. Trust still reads no per-request map.
 
 ### The trust pull (tokenless CP client)
 

--- a/trust/clientcert_prompt_test.go
+++ b/trust/clientcert_prompt_test.go
@@ -1,0 +1,106 @@
+package trust
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"testing"
+	"time"
+)
+
+// recordCertRequest stands up the core's real ServerTLSConfig and performs one TLS
+// handshake from a client that records (a) whether the server asked for a client cert
+// — the client's GetClientCertificate fires iff the server sent a CertificateRequest —
+// and (b) which CA subjects the server advertised (req.AcceptableCAs). AcceptableCAs is
+// exactly the list a browser filters its offered client certs against: a server that
+// requests a cert with an EMPTY AcceptableCAs is what makes a Windows browser (whose
+// CryptoAPI store often holds client certs) pop the certificate-selection modal.
+func recordCertRequest(t *testing.T, m *Manager) (requested bool, acceptableCAs [][]byte) {
+	t.Helper()
+	serverCert := genServerCert(t)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	cfg := m.ServerTLSConfig(nil, []tls.Certificate{serverCert})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		tc := tls.Server(conn, cfg)
+		_ = tc.Handshake() // outcome is observed via the client callback below
+	}()
+
+	clientCfg := &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec // this test inspects the CertificateRequest, not the server cert
+		GetClientCertificate: func(req *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			requested = true
+			acceptableCAs = req.AcceptableCAs
+			return &tls.Certificate{}, nil // present no client cert
+		},
+	}
+	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: 5 * time.Second}, "tcp", ln.Addr().String(), clientCfg)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	_ = conn.CloseWrite()
+	conn.Close()
+	return requested, acceptableCAs
+}
+
+// TestServerTLSConfig_NoCertPromptBeforeCALoaded asserts the cold-start window does not
+// prompt: with no edge CA loaded yet (CIDR-only), nobody can be mTLS-trusted, so the
+// core must not send a CertificateRequest at all — otherwise every directly-connecting
+// browser is prompted for a certificate it can never usefully provide.
+func TestServerTLSConfig_NoCertPromptBeforeCALoaded(t *testing.T) {
+	m := NewManager() // never applied: ClientCAs() == nil
+	requested, _ := recordCertRequest(t, m)
+	if requested {
+		t.Error("cold start (no edge CA loaded) sent a CertificateRequest — a directly-connecting " +
+			"browser would be prompted to select a client certificate")
+	}
+}
+
+// TestServerTLSConfig_AdvertisesEdgeCAFilter asserts that once an edge CA is loaded the
+// core still requests the edge's client cert, but advertises the edge CA's subject in the
+// CertificateRequest. Browsers offer only client certs chaining to an advertised CA, so a
+// user with no cert under the (internal) edge CA is offered nothing and never prompts;
+// the edge's CP-issued cert still chains and is presented + trusted per request.
+func TestServerTLSConfig_AdvertisesEdgeCAFilter(t *testing.T) {
+	m := NewManager()
+	caPEM, _ := caPEMFor(t)
+	if _, err := m.apply(Bundle{Generation: 1, CAPEM: caPEM, CAID: "a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	requested, cas := recordCertRequest(t, m)
+	if !requested {
+		t.Fatal("with an edge CA loaded the core must still request the edge's client cert")
+	}
+	if len(cas) == 0 {
+		t.Fatal("CertificateRequest advertised an EMPTY acceptable-CA list — browsers offer ALL " +
+			"client certs and prompt; the edge CA subject must be advertised so they can filter")
+	}
+
+	blk, _ := pem.Decode(caPEM)
+	caCert, err := x509.ParseCertificate(blk.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, s := range cas {
+		if bytes.Equal(s, caCert.RawSubject) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("advertised acceptable-CA list does not include the edge CA subject")
+	}
+}

--- a/trust/trust.go
+++ b/trust/trust.go
@@ -215,9 +215,9 @@ const verifyCacheCap = 4096
 
 func NewManager() *Manager { return &Manager{} }
 
-// ClientCAs returns the live pool (nil before the first successful load — the
-// caller then requests-but-does-not-verify client certs so the cold-start window
-// degrades to CIDR-only rather than aborting edge handshakes).
+// ClientCAs returns the live pool (nil before the first successful load — while it is
+// nil ServerTLSConfig requests no client cert at all, so the cold-start window degrades
+// to CIDR-only without prompting directly-connecting browsers; see ServerTLSConfig).
 func (m *Manager) ClientCAs() *x509.CertPool { return m.clientCAs.Load() }
 
 // WarmStartFloor returns the persisted last-good generation loaded as the
@@ -327,24 +327,61 @@ func (m *Manager) CAID() string {
 	return ""
 }
 
-// ServerTLSConfig builds the core's :443 *tls.Config. It REQUESTS an optional client
-// cert (tls.RequestClientCert) but NEVER verifies it at the TLS layer — so a client
-// cert that doesn't chain to the edge CA (e.g. Cloudflare Authenticated Origin Pulls)
-// can't abort the handshake. Edge trust is decided per request by VerifyClientCert
-// against the live edge-CA pool: a chaining cert is mTLS-trusted, anything else falls
-// through to CIDR, and the handshake always completes. The SNI server cert is
-// unchanged — getCertificate (the controller's cert table) and the self-signed
-// fallback are served exactly as before.
+// ServerTLSConfig builds the core's :443 *tls.Config. When an edge CA is loaded it
+// REQUESTS an optional client cert (tls.RequestClientCert) but NEVER verifies it at the
+// TLS layer — so a client cert that doesn't chain to the edge CA (e.g. Cloudflare
+// Authenticated Origin Pulls) can't abort the handshake. Edge trust is decided per
+// request by VerifyClientCert against the live edge-CA pool: a chaining cert is
+// mTLS-trusted, anything else falls through to CIDR, and the handshake always completes.
+// The SNI server cert is unchanged — getCertificate (the controller's cert table) and
+// the self-signed fallback are served exactly as before.
+//
+// The request advertises the live edge-CA subjects (ClientCAs) so a browser connecting
+// DIRECTLY to :443 can filter by them: Chromium (Chrome/Edge) and Safari offer only
+// client certs chaining to the (internal) edge CA, so a normal user — who has none — is
+// offered nothing and is NOT shown the certificate-selection modal. That is the reported
+// symptom: a bare RequestClientCert with no advertised CAs makes those browsers offer
+// EVERY client cert in the store, which is why Windows users with an enrollment/smartcard
+// cert get prompted. (Firefox filters the offered list weakly, so a Firefox user with an
+// unrelated personal cert may still be prompted; enterprise AutoSelectCertificateForUrls
+// and smartcard-PIN prompts also live outside this filter — both pre-exist this code.)
+// The edge's CP-issued cert still chains and is presented. Advertising ClientCAs does NOT
+// enable TLS-layer verification — that needs ClientAuth >= VerifyClientCertIfGiven; under
+// RequestClientCert it only populates the advertised CA list, so a non-chaining cert
+// still can't abort the handshake. Resolved per handshake (GetConfigForClient) against
+// the hot-reloaded pool, so a CA rotation is picked up without rebuilding the listener.
+//
+// Before any CA is loaded (cold start) nobody can be mTLS-trusted, so the core requests
+// no client cert at all: a directly-connecting browser is never prompted, and the edge
+// simply stays CIDR-only until the first bundle loads — the same cold-start trust outcome
+// as requesting-but-not-verifying (the edge is untrusted while the pool is nil either
+// way), minus the prompt. One nuance vs the old always-request config: a keep-alive
+// connection the edge opens DURING cold start carries no client cert for its lifetime, so
+// it stays CIDR-only until recycled (~idle timeout) even after the pool loads, instead of
+// flipping to mTLS-trusted mid-connection. It self-heals on reconnect and is never an
+// abort, so the bounded CIDR-only window is an acceptable trade for never prompting.
 func (m *Manager) ServerTLSConfig(
 	getCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error),
 	fallback []tls.Certificate,
 ) *tls.Config {
-	return &tls.Config{
+	base := &tls.Config{
 		MinVersion:     tls.VersionTLS12,
 		Certificates:   fallback,
 		GetCertificate: getCertificate,
-		ClientAuth:     tls.RequestClientCert,
+		// ClientAuth left at NoClientCert: the cold-start (nil-pool) config below
+		// returns base unchanged, so no client cert is requested and no browser prompts.
 	}
+	base.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+		pool := m.clientCAs.Load()
+		if pool == nil {
+			return nil, nil // no edge CA yet → reuse base (NoClientCert): never prompt
+		}
+		c := base.Clone()
+		c.ClientAuth = tls.RequestClientCert
+		c.ClientCAs = pool // advertise the edge-CA subjects so browsers filter and skip the prompt
+		return c, nil
+	}
+	return base
 }
 
 // VerifyClientCert reports whether the peer presented a client cert that chains to the


### PR DESCRIPTION
## Symptom

A Windows user reported their browser pops a **\"select a certificate\"** modal when opening the site.

That modal is the browser responding to a TLS **`CertificateRequest`**. The only public listener in the tree that sends one is the **controller's `:443`**, and only when **edge auto-trust is enabled** (`EDGE_TRUST_CP_ENDPOINT` set). In that mode `trust.Manager.ServerTLSConfig` used `ClientAuth: tls.RequestClientCert` **with no `ClientCAs`**, so the `CertificateRequest` carried an **empty acceptable-CA list**. Browsers use that list to decide which client certs to offer; empty = "offer everything", so Chrome/Edge on Windows (which read the OS CryptoAPI store) surface every enrollment/smartcard cert and prompt.

Two conditions must both hold to hit it:
1. controller runs with edge auto-trust on (`EDGE_TRUST_CP_ENDPOINT` set), and
2. the browser reaches the controller's `:443` **directly** (L4/passthrough LB, or no L7 edge in front). The edge-proxy's own `:443` sets no `ClientAuth`, so *browser → edge* never prompts.

## Fix

`ServerTLSConfig` now resolves client-auth **per handshake** (`GetConfigForClient`) against the live edge-CA pool:

- **Cold start (no CA loaded):** request **no** client cert → no prompt; edge stays CIDR-only (unchanged trust outcome).
- **CA loaded:** request it **and advertise the edge-CA subjects** (`ClientCAs = live pool`). Browsers offer only certs chaining to the *internal* edge CA — a normal user has none → no modal. The edge's CP-issued cert still chains, so it's presented and trusted as before.

Under `RequestClientCert`, Go never verifies against `ClientCAs` — it only advertises the CA list — so the handshake still never aborts and per-request trust via `VerifyClientCert` is unchanged. All four edge-mTLS invariants (edge-trusted / no-cert-untrusted / **rogue-cert-no-abort** / cold-start-no-abort) hold.

## Tests / verification

- New deterministic regression `trust/clientcert_prompt_test.go` observes the on-wire `CertificateRequest` (presence + `AcceptableCAs`) the way a browser does — **red** before the fix (cold-start prompted; CA list empty), **green** after.
- `TestAutoTrustEndToEnd` and full `go test ./...` pass; `gofmt`/`vet` clean; `-race` clean.
- Verified against the Go 1.26.4 `crypto/tls` source that `ClientCAs.Subjects()` populates `certificate_authorities` on **both** TLS 1.2 and 1.3, and that `RequestClientCert` gates verification off.

## Known caveats (documented in code + `EDGE-AUTOTRUST.md`)

- **Firefox** filters the offered list weakly, so a Firefox user with an *unrelated* personal cert could still be prompted (not the reported Chrome/Edge-on-Windows symptom).
- A keep-alive connection the edge opens **during** the cold-start window stays CIDR-only until it recycles (~idle timeout) instead of flipping mid-connection — bounded, self-healing, never a security downgrade.

Deliberately **did not** gate `:443` readiness on a loaded CA: that would couple the core's availability to the trust CP, violating the fail-static posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)