### PR TITLE
refactor(edge): use parapet/pkg/cache/purge for cache invalidation

### DIFF
--- a/edge/purge.go
+++ b/edge/purge.go
@@ -1,21 +1,16 @@
 package edge
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io/fs"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
-	"sync/atomic"
-	"time"
 
 	"github.com/moonrhythm/parapet/pkg/cache"
+	"github.com/moonrhythm/parapet/pkg/cache/purge"
 )
 
 // Scope is a purge's breadth.
@@ -49,170 +44,62 @@ type PurgeEntry struct {
 	Tag   string `json:"tag,omitempty"`
 }
 
-// PurgeTable is the edge's cache-invalidation state: a small, in-memory table of
-// "everything cached at or before epoch T is invalid", consulted at cache-lookup
-// time via InvalidatedAfter (the parapet/pkg/cache Options.InvalidatedAfter hook).
+// PurgeTable is the edge's cache-invalidation state. The invalidation mechanics —
+// the lazy epoch table consulted via InvalidatedAfter, the per-host/url/prefix/tag
+// scopes, the monotonic clamp, and the cap-fold memory bound — live in
+// parapet's pkg/cache/purge. This type adds the control-plane DISTRIBUTION layer
+// on top: the journal cursor (idempotency), Apply/FlushAll over journal records,
+// and atomic persistence of {table snapshot, cursor} so the two can never desync.
 //
-// It implements LAZY epoch invalidation: issuing a purge is O(1) (one map write
-// stamping the edge's own wall clock), and an invalidated entry is physically
-// reaped only on its NEXT lookup — exactly when the hook reports it stale, like a
-// passed FreshUntil. Correctness is immediate (a purged entry can never be
-// served); the storage backend's LRU byte cap reclaims disk regardless.
-//
-// Scopes, checked as a max at lookup so a URL is also covered by its host's purge,
-// a matching path prefix, and a global flush:
-//   - global  — flush-all (one epoch)
-//   - host    — every URL under a host (keyed by normalized host)
-//   - url     — one URL across all methods, schemes, and Vary variants (keyed by
-//     hash(host ⊕ uri), so a single purge of /a covers GET+HEAD, http+https, and
-//     every cached variant)
-//   - prefix  — every URL under a path prefix on a host (path-only, boundary-aware:
-//     /blog matches /blog and /blog/x but not /blogger; query strings ignored).
-//     A linear scan of the host's prefix records, so it is O(prefixes-for-host) at
-//     lookup rather than O(1); the record count is bounded by the cap-fold.
-//   - tag     — every cached response carrying a surrogate key (the origin's
-//     Cache-Tag header, stored in Meta.Tags); host-independent, matched against the
-//     entry's own tags at lookup (O(tags-on-entry), a small bounded set).
-//
-// The table persists {global, host, url, prefix, cursor} to a single file with an
-// atomic temp+fsync+rename, so maps and cursor can never desync. It is safe for
-// concurrent use.
+// It is safe for concurrent use. The embedded purge.Table guards its own state;
+// mu here guards the cursor and serializes the persistence orchestration.
 type PurgeTable struct {
-	mu     sync.RWMutex
-	global int64                  // flush-all epoch (unix nanos); 0 = never flushed
-	host   map[string]int64       // normalized host    -> epoch
-	url    map[string]int64       // hash(host ⊕ uri)   -> epoch
-	prefix map[string][]prefixRec // normalized host    -> path-prefix records
-	tag    map[string]int64       // surrogate key      -> epoch (host-independent)
-	cursor uint64                 // last journal seq applied (idempotency)
+	tbl *purge.Table
 
-	// highWater is the largest epoch ever stamped. Every new stamp is clamped to be
-	// >= highWater so a wall-clock step back (NTP correction) can never lower an
-	// epoch and "un-purge" entries — purges are monotonic non-decreasing.
-	highWater int64
-
-	// folds counts conservative cap-folds (a map exceeded maxRecords and was folded
-	// into the global epoch). Surfaced via Stats for metrics.
-	folds uint64
-
-	path     string       // persistence file; "" disables persistence (e.g. memory backend)
-	maxRecs  int          // per-map record cap before a conservative fold-to-global
-	nowNanos func() int64 // injectable clock (unix nanos); nil => time.Now
+	mu     sync.Mutex // guards cursor (+ dirtyVer)
+	cursor uint64     // last journal seq applied (idempotency)
 
 	// dirtyVer is bumped (under mu) for each persisted snapshot. persistMu serializes
 	// the actual file write OFF the mu critical section — so the fsync never blocks a
-	// serving-path InvalidatedAfter RLock — while persistedVer (under persistMu)
-	// drops a stale snapshot whose newer successor already landed.
+	// serving-path InvalidatedAfter — while persistedVer (under persistMu) drops a
+	// stale snapshot whose newer successor already landed.
 	dirtyVer     uint64
 	persistMu    sync.Mutex
 	persistedVer uint64
 
-	// active is true once any purge has ever been stamped (or loaded from disk). The
-	// serving-path hook (InvalidatedAfter -> epochFor) reads it lock-free FIRST and
-	// returns 0 immediately when false — so an edge that caches but has never been
-	// issued a purge pays nothing per cache hit (no RLock, no urlKey hash, no scans).
-	// It only ever flips false->true (epochs and the global flush never revert), so a
-	// stale false read just costs one request the (eventually-consistent) miss.
-	active atomic.Bool
+	path string // persistence file; "" disables persistence (e.g. memory backend)
 }
-
-// prefixRec is one path-prefix purge for a host: the normalized prefix (trailing
-// slash trimmed; "" means the whole host, i.e. a "/" purge) and its epoch. Exported
-// fields so it round-trips through the persisted JSON.
-type prefixRec struct {
-	Prefix string `json:"prefix"`
-	Epoch  int64  `json:"epoch"`
-}
-
-// defaultMaxPurgeRecords bounds each of the host/url maps. Purge records are
-// created by operator-issued purges (not per request), so this is generous; on
-// overflow the map folds into the global epoch (conservative over-invalidation,
-// never under-invalidation), keeping memory finite without a reaper.
-const defaultMaxPurgeRecords = 1 << 16
 
 // NewPurgeTable builds the table, loading any persisted state from path. A path of
 // "" disables persistence (the table lives only in memory). maxRecords <= 0 uses
-// defaultMaxPurgeRecords. A missing state file is a clean first start (cursor 0); a
-// corrupt/unreadable one resets to an empty table (cursor 0) so the next poll
-// gaps and the control plane returns flush_required — conservative, never a silent
-// under-invalidation. The load outcome is returned for logging; the table is
-// always usable.
-func NewPurgeTable(path string, maxRecords int) (*PurgeTable, error) {
-	if maxRecords <= 0 {
-		maxRecords = defaultMaxPurgeRecords
-	}
+// the package default. A missing state file is a clean first start (cursor 0); a
+// corrupt/unreadable one resets to an empty table (cursor 0) so the next poll gaps
+// and the control plane returns flush_required — conservative, never a silent
+// under-invalidation. The load outcome is returned for logging; the table is always
+// usable. Extra purge.Options (e.g. a test clock) are forwarded to the table.
+func NewPurgeTable(path string, maxRecords int, opts ...purge.Option) (*PurgeTable, error) {
 	t := &PurgeTable{
-		host:    map[string]int64{},
-		url:     map[string]int64{},
-		prefix:  map[string][]prefixRec{},
-		tag:     map[string]int64{},
-		path:    path,
-		maxRecs: maxRecords,
+		tbl:  purge.New(append([]purge.Option{purge.WithMaxRecords(maxRecords)}, opts...)...),
+		path: path,
 	}
-	err := t.load()
-	return t, err
+	return t, t.load()
 }
 
-// now returns the current unix-nano clock (injectable for tests).
-func (t *PurgeTable) now() int64 {
-	if t.nowNanos != nil {
-		return t.nowNanos()
-	}
-	return time.Now().UnixNano()
-}
-
-// InvalidatedAfter is the parapet/pkg/cache Options.InvalidatedAfter hook. It
-// returns the invalidation epoch (unix nanos) applying to r: the max of the global,
-// per-host, per-url, per-prefix, and per-tag epochs. The cache treats a hit whose
-// Meta.Created is <= this value as stale. Host normalization mirrors
-// cache.primaryHash (lowercase + strip port) so the keys line up exactly. The
-// stored entry's surrogate keys (m.Tags) are folded in for tag-scoped purges.
+// InvalidatedAfter is the parapet/pkg/cache Options.InvalidatedAfter hook.
 func (t *PurgeTable) InvalidatedAfter(r *http.Request, m cache.Meta) int64 {
-	return t.epochFor(normHost(r.Host), r.URL.RequestURI(), m.Tags)
+	return t.tbl.InvalidatedAfter(r, m)
 }
 
-// InvalidatedAfterMeta is the reaper's variant of InvalidatedAfter: it reads the
-// (already-normalized) host + uri from a stored entry's Meta instead of a live
-// request, so a sweep can match entries off the serving path. normHost is
-// idempotent on Meta.Host (the cache stamps it normalized); an old entry with an
-// empty Host matches only the global scope.
+// InvalidatedAfterMeta is the reaper's variant: it reads host+uri from a stored
+// entry's Meta instead of a live request.
 func (t *PurgeTable) InvalidatedAfterMeta(m cache.Meta) int64 {
-	return t.epochFor(normHost(m.Host), m.URI, m.Tags)
+	return t.tbl.InvalidatedAfterMeta(m)
 }
 
-// epochFor returns the invalidation epoch (unix nanos) applying to an entry: the
-// max of the global, per-host, per-url, per-prefix, and per-tag epochs. host+uri
-// come from the request or the stored Meta; tags come from the stored Meta (the
-// origin's surrogate keys). Shared by the lookup hook and the reaper.
-func (t *PurgeTable) epochFor(host, uri string, tags []string) int64 {
-	if !t.active.Load() {
-		return 0 // no purge ever applied: skip the lock, the urlKey hash, and the scans
-	}
-	uk := urlKey(host, uri)
-	path := pathOf(uri)
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	e := t.global
-	if v := t.host[host]; v > e {
-		e = v
-	}
-	if v := t.url[uk]; v > e {
-		e = v
-	}
-	// Prefix scope: linear scan of this host's prefix records (epoch check first so
-	// the string match is skipped once a higher epoch is already found).
-	for _, p := range t.prefix[host] {
-		if p.Epoch > e && matchPrefix(path, p.Prefix) {
-			e = p.Epoch
-		}
-	}
-	// Tag scope: each surrogate key the entry carries (host-independent).
-	for _, tg := range tags {
-		if v := t.tag[tg]; v > e {
-			e = v
-		}
-	}
-	return e
+// Reap physically deletes every entry the table has invalidated, returning the
+// count. See ReapOnce / RunReaper for the scheduled wrapper.
+func (t *PurgeTable) Reap(storage cache.Storage) int {
+	return t.tbl.Reap(storage)
 }
 
 // Apply applies a batch of journal entries (only those with Seq > the pre-batch
@@ -231,15 +118,14 @@ func (t *PurgeTable) Apply(entries []PurgeEntry, maxSeq uint64) error {
 		if e.Seq <= base {
 			continue // already applied in an earlier poll
 		}
-		t.applyLocked(e)
+		t.applyOne(e)
 		changed = true
 	}
 	if maxSeq > t.cursor {
 		t.cursor = maxSeq
 		changed = true
 	}
-	// Persist only on a real change, so an idle poll (no new entries, cursor
-	// unchanged) doesn't fsync.
+	// Persist only on a real change, so an idle poll doesn't fsync.
 	if !changed {
 		t.mu.Unlock()
 		return nil
@@ -249,8 +135,24 @@ func (t *PurgeTable) Apply(entries []PurgeEntry, maxSeq uint64) error {
 	return t.persist(snap, ver)
 }
 
-// FlushAll bumps the global epoch (lazy flush-all), clears the host/url maps (now
-// redundant — global supersedes any record <= it), sets the cursor to maxSeq, and
+// applyOne dispatches one journal record to the table. The table normalizes hosts
+// and stamps a monotonic epoch internally.
+func (t *PurgeTable) applyOne(e PurgeEntry) {
+	switch e.Scope {
+	case ScopeFlushAll:
+		t.tbl.FlushAll()
+	case ScopeHost:
+		t.tbl.PurgeHost(e.Host)
+	case ScopeURL:
+		t.tbl.PurgeURL(e.Host, e.URI)
+	case ScopePrefix:
+		t.tbl.PurgePrefix(e.Host, e.URI)
+	case ScopeTag:
+		t.tbl.PurgeTag(e.Tag)
+	}
+}
+
+// FlushAll bumps the global epoch (lazy flush-all), sets the cursor to maxSeq, and
 // persists. Used on the control plane's flush_required signal — both a cursor gap
 // (maxSeq >= cursor: advance) and a journal reset where the CP's seq fell below the
 // edge's cursor (maxSeq < cursor: realign DOWN). The cursor is set unconditionally
@@ -259,120 +161,17 @@ func (t *PurgeTable) Apply(entries []PurgeEntry, maxSeq uint64) error {
 // leave the cursor stuck above the CP's journal and re-flush on every poll forever.
 func (t *PurgeTable) FlushAll(maxSeq uint64) error {
 	t.mu.Lock()
-	t.global = t.stamp()
-	t.host = map[string]int64{}
-	t.url = map[string]int64{}
-	t.prefix = map[string][]prefixRec{}
-	t.tag = map[string]int64{}
+	t.tbl.FlushAll()
 	t.cursor = maxSeq
 	snap, ver := t.snapshotLocked()
 	t.mu.Unlock()
 	return t.persist(snap, ver)
 }
 
-// applyLocked applies one entry's effect. Caller holds t.mu.
-func (t *PurgeTable) applyLocked(e PurgeEntry) {
-	switch e.Scope {
-	case ScopeFlushAll:
-		t.global = t.stamp()
-		// global at >= every existing record makes them redundant; drop to reclaim memory.
-		t.host = map[string]int64{}
-		t.url = map[string]int64{}
-		t.prefix = map[string][]prefixRec{}
-		t.tag = map[string]int64{}
-	case ScopeHost:
-		if h := normHost(e.Host); h != "" {
-			t.host[h] = t.stamp()
-			t.enforceCapLocked()
-		}
-	case ScopeURL:
-		if h := normHost(e.Host); h != "" {
-			t.url[urlKey(h, e.URI)] = t.stamp()
-			t.enforceCapLocked()
-		}
-	case ScopePrefix:
-		if h := normHost(e.Host); h != "" {
-			t.applyPrefixLocked(h, normalizePrefix(e.URI), t.stamp())
-			t.enforceCapLocked()
-		}
-	case ScopeTag:
-		if e.Tag != "" {
-			t.tag[e.Tag] = t.stamp()
-			t.enforceCapLocked()
-		}
-	}
-}
-
-// applyPrefixLocked stamps (or refreshes) a host's path-prefix record. A repeat of
-// the same prefix updates its epoch in place (monotonic, so always upward); a new
-// prefix is appended. Caller holds t.mu.
-func (t *PurgeTable) applyPrefixLocked(host, prefix string, epoch int64) {
-	recs := t.prefix[host]
-	for i := range recs {
-		if recs[i].Prefix == prefix {
-			if epoch > recs[i].Epoch {
-				recs[i].Epoch = epoch
-			}
-			return
-		}
-	}
-	t.prefix[host] = append(recs, prefixRec{Prefix: prefix, Epoch: epoch})
-}
-
-// stamp returns a fresh epoch, clamped to be monotonic non-decreasing (>=
-// highWater) so a wall-clock step back can't un-purge. Caller holds t.mu.
-func (t *PurgeTable) stamp() int64 {
-	n := t.now()
-	if n < t.highWater {
-		n = t.highWater
-	}
-	t.highWater = n
-	t.active.Store(true) // a purge now exists; the serving-path gate must stop short-circuiting
-	return n
-}
-
-// enforceCapLocked keeps each map within maxRecs by folding an overflowing map
-// into the global epoch: global jumps to highWater (covering every record purged
-// so far) and the map is cleared. This over-invalidates (a coarser flush) but
-// NEVER under-invalidates, and bounds memory without a background reaper. Caller
-// holds t.mu.
-func (t *PurgeTable) enforceCapLocked() {
-	folded := false
-	if len(t.url) > t.maxRecs {
-		t.url = map[string]int64{}
-		folded = true
-	}
-	if len(t.host) > t.maxRecs {
-		t.host = map[string]int64{}
-		folded = true
-	}
-	if t.prefixCount() > t.maxRecs {
-		t.prefix = map[string][]prefixRec{}
-		folded = true
-	}
-	if len(t.tag) > t.maxRecs {
-		t.tag = map[string]int64{}
-		folded = true
-	}
-	if folded {
-		t.global = t.highWater // highWater >= every epoch stamped, so it covers the dropped records
-		t.folds++
-	}
-}
-
-// prefixCount totals the prefix records across hosts. Caller holds t.mu.
-func (t *PurgeTable) prefixCount() int {
-	n := 0
-	for _, recs := range t.prefix {
-		n += len(recs)
-	}
-	return n
-}
-
 // Cursor returns the last journal seq applied (for building the poll request).
 func (t *PurgeTable) Cursor() uint64 {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	return t.cursor
 }
 
@@ -389,30 +188,27 @@ type PurgeStats struct {
 
 // Stats returns a concurrent-safe snapshot.
 func (t *PurgeTable) Stats() PurgeStats {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
+	s := t.tbl.Stats()
 	return PurgeStats{
-		Cursor:     t.cursor,
-		Global:     t.global,
-		HostRecs:   len(t.host),
-		URLRecs:    len(t.url),
-		PrefixRecs: t.prefixCount(),
-		TagRecs:    len(t.tag),
-		Folds:      t.folds,
+		Cursor:     t.Cursor(),
+		Global:     s.Global,
+		HostRecs:   s.HostRecs,
+		URLRecs:    s.URLRecs,
+		PrefixRecs: s.PrefixRecs,
+		TagRecs:    s.TagRecs,
+		Folds:      s.Folds,
 	}
 }
 
 // --- persistence ---
 
-// persistState is the on-disk shape. Maps + cursor share one atomic write so they
-// can never desync.
+// persistState is the on-disk shape: the table's snapshot (host/url/prefix/tag/
+// global, promoted to top-level keys by the embed) plus the cursor, in one atomic
+// write so they can never desync. The layout matches the pre-migration format, so
+// existing state files load without a flush.
 type persistState struct {
-	Global int64                  `json:"global"`
-	Host   map[string]int64       `json:"host"`
-	URL    map[string]int64       `json:"url"`
-	Prefix map[string][]prefixRec `json:"prefix,omitempty"`
-	Tag    map[string]int64       `json:"tag,omitempty"`
-	Cursor uint64                 `json:"cursor"`
+	purge.Snapshot
+	Cursor uint64 `json:"cursor"`
 }
 
 // load reads persisted state into the table. A missing file is a clean start. Any
@@ -433,73 +229,22 @@ func (t *PurgeTable) load() error {
 	if err := json.Unmarshal(data, &st); err != nil {
 		return err // table stays empty; conservative re-sync on next poll
 	}
-	if st.Host != nil {
-		t.host = st.Host
-	}
-	if st.URL != nil {
-		t.url = st.URL
-	}
-	if st.Prefix != nil {
-		t.prefix = st.Prefix
-	}
-	if st.Tag != nil {
-		t.tag = st.Tag
-	}
-	t.global = st.Global
+	t.tbl.Restore(st.Snapshot)
 	t.cursor = st.Cursor
-	t.highWater = st.Global
-	for _, v := range t.host {
-		if v > t.highWater {
-			t.highWater = v
-		}
-	}
-	for _, v := range t.url {
-		if v > t.highWater {
-			t.highWater = v
-		}
-	}
-	for _, recs := range t.prefix {
-		for _, p := range recs {
-			if p.Epoch > t.highWater {
-				t.highWater = p.Epoch
-			}
-		}
-	}
-	for _, v := range t.tag {
-		if v > t.highWater {
-			t.highWater = v
-		}
-	}
-	// highWater > 0 ⇒ at least one purge was loaded ⇒ the serving-path gate must
-	// stop short-circuiting after a restart that reloaded persisted purge state.
-	if t.highWater > 0 {
-		t.active.Store(true)
-	}
 	return nil
 }
 
-// snapshotLocked captures an immutable, deep copy of the persistable state and a
-// monotonic version, so the caller can fsync it OUTSIDE t.mu (see persist) without
-// the live maps being mutated underneath the marshal. Caller holds t.mu. The copy
-// is O(records) — cheap (records are operator-issued, not per-request) and far less
-// than holding the lock across an fsync.
+// snapshotLocked captures the persistable state and a monotonic version, so the
+// caller can fsync it OUTSIDE t.mu (see persist). Caller holds t.mu.
 func (t *PurgeTable) snapshotLocked() (persistState, uint64) {
 	t.dirtyVer++
-	return persistState{
-		Global: t.global,
-		Host:   cloneInt64Map(t.host),
-		URL:    cloneInt64Map(t.url),
-		Prefix: clonePrefixMap(t.prefix),
-		Tag:    cloneInt64Map(t.tag),
-		Cursor: t.cursor,
-	}, t.dirtyVer
+	return persistState{Snapshot: t.tbl.Snapshot(), Cursor: t.cursor}, t.dirtyVer
 }
 
-// persist atomically writes a snapshot to disk WITHOUT holding t.mu (so the fsync
-// never blocks a serving-path InvalidatedAfter RLock). persistMu serializes writes
-// and persistedVer drops a stale snapshot whose newer successor already landed, so
-// an older Apply can never overwrite a newer one's state on disk. A "" path is a
-// no-op (in-memory backend). A write error is returned for logging; the in-memory
+// persist atomically writes a snapshot to disk WITHOUT holding t.mu. persistMu
+// serializes writes and persistedVer drops a stale snapshot whose newer successor
+// already landed, so an older Apply can never overwrite a newer one's on-disk
+// state. A "" path is a no-op. A write error is returned for logging; the in-memory
 // table is authoritative and the next change re-persists.
 func (t *PurgeTable) persist(snap persistState, ver uint64) error {
 	if t.path == "" {
@@ -521,26 +266,9 @@ func (t *PurgeTable) persist(snap persistState, ver uint64) error {
 	return nil
 }
 
-func cloneInt64Map(m map[string]int64) map[string]int64 {
-	out := make(map[string]int64, len(m))
-	for k, v := range m {
-		out[k] = v
-	}
-	return out
-}
-
-func clonePrefixMap(m map[string][]prefixRec) map[string][]prefixRec {
-	out := make(map[string][]prefixRec, len(m))
-	for k, v := range m {
-		out[k] = append([]prefixRec(nil), v...) // prefixRec is a value type — copied by value
-	}
-	return out
-}
-
 // atomicWriteFile writes data to path via a same-dir temp file with
 // write+fsync+close+rename, then fsyncs the parent directory so the rename itself
-// is durable — without the dir fsync a crash right after rename can lose the new
-// file, leaving stale/absent state (matches the disk cache's commit idiom).
+// is durable.
 func atomicWriteFile(path string, data []byte) error {
 	dir := filepath.Dir(path)
 	f, err := os.CreateTemp(dir, ".purge-state-*.tmp")
@@ -569,10 +297,7 @@ func atomicWriteFile(path string, data []byte) error {
 	return fsyncDir(dir)
 }
 
-// fsyncDir flushes a directory entry so a rename into it survives a crash. A
-// failure to open/sync the dir is best-effort (some filesystems don't support it);
-// the rename already happened, so it is logged via the returned error but not fatal
-// to the in-memory state.
+// fsyncDir flushes a directory entry so a rename into it survives a crash.
 func fsyncDir(dir string) error {
 	d, err := os.Open(dir)
 	if err != nil {
@@ -580,52 +305,4 @@ func fsyncDir(dir string) error {
 	}
 	defer d.Close()
 	return d.Sync()
-}
-
-// --- keys ---
-
-// normHost lowercases and strips the port from a host, mirroring
-// cache.primaryHash exactly so a purge key matches the cache's stored key. It does
-// NOT strip a trailing dot (neither does the cache).
-func normHost(host string) string {
-	h := strings.ToLower(host)
-	if hh, _, err := net.SplitHostPort(h); err == nil {
-		h = hh
-	}
-	return h
-}
-
-// urlKey is the per-url map key: hash(host ⊕ uri). uri is the request-uri
-// (path+query). Hashing host⊕uri (not method/scheme) makes one url purge cover
-// GET+HEAD, http+https, and every Vary variant at once.
-func urlKey(host, uri string) string {
-	sum := sha256.Sum256([]byte(host + "\n" + uri))
-	return hex.EncodeToString(sum[:16])
-}
-
-// pathOf returns the path portion of a request-uri (everything before the first
-// '?'). Prefix purges match on the path only, so a query string never affects
-// whether an entry is covered.
-func pathOf(uri string) string {
-	if i := strings.IndexByte(uri, '?'); i >= 0 {
-		return uri[:i]
-	}
-	return uri
-}
-
-// normalizePrefix trims a single trailing slash so "/blog" and "/blog/" purge the
-// same section; "/" normalizes to "" (the whole-host prefix). The normalized form
-// is what matchPrefix compares against.
-func normalizePrefix(p string) string {
-	return strings.TrimRight(p, "/")
-}
-
-// matchPrefix reports whether path is covered by the normalized prefix pre, on a
-// path boundary: pre "/blog" matches "/blog" and "/blog/x" but NOT "/blogger". An
-// empty pre (from a "/" purge) matches every path.
-func matchPrefix(path, pre string) bool {
-	if pre == "" {
-		return true
-	}
-	return path == pre || strings.HasPrefix(path, pre+"/")
 }

--- a/edge/purge.go
+++ b/edge/purge.go
@@ -186,11 +186,16 @@ type PurgeStats struct {
 	Folds      uint64
 }
 
-// Stats returns a concurrent-safe snapshot.
+// Stats returns a concurrent-safe snapshot. The cursor and the table's record
+// counts are read under one mu hold (lock order mu -> table) so they reflect the
+// same instant — a concurrent Apply can't slip a newer cursor past stale counts.
 func (t *PurgeTable) Stats() PurgeStats {
+	t.mu.Lock()
+	cursor := t.cursor
 	s := t.tbl.Stats()
+	t.mu.Unlock()
 	return PurgeStats{
-		Cursor:     t.Cursor(),
+		Cursor:     cursor,
 		Global:     s.Global,
 		HostRecs:   s.HostRecs,
 		URLRecs:    s.URLRecs,

--- a/edge/purge_test.go
+++ b/edge/purge_test.go
@@ -4,96 +4,77 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/moonrhythm/parapet/pkg/cache"
+	"github.com/moonrhythm/parapet/pkg/cache/purge"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// epochFor is the table's hook applied to a synthetic request for method/url.
+// The scope mechanics (host/url/prefix/tag matching, the monotonic clamp, the
+// cap-fold, the active gate) live in and are tested by parapet/pkg/cache/purge.
+// These tests cover the control-plane DISTRIBUTION layer this package adds: the
+// journal cursor, Apply's idempotency, FlushAll's cursor handling, and the
+// {snapshot, cursor} persistence.
+
+// stepClock is a manually-advanced clock for deterministic epochs.
+type stepClock struct{ n atomic.Int64 }
+
+func (c *stepClock) now() time.Time { return time.Unix(0, c.n.Load()) }
+func (c *stepClock) set(n int64)    { c.n.Store(n) }
+
+func newClockedTable(t *testing.T, path string, clk *stepClock) *PurgeTable {
+	t.Helper()
+	tbl, err := NewPurgeTable(path, 0, purge.WithClock(clk.now))
+	require.NoError(t, err)
+	return tbl
+}
+
+// epochFor applies the lookup hook to a synthetic request.
 func epochFor(t *PurgeTable, method, rawurl string) int64 {
 	return t.InvalidatedAfter(httptest.NewRequest(method, rawurl, nil), cache.Meta{})
 }
 
-// fixedClock pins the table's clock for deterministic epochs.
-func fixedClock(t *PurgeTable, nanos int64) {
-	t.nowNanos = func() int64 { return nanos }
-}
+func TestPurge_ApplyDispatchesScopes(t *testing.T) {
+	clk := &stepClock{}
+	clk.set(1000)
+	tbl := newClockedTable(t, "", clk)
 
-func TestPurge_ScopesAndMax(t *testing.T) {
-	tbl, err := NewPurgeTable("", 0)
-	require.NoError(t, err)
-	fixedClock(tbl, 1000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{
+		{Seq: 1, Scope: ScopeURL, Host: "acme.com", URI: "/a"},
+		{Seq: 2, Scope: ScopeHost, Host: "h.com"},
+		{Seq: 3, Scope: ScopePrefix, Host: "p.com", URI: "/blog"},
+		{Seq: 4, Scope: ScopeTag, Tag: "t1"},
+	}, 4))
 
-	// url scope: only the exact url is invalidated.
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeURL, Host: "acme.com", URI: "/a"}}, 1))
-	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://acme.com/a"))
+	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://acme.com/a"), "url scope dispatched")
 	assert.EqualValues(t, 0, epochFor(tbl, "GET", "http://acme.com/b"), "sibling url untouched")
+	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://h.com/x"), "host scope dispatched")
+	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://p.com/blog/post"), "prefix scope dispatched")
+	assert.EqualValues(t, 1000, tbl.InvalidatedAfterMeta(cache.Meta{Tags: []string{"t1"}}), "tag scope dispatched")
+	assert.EqualValues(t, 4, tbl.Cursor())
 
-	// host scope: every url under the host. A later epoch wins via max.
-	fixedClock(tbl, 2000)
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 2, Scope: ScopeHost, Host: "acme.com"}}, 2))
-	assert.EqualValues(t, 2000, epochFor(tbl, "GET", "http://acme.com/b"))
-	assert.EqualValues(t, 2000, epochFor(tbl, "GET", "http://acme.com/a"), "host epoch > url epoch wins")
-	assert.EqualValues(t, 0, epochFor(tbl, "GET", "http://other.com/a"), "other host untouched")
-
-	// global scope: everything.
-	fixedClock(tbl, 3000)
-	require.NoError(t, tbl.FlushAll(3))
-	assert.EqualValues(t, 3000, epochFor(tbl, "GET", "http://other.com/a"))
-}
-
-func TestPurge_URLCoversMethodSchemeVariant(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 0)
-	fixedClock(tbl, 7000)
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeURL, Host: "acme.com", URI: "/p?x=1"}}, 1))
-
-	// Same host+uri, regardless of method/scheme, resolves to the same key.
-	assert.EqualValues(t, 7000, epochFor(tbl, "GET", "http://acme.com/p?x=1"))
-	assert.EqualValues(t, 7000, epochFor(tbl, "HEAD", "http://acme.com/p?x=1"))
-	assert.EqualValues(t, 7000, epochFor(tbl, "GET", "https://acme.com/p?x=1"))
-	// Different query is a different url.
-	assert.EqualValues(t, 0, epochFor(tbl, "GET", "http://acme.com/p?x=2"))
-}
-
-func TestPurge_HostNormalizationMatchesCacheKey(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 0)
-	fixedClock(tbl, 5000)
-	// Purge issued with mixed case + port; lookups with other case/port must match.
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeHost, Host: "ACME.com:443"}}, 1))
-	assert.EqualValues(t, 5000, epochFor(tbl, "GET", "http://acme.com/x"))
-	assert.EqualValues(t, 5000, epochFor(tbl, "GET", "http://Acme.COM:8443/x"))
-}
-
-func TestPurge_MonotonicClampOnClockStepBack(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 0)
-	fixedClock(tbl, 10_000)
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeHost, Host: "a.com"}}, 1))
-	assert.EqualValues(t, 10_000, epochFor(tbl, "GET", "http://a.com/"))
-
-	// Clock steps back; a new purge must not get a lower epoch.
-	fixedClock(tbl, 9_000)
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 2, Scope: ScopeHost, Host: "b.com"}}, 2))
-	assert.EqualValues(t, 10_000, epochFor(tbl, "GET", "http://b.com/"), "clamped to highWater, not the stepped-back clock")
-
-	// A flush after a step-back is also clamped.
-	fixedClock(tbl, 8_000)
-	require.NoError(t, tbl.FlushAll(3))
-	assert.GreaterOrEqual(t, epochFor(tbl, "GET", "http://c.com/"), int64(10_000))
+	// flush-all dispatch.
+	clk.set(2000)
+	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 5, Scope: ScopeFlushAll}}, 5))
+	assert.EqualValues(t, 2000, epochFor(tbl, "GET", "http://anything.com/q"), "flush-all dispatched")
 }
 
 func TestPurge_ApplyIdempotentByCursor(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 0)
-	fixedClock(tbl, 1000)
+	clk := &stepClock{}
+	clk.set(1000)
+	tbl := newClockedTable(t, "", clk)
 	require.NoError(t, tbl.Apply([]PurgeEntry{
 		{Seq: 1, Scope: ScopeURL, Host: "a.com", URI: "/x"},
 		{Seq: 2, Scope: ScopeURL, Host: "a.com", URI: "/y"},
 	}, 2))
 	assert.EqualValues(t, 2, tbl.Cursor())
 
-	// Re-deliver seq 1-2 plus a new seq 3 with a later clock; only seq 3 applies.
-	fixedClock(tbl, 9000)
+	// Re-deliver seq 1-2 plus a new seq 3 under a later clock; only seq 3 applies.
+	clk.set(9000)
 	require.NoError(t, tbl.Apply([]PurgeEntry{
 		{Seq: 1, Scope: ScopeURL, Host: "a.com", URI: "/x"},
 		{Seq: 2, Scope: ScopeURL, Host: "a.com", URI: "/y"},
@@ -105,192 +86,49 @@ func TestPurge_ApplyIdempotentByCursor(t *testing.T) {
 }
 
 func TestPurge_ApplyAdvancesCursorOnGap(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 0)
+	tbl, err := NewPurgeTable("", 0)
+	require.NoError(t, err)
 	// An empty batch with a higher maxSeq still advances the cursor.
 	require.NoError(t, tbl.Apply(nil, 42))
 	assert.EqualValues(t, 42, tbl.Cursor())
-	// Cursor never regresses.
+	// Cursor never regresses on a normal apply.
 	require.NoError(t, tbl.Apply(nil, 10))
 	assert.EqualValues(t, 42, tbl.Cursor())
 }
 
-func TestPurge_FlushAllClearsAndSupersedes(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 0)
-	fixedClock(tbl, 1000)
-	require.NoError(t, tbl.Apply([]PurgeEntry{
-		{Seq: 1, Scope: ScopeURL, Host: "a.com", URI: "/x"},
-		{Seq: 2, Scope: ScopeHost, Host: "b.com"},
-		{Seq: 3, Scope: ScopePrefix, Host: "c.com", URI: "/blog"},
-		{Seq: 4, Scope: ScopeTag, Tag: "t1"},
-	}, 4))
-	fixedClock(tbl, 5000)
-	require.NoError(t, tbl.FlushAll(5))
-
-	st := tbl.Stats()
-	assert.Zero(t, st.HostRecs, "host map cleared on flush")
-	assert.Zero(t, st.URLRecs, "url map cleared on flush")
-	assert.Zero(t, st.PrefixRecs, "prefix map cleared on flush")
-	assert.Zero(t, st.TagRecs, "tag map cleared on flush")
-	assert.EqualValues(t, 5000, epochFor(tbl, "GET", "http://anything.com/q"))
-}
-
-func TestPurge_CapFoldBoundsMemory(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 2) // tiny cap to force a fold
-	fixedClock(tbl, 1000)
-	require.NoError(t, tbl.Apply([]PurgeEntry{
-		{Seq: 1, Scope: ScopeURL, Host: "a.com", URI: "/1"},
-		{Seq: 2, Scope: ScopeURL, Host: "a.com", URI: "/2"},
-		{Seq: 3, Scope: ScopeURL, Host: "a.com", URI: "/3"}, // overflow -> fold
-	}, 3))
-
-	st := tbl.Stats()
-	assert.Zero(t, st.URLRecs, "overflowing url map folded to global")
-	assert.EqualValues(t, 1, st.Folds)
-	// Conservative: the folded urls are still invalidated (via the global epoch).
-	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://a.com/1"))
-	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://a.com/2"))
-}
-
-func TestPurge_InvalidatedAfterMetaMatchesRequest(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 0)
-	fixedClock(tbl, 4000)
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeURL, Host: "acme.com", URI: "/p?x=1"}}, 1))
-
-	// The reaper's Meta-based lookup must agree with the request-based hook for the
-	// same host+uri (Meta.Host is already normalized; normHost is idempotent).
-	m := cache.Meta{Host: "acme.com", URI: "/p?x=1"}
-	assert.EqualValues(t, 4000, tbl.InvalidatedAfterMeta(m))
-	assert.Equal(t, epochFor(tbl, "GET", "http://acme.com/p?x=1"), tbl.InvalidatedAfterMeta(m))
-	// A different uri doesn't match.
-	assert.EqualValues(t, 0, tbl.InvalidatedAfterMeta(cache.Meta{Host: "acme.com", URI: "/p?x=2"}))
-	// An empty-Host (old) entry matches only the global scope.
-	assert.EqualValues(t, 0, tbl.InvalidatedAfterMeta(cache.Meta{Host: "", URI: "/p?x=1"}))
-}
-
-func TestPurge_PrefixScope(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 0)
-	fixedClock(tbl, 1000)
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopePrefix, Host: "acme.com", URI: "/blog"}}, 1))
-
-	// Covered: the prefix itself, anything under it, and any query variant (path-only).
-	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://acme.com/blog"))
-	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://acme.com/blog/post-1"))
-	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://acme.com/blog/post-1?utm=x"))
-	// Not covered: boundary (/blogger), a sibling path, or another host.
-	assert.EqualValues(t, 0, epochFor(tbl, "GET", "http://acme.com/blogger"), "path boundary respected")
-	assert.EqualValues(t, 0, epochFor(tbl, "GET", "http://acme.com/about"))
-	assert.EqualValues(t, 0, epochFor(tbl, "GET", "http://other.com/blog/x"), "prefix is host-scoped")
-}
-
-func TestPurge_PrefixNormalizationAndRoot(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 0)
-	fixedClock(tbl, 2000)
-	// Trailing slash is normalized away: "/docs/" purges the same section as "/docs".
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopePrefix, Host: "a.com", URI: "/docs/"}}, 1))
-	assert.EqualValues(t, 2000, epochFor(tbl, "GET", "http://a.com/docs"))
-	assert.EqualValues(t, 2000, epochFor(tbl, "GET", "http://a.com/docs/intro"))
-	assert.EqualValues(t, 0, epochFor(tbl, "GET", "http://a.com/docsource"))
-
-	// "/" is the whole-host prefix.
-	fixedClock(tbl, 3000)
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 2, Scope: ScopePrefix, Host: "b.com", URI: "/"}}, 2))
-	assert.EqualValues(t, 3000, epochFor(tbl, "GET", "http://b.com/anything/here"))
-}
-
-func TestPurge_PrefixRepeatUpdatesEpochInPlace(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 0)
-	fixedClock(tbl, 1000)
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopePrefix, Host: "a.com", URI: "/x"}}, 1))
-	fixedClock(tbl, 5000)
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 2, Scope: ScopePrefix, Host: "a.com", URI: "/x"}}, 2))
-	assert.EqualValues(t, 1, tbl.Stats().PrefixRecs, "same prefix updates in place, no duplicate record")
-	assert.EqualValues(t, 5000, epochFor(tbl, "GET", "http://a.com/x/y"), "epoch advanced to the latest purge")
-}
-
-func TestPurge_PrefixPersistenceRoundTrip(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "purge-state")
-	t1, err := NewPurgeTable(path, 0)
-	require.NoError(t, err)
-	fixedClock(t1, 4000)
-	require.NoError(t, t1.Apply([]PurgeEntry{{Seq: 1, Scope: ScopePrefix, Host: "a.com", URI: "/sec"}}, 1))
-
-	t2, err := NewPurgeTable(path, 0)
-	require.NoError(t, err)
-	assert.EqualValues(t, 4000, epochFor(t2, "GET", "http://a.com/sec/page"), "prefix record survives reload")
-	assert.EqualValues(t, 1, t2.Stats().PrefixRecs)
-}
-
-func TestPurge_PrefixCapFold(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 2) // tiny cap
-	fixedClock(tbl, 1000)
-	require.NoError(t, tbl.Apply([]PurgeEntry{
-		{Seq: 1, Scope: ScopePrefix, Host: "a.com", URI: "/1"},
-		{Seq: 2, Scope: ScopePrefix, Host: "a.com", URI: "/2"},
-		{Seq: 3, Scope: ScopePrefix, Host: "a.com", URI: "/3"}, // overflow -> fold to global
-	}, 3))
-	assert.Zero(t, tbl.Stats().PrefixRecs, "overflowing prefix records folded into global")
-	assert.EqualValues(t, 1, tbl.Stats().Folds)
-	assert.EqualValues(t, 1000, epochFor(tbl, "GET", "http://a.com/1"), "still invalidated via the global epoch")
-}
-
-func TestPurge_NoPurgeGate(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 0)
-	// Before any purge: the serving-path gate short-circuits to 0 without locking.
-	assert.False(t, tbl.active.Load())
-	assert.EqualValues(t, 0, tbl.InvalidatedAfterMeta(cache.Meta{Host: "a.com", URI: "/x", Tags: []string{"t"}}))
-
-	fixedClock(tbl, 1000)
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeHost, Host: "a.com"}}, 1))
-	// After a purge: the gate opens and lookups resolve normally.
-	assert.True(t, tbl.active.Load())
-	assert.EqualValues(t, 1000, tbl.InvalidatedAfterMeta(cache.Meta{Host: "a.com", URI: "/x"}))
-	assert.EqualValues(t, 0, tbl.InvalidatedAfterMeta(cache.Meta{Host: "other.com", URI: "/x"}))
-}
-
-func TestPurge_GateActiveAfterReload(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "purge-state")
-	t1, _ := NewPurgeTable(path, 0)
-	fixedClock(t1, 2000)
-	require.NoError(t, t1.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeHost, Host: "a.com"}}, 1))
-
-	// A reload of persisted purge state must re-open the gate (else lookups would
-	// short-circuit to 0 and silently under-invalidate after a restart).
-	t2, _ := NewPurgeTable(path, 0)
-	assert.True(t, t2.active.Load())
-	assert.EqualValues(t, 2000, t2.InvalidatedAfterMeta(cache.Meta{Host: "a.com", URI: "/x"}))
-}
-
-func TestPurge_TagScope(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 0)
-	fixedClock(tbl, 1000)
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeTag, Tag: "product-42"}}, 1))
-
-	// Any entry carrying the surrogate key is invalidated, regardless of host/url.
-	assert.EqualValues(t, 1000, tbl.InvalidatedAfterMeta(cache.Meta{Host: "shop.com", URI: "/p", Tags: []string{"product-42"}}))
-	assert.EqualValues(t, 1000, tbl.InvalidatedAfterMeta(cache.Meta{Host: "other.com", URI: "/x", Tags: []string{"a", "product-42"}}))
-	// Entries without the tag are untouched.
-	assert.EqualValues(t, 0, tbl.InvalidatedAfterMeta(cache.Meta{Host: "shop.com", URI: "/p", Tags: []string{"category-shoes"}}))
-	assert.EqualValues(t, 0, tbl.InvalidatedAfterMeta(cache.Meta{Host: "shop.com", URI: "/p"}))
-}
-
-func TestPurge_TagPersistenceRoundTrip(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "purge-state")
-	t1, err := NewPurgeTable(path, 0)
-	require.NoError(t, err)
-	fixedClock(t1, 6000)
-	require.NoError(t, t1.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeTag, Tag: "sku-7"}}, 1))
-
-	t2, err := NewPurgeTable(path, 0)
-	require.NoError(t, err)
-	assert.EqualValues(t, 6000, t2.InvalidatedAfterMeta(cache.Meta{Tags: []string{"sku-7"}}), "tag record survives reload")
-	assert.EqualValues(t, 1, t2.Stats().TagRecs)
-}
-
 func TestPurge_FlushAllRealignsCursorDown(t *testing.T) {
-	tbl, _ := NewPurgeTable("", 0)
+	tbl, err := NewPurgeTable("", 0)
+	require.NoError(t, err)
 	require.NoError(t, tbl.Apply(nil, 500)) // cursor 500 (persisted against an old journal)
 	require.NoError(t, tbl.FlushAll(3))     // journal reset: realign the cursor DOWN to maxSeq
 	assert.EqualValues(t, 3, tbl.Cursor(), "a reset flush realigns the cursor down so it can't re-flush forever")
+}
+
+func TestPurge_PersistenceRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "purge-state")
+	clk := &stepClock{}
+	clk.set(5000)
+	t1 := newClockedTable(t, path, clk)
+	require.NoError(t, t1.Apply([]PurgeEntry{
+		{Seq: 7, Scope: ScopeHost, Host: "a.com"},
+		{Seq: 8, Scope: ScopeURL, Host: "b.com", URI: "/p"},
+		{Seq: 9, Scope: ScopePrefix, Host: "c.com", URI: "/blog"},
+		{Seq: 10, Scope: ScopeTag, Tag: "sku-7"},
+	}, 10))
+
+	// Reopen under a stepped-back clock: state + cursor + highWater survive.
+	clk2 := &stepClock{}
+	clk2.set(1)
+	t2 := newClockedTable(t, path, clk2)
+	assert.EqualValues(t, 10, t2.Cursor())
+	assert.EqualValues(t, 5000, epochFor(t2, "GET", "http://a.com/anything"))
+	assert.EqualValues(t, 5000, epochFor(t2, "GET", "http://b.com/p"))
+	assert.EqualValues(t, 5000, epochFor(t2, "GET", "http://c.com/blog/post"))
+	assert.EqualValues(t, 5000, t2.InvalidatedAfterMeta(cache.Meta{Tags: []string{"sku-7"}}))
+
+	// highWater restored: a new purge under the stepped-back clock still clamps up.
+	require.NoError(t, t2.Apply([]PurgeEntry{{Seq: 11, Scope: ScopeHost, Host: "d.com"}}, 11))
+	assert.EqualValues(t, 5000, epochFor(t2, "GET", "http://d.com/"), "highWater reloaded")
 }
 
 func TestPurge_PersistStaleVersionSkipped(t *testing.T) {
@@ -298,15 +136,15 @@ func TestPurge_PersistStaleVersionSkipped(t *testing.T) {
 	// whose newer successor already landed, so an older Apply can't clobber a newer
 	// one's on-disk state.
 	path := filepath.Join(t.TempDir(), "purge-state")
-	tbl, err := NewPurgeTable(path, 0)
-	require.NoError(t, err)
-	fixedClock(tbl, 1000)
+	clk := &stepClock{}
+	clk.set(1000)
+	tbl := newClockedTable(t, path, clk)
 
 	// Capture two ordered snapshots (newer = v2).
 	tbl.mu.Lock()
-	tbl.host["a.com"] = 100
+	tbl.tbl.PurgeHost("a.com")
 	snap1, ver1 := tbl.snapshotLocked()
-	tbl.host["b.com"] = 200
+	tbl.tbl.PurgeHost("b.com")
 	snap2, ver2 := tbl.snapshotLocked()
 	tbl.mu.Unlock()
 	require.Greater(t, ver2, ver1)
@@ -317,32 +155,23 @@ func TestPurge_PersistStaleVersionSkipped(t *testing.T) {
 
 	reloaded, err := NewPurgeTable(path, 0)
 	require.NoError(t, err)
-	assert.EqualValues(t, 200, reloaded.InvalidatedAfterMeta(cache.Meta{Host: "b.com"}), "newer snapshot survived")
-	assert.EqualValues(t, 100, reloaded.InvalidatedAfterMeta(cache.Meta{Host: "a.com"}), "stale persist did not roll the file back")
+	assert.Positive(t, reloaded.InvalidatedAfterMeta(cache.Meta{Host: "b.com"}), "newer snapshot survived")
+	assert.Positive(t, reloaded.InvalidatedAfterMeta(cache.Meta{Host: "a.com"}), "stale persist did not roll the file back")
 }
 
-func TestPurge_PersistenceRoundTrip(t *testing.T) {
+func TestPurge_GateActiveAfterReload(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "purge-state")
+	clk := &stepClock{}
+	clk.set(2000)
+	t1 := newClockedTable(t, path, clk)
+	require.NoError(t, t1.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeHost, Host: "a.com"}}, 1))
 
-	t1, err := NewPurgeTable(path, 0)
-	require.NoError(t, err)
-	fixedClock(t1, 5000)
-	require.NoError(t, t1.Apply([]PurgeEntry{
-		{Seq: 7, Scope: ScopeHost, Host: "a.com"},
-		{Seq: 8, Scope: ScopeURL, Host: "b.com", URI: "/p"},
-	}, 8))
-
-	// Reopen: state + cursor + highWater survive.
+	// A reload must re-open the gate; else lookups would short-circuit to 0 and
+	// silently under-invalidate after a restart.
 	t2, err := NewPurgeTable(path, 0)
 	require.NoError(t, err)
-	assert.EqualValues(t, 8, t2.Cursor())
-	assert.EqualValues(t, 5000, epochFor(t2, "GET", "http://a.com/anything"))
-	assert.EqualValues(t, 5000, epochFor(t2, "GET", "http://b.com/p"))
-
-	// highWater restored: a purge under a stepped-back clock still clamps up.
-	fixedClock(t2, 1)
-	require.NoError(t, t2.Apply([]PurgeEntry{{Seq: 9, Scope: ScopeHost, Host: "c.com"}}, 9))
-	assert.EqualValues(t, 5000, epochFor(t2, "GET", "http://c.com/"), "highWater reloaded")
+	assert.EqualValues(t, 2000, t2.InvalidatedAfterMeta(cache.Meta{Host: "a.com", URI: "/x"}))
+	assert.EqualValues(t, 0, t2.InvalidatedAfterMeta(cache.Meta{Host: "other.com", URI: "/x"}))
 }
 
 func TestPurge_CorruptStateResetsToEmpty(t *testing.T) {
@@ -360,4 +189,26 @@ func TestPurge_MissingStateIsCleanStart(t *testing.T) {
 	tbl, err := NewPurgeTable(path, 0)
 	require.NoError(t, err)
 	assert.EqualValues(t, 0, tbl.Cursor())
+}
+
+// A state file written by the PRE-MIGRATION code (flat host/url/prefix/tag/global
+// + cursor) must load unchanged, so an in-place upgrade doesn't gap the cursor and
+// trigger a fleet-wide flush.
+func TestPurge_LoadsPreMigrationFormat(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "purge-state")
+	old := `{"global":5000,` +
+		`"host":{"a.com":5000},` +
+		`"url":{},` +
+		`"prefix":{"c.com":[{"prefix":"/blog","epoch":5000}]},` +
+		`"tag":{"sku-7":5000},` +
+		`"cursor":8}`
+	require.NoError(t, os.WriteFile(path, []byte(old), 0o644))
+
+	tbl, err := NewPurgeTable(path, 0)
+	require.NoError(t, err)
+	assert.EqualValues(t, 8, tbl.Cursor(), "cursor preserved")
+	assert.EqualValues(t, 5000, epochFor(tbl, "GET", "http://a.com/x"), "host record loaded")
+	assert.EqualValues(t, 5000, epochFor(tbl, "GET", "http://c.com/blog/post"), "prefix record loaded")
+	assert.EqualValues(t, 5000, tbl.InvalidatedAfterMeta(cache.Meta{Tags: []string{"sku-7"}}), "tag record loaded")
+	assert.EqualValues(t, 5000, epochFor(tbl, "GET", "http://anything.com/"), "global loaded")
 }

--- a/edge/purgereaper.go
+++ b/edge/purgereaper.go
@@ -26,14 +26,7 @@ import (
 // bounded by the monotonic, over-invalidating count-cap fold (enforceCapLocked) —
 // see PurgeTable. Purges are operator-issued, so the maps stay small regardless.
 func ReapOnce(storage cache.Storage, table *PurgeTable) {
-	var reaped int
-	storage.Range(func(key string, m cache.Meta) bool {
-		if m.Created <= table.InvalidatedAfterMeta(m) {
-			storage.Delete(key)
-			reaped++
-		}
-		return true
-	})
+	reaped := table.Reap(storage)
 	if reaped > 0 {
 		slog.Info("edge: cache reaper swept invalidated entries", "reaped", reaped)
 	}

--- a/edge/purgereaper_test.go
+++ b/edge/purgereaper_test.go
@@ -26,18 +26,22 @@ func storageLen(s cache.Storage) int {
 	return n
 }
 
+// ReapOnce delegates to the parapet purge table's Reap (covered exhaustively
+// there); these verify the edge wrapper end-to-end through the journal Apply path.
+
 func TestReapOnce_DeletesInvalidatedKeepsOthers(t *testing.T) {
 	s := cache.NewMemory(1 << 20)
 	fresh := time.Now().Add(time.Hour).UnixNano()
-	putEntry(t, s, "aa01", cache.Meta{PrimaryHex: "aa01", Host: "acme.com", URI: "/a", Created: 100, FreshUntil: fresh}, []byte("x"))
-	putEntry(t, s, "bb02", cache.Meta{PrimaryHex: "bb02", Host: "other.com", URI: "/b", Created: 100, FreshUntil: fresh}, []byte("y"))
-	putEntry(t, s, "cc03", cache.Meta{PrimaryHex: "cc03", Host: "acme.com", URI: "/c", Created: 250, FreshUntil: fresh}, []byte("z")) // created AFTER the purge
+	putEntry(t, s, "aa01", cache.Meta{Host: "acme.com", URI: "/a", Created: 100, FreshUntil: fresh}, []byte("x"))
+	putEntry(t, s, "bb02", cache.Meta{Host: "other.com", URI: "/b", Created: 100, FreshUntil: fresh}, []byte("y"))
+	putEntry(t, s, "cc03", cache.Meta{Host: "acme.com", URI: "/c", Created: 250, FreshUntil: fresh}, []byte("z")) // created AFTER the purge
 
-	tbl, _ := NewPurgeTable("", 0)
-	fixedClock(tbl, 200)
+	clk := &stepClock{}
+	clk.set(200)
+	tbl := newClockedTable(t, "", clk)
 	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeHost, Host: "acme.com"}}, 1)) // host epoch 200
 
-	fixedClock(tbl, 300)
+	clk.set(300)
 	ReapOnce(s, tbl)
 
 	_, _, okA := s.Get("aa01")
@@ -46,60 +50,38 @@ func TestReapOnce_DeletesInvalidatedKeepsOthers(t *testing.T) {
 	assert.True(t, okB, "other.com untouched (different host)")
 	_, _, okC := s.Get("cc03")
 	assert.True(t, okC, "acme.com /c (created 250 > 200) survives — not over-reaped")
-
-	// The reaper does NOT retire records (that direction is unsafe under a clock
-	// step); the host record stays and keeps gating future entries.
 	assert.EqualValues(t, 1, tbl.Stats().HostRecs, "record kept (retirement intentionally not done)")
 }
 
 func TestReapOnce_GlobalReapsAllIncludingEmptyHost(t *testing.T) {
 	s := cache.NewMemory(1 << 20)
 	fresh := time.Now().Add(time.Hour).UnixNano()
-	putEntry(t, s, "aa01", cache.Meta{PrimaryHex: "aa01", Host: "", URI: "/old", Created: 100, FreshUntil: fresh}, []byte("x")) // pre-v0.17.1 entry, no Host
-	putEntry(t, s, "bb02", cache.Meta{PrimaryHex: "bb02", Host: "a.com", URI: "/y", Created: 100, FreshUntil: fresh}, []byte("y"))
+	putEntry(t, s, "aa01", cache.Meta{Host: "", URI: "/old", Created: 100, FreshUntil: fresh}, []byte("x")) // no Host
+	putEntry(t, s, "bb02", cache.Meta{Host: "a.com", URI: "/y", Created: 100, FreshUntil: fresh}, []byte("y"))
 
-	tbl, _ := NewPurgeTable("", 0)
-	fixedClock(tbl, 200)
+	clk := &stepClock{}
+	clk.set(200)
+	tbl := newClockedTable(t, "", clk)
 	require.NoError(t, tbl.FlushAll(1)) // global epoch 200
 
-	fixedClock(tbl, 300)
+	clk.set(300)
 	ReapOnce(s, tbl)
-
 	assert.Zero(t, storageLen(s), "flush-all reaps every entry, even one with an empty Host")
-	assert.Positive(t, epochFor(tbl, "GET", "http://anything.com/"), "global epoch kept (no retirement)")
 }
 
-func TestReapOnce_PrefixReaps(t *testing.T) {
+func TestReapOnce_TagReapsAcrossHosts(t *testing.T) {
 	s := cache.NewMemory(1 << 20)
 	fresh := time.Now().Add(time.Hour).UnixNano()
-	putEntry(t, s, "aa01", cache.Meta{PrimaryHex: "aa01", Host: "acme.com", URI: "/blog/p1", Created: 100, FreshUntil: fresh}, []byte("x"))
-	putEntry(t, s, "bb02", cache.Meta{PrimaryHex: "bb02", Host: "acme.com", URI: "/about", Created: 100, FreshUntil: fresh}, []byte("y"))
+	putEntry(t, s, "aa01", cache.Meta{Host: "shop.com", URI: "/p1", Tags: []string{"product-42"}, Created: 100, FreshUntil: fresh}, []byte("x"))
+	putEntry(t, s, "bb02", cache.Meta{Host: "blog.com", URI: "/post", Tags: []string{"product-42"}, Created: 100, FreshUntil: fresh}, []byte("y"))
+	putEntry(t, s, "cc03", cache.Meta{Host: "shop.com", URI: "/p2", Tags: []string{"product-99"}, Created: 100, FreshUntil: fresh}, []byte("z"))
 
-	tbl, _ := NewPurgeTable("", 0)
-	fixedClock(tbl, 200)
-	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopePrefix, Host: "acme.com", URI: "/blog"}}, 1))
-
-	fixedClock(tbl, 300)
-	ReapOnce(s, tbl)
-
-	_, _, okA := s.Get("aa01")
-	assert.False(t, okA, "/blog/p1 reaped by the /blog prefix purge")
-	_, _, okB := s.Get("bb02")
-	assert.True(t, okB, "/about untouched (outside the prefix)")
-}
-
-func TestReapOnce_TagReaps(t *testing.T) {
-	s := cache.NewMemory(1 << 20)
-	fresh := time.Now().Add(time.Hour).UnixNano()
-	putEntry(t, s, "aa01", cache.Meta{PrimaryHex: "aa01", Host: "shop.com", URI: "/p1", Tags: []string{"product-42"}, Created: 100, FreshUntil: fresh}, []byte("x"))
-	putEntry(t, s, "bb02", cache.Meta{PrimaryHex: "bb02", Host: "blog.com", URI: "/post", Tags: []string{"product-42"}, Created: 100, FreshUntil: fresh}, []byte("y")) // different host, same tag
-	putEntry(t, s, "cc03", cache.Meta{PrimaryHex: "cc03", Host: "shop.com", URI: "/p2", Tags: []string{"product-99"}, Created: 100, FreshUntil: fresh}, []byte("z"))
-
-	tbl, _ := NewPurgeTable("", 0)
-	fixedClock(tbl, 200)
+	clk := &stepClock{}
+	clk.set(200)
+	tbl := newClockedTable(t, "", clk)
 	require.NoError(t, tbl.Apply([]PurgeEntry{{Seq: 1, Scope: ScopeTag, Tag: "product-42"}}, 1))
 
-	fixedClock(tbl, 300)
+	clk.set(300)
 	ReapOnce(s, tbl)
 
 	_, _, okA := s.Get("aa01")
@@ -113,9 +95,10 @@ func TestReapOnce_TagReaps(t *testing.T) {
 func TestReapOnce_NoPurgesIsNoOp(t *testing.T) {
 	s := cache.NewMemory(1 << 20)
 	fresh := time.Now().Add(time.Hour).UnixNano()
-	putEntry(t, s, "aa01", cache.Meta{PrimaryHex: "aa01", Host: "a.com", URI: "/a", Created: 100, FreshUntil: fresh}, []byte("x"))
+	putEntry(t, s, "aa01", cache.Meta{Host: "a.com", URI: "/a", Created: 100, FreshUntil: fresh}, []byte("x"))
 
-	tbl, _ := NewPurgeTable("", 0)
+	tbl, err := NewPurgeTable("", 0)
+	require.NoError(t, err)
 	ReapOnce(s, tbl)
 	assert.Equal(t, 1, storageLen(s), "nothing purged -> nothing reaped")
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/profiler v0.6.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.32.0
 	github.com/acoshift/configfile v1.9.0
-	github.com/moonrhythm/parapet v0.17.2
+	github.com/moonrhythm/parapet v0.17.3-0.20260608160136-32c4dca655d2
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moonrhythm/parapet v0.17.2 h1:dXLEhjY1iDk50XQS9M7WSKepTv/nPUoCxqu61CcwDZo=
-github.com/moonrhythm/parapet v0.17.2/go.mod h1:mfLCzU9zBm6vn05mnOgO0G8/+pArndciyLv3BYM9HJA=
+github.com/moonrhythm/parapet v0.17.3-0.20260608160136-32c4dca655d2 h1:FUo0iHLQyoqIdtypH/YvzAC2nWWrCCPMnxut6ltqes0=
+github.com/moonrhythm/parapet v0.17.3-0.20260608160136-32c4dca655d2/go.mod h1:mfLCzU9zBm6vn05mnOgO0G8/+pArndciyLv3BYM9HJA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=


### PR DESCRIPTION
## What

The cache-purge **mechanics** were upstreamed into parapet as [`pkg/cache/purge`](https://github.com/moonrhythm/parapet/pull/214) (extracted from this very code). This PR makes `edge.PurgeTable` a thin wrapper over it, keeping only the parts that are genuinely ours: the **control-plane distribution layer**.

**Moved to parapet** (deleted here): the lazy epoch table, host/url/prefix/tag/global scopes, the monotonic clock-step-back clamp, the cap-fold memory bound, the lock-free `active` gate, and the reaper — plus the key helpers (`normHost`/`urlKey`/`matchPrefix`/…).

**Kept here** (the CP layer): the journal cursor + idempotency, `Apply`/`FlushAll` over `PurgeEntry` records, and the atomic `{snapshot, cursor}` persistence (now serializing `purge.Snapshot`).

Net `edge/purge.go`: **+80 / −403**.

## Compatibility — nothing else changes

- **Public API unchanged** — `NewPurgeTable`, `Apply`, `FlushAll`, `Cursor`, `InvalidatedAfter`, `InvalidatedAfterMeta`, `Stats`, `ReapOnce`/`RunReaper`. So `purgerefresh.go` (CP polling), `cmd/edge-proxy/main.go`, and the metrics are untouched.
- **On-disk format unchanged** — `persistState` embeds `purge.Snapshot`, so `host`/`url`/`prefix`/`tag`/`global` stay top-level JSON keys alongside `cursor`. **Pre-migration state files load without a flush** — an in-place upgrade does not gap the cursor or trigger a fleet-wide invalidation. Locked in by `TestPurge_LoadsPreMigrationFormat` (hand-written old-format file).
- **`{snapshot, cursor}` still atomic** — `snapshotLocked` captures both under `mu`; the versioned off-lock persist (drop-stale-snapshot) is preserved.

## Tests

Scope-mechanics tests dropped (now covered exhaustively in parapet). Kept + adapted the CP-layer tests: `Apply` scope-dispatch, cursor idempotency, empty-batch cursor advance, `FlushAll` cursor realign-down, persistence round-trip (state + cursor + highWater under a stepped-back clock), stale-version-skip, gate-active-after-reload, corrupt/missing state, and the new pre-migration-format load. Reaper tests adapted to drive through `Apply`. `make test` (`go vet ./... && go test ./...`) green; `go test -race ./...` green.

## Dependency

parapet bumped `v0.17.2 → v0.17.3-0.20260608…-32c4dca` (master pseudo-version; the `purge` package isn't in a release tag yet). Re-pin to a real tag when parapet cuts one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)