### PR TITLE
Update parapet to v0.18.0 + wire its new observability hooks

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -275,6 +275,14 @@ Rule snapshots apply with the same **all-or-nothing compile + atomic swap +
 keep-last-good** semantics as parapet's `SetRules`; on a fetch failure the edge
 **fails static** (keeps last-good) — never fail-open to "no WAF".
 
+Both layers record per-request rule-eval latency on `:9187` as
+`parapet_waf_eval_duration_seconds{outcome,scope}` (`outcome` =
+`pass|allow|block|error`, `scope` = `global|zone`), same metric as the
+controller; an empty ruleset (before the first snapshot lands) takes the
+no-rules fast path and records nothing. Edge rule *matches* are debug-logged
+but not yet a counter (the controller's `parapet_waf_matches` is
+controller-only).
+
 ### parapet stays authoritative (the backstop)
 
 The control plane derives `host[/path] → zoneKey` from the Ingress objects
@@ -364,10 +372,17 @@ cacheable object locally removes a full origin round trip. Enabled with
   fetch (no stampede): the first request fills while streaming to its own client
   and to disk; others wait (≤ a 2s timeout) then read the just-filled entry, or
   fall through to their own fetch if it turned out uncacheable.
-- **Observability.** Sets `X-Cache: HIT|MISS` (HIT = served from the edge cache,
-  MISS = fetched from parapet). Cache hit/miss counts are not yet a Prometheus
-  metric; the edge does expose a `:9187` metrics endpoint (connections, bytes, Go
-  runtime) — `EDGE_METRICS_LISTEN`, set `""` to disable.
+- **Observability.** Sets `X-Cache: HIT|MISS|STALE` (HIT = served from the edge
+  cache, MISS = fetched from parapet, STALE = served stale under RFC 5861).
+  Cache outcomes are counted on the `:9187` metrics
+  endpoint (`EDGE_METRICS_LISTEN`, set `""` to disable) as
+  `parapet_cache_total{result}` (`HIT|MISS|STALE|STALE_ERROR|BYPASS` — BYPASS is
+  the ineligible-request path that sends no `X-Cache` header) plus
+  `parapet_cache_fill_duration_seconds` (origin-fill latency, observed only when
+  parapet was contacted on the serving path). Deliberately **no `host` label** —
+  the edge serves any Host the client sends, so a host label would be unbounded
+  series under a flood. Unless `DISABLE_LOG` is set, each access-log line also
+  carries the outcome as a `cacheStatus` field.
 
 ### On-disk layout (sharded by hash)
 
@@ -424,11 +439,11 @@ invalidated entries off the serving path; the in-memory record table is bounded 
 the count-cap fold, and disk by the cache's LRU byte cap.
 
 A fetch/IO error on the read path **fails static** (degrades to a cache miss →
-serve from origin), never erroring the client request. **Not yet:**
-stale-while-revalidate / stale-if-error, Range/partial caching, per-route policy
-via Ingress annotations, chunked-GET caching (a GET needs a `Content-Length`),
-and cache hit/miss Prometheus metrics (the `:9187` listener exists for
-connection/byte/runtime metrics).
+serve from origin), never erroring the client request. RFC 5861
+stale-while-revalidate / stale-if-error are honored when the origin opts in via
+`Cache-Control` (part of `parapet/pkg/cache`). **Not yet:** Range/partial
+caching, per-route policy via Ingress annotations, and chunked-GET caching (a
+GET needs a `Content-Length`).
 
 ### Purge / invalidation
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -228,6 +228,8 @@ the metric exists in both.
 | `parapet_backend_network_read_bytes{addr}` / `_write_bytes{addr}` | both |
 | `parapet_network_request_bytes` / `parapet_network_response_bytes` | both |
 | `parapet_waf_matches{rule_id,action,scope}` | both (note: **no** `_total` suffix) |
+| `parapet_waf_eval_duration_seconds{outcome,scope}` | **Go-only** (histogram of per-request rule-eval latency; `outcome` = `pass\|allow\|block\|error`, fired once per evaluated request — the pass path `parapet_waf_matches` can't see) |
+| `parapet_ratelimit_total{name,result}` | **Go-only** (`result` = `allowed\|limited`; `name` = `host` / `host-country` for the env-configured limiters, `<ns>/<name>:<s\|m\|h>` for annotation limiters) |
 | `parapet_connections{state}` | **Go-only** (no Pingora `ConnState` equivalent) |
 | `go_*` runtime, Cloud Profiler/Trace | **Go-only** |
 | `parapet_rejected_requests{reason}`, `parapet_tls_sni_no_cert_total{reason}`, `process_*` (custom `/proc`) | **Rust-only** (Go gets `process_*` from client_golang) |

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/moonrhythm/parapet-ingress-controller/edge"
 	"github.com/moonrhythm/parapet-ingress-controller/geoip"
+	"github.com/moonrhythm/parapet-ingress-controller/metric/observe"
 	"github.com/moonrhythm/parapet-ingress-controller/trustcidr"
 )
 
@@ -220,7 +221,17 @@ func main() {
 			}
 		}
 		if storage != nil {
-			opts := cache.Options{MaxFileSize: maxFile}
+			// Cache outcomes: bounded prom counters (no host label — serve-all
+			// means r.Host is unbounded) + a cacheStatus access-log field
+			// (no-op under DISABLE_LOG — no logger record to set).
+			cacheMetrics := observe.CacheResult()
+			opts := cache.Options{
+				MaxFileSize: maxFile,
+				OnResult: func(r *http.Request, info cache.ResultInfo) {
+					cacheMetrics(r, info)
+					cache.LogResult(r, info)
+				},
+			}
 			// Cache-purge: an invalidation table fed from the control plane gates each
 			// hit (parapet's Options.InvalidatedAfter). On by default with the cache; the
 			// poll loop fail-statics if the CP isn't distributing purges. The table

--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/moonrhythm/parapet-ingress-controller/geoip"
 	"github.com/moonrhythm/parapet-ingress-controller/k8s"
 	"github.com/moonrhythm/parapet-ingress-controller/metric"
+	"github.com/moonrhythm/parapet-ingress-controller/metric/observe"
 	"github.com/moonrhythm/parapet-ingress-controller/plugin"
 	"github.com/moonrhythm/parapet-ingress-controller/proxy"
 	"github.com/moonrhythm/parapet-ingress-controller/state"
@@ -471,9 +472,15 @@ func hostRateLimit(isKnownHost func(host string) bool) parapet.Middleware {
 		metric.RejectedRequest("host_limit")
 	}
 
+	// Decision counter (allowed|limited) — the limited side complements the
+	// existing host-limit rejection metrics with an allowed denominator.
+	rlObserve := observe.RateLimit("host")
+
 	if concurrentSize > 0 {
 		slog.Info("setting up host rate limit", "strategy", "ConcurrentQueue", "capacity", concurrentCapacity, "size", concurrentSize)
 		return ratelimit.RateLimiter{
+			Name:    "host",
+			Observe: rlObserve,
 			Strategy: &ratelimit.ConcurrentQueueStrategy{
 				Capacity: concurrentCapacity,
 				Size:     concurrentSize,
@@ -487,6 +494,8 @@ func hostRateLimit(isKnownHost func(host string) bool) parapet.Middleware {
 
 	slog.Info("setting up host rate limit", "strategy", "Concurrent", "capacity", concurrentCapacity)
 	return ratelimit.RateLimiter{
+		Name:    "host",
+		Observe: rlObserve,
 		Strategy: &ratelimit.ConcurrentStrategy{
 			Capacity: concurrentCapacity,
 		},
@@ -540,9 +549,13 @@ func hostCountryRateLimit(isKnownHost func(host string) bool) parapet.Middleware
 		metric.RejectedRequest("host_limit")
 	}
 
+	rlObserve := observe.RateLimit("host-country")
+
 	if concurrentSize > 0 {
 		slog.Info("setting up host country rate limit", "strategy", "ConcurrentQueue", "capacity", concurrentCapacity, "size", concurrentSize)
 		return ratelimit.RateLimiter{
+			Name:    "host-country",
+			Observe: rlObserve,
 			Strategy: &ratelimit.ConcurrentQueueStrategy{
 				Capacity: concurrentCapacity,
 				Size:     concurrentSize,
@@ -556,6 +569,8 @@ func hostCountryRateLimit(isKnownHost func(host string) bool) parapet.Middleware
 
 	slog.Info("setting up host country rate limit", "strategy", "Concurrent", "capacity", concurrentCapacity)
 	return ratelimit.RateLimiter{
+		Name:    "host-country",
+		Observe: rlObserve,
 		Strategy: &ratelimit.ConcurrentStrategy{
 			Capacity: concurrentCapacity,
 		},

--- a/controller_waf.go
+++ b/controller_waf.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/moonrhythm/parapet-ingress-controller/k8s"
 	"github.com/moonrhythm/parapet-ingress-controller/metric"
+	"github.com/moonrhythm/parapet-ingress-controller/metric/observe"
 	"github.com/moonrhythm/parapet-ingress-controller/wafrule"
 )
 
@@ -99,6 +100,9 @@ func (ctrl *Controller) newWAF(scope string) *waf.WAF {
 	w.Logger = waf.LoggerFunc(func(format string, args ...any) {
 		slog.Debug(fmt.Sprintf(format, args...))
 	})
+	// Eval latency + outcome, once per evaluated request — the pass path OnMatch
+	// can't see. Handles resolve here (per WAF instance), not per request.
+	w.Observe = observe.WAFEval(scope)
 	w.OnMatch = func(ev waf.MatchEvent) {
 		metric.WAFMatch(ev.RuleID, ev.Action.String(), scope)
 		lvl := slog.LevelDebug

--- a/edge/import_boundary_test.go
+++ b/edge/import_boundary_test.go
@@ -1,0 +1,33 @@
+package edge_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The metric package init-materializes the CONTROLLER's core-trust alerting
+// series (metric/trust.go pre-resolves its gauge/counter handles), so any binary
+// that links it exports trust_warmstart_active, trust_bundle_age_seconds, etc.
+// as constant zeros. On the edge those bogus series would dilute the fleet-wide
+// aggregations they exist to alert on (e.g. avg(trust_bundle_age_seconds)).
+// That is why the shared per-request observers live in the LEAF package
+// metric/observe — and this test is the mechanical guarantee the edge binaries
+// stay on the leaf (the boundary regressed once, unnoticed, before this test).
+func TestEdgeBinariesDoNotImportMetric(t *testing.T) {
+	const metricPkg = "github.com/moonrhythm/parapet-ingress-controller/metric"
+	for _, pkg := range []string{
+		"github.com/moonrhythm/parapet-ingress-controller/cmd/edge-proxy",
+		"github.com/moonrhythm/parapet-ingress-controller/cmd/edge-controlplane",
+	} {
+		out, err := exec.Command("go", "list", "-deps", pkg).Output()
+		if err != nil {
+			t.Fatalf("go list -deps %s: %v", pkg, err)
+		}
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.TrimSpace(line) == metricPkg {
+				t.Errorf("%s transitively imports %s — edge binaries must use metric/observe (the leaf) so the controller's init-materialized core-trust series stay off the edge's /metrics", pkg, metricPkg)
+			}
+		}
+	}
+}

--- a/edge/waf.go
+++ b/edge/waf.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moonrhythm/parapet"
 	"github.com/moonrhythm/parapet/pkg/waf"
 
+	"github.com/moonrhythm/parapet-ingress-controller/metric/observe"
 	"github.com/moonrhythm/parapet-ingress-controller/wafrule"
 )
 
@@ -40,7 +41,7 @@ type EdgeWAF struct {
 // ruleset and every zone, so the edge — the first hop — resolves both from the
 // true client IP.
 func NewEdgeWAF(country func(*http.Request) string, asn func(*http.Request) int64) *EdgeWAF {
-	newWAF := func() *waf.WAF {
+	newWAF := func(scope string) *waf.WAF {
 		w := waf.New()
 		w.Country = country
 		w.ASN = asn
@@ -49,10 +50,15 @@ func NewEdgeWAF(country func(*http.Request) string, asn func(*http.Request) int6
 		w.Logger = waf.LoggerFunc(func(format string, args ...any) {
 			slog.Debug(fmt.Sprintf(format, args...))
 		})
+		// Eval latency + outcome per evaluated request (the no-rules pass-through
+		// before rules load doesn't fire it), same metric as the controller.
+		// observe (not metric) keeps the controller's init-materialized
+		// core-trust series off the edge's /metrics.
+		w.Observe = observe.WAFEval(scope)
 		return w
 	}
-	w := &EdgeWAF{newZone: newWAF}
-	w.global = newWAF()
+	w := &EdgeWAF{newZone: func() *waf.WAF { return newWAF("zone") }}
+	w.global = newWAF("global")
 	empty := map[string]*waf.WAF{}
 	w.zones.Store(&empty)
 	emptyHZ := map[string]string{}

--- a/edgecp/converge/import_boundary_test.go
+++ b/edgecp/converge/import_boundary_test.go
@@ -26,6 +26,7 @@ func TestServingPathDoesNotImportConvergeOrPromClient(t *testing.T) {
 		"github.com/moonrhythm/parapet-ingress-controller/cmd/edge-proxy",
 		"github.com/moonrhythm/parapet-ingress-controller/trust", // the core trust manager
 		"github.com/moonrhythm/parapet-ingress-controller/metric",
+		"github.com/moonrhythm/parapet-ingress-controller/metric/observe",
 	}
 	for _, pkg := range servingPkgs {
 		out, err := exec.Command("go", "list", "-deps", pkg).Output()

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/profiler v0.6.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.32.0
 	github.com/acoshift/configfile v1.9.0
-	github.com/moonrhythm/parapet v0.17.3-0.20260608160136-32c4dca655d2
+	github.com/moonrhythm/parapet v0.18.0
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/moonrhythm/parapet v0.18.0
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
@@ -63,7 +64,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moonrhythm/parapet v0.17.3-0.20260608160136-32c4dca655d2 h1:FUo0iHLQyoqIdtypH/YvzAC2nWWrCCPMnxut6ltqes0=
-github.com/moonrhythm/parapet v0.17.3-0.20260608160136-32c4dca655d2/go.mod h1:mfLCzU9zBm6vn05mnOgO0G8/+pArndciyLv3BYM9HJA=
+github.com/moonrhythm/parapet v0.18.0 h1:QuO2glZucg7ARkoBMXmeM7yqqkj1nNZ/T+m7XatlIqE=
+github.com/moonrhythm/parapet v0.18.0/go.mod h1:mfLCzU9zBm6vn05mnOgO0G8/+pArndciyLv3BYM9HJA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=

--- a/metric/observe/cache.go
+++ b/metric/observe/cache.go
@@ -1,0 +1,65 @@
+package observe
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/moonrhythm/parapet/pkg/cache"
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// _respCache holds the response-cache outcome metrics. Unlike the package's
+// other metrics it registers lazily (first CacheResult call), NOT in init():
+// the fill histogram is labelless, so registering it exports a zero series
+// immediately — and the controller binary imports this package for the WAF and
+// ratelimit observers but has no response cache, so it must not grow cache
+// series it can never move.
+var _respCache struct {
+	once  sync.Once
+	total map[cache.Result]prometheus.Counter
+	fill  prometheus.Histogram
+}
+
+// CacheResult returns a cache.ResultFunc for cache.Options.OnResult recording:
+//
+//	parapet_cache_total{result}             counter (HIT|MISS|STALE|STALE_ERROR|BYPASS)
+//	parapet_cache_fill_duration_seconds     histogram of origin-fill latency
+//	    (FillDuration is non-zero only when the origin was contacted on the
+//	     serving path — a MISS fill or a stale-if-error revalidation — so hits
+//	     don't dilute it)
+//
+// These are parapet's prom.Cache metrics WITHOUT the host label: the edge
+// serves any Host the client sends (serve-all), so r.Host is attacker-
+// controlled and would mint unbounded series. The result label is cache's
+// closed five-value set; handles are resolved once, so the per-request hook is
+// alloc- and lookup-free. An unknown Result is dropped rather than labeled.
+func CacheResult() cache.ResultFunc {
+	_respCache.once.Do(func() {
+		vec := prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: prom.Namespace,
+			Name:      "cache_total",
+		}, []string{"result"})
+		_respCache.total = make(map[cache.Result]prometheus.Counter)
+		for _, res := range []cache.Result{
+			cache.ResultHit, cache.ResultMiss, cache.ResultStale,
+			cache.ResultStaleError, cache.ResultBypass,
+		} {
+			_respCache.total[res] = vec.With(prometheus.Labels{"result": string(res)})
+		}
+		_respCache.fill = prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: prom.Namespace,
+			Name:      "cache_fill_duration_seconds",
+			Buckets:   prometheus.DefBuckets,
+		})
+		prom.Registry().MustRegister(vec, _respCache.fill)
+	})
+	return func(_ *http.Request, info cache.ResultInfo) {
+		if c, ok := _respCache.total[info.Result]; ok {
+			c.Inc()
+		}
+		if info.FillDuration > 0 {
+			_respCache.fill.Observe(info.FillDuration.Seconds())
+		}
+	}
+}

--- a/metric/observe/cache_test.go
+++ b/metric/observe/cache_test.go
@@ -1,0 +1,36 @@
+package observe
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	pcache "github.com/moonrhythm/parapet/pkg/cache"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheResult(t *testing.T) {
+	obs := CacheResult()
+	r := httptest.NewRequest("GET", "http://cache-result-test.example.com/x", nil)
+
+	obs(r, pcache.ResultInfo{Result: pcache.ResultHit})
+	obs(r, pcache.ResultInfo{Result: pcache.ResultMiss, FillDuration: 30 * time.Millisecond})
+	obs(r, pcache.ResultInfo{Result: pcache.ResultBypass})
+	// an unknown result is dropped, not counted under a new label
+	obs(r, pcache.ResultInfo{Result: pcache.Result("WEIRD")})
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(_respCache.total[pcache.ResultHit]))
+	assert.Equal(t, 1.0, testutil.ToFloat64(_respCache.total[pcache.ResultMiss]))
+	assert.Equal(t, 1.0, testutil.ToFloat64(_respCache.total[pcache.ResultBypass]))
+	assert.Equal(t, 0.0, testutil.ToFloat64(_respCache.total[pcache.ResultStale]))
+	assert.Equal(t, 0.0, testutil.ToFloat64(_respCache.total[pcache.ResultStaleError]))
+
+	// the fill histogram saw only the MISS — the sole event with FillDuration set
+	var m dto.Metric
+	require.NoError(t, _respCache.fill.Write(&m))
+	assert.EqualValues(t, 1, m.GetHistogram().GetSampleCount())
+	assert.InDelta(t, 0.030, m.GetHistogram().GetSampleSum(), 1e-9)
+}

--- a/metric/observe/observe.go
+++ b/metric/observe/observe.go
@@ -1,0 +1,21 @@
+// Package observe provides bounded, pre-resolved Prometheus observers for
+// parapet's per-request observability hooks (waf.WAF.Observe,
+// ratelimit.RateLimiter.Observe, cache.Options.OnResult), shared by the
+// controller and edge-proxy binaries.
+//
+// It is deliberately a LEAF package, separate from metric: importing metric
+// materializes the controller's core-trust alerting series at init
+// (metric/trust.go pre-resolves its gauge/counter handles), and the edge must
+// not export constant-zero core-trust gauges that would dilute fleet-wide
+// aggregations. Each binary imports only the observers it can actually move.
+//
+// The observers record the same metric names as parapet's prom.WAF /
+// prom.RateLimit / prom.Cache helpers (so dashboards are interchangeable), with
+// two differences: handles are resolved at construction, once per instance, so
+// the per-request hook is alloc- and lookup-free (the prom helpers re-resolve
+// labels on every event); and the label sets are adjusted for this deployment
+// (WAF gains the scope label, cache drops the unbounded host label). Because
+// the names collide, never wire parapet's prom.WAF()/prom.RateLimit()/
+// prom.Cache() in a binary that uses this package — the duplicate
+// MustRegister panics at startup.
+package observe

--- a/metric/observe/ratelimit.go
+++ b/metric/observe/ratelimit.go
@@ -1,0 +1,40 @@
+package observe
+
+import (
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/moonrhythm/parapet/pkg/ratelimit"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var _ratelimit struct {
+	vec *prometheus.CounterVec
+}
+
+func init() {
+	_ratelimit.vec = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "ratelimit_total",
+	}, []string{"name", "result"})
+	prom.Registry().MustRegister(_ratelimit.vec)
+}
+
+// RateLimit returns a ratelimit.ObserveFunc counting every limiter decision as
+// parapet_ratelimit_total{name,result} (result = allowed|limited) — the same
+// metric parapet's prom.RateLimit records, but with the two counter handles
+// resolved here, once per limiter, so the per-request hook is alloc- and
+// lookup-free (prom.RateLimit re-resolves labels on every decision). name must
+// be bounded: an operator-set limiter id, never request input. The hook fires
+// IN ADDITION to ExceededHandler — rejections keep their existing 503 and
+// host-limit metrics.
+func RateLimit(name string) ratelimit.ObserveFunc {
+	allowed := _ratelimit.vec.With(prometheus.Labels{"name": name, "result": ratelimit.ResultAllowed.String()})
+	limited := _ratelimit.vec.With(prometheus.Labels{"name": name, "result": ratelimit.ResultLimited.String()})
+	return func(e ratelimit.Event) {
+		switch e.Result {
+		case ratelimit.ResultAllowed:
+			allowed.Inc()
+		case ratelimit.ResultLimited:
+			limited.Inc()
+		}
+	}
+}

--- a/metric/observe/ratelimit_test.go
+++ b/metric/observe/ratelimit_test.go
@@ -1,0 +1,32 @@
+package observe
+
+import (
+	"testing"
+
+	"github.com/moonrhythm/parapet/pkg/ratelimit"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateLimit(t *testing.T) {
+	const name = "ratelimit-observer-test"
+	obs := RateLimit(name)
+
+	obs(ratelimit.Event{Name: name, Result: ratelimit.ResultAllowed})
+	obs(ratelimit.Event{Name: name, Result: ratelimit.ResultAllowed})
+	obs(ratelimit.Event{Name: name, Result: ratelimit.ResultLimited})
+	// an unknown result is dropped, not counted
+	obs(ratelimit.Event{Name: name, Result: ratelimit.Result(99)})
+
+	allowed := _ratelimit.vec.With(prometheus.Labels{"name": name, "result": "allowed"})
+	limited := _ratelimit.vec.With(prometheus.Labels{"name": name, "result": "limited"})
+	assert.Equal(t, 2.0, testutil.ToFloat64(allowed))
+	assert.Equal(t, 1.0, testutil.ToFloat64(limited))
+
+	// a re-created observer for the same name (e.g. a reload re-running the
+	// plugin) resolves to the same underlying series — counts continue
+	obs2 := RateLimit(name)
+	obs2(ratelimit.Event{Name: name, Result: ratelimit.ResultAllowed})
+	assert.Equal(t, 3.0, testutil.ToFloat64(allowed))
+}

--- a/metric/observe/waf.go
+++ b/metric/observe/waf.go
@@ -1,0 +1,58 @@
+package observe
+
+import (
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/moonrhythm/parapet/pkg/waf"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var _wafEval struct {
+	vec *prometheus.HistogramVec
+}
+
+// wafEvalBuckets match parapet's prom.WAF tuning: dense below 1ms where the bulk
+// of evals sit, an edge ON the 5ms default EvalTimeout (the SLO line), and
+// 10/25ms headroom for raised timeouts. prometheus.DefBuckets starts AT 5ms, so
+// it would collapse the whole distribution into one bucket.
+var wafEvalBuckets = []float64{
+	0.000025, 0.00005, 0.0001, 0.00025, 0.0005, // 25us..500us
+	0.001, 0.0025, 0.005, // 1ms..5ms (default EvalTimeout)
+	0.01, 0.025, // past-timeout tail
+}
+
+func init() {
+	_wafEval.vec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: prom.Namespace,
+		Name:      "waf_eval_duration_seconds",
+		Buckets:   wafEvalBuckets,
+	}, []string{"outcome", "scope"})
+	prom.Registry().MustRegister(_wafEval.vec)
+}
+
+// WAFEval returns a waf.ObserveFunc recording per-request rule-eval latency as
+// parapet_waf_eval_duration_seconds{outcome,scope} — parapet's prom.WAF metric
+// plus the scope label ("global"/"zone"), matching parapet_waf_matches. Unlike
+// OnMatch it fires once per evaluated request, so the silent-majority no-match
+// path and the WAF's per-request overhead are visible. Both labels are bounded:
+// outcome is waf's closed four-value set and scope is caller-fixed. Handles are
+// resolved here, once per WAF instance, so the hook itself is alloc- and
+// lookup-free on the request path. Call only when the WAF is actually enabled —
+// resolving the handles creates the (zero) series.
+func WAFEval(scope string) waf.ObserveFunc {
+	obs := func(o waf.Outcome) prometheus.Observer {
+		return _wafEval.vec.With(prometheus.Labels{"outcome": o.String(), "scope": scope})
+	}
+	handles := [...]prometheus.Observer{
+		waf.OutcomePass:  obs(waf.OutcomePass),
+		waf.OutcomeAllow: obs(waf.OutcomeAllow),
+		waf.OutcomeBlock: obs(waf.OutcomeBlock),
+		waf.OutcomeError: obs(waf.OutcomeError),
+	}
+	return func(ev waf.EvalEvent) {
+		// An outcome outside the known set is dropped rather than minting an
+		// "unknown" series from request-path input.
+		if int(ev.Outcome) < len(handles) {
+			handles[ev.Outcome].Observe(ev.Duration.Seconds())
+		}
+	}
+}

--- a/metric/observe/waf_test.go
+++ b/metric/observe/waf_test.go
@@ -1,0 +1,50 @@
+package observe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moonrhythm/parapet/pkg/waf"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func wafEvalSampleCount(t *testing.T, outcome, scope string) uint64 {
+	t.Helper()
+	h, err := _wafEval.vec.GetMetricWith(prometheus.Labels{"outcome": outcome, "scope": scope})
+	require.NoError(t, err)
+	var m dto.Metric
+	require.NoError(t, h.(prometheus.Metric).Write(&m))
+	return m.GetHistogram().GetSampleCount()
+}
+
+func TestWAFEval(t *testing.T) {
+	const scope = "waf-eval-test"
+	obs := WAFEval(scope)
+
+	obs(waf.EvalEvent{Outcome: waf.OutcomePass, Duration: 40 * time.Microsecond})
+	obs(waf.EvalEvent{Outcome: waf.OutcomePass, Duration: 60 * time.Microsecond})
+	obs(waf.EvalEvent{Outcome: waf.OutcomeBlock, Duration: time.Millisecond})
+	// an outcome outside waf's closed set must be dropped, not panic or
+	// mint a series from request-path input
+	obs(waf.EvalEvent{Outcome: waf.Outcome(200), Duration: time.Millisecond})
+
+	assert.EqualValues(t, 2, wafEvalSampleCount(t, "pass", scope))
+	assert.EqualValues(t, 1, wafEvalSampleCount(t, "block", scope))
+	assert.EqualValues(t, 0, wafEvalSampleCount(t, "allow", scope))
+	assert.EqualValues(t, 0, wafEvalSampleCount(t, "error", scope))
+}
+
+func TestWAFEvalScopesAreDistinct(t *testing.T) {
+	global := WAFEval("waf-eval-scope-g")
+	zone := WAFEval("waf-eval-scope-z")
+
+	global(waf.EvalEvent{Outcome: waf.OutcomePass, Duration: time.Microsecond})
+	zone(waf.EvalEvent{Outcome: waf.OutcomePass, Duration: time.Microsecond})
+	zone(waf.EvalEvent{Outcome: waf.OutcomePass, Duration: time.Microsecond})
+
+	assert.EqualValues(t, 1, wafEvalSampleCount(t, "pass", "waf-eval-scope-g"))
+	assert.EqualValues(t, 2, wafEvalSampleCount(t, "pass", "waf-eval-scope-z"))
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/yaml.v3"
 	networking "k8s.io/api/networking/v1"
 
+	"github.com/moonrhythm/parapet-ingress-controller/metric/observe"
 	"github.com/moonrhythm/parapet-ingress-controller/state"
 )
 
@@ -143,14 +144,23 @@ func RateLimit(ctx Context) {
 		return n
 	}
 
+	// use wires the decision counter (allowed|limited) before mounting. The
+	// name label is <ns>/<name>:<window> — bounded by the ingresses an operator
+	// creates (the same argument as rule_id on parapet_waf_matches).
+	use := func(rl *ratelimit.RateLimiter, window string) {
+		rl.Name = ctx.ingressID() + ":" + window
+		rl.Observe = observe.RateLimit(rl.Name)
+		ctx.Use(rl)
+	}
+
 	if n := rate("/ratelimit-s"); n > 0 {
-		ctx.Use(ratelimit.FixedWindowPerSecond(n))
+		use(ratelimit.FixedWindowPerSecond(n), "s")
 	}
 	if n := rate("/ratelimit-m"); n > 0 {
-		ctx.Use(ratelimit.FixedWindowPerMinute(n))
+		use(ratelimit.FixedWindowPerMinute(n), "m")
 	}
 	if n := rate("/ratelimit-h"); n > 0 {
-		ctx.Use(ratelimit.FixedWindowPerHour(n))
+		use(ratelimit.FixedWindowPerHour(n), "h")
 	}
 }
 


### PR DESCRIPTION
## Summary

Two commits:

**1. `chore(deps)`: parapet v0.17.3-pre → v0.18.0.** No code changes needed — the one breaking rename (`timeout.Timout` → `Timeout`) has no usage here. Picks up the `onShutdown` SIGTERM-registration race fix and the `logger.OmitEmpty` fix for free.

**2. `feat(metrics)`: wire the three drop-in observability hooks** from the release, with bounded labels and handles resolved at construction (per-request hook is alloc- and lookup-free — the `metric/cache.go` rationale; parapet's own prom helpers re-resolve labels per event):

| Hook | Metric | Where |
|---|---|---|
| `waf.WAF.Observe` | `parapet_waf_eval_duration_seconds{outcome,scope}` | controller global+zone WAFs, edge global+zone WAFs |
| `cache.Options.OnResult` | `parapet_cache_total{result}` + `parapet_cache_fill_duration_seconds` + `cacheStatus` log field | edge response cache |
| `ratelimit.RateLimiter.Observe` | `parapet_ratelimit_total{name,result}` | `host` / `host-country` env limiters + per-ingress annotation limiters (`<ns>/<name>:<s\|m\|h>`) |

Notable decisions:

- **WAF eval latency** fires once per evaluated request — the silent-majority pass path `OnMatch` can never see — and adds the `scope` label for parity with `parapet_waf_matches`. The edge cache, adopted in #137, was previously blind (no hit-ratio metric at all).
- **No `host` label on the cache metrics** (parapet's `prom.Cache` has one): the serve-all edge accepts any client `Host`, which would mint unbounded series under a flood.
- **`metric/observe` is a deliberate leaf package.** Importing `metric` init-materializes the controller's core-trust alerting series (`metric/trust.go` pre-resolves its handles); an edge binary linking it would export `trust_warmstart_active` / `trust_bundle_age_seconds` etc. as constant zeros, diluting the fleet-wide aggregations they exist to alert on. A new boundary test (`edge/import_boundary_test.go`) pins both edge binaries to the leaf, and `metric/observe` joins the converge boundary test's serving-path list.
- **Disabled features stay zero-cost:** every observer is constructed only inside the existing enablement gates (`InitWAF` no-ops when disabled, limiters return early without capacity, `CacheResult` registers lazily on first call), so a disabled feature emits no series and does no per-request work.

Docs: SPEC.md metrics table + EDGE.md cache/WAF observability sections. Also corrects EDGE.md's stale claim that SWR/stale-if-error are unsupported — `parapet/pkg/cache` has honored origin-driven RFC 5861 since the #137 refactor.

## Testing

- `go test -race ./...` — 479 pass (4 new observer tests + 1 new boundary test)
- `go vet` clean, `gofmt` clean
- `go list -deps ./cmd/edge-proxy` verified: depends on `metric/observe`, not `metric`

🤖 Generated with [Claude Code](https://claude.com/claude-code)