### PR TITLE
docs(metrics): document v0.18.0 observability metrics, fix stale label

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,11 @@ annotations:
 - parapet_backend_network_write_bytes{addr}
 - parapet_reload{success}
 - parapet_host_ratelimit_requests{host}
-- parapet_host_active_requests{host, upgrade}
+- parapet_host_active_requests{host, kind}
+- parapet_ratelimit_total{name, result}
+- parapet_rejected_requests{reason}
 - parapet_waf_matches{rule_id, action, scope}
+- parapet_waf_eval_duration_seconds{outcome, scope}
 
 #### Metrics directly use from parapet
 


### PR DESCRIPTION
## Summary

Documentation-only follow-up to #138 (which already merged the parapet v0.18.0 update and observability wiring). Updates the README metrics list to match what the code now exports.

- Added `parapet_ratelimit_total{name, result}`, `parapet_rejected_requests{reason}`, and `parapet_waf_eval_duration_seconds{outcome, scope}`
- Corrected `parapet_host_active_requests` label from `{host, upgrade}` to `{host, kind}` (matches `metric/host.go` and SPEC.md)

## Test plan

- README-only change; not covered by CI (path-filtered to `**/*.go`)
- Metric names/labels verified against `metric/` and `metric/observe/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)