### PR TITLE
feat(edge): push edge-proxy metrics to the control plane; Prometheus scrapes CP /metrics

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -206,6 +206,18 @@ POST /v1/purges       Authorization: Bearer <ADMIN token>   ← stronger cred th
         applied on the read side, not at issue time)
   401 (no/invalid admin token)  400 (invalid scope/host/uri)  404 (purge distribution disabled)
 
+POST /v1/metrics      Authorization: Bearer <token>   X-Edge-Instance: <instance>
+  body: the edge's FULL Prometheus registry in text exposition format
+  204 (snapshot stored; served merged into the CP's /metrics listener)
+  401 (no/invalid token)
+  403 (token has no id grant — the edge_id label is the token's identity, so an
+       id-less token cannot push)
+  400 (missing/oversized X-Edge-Instance, or unparseable body)  413 (body > 8 MiB)
+  404 (CP_METRICS_LISTEN="" — ingestion disabled with the listener)
+       (the CP OVERRIDES any edge_id label in the body with the token's id and adds
+        edge_instance from the header — a pushed body can never impersonate another
+        edge. EDGE_ID should match the token's id; the label is always the latter.)
+
 GET /healthz          (no auth)
   200 always (liveness)
 GET /healthz?ready=1  (no auth)
@@ -696,7 +708,55 @@ controlplane   :8443  HTTPS GET (server-TLS + bearer)       NEW — Go, own Serv
                       (or plaintext HTTP on a trusted private network — TLS off)
                       distributes PRIVATE KEYS; NetworkPolicy: edge sources only;
                       NOT on the public LB
+               :9187  metrics (CP_METRICS_LISTEN) — the CP's own convergence
+                      metrics MERGED with every pushed edge snapshot (below)
 ```
+
+### Edge metrics push (scrape the CP, not the fleet)
+
+The edge fleet is out-of-cluster, so an in-cluster Prometheus often can't reach
+each edge's `EDGE_METRICS_LISTEN`. Opt-in alternative: the edge pushes its **full
+registry** (request/host/backend series + the `edge_*` convergence gauges +
+`go_*`/`process_*`) to `POST /v1/metrics` on its existing authenticated CP
+channel, and the CP serves every live snapshot merged into its own `/metrics` on
+`CP_METRICS_LISTEN` — **one scrape target** for the CP plus the whole fleet.
+`EDGE_METRICS_LISTEN` is untouched (useful for local debugging; set `""` to
+close the port when pushing).
+
+```
+EDGE_METRICS_PUSH_INTERVAL   seconds between pushes; 0 (default) = disabled.
+                             First tick jittered to decorrelate the fleet.
+EDGE_INSTANCE_ID             per-PROCESS discriminator (default: hostname), sent as
+                             X-Edge-Instance. Replicas may share one EDGE_ID/token
+                             identity, so edge_id alone cannot key snapshots — the
+                             CP stores and labels by (edge_id, edge_instance).
+CP_EDGE_METRICS_TTL          seconds a snapshot stays served after its last push
+                             (default 300; keep >= 3x the fleet push interval). A
+                             dead instance's series disappear at TTL instead of
+                             being served stale forever; instance-id churn stays
+                             bounded the same way.
+```
+
+The CP labels every pushed series with the **token-derived** `edge_id`
+(overriding any self-reported value — `EDGE_ID` should match the token's id) plus
+`edge_instance`, so per-family `# HELP`/`# TYPE` blocks merge cleanly: one block,
+one label set per CP/instance (the CP's own HELP/TYPE wins; a TYPE-conflicting
+edge family is dropped and counted in
+`parapet_edge_metrics_family_dropped_total`). Stored samples carry **no
+timestamps** — Prometheus stamps at scrape time — so staleness is bounded by the
+TTL plus the per-instance freshness gauge
+`parapet_edge_metrics_last_push_seconds{edge_id,edge_instance}` (deleted on
+eviction, so its presence implies the snapshot is still served). Push outcomes
+count in `parapet_edge_metrics_push_total{status}` (CP side) and
+`parapet_edge_metrics_client_push_total{result,edge_id}` (edge side). Note the
+per-instance `go_*`/`process_*` series land on the one scrape target — fleet
+cardinality is bounded by live instances via the TTL.
+
+The instance id is self-reported, so the CP also caps DISTINCT instances per
+edge_id (128): at the cap a new instance evicts that identity's stalest snapshot
+(`parapet_edge_metrics_instance_evicted_total`), bounding memory at
+tokens × cap × snapshot even if a compromised edge mints instance ids. Bodies are
+capped at 8 MiB (413).
 
 ### Plaintext HTTP listener (no redirect — the core decides)
 
@@ -745,6 +805,7 @@ edge *can* be co-located, prefer keyless (recoverable in git history).
 | Purge cursor gap (`since+1 < min_seq`, journal trimmed) | CP returns `flush_required` → edge bumps the global epoch (lazy flush-all) and realigns to `max_seq`. Conservative; never under-invalidates. |
 | CP restart / fresh replica (in-memory journal seq resets below the edge cursor, `since > max_seq`) | CP returns `flush_required` (the cursor-ahead-of-journal check) → edge flushes and realigns its cursor **down** to `max_seq`. The edge also independently flushes on `max_seq < cursor` as defense-in-depth against an older CP. Never silently under-invalidates. |
 | `purge-state` lost/corrupt | Cursor resets to 0 → next poll re-syncs (a trim gap or cursor-ahead → flush-all). Cursor + maps share **one atomic write** so they can't desync. |
+| `POST /v1/metrics` unreachable | Edge keeps serving traffic (**fail static** — push is pure observability); the CP serves the last snapshot until `CP_EDGE_METRICS_TTL`, then the instance's series disappear (its `last_push_seconds` series with them). The next successful push restores everything — counters are cumulative, nothing is lost. |
 
 ## Conformance
 

--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -18,8 +18,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/moonrhythm/parapet/pkg/prom"
-
 	"github.com/moonrhythm/parapet-ingress-controller/edgecp"
 	"github.com/moonrhythm/parapet-ingress-controller/k8s"
 )
@@ -369,13 +367,30 @@ func main() {
 	// The payload is non-secret (ca_id fingerprints, counters, generations — no key
 	// material); a NetworkPolicy must still restrict it to the scraper.
 	//
+	// The same listener also serves the PUSHED edge-fleet metrics: edges POST their
+	// registry snapshots to /v1/metrics on the API (token-gated), and MetricsHandler
+	// merges those per-instance snapshots into the CP's own families — one scrape
+	// target for the CP + the out-of-cluster fleet. Snapshots expire CP_EDGE_METRICS_TTL
+	// seconds after their last push, so a dead edge's series disappear instead of
+	// being served stale forever.
+	//
 	// A failed bind is logged loudly but NOT fatal: the control plane's job is issuance
 	// + trust distribution, which must never be taken down because an observability port
 	// is contended. A missing /metrics is already loud to the scraper (the target's
 	// `up == 0`), and the convergence interlock fails closed on a non-reporting target.
 	if metricsListen != "" {
+		metricsStore := edgecp.NewMetricsStore(time.Duration(envInt("CP_EDGE_METRICS_TTL", 300)) * time.Second)
+		server = server.WithMetricsIngest(metricsStore)
+		metricsSrv := &http.Server{
+			Addr:              metricsListen,
+			Handler:           edgecp.MetricsHandler(metricsStore),
+			ReadHeaderTimeout: 10 * time.Second,
+			ReadTimeout:       30 * time.Second,
+			WriteTimeout:      30 * time.Second,
+			IdleTimeout:       120 * time.Second,
+		}
 		go func() {
-			if err := prom.Start(metricsListen); err != nil && err != http.ErrServerClosed {
+			if err := metricsSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 				slog.Error("edge control plane: metrics listener failed; serving API without /metrics", "addr", metricsListen, "err", err)
 			}
 		}()

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -294,6 +294,22 @@ func main() {
 		}()
 	}
 
+	// Opt-in metrics push: the full registry is pushed to the control plane so an
+	// in-cluster Prometheus scrapes the CP's /metrics instead of reaching every
+	// out-of-cluster edge. EDGE_INSTANCE_ID disambiguates replicas that share one
+	// EDGE_ID; the CP labels every pushed series with (edge_id, edge_instance).
+	if pushInterval := time.Duration(envInt64("EDGE_METRICS_PUSH_INTERVAL", 0)) * time.Second; pushInterval > 0 {
+		instance := envOr("EDGE_INSTANCE_ID", "")
+		if instance == "" {
+			instance, _ = os.Hostname()
+		}
+		if instance == "" {
+			instance = "unknown"
+		}
+		go edge.RunMetricsPush(ctx, cp, instance, pushInterval)
+		slog.Info("edge: metrics push enabled", "interval", pushInterval, "instance", instance)
+	}
+
 	health := healthz.New()
 	health.SetReady(false) // healthz defaults to ready; gate it on a usable cert below
 

--- a/deploy/edge/controlplane.yaml
+++ b/deploy/edge/controlplane.yaml
@@ -92,11 +92,20 @@ spec:
             #   value: /edge-ca/tls.key
             # - name: EDGE_CLIENTCERT_TTL
             #   value: 168h
+            # --- Pushed edge-fleet metrics ---
+            # Edges with EDGE_METRICS_PUSH_INTERVAL set POST their registry to
+            # /v1/metrics; the snapshots are served merged into /metrics below.
+            # A snapshot expires this many seconds after its last push (keep
+            # >= 3x the fleet push interval). See EDGE.md "Edge metrics push".
+            # - name: CP_EDGE_METRICS_TTL
+            #   value: "300"
           ports:
             - name: https
               containerPort: 8443
             - name: metrics # CP_METRICS_LISTEN — UNAUTHENTICATED Prometheus /metrics
-              containerPort: 9187 #   (non-secret: ca_id fingerprints, counters, generations).
+              containerPort: 9187 #   (non-secret: ca_id fingerprints, counters, generations,
+              #                        plus pushed edge-fleet snapshots when edges enable
+              #                        EDGE_METRICS_PUSH_INTERVAL — see EDGE.md "Edge metrics push").
               #                        Restrict to the scraper via the NetworkPolicy below.
           livenessProbe:
             httpGet:

--- a/deploy/edge/edge.yaml
+++ b/deploy/edge/edge.yaml
@@ -130,6 +130,14 @@ spec:
             # "" to disable.
             - name: EDGE_METRICS_LISTEN
               value: ":9187"
+            # Metrics push (opt-in): POST the full registry to the control plane's
+            # /v1/metrics every N seconds, so an in-cluster Prometheus scrapes the
+            # CP's /metrics instead of reaching this out-of-cluster edge. See
+            # EDGE.md "Edge metrics push".
+            # - name: EDGE_METRICS_PUSH_INTERVAL # seconds; 0 (default) = disabled
+            #   value: "60"
+            # - name: EDGE_INSTANCE_ID           # per-process discriminator (default: hostname);
+            #   value: "edge-a-1"                #   replicas may share one EDGE_ID
           ports:
             - name: https
               containerPort: 443

--- a/edge/cp.go
+++ b/edge/cp.go
@@ -355,6 +355,31 @@ func (c *CpClient) FetchEdgeCert(csrPEM []byte) (EdgeCertFetch, error) {
 	}, nil
 }
 
+// PushMetrics POSTs one registry snapshot (text exposition) to POST /v1/metrics.
+// instance is the per-process discriminator (X-Edge-Instance): replicas can share
+// one EDGE_ID/token identity, so the CP keys and labels snapshots by (edge_id,
+// instance). Any non-2xx is an error; the caller fail-statics (the next tick
+// pushes a fresh snapshot — nothing is lost).
+func (c *CpClient) PushMetrics(instance, contentType string, body []byte) error {
+	req, err := http.NewRequest(http.MethodPost, c.base+"/v1/metrics", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("X-Edge-Instance", instance)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("control plane returned %d for /v1/metrics", resp.StatusCode)
+	}
+	return nil
+}
+
 // parseRetryAfter parses an HTTP Retry-After header value: either delta-seconds
 // (e.g. "5") or an HTTP-date. Returns 0 on empty/unparseable/negative.
 func parseRetryAfter(v string) time.Duration {

--- a/edge/metrics.go
+++ b/edge/metrics.go
@@ -147,11 +147,21 @@ var (
 		Name:      "edge_cache_purge_reap_entries_total",
 		Help:      "Cache entries physically reclaimed by the reaper (cumulative).",
 	}, []string{"edge_id"})
+
+	// edgeMetricsClientPush counts metrics-push attempts to the control plane. The
+	// name deliberately differs from the CP-side parapet_edge_metrics_push_total —
+	// this family is itself pushed and merged into the CP's /metrics, and two
+	// same-name families with different label sets would merge confusingly.
+	edgeMetricsClientPush = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_metrics_client_push_total",
+		Help:      "Edge metrics pushes to the control plane by result (ok|gather_fail|push_fail).",
+	}, []string{"result", "edge_id"})
 )
 
 func init() {
 	prom.Registry().MustRegister(edgeClientCertCAID, edgeClientCertNotAfter, edgeClientCertLoaded, edgeRemint, edgeCPTargetCAID, edgeRefresh, edgeClientCertSignerFP, edgeCPActiveSignerFP, edgeOnDemand,
-		edgePurgePoll, edgePurgeEntries, edgePurgeCursor, edgePurgeRecords, edgePurgeFolds, edgePurgeReapSweeps, edgePurgeReapEntries)
+		edgePurgePoll, edgePurgeEntries, edgePurgeCursor, edgePurgeRecords, edgePurgeFolds, edgePurgeReapSweeps, edgePurgeReapEntries, edgeMetricsClientPush)
 }
 
 // purgeReap records one completed reaper sweep and the entries it reclaimed.
@@ -161,6 +171,9 @@ func purgeReap(reaped int) {
 		edgePurgeReapEntries.WithLabelValues(edgeID).Add(float64(reaped))
 	}
 }
+
+// metricsPush counts one metrics-push attempt by result.
+func metricsPush(result string) { edgeMetricsClientPush.WithLabelValues(result, edgeID).Inc() }
 
 // purgePoll counts one purge poll by result.
 func purgePoll(result string) { edgePurgePoll.WithLabelValues(result, edgeID).Inc() }

--- a/edge/metricspush.go
+++ b/edge/metricspush.go
@@ -1,0 +1,70 @@
+package edge
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/prometheus/common/expfmt"
+)
+
+// PushMetricsOnce gathers the FULL shared registry (parapet request/host/backend
+// vecs + the edge_* convergence gauges + go_*/process_*) as one text-exposition
+// snapshot and pushes it to the control plane. The CP injects the authoritative
+// edge_id (from the bearer token) and the edge_instance label, so what's gathered
+// here never needs to self-label. Fail-static: an error leaves the CP serving the
+// previous snapshot until it TTL-expires; the next tick pushes a complete fresh one.
+func PushMetricsOnce(cp *CpClient, instance string) error {
+	mfs, err := prom.Registry().Gather()
+	if err != nil && len(mfs) == 0 {
+		metricsPush("gather_fail")
+		return err
+	}
+	format := expfmt.NewFormat(expfmt.TypeTextPlain)
+	var buf bytes.Buffer
+	enc := expfmt.NewEncoder(&buf, format)
+	for _, mf := range mfs {
+		if err := enc.Encode(mf); err != nil {
+			metricsPush("gather_fail")
+			return err
+		}
+	}
+	if err := cp.PushMetrics(instance, string(format), buf.Bytes()); err != nil {
+		metricsPush("push_fail")
+		return err
+	}
+	metricsPush("ok")
+	return nil
+}
+
+// RunMetricsPush pushes the registry to the control plane every interval, forever.
+// The first tick is jittered by [0,interval] to decorrelate the fleet's push
+// instants. Failures are logged + counted and the loop keeps going (fail-static —
+// the CP serves the last-good snapshot until its TTL).
+func RunMetricsPush(ctx context.Context, cp *CpClient, instance string, interval time.Duration) {
+	if interval <= 0 { // time.NewTicker panics on a non-positive interval
+		interval = 60 * time.Second
+	}
+	if !sleepCtx(ctx, fullJitter(interval)) {
+		return
+	}
+	// Push once right after the jitter so the CP has fleet data within ONE interval
+	// of boot (the ticker alone would delay the first snapshot to jitter+interval).
+	if err := PushMetricsOnce(cp, instance); err != nil {
+		slog.Warn("edge: metrics push failed; control plane keeps last snapshot until TTL", "error", err)
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := PushMetricsOnce(cp, instance); err != nil {
+				slog.Warn("edge: metrics push failed; control plane keeps last snapshot until TTL", "error", err)
+			}
+		}
+	}
+}

--- a/edge/metricspush_test.go
+++ b/edge/metricspush_test.go
@@ -1,0 +1,63 @@
+package edge
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPushMetricsOnce(t *testing.T) {
+	type got struct {
+		method, path, auth, instance, contentType string
+		body                                      string
+	}
+	var last got
+	status := http.StatusNoContent
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		last = got{
+			method:      r.Method,
+			path:        r.URL.Path,
+			auth:        r.Header.Get("Authorization"),
+			instance:    r.Header.Get("X-Edge-Instance"),
+			contentType: r.Header.Get("Content-Type"),
+			body:        string(b),
+		}
+		w.WriteHeader(status)
+	}))
+	defer srv.Close()
+
+	cp, err := NewCpClient(srv.URL, "tok-1", nil)
+	require.NoError(t, err)
+
+	t.Run("ok", func(t *testing.T) {
+		// Ensure a known edge_* family has at least one series (a vec with no
+		// series is omitted from Gather output).
+		metricsPush("ok")
+		require.NoError(t, PushMetricsOnce(cp, "pod-1"))
+		assert.Equal(t, http.MethodPost, last.method)
+		assert.Equal(t, "/v1/metrics", last.path)
+		assert.Equal(t, "Bearer tok-1", last.auth)
+		assert.Equal(t, "pod-1", last.instance)
+		assert.Contains(t, last.contentType, "text/plain")
+
+		// The body must re-parse as valid exposition and carry the full shared
+		// registry — a known edge_* family proves it isn't a filtered subset.
+		parser := expfmt.NewTextParser(model.UTF8Validation)
+		families, err := parser.TextToMetricFamilies(strings.NewReader(last.body))
+		require.NoError(t, err)
+		assert.Contains(t, families, "parapet_edge_metrics_client_push_total")
+	})
+
+	t.Run("non-2xx is an error", func(t *testing.T) {
+		status = http.StatusServiceUnavailable
+		assert.Error(t, PushMetricsOnce(cp, "pod-1"))
+	})
+}

--- a/edgecp/metrics.go
+++ b/edgecp/metrics.go
@@ -182,10 +182,47 @@ var (
 		Name:      "edge_cache_purge_journal_entries",
 		Help:      "Current number of retained entries in the cache-purge journal.",
 	})
+
+	// edgeMetricsLastPush is the per-instance freshness signal for pushed edge
+	// metrics: the unix time of the last accepted POST /v1/metrics. The series is
+	// DELETED when the snapshot is TTL-evicted, so it disappears with the data it
+	// describes — a present-but-old value means the instance stopped pushing but
+	// hasn't expired yet.
+	edgeMetricsLastPush = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_metrics_last_push_seconds",
+		Help:      "Unix time of the last accepted edge metrics push, by edge_id + edge_instance (deleted on TTL eviction).",
+	}, []string{"edge_id", "edge_instance"})
+
+	// edgeMetricsPushIn counts POST /v1/metrics outcomes. No edge_id label — the
+	// failure arms (unauthorized, no identity) have no trustworthy identity to stamp.
+	edgeMetricsPushIn = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_metrics_push_total",
+		Help:      "Edge metrics pushes by status (ok|unauthorized|forbidden|no_instance|too_large|bad_body).",
+	}, []string{"status"})
+
+	// edgeMetricsFamilyDropped counts pushed metric families dropped at merge time
+	// because their TYPE conflicted with an already-merged family of the same name.
+	edgeMetricsFamilyDropped = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_metrics_family_dropped_total",
+		Help:      "Pushed edge metric families dropped on /metrics merge due to a TYPE conflict.",
+	})
+
+	// edgeMetricsInstanceEvicted counts snapshots evicted because an edge_id hit its
+	// instance cap (a NEW self-reported instance id displaced the stalest one — the
+	// bound that keeps a token from minting unbounded instance ids). A climbing rate
+	// at steady fleet size flags instance-id churn or a misbehaving edge.
+	edgeMetricsInstanceEvicted = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_metrics_instance_evicted_total",
+		Help:      "Edge metrics snapshots evicted by the per-edge_id instance cap (stalest-first).",
+	})
 )
 
 func init() {
-	prom.Registry().MustRegister(signerFingerprint, signerGeneration, signerBundleCerts, signerLoaded, targetCAID, signerFloored, signerRVUnparsed, registryTotal, authzGeneration, activeSignerFP, signerActiveFlipFailed, issuedUnderSigner, tokenDisabledNoRotation, rotationStuck, purgeIssued, purgeJournalSize)
+	prom.Registry().MustRegister(signerFingerprint, signerGeneration, signerBundleCerts, signerLoaded, targetCAID, signerFloored, signerRVUnparsed, registryTotal, authzGeneration, activeSignerFP, signerActiveFlipFailed, issuedUnderSigner, tokenDisabledNoRotation, rotationStuck, purgeIssued, purgeJournalSize, edgeMetricsLastPush, edgeMetricsPushIn, edgeMetricsFamilyDropped, edgeMetricsInstanceEvicted)
 }
 
 // SetRotationStuckDeadline configures the overlap-stuck threshold (call once at startup).

--- a/edgecp/metricstore.go
+++ b/edgecp/metricstore.go
@@ -1,0 +1,231 @@
+package edgecp
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/moonrhythm/parapet/pkg/prom"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+)
+
+// maxEdgeMetricsBody bounds one POST /v1/metrics body. A full edge registry
+// (request/host/backend vecs + edge_* gauges + go_*/process_*) is tens-to-hundreds
+// of KiB; 8 MiB is generous headroom without letting a compromised edge OOM the CP.
+const maxEdgeMetricsBody = 8 << 20
+
+// maxInstanceLen bounds the self-reported X-Edge-Instance header (it becomes a
+// label value, so it must stay sane).
+const maxInstanceLen = 128
+
+// maxEdgeMetricsInstances bounds DISTINCT instances stored per edge_id. The
+// instance id is self-reported, so without this one token could mint unbounded
+// instance ids (each holding a parsed multi-MiB snapshot) and OOM the CP long
+// before the TTL fires. At the cap a NEW instance evicts that identity's STALEST
+// one (counted) — legitimate instance-id churn self-heals instead of hard-failing,
+// and total memory stays bounded at tokens x cap x snapshot.
+const maxEdgeMetricsInstances = 128
+
+// MetricsStore holds the last pushed metrics snapshot per edge INSTANCE. Multiple
+// edge processes can run under one edge_id (a scaled fleet behind one token), so
+// snapshots are keyed by (edge_id, instance) — edge_id alone would have replicas
+// clobbering each other. Snapshots are parsed and edge_id/edge_instance-labelled at
+// push time, so a scrape only flattens maps. A snapshot not refreshed within ttl is
+// lazily evicted at read time (no janitor goroutine): a dead instance's series
+// disappear instead of being served stale forever, and instance-id churn (random
+// hostnames across reboots) stays bounded.
+type MetricsStore struct {
+	mu    sync.Mutex
+	ttl   time.Duration
+	edges map[string]edgeMetricsSnapshot // edge_id + "/" + instance -> snapshot
+	now   func() time.Time               // injectable for tests
+}
+
+type edgeMetricsSnapshot struct {
+	edgeID     string
+	instance   string
+	families   map[string]*dto.MetricFamily
+	receivedAt time.Time
+}
+
+// NewMetricsStore builds a store whose snapshots expire ttl after their last push
+// (recommend >= 3x the fleet's push interval). ttl <= 0 falls back to 5 minutes.
+func NewMetricsStore(ttl time.Duration) *MetricsStore {
+	if ttl <= 0 {
+		ttl = 5 * time.Minute
+	}
+	return &MetricsStore{
+		ttl:   ttl,
+		edges: make(map[string]edgeMetricsSnapshot),
+		now:   time.Now,
+	}
+}
+
+// Ingest parses one text-exposition body and replaces the (edgeID, instance)
+// snapshot. Every metric gets edge_id and edge_instance labels injected — OVERRIDING
+// any self-reported value, so the label is always the server-derived identity
+// (edgeID comes from the bearer token's id grant, never the body). A parse error
+// stores nothing (the last-good snapshot is kept).
+func (s *MetricsStore) Ingest(edgeID, instance string, r io.Reader) error {
+	parser := expfmt.NewTextParser(model.UTF8Validation)
+	families, err := parser.TextToMetricFamilies(r)
+	if err != nil {
+		return fmt.Errorf("parse metrics: %w", err)
+	}
+	for _, mf := range families {
+		for _, m := range mf.Metric {
+			setLabel(m, "edge_id", edgeID)
+			setLabel(m, "edge_instance", instance)
+		}
+	}
+	now := s.now()
+	key := edgeID + "/" + instance
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.edges[key]; !exists {
+		s.evictAtCapLocked(edgeID)
+	}
+	s.edges[key] = edgeMetricsSnapshot{
+		edgeID:     edgeID,
+		instance:   instance,
+		families:   families,
+		receivedAt: now,
+	}
+	edgeMetricsLastPush.WithLabelValues(edgeID, instance).Set(float64(now.Unix()))
+	return nil
+}
+
+// evictAtCapLocked makes room for one NEW instance under edgeID: while the
+// identity is at maxEdgeMetricsInstances, its stalest instance is evicted
+// (freshness series deleted with it, eviction counted). Callers hold s.mu.
+func (s *MetricsStore) evictAtCapLocked(edgeID string) {
+	for {
+		count := 0
+		var oldestKey string
+		var oldest time.Time
+		for k, snap := range s.edges {
+			if snap.edgeID != edgeID {
+				continue
+			}
+			count++
+			if oldestKey == "" || snap.receivedAt.Before(oldest) {
+				oldestKey, oldest = k, snap.receivedAt
+			}
+		}
+		if count < maxEdgeMetricsInstances {
+			return
+		}
+		snap := s.edges[oldestKey]
+		edgeMetricsLastPush.DeleteLabelValues(snap.edgeID, snap.instance)
+		delete(s.edges, oldestKey)
+		edgeMetricsInstanceEvicted.Inc()
+	}
+}
+
+// setLabel sets (or overrides) one label on a metric, keeping the pair list sorted
+// by name — the dto contract expfmt encoders and Prometheus expect.
+func setLabel(m *dto.Metric, name, value string) {
+	for _, lp := range m.Label {
+		if lp.GetName() == name {
+			lp.Value = &value
+			return
+		}
+	}
+	m.Label = append(m.Label, &dto.LabelPair{Name: &name, Value: &value})
+	sort.Slice(m.Label, func(i, j int) bool { return m.Label[i].GetName() < m.Label[j].GetName() })
+}
+
+// families returns every live (non-expired) instance's metric families, evicting
+// expired snapshots and deleting their freshness series on the way. Deterministic
+// order (sorted by instance key) so merged output is stable across scrapes.
+func (s *MetricsStore) families() []*dto.MetricFamily {
+	now := s.now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	keys := make([]string, 0, len(s.edges))
+	for k, snap := range s.edges {
+		if now.Sub(snap.receivedAt) > s.ttl {
+			edgeMetricsLastPush.DeleteLabelValues(snap.edgeID, snap.instance)
+			delete(s.edges, k)
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var out []*dto.MetricFamily
+	for _, k := range keys {
+		snap := s.edges[k]
+		names := make([]string, 0, len(snap.families))
+		for name := range snap.families {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			out = append(out, snap.families[name])
+		}
+	}
+	return out
+}
+
+// MetricsHandler serves the CP's own registry MERGED with every live pushed edge
+// snapshot as one text-exposition response — the single scrape target for the CP +
+// the edge fleet. Mount it on the (NetworkPolicy-restricted) CP_METRICS_LISTEN.
+func MetricsHandler(store *MetricsStore) http.Handler {
+	format := expfmt.NewFormat(expfmt.TypeTextPlain)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		own, err := prom.Registry().Gather()
+		if err != nil && len(own) == 0 {
+			http.Error(w, "gather failed", http.StatusInternalServerError)
+			return
+		}
+		merged := mergeFamilies(own, store.families())
+		w.Header().Set("Content-Type", string(format))
+		enc := expfmt.NewEncoder(w, format)
+		for _, mf := range merged {
+			_ = enc.Encode(mf)
+		}
+	})
+}
+
+// mergeFamilies merges edge families into the CP's own, BY FAMILY NAME, so each
+// family is encoded exactly once (one # HELP/# TYPE block, all label sets — the
+// CP's series plus one per edge instance). The first family seen for a name wins
+// HELP/TYPE (own comes first, so the CP is authoritative); a later family with a
+// conflicting TYPE is dropped whole (counted) rather than emitting an invalid
+// exposition. Inputs are never mutated — merged entries are fresh copies — so a
+// scrape can't corrupt a stored snapshot. Output is sorted by family name.
+func mergeFamilies(own, edge []*dto.MetricFamily) []*dto.MetricFamily {
+	idx := make(map[string]*dto.MetricFamily, len(own)+len(edge))
+	out := make([]*dto.MetricFamily, 0, len(own)+len(edge))
+	add := func(mf *dto.MetricFamily) {
+		if base, ok := idx[mf.GetName()]; ok {
+			if base.GetType() != mf.GetType() {
+				edgeMetricsFamilyDropped.Inc()
+				return
+			}
+			base.Metric = append(base.Metric, mf.Metric...)
+			return
+		}
+		cp := &dto.MetricFamily{
+			Name:   mf.Name,
+			Help:   mf.Help,
+			Type:   mf.Type,
+			Metric: append([]*dto.Metric{}, mf.Metric...),
+		}
+		idx[cp.GetName()] = cp
+		out = append(out, cp)
+	}
+	for _, mf := range own {
+		add(mf)
+	}
+	for _, mf := range edge {
+		add(mf)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].GetName() < out[j].GetName() })
+	return out
+}

--- a/edgecp/metricstore_test.go
+++ b/edgecp/metricstore_test.go
@@ -1,0 +1,321 @@
+package edgecp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleExposition = `# HELP parapet_requests_total Number of requests
+# TYPE parapet_requests_total counter
+parapet_requests_total{host="acme.com"} 42
+# HELP parapet_edge_refresh_total Successful control-plane polls
+# TYPE parapet_edge_refresh_total counter
+parapet_edge_refresh_total{edge_id="self-reported"} 7
+`
+
+// metricsTestServer builds a Server with ingestion enabled: one token WITH an id
+// grant, one without.
+func metricsTestServer(ttl time.Duration) (*Server, *MetricsStore) {
+	authz := NewAuthzEntries(map[string]Entry{
+		"edge-tok": {ID: "edge-a", Domains: []string{"*"}},
+		"no-id":    {Domains: []string{"*"}},
+	})
+	store := NewMetricsStore(ttl)
+	srv := NewServer(NewCertStore(), authz).WithMetricsIngest(store)
+	return srv, store
+}
+
+func pushReq(h http.Handler, auth, instance, body string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest("POST", "/v1/metrics", strings.NewReader(body))
+	if auth != "" {
+		r.Header.Set("Authorization", "Bearer "+auth)
+	}
+	if instance != "" {
+		r.Header.Set("X-Edge-Instance", instance)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, r)
+	return rec
+}
+
+func parseExposition(t *testing.T, body string) map[string]*dto.MetricFamily {
+	t.Helper()
+	parser := expfmt.NewTextParser(model.UTF8Validation)
+	families, err := parser.TextToMetricFamilies(strings.NewReader(body))
+	require.NoError(t, err, "merged /metrics output must re-parse as valid text exposition")
+	return families
+}
+
+func labelValue(m *dto.Metric, name string) string {
+	for _, lp := range m.Label {
+		if lp.GetName() == name {
+			return lp.GetValue()
+		}
+	}
+	return ""
+}
+
+func TestMetricsStore_IngestInjectsAndOverridesLabels(t *testing.T) {
+	store := NewMetricsStore(time.Minute)
+	require.NoError(t, store.Ingest("edge-a", "pod-1", strings.NewReader(sampleExposition)))
+
+	fams := store.families()
+	byName := map[string]*dto.MetricFamily{}
+	for _, mf := range fams {
+		byName[mf.GetName()] = mf
+	}
+
+	// A label-less series gains both labels.
+	req := byName["parapet_requests_total"]
+	require.NotNil(t, req)
+	require.Len(t, req.Metric, 1)
+	assert.Equal(t, "edge-a", labelValue(req.Metric[0], "edge_id"))
+	assert.Equal(t, "pod-1", labelValue(req.Metric[0], "edge_instance"))
+	assert.Equal(t, "acme.com", labelValue(req.Metric[0], "host"))
+
+	// A self-reported edge_id is OVERRIDDEN by the server-derived identity.
+	refresh := byName["parapet_edge_refresh_total"]
+	require.NotNil(t, refresh)
+	assert.Equal(t, "edge-a", labelValue(refresh.Metric[0], "edge_id"))
+
+	// Label pairs stay sorted by name (the dto/expfmt contract).
+	for _, mf := range fams {
+		for _, m := range mf.Metric {
+			for i := 1; i < len(m.Label); i++ {
+				assert.LessOrEqual(t, m.Label[i-1].GetName(), m.Label[i].GetName())
+			}
+		}
+	}
+}
+
+func TestMetricsStore_BadBodyStoresNothing(t *testing.T) {
+	store := NewMetricsStore(time.Minute)
+	require.Error(t, store.Ingest("edge-a", "pod-1", strings.NewReader("this is { not exposition\nformat===")))
+	assert.Empty(t, store.families())
+}
+
+func TestMetricsStore_InstancesUnderOneEdgeIDCoexist(t *testing.T) {
+	store := NewMetricsStore(time.Minute)
+	require.NoError(t, store.Ingest("edge-a", "pod-1", strings.NewReader(sampleExposition)))
+	require.NoError(t, store.Ingest("edge-a", "pod-2", strings.NewReader(sampleExposition)))
+
+	// No clobber: both instances' series are live, distinguished by edge_instance.
+	instances := map[string]bool{}
+	for _, mf := range store.families() {
+		if mf.GetName() != "parapet_requests_total" {
+			continue
+		}
+		for _, m := range mf.Metric {
+			instances[labelValue(m, "edge_instance")] = true
+		}
+	}
+	assert.Equal(t, map[string]bool{"pod-1": true, "pod-2": true}, instances)
+
+	// A re-push for one instance replaces only that instance's snapshot.
+	require.NoError(t, store.Ingest("edge-a", "pod-1", strings.NewReader(sampleExposition)))
+	count := 0
+	for _, mf := range store.families() {
+		if mf.GetName() == "parapet_requests_total" {
+			count += len(mf.Metric)
+		}
+	}
+	assert.Equal(t, 2, count)
+}
+
+func TestMetricsStore_InstanceCapEvictsStalest(t *testing.T) {
+	store := NewMetricsStore(time.Hour)
+	now := time.Unix(1000, 0)
+	store.now = func() time.Time { return now }
+
+	for i := 0; i < maxEdgeMetricsInstances; i++ {
+		now = now.Add(time.Second)
+		require.NoError(t, store.Ingest("edge-a", "pod-"+strconv.Itoa(i), strings.NewReader(sampleExposition)))
+	}
+	// A different identity is NOT affected by edge-a's cap.
+	now = now.Add(time.Second)
+	require.NoError(t, store.Ingest("edge-b", "pod-x", strings.NewReader(sampleExposition)))
+
+	// One past the cap: pod-0 (stalest) is evicted, the new instance lands.
+	now = now.Add(time.Second)
+	require.NoError(t, store.Ingest("edge-a", "pod-new", strings.NewReader(sampleExposition)))
+
+	live := map[string]bool{}
+	for _, mf := range store.families() {
+		for _, m := range mf.Metric {
+			if labelValue(m, "edge_id") == "edge-a" {
+				live[labelValue(m, "edge_instance")] = true
+			}
+		}
+	}
+	assert.Len(t, live, maxEdgeMetricsInstances)
+	assert.False(t, live["pod-0"], "stalest instance must be evicted at the cap")
+	assert.True(t, live["pod-new"])
+	assert.True(t, live["pod-1"])
+
+	// Re-pushing an EXISTING instance never evicts (replacement, not growth).
+	now = now.Add(time.Second)
+	require.NoError(t, store.Ingest("edge-a", "pod-new", strings.NewReader(sampleExposition)))
+	count := 0
+	for _, mf := range store.families() {
+		if mf.GetName() != "parapet_requests_total" {
+			continue
+		}
+		for _, m := range mf.Metric {
+			if labelValue(m, "edge_id") == "edge-a" {
+				count++
+			}
+		}
+	}
+	assert.Equal(t, maxEdgeMetricsInstances, count)
+}
+
+func TestMetricsStore_TTLEviction(t *testing.T) {
+	store := NewMetricsStore(time.Minute)
+	now := time.Unix(1000, 0)
+	store.now = func() time.Time { return now }
+
+	require.NoError(t, store.Ingest("edge-a", "pod-1", strings.NewReader(sampleExposition)))
+	now = now.Add(30 * time.Second)
+	require.NoError(t, store.Ingest("edge-a", "pod-2", strings.NewReader(sampleExposition)))
+
+	// 61s after pod-1's push (31s after pod-2's): only pod-1 expires.
+	now = now.Add(31 * time.Second)
+	live := map[string]bool{}
+	for _, mf := range store.families() {
+		for _, m := range mf.Metric {
+			live[labelValue(m, "edge_instance")] = true
+		}
+	}
+	assert.Equal(t, map[string]bool{"pod-2": true}, live)
+
+	// The evicted instance's freshness series is deleted with it; the live one stays.
+	assert.Equal(t, 0, deleteCheckGaugeCount(t, "edge-a", "pod-1"))
+	assert.Equal(t, 1, deleteCheckGaugeCount(t, "edge-a", "pod-2"))
+}
+
+// deleteCheckGaugeCount reports whether the freshness gauge still has a series for
+// (edgeID, instance) — Delete returns true when the series existed.
+func deleteCheckGaugeCount(t *testing.T, edgeID, instance string) int {
+	t.Helper()
+	if edgeMetricsLastPush.DeleteLabelValues(edgeID, instance) {
+		// Put nothing back: callers only run this at the end of a test.
+		return 1
+	}
+	return 0
+}
+
+func TestMergeFamilies_SingleBlockPerFamily(t *testing.T) {
+	store := NewMetricsStore(time.Minute)
+	require.NoError(t, store.Ingest("edge-a", "pod-1", strings.NewReader(sampleExposition)))
+	require.NoError(t, store.Ingest("edge-b", "pod-9", strings.NewReader(sampleExposition)))
+
+	rec := httptest.NewRecorder()
+	MetricsHandler(store).ServeHTTP(rec, httptest.NewRequest("GET", "/metrics", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+
+	// The merged output must re-parse as valid exposition (proves one HELP/TYPE
+	// block per family even when several edges push the same family).
+	families := parseExposition(t, body)
+
+	// Both edges' series are present in ONE family.
+	req := families["parapet_requests_total"]
+	require.NotNil(t, req)
+	ids := map[string]bool{}
+	for _, m := range req.Metric {
+		ids[labelValue(m, "edge_id")] = true
+	}
+	assert.True(t, ids["edge-a"] && ids["edge-b"])
+	assert.Equal(t, 1, strings.Count(body, "# TYPE parapet_requests_total "))
+
+	// The CP's own registry rides the same response (any parapet_edge_ca_* family
+	// from the shared registry suffices; signer gauges register in this package).
+	assert.Contains(t, body, "parapet_edge_metrics_last_push_seconds")
+}
+
+func TestMergeFamilies_TypeConflictDropsEdgeFamily(t *testing.T) {
+	counter := dto.MetricType_COUNTER
+	gauge := dto.MetricType_GAUGE
+	name := "demo_metric"
+	v := 1.0
+	own := []*dto.MetricFamily{{
+		Name: &name, Type: &counter,
+		Metric: []*dto.Metric{{Counter: &dto.Counter{Value: &v}}},
+	}}
+	edge := []*dto.MetricFamily{{
+		Name: &name, Type: &gauge,
+		Metric: []*dto.Metric{{Gauge: &dto.Gauge{Value: &v}}},
+	}}
+	out := mergeFamilies(own, edge)
+	require.Len(t, out, 1)
+	assert.Equal(t, dto.MetricType_COUNTER, out[0].GetType())
+	assert.Len(t, out[0].Metric, 1) // the conflicting edge family was dropped whole
+}
+
+func TestMergeFamilies_DoesNotMutateInputs(t *testing.T) {
+	counter := dto.MetricType_COUNTER
+	name := "demo_total"
+	v := 1.0
+	base := &dto.MetricFamily{Name: &name, Type: &counter, Metric: []*dto.Metric{{Counter: &dto.Counter{Value: &v}}}}
+	other := &dto.MetricFamily{Name: &name, Type: &counter, Metric: []*dto.Metric{{Counter: &dto.Counter{Value: &v}}}}
+	mergeFamilies([]*dto.MetricFamily{base}, []*dto.MetricFamily{other})
+	assert.Len(t, base.Metric, 1, "merge must copy, not append into a stored snapshot")
+	assert.Len(t, other.Metric, 1)
+}
+
+func TestMetricsPushAPI(t *testing.T) {
+	srv, store := metricsTestServer(time.Minute)
+	h := srv.Handler()
+
+	t.Run("disabled is 404", func(t *testing.T) {
+		off := NewServer(NewCertStore(), NewAuthz(nil)).Handler()
+		assert.Equal(t, http.StatusNotFound, pushReq(off, "edge-tok", "pod-1", sampleExposition).Code)
+	})
+	t.Run("unknown token is 401", func(t *testing.T) {
+		assert.Equal(t, http.StatusUnauthorized, pushReq(h, "", "pod-1", sampleExposition).Code)
+		assert.Equal(t, http.StatusUnauthorized, pushReq(h, "bogus", "pod-1", sampleExposition).Code)
+	})
+	t.Run("token without id grant is 403", func(t *testing.T) {
+		assert.Equal(t, http.StatusForbidden, pushReq(h, "no-id", "pod-1", sampleExposition).Code)
+	})
+	t.Run("missing instance header is 400", func(t *testing.T) {
+		assert.Equal(t, http.StatusBadRequest, pushReq(h, "edge-tok", "", sampleExposition).Code)
+	})
+	t.Run("oversized instance header is 400", func(t *testing.T) {
+		assert.Equal(t, http.StatusBadRequest, pushReq(h, "edge-tok", strings.Repeat("x", maxInstanceLen+1), sampleExposition).Code)
+	})
+	t.Run("garbage body is 400", func(t *testing.T) {
+		assert.Equal(t, http.StatusBadRequest, pushReq(h, "edge-tok", "pod-1", "not { exposition ===").Code)
+	})
+	t.Run("oversized body is 413", func(t *testing.T) {
+		big := sampleExposition + strings.Repeat("# padding padding padding\n", maxEdgeMetricsBody/26+1)
+		assert.Equal(t, http.StatusRequestEntityTooLarge, pushReq(h, "edge-tok", "pod-1", big).Code)
+	})
+	t.Run("ok push is 204 and lands with server-derived identity", func(t *testing.T) {
+		assert.Equal(t, http.StatusNoContent, pushReq(h, "edge-tok", "pod-1", sampleExposition).Code)
+
+		rec := httptest.NewRecorder()
+		MetricsHandler(store).ServeHTTP(rec, httptest.NewRequest("GET", "/metrics", nil))
+		require.Equal(t, http.StatusOK, rec.Code)
+		families := parseExposition(t, rec.Body.String())
+		req := families["parapet_requests_total"]
+		require.NotNil(t, req)
+		found := false
+		for _, m := range req.Metric {
+			if labelValue(m, "edge_id") == "edge-a" && labelValue(m, "edge_instance") == "pod-1" {
+				found = true
+			}
+		}
+		assert.True(t, found, "pushed series must carry the token-derived edge_id and the instance label")
+	})
+}

--- a/edgecp/server.go
+++ b/edgecp/server.go
@@ -3,6 +3,7 @@ package edgecp
 import (
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strconv"
@@ -30,6 +31,11 @@ type Server struct {
 	// than the per-edge read tokens (an edge can read its purges but not issue them).
 	purge           *PurgeStore
 	purgeAdminToken string
+
+	// metricsStore is the optional pushed-edge-metrics store (nil = ingestion
+	// disabled, POST /v1/metrics → 404). Serving happens on the separate
+	// CP_METRICS_LISTEN via MetricsHandler, not on this API mux.
+	metricsStore *MetricsStore
 
 	// signerState is the (signer, generation) snapshot, replaced WHOLESALE by
 	// SetSigner so a reader Loads both halves coherently (never a torn signer-from-A
@@ -107,6 +113,14 @@ func NewServer(certs *CertStore, authz *Authz) *Server {
 // chaining.
 func (s *Server) WithWAF(waf *WafStore) *Server {
 	s.waf = waf
+	return s
+}
+
+// WithMetricsIngest enables edge metrics ingestion (POST /v1/metrics): edges push
+// their registry snapshots here, and the same store backs the merged /metrics on
+// the CP's metrics listener (MetricsHandler). Returns the server for chaining.
+func (s *Server) WithMetricsIngest(store *MetricsStore) *Server {
+	s.metricsStore = store
 	return s
 }
 
@@ -194,6 +208,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /v1/ratelimit", s.handleRateLimit)
 	mux.HandleFunc("GET /v1/purges", s.handlePurges)
 	mux.HandleFunc("POST /v1/purges", s.handlePurgeAdmin)
+	mux.HandleFunc("POST /v1/metrics", s.handleMetricsPush)
 	mux.HandleFunc("POST /v1/edge-cert", s.handleEdgeCert)
 	mux.HandleFunc("GET /v1/trust-bundle", s.handleTrustBundle)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
@@ -448,6 +463,51 @@ func (s *Server) handlePurgeAdmin(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]uint64{"seq": seq})
+}
+
+// handleMetricsPush ingests one edge instance's registry snapshot
+// (POST /v1/metrics, text exposition body). The edge_id label is the bearer
+// token's id grant — server-derived, so a token without an identity cannot push
+// (403) and a pushed body can never impersonate another edge. The per-process
+// X-Edge-Instance header disambiguates replicas sharing one edge_id; it is
+// self-reported, but only collides within the caller's own identity.
+func (s *Server) handleMetricsPush(w http.ResponseWriter, r *http.Request) {
+	if s.metricsStore == nil {
+		http.Error(w, "metrics ingestion disabled", http.StatusNotFound)
+		return
+	}
+	token, ok := bearer(r)
+	if !ok || !s.authz.Known(token) {
+		edgeMetricsPushIn.WithLabelValues("unauthorized").Inc()
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	edgeID, ok := s.authz.Identity(token)
+	if !ok {
+		edgeMetricsPushIn.WithLabelValues("forbidden").Inc()
+		http.Error(w, "forbidden: token has no edge id", http.StatusForbidden)
+		return
+	}
+	instance := strings.TrimSpace(r.Header.Get("X-Edge-Instance"))
+	if instance == "" || len(instance) > maxInstanceLen {
+		edgeMetricsPushIn.WithLabelValues("no_instance").Inc()
+		http.Error(w, "missing or oversized X-Edge-Instance header", http.StatusBadRequest)
+		return
+	}
+	body := http.MaxBytesReader(w, r.Body, maxEdgeMetricsBody)
+	if err := s.metricsStore.Ingest(edgeID, instance, body); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			edgeMetricsPushIn.WithLabelValues("too_large").Inc()
+			http.Error(w, "metrics body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		edgeMetricsPushIn.WithLabelValues("bad_body").Inc()
+		http.Error(w, "invalid metrics body", http.StatusBadRequest)
+		return
+	}
+	edgeMetricsPushIn.WithLabelValues("ok").Inc()
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // bearer extracts the token from an "Authorization: Bearer <token>" header.


### PR DESCRIPTION
## Why

The edge fleet runs out-of-cluster, so an in-cluster Prometheus can't reach each edge's `EDGE_METRICS_LISTEN :9187`. The edge already holds an authenticated HTTPS channel to the control plane — this reuses it: the edge pushes its **full registry** to the CP, and the CP serves every live snapshot **merged into its existing `CP_METRICS_LISTEN /metrics`**. One scrape target for the CP plus the whole fleet.

## How

**Edge** (`edge/metricspush.go`, `edge/cp.go`, `cmd/edge-proxy/main.go`)
- Opt-in via `EDGE_METRICS_PUSH_INTERVAL` (seconds; `0` = off, default). `EDGE_METRICS_LISTEN` is untouched.
- Gathers the shared prom registry → text exposition → `POST /v1/metrics` with the bearer token + `X-Edge-Instance` (`EDGE_INSTANCE_ID`, default hostname). Loop mirrors the purge poll: first-tick jitter (plus an immediate post-jitter push so the CP has data within one interval of boot), fail-static, `parapet_edge_metrics_client_push_total{result}`.

**CP** (`edgecp/metricstore.go`, `edgecp/server.go`, `cmd/edge-controlplane/main.go`)
- `POST /v1/metrics`: 401 unknown token, **403 if the token has no id grant** — the `edge_id` label is the token's identity, server-derived; any self-reported `edge_id` in the body is overridden, so a push can never impersonate another edge.
- **Replicas can share one `EDGE_ID`**, so snapshots are keyed and labeled by `(edge_id, edge_instance)` — edge_id alone would have replicas clobbering each other.
- `/metrics` merge is by family name with exactly one `# HELP`/`# TYPE` block (CP's wins; a TYPE-conflicting edge family is dropped + counted). No sample timestamps — Prometheus stamps at scrape time.
- Staleness: snapshots TTL-expire (`CP_EDGE_METRICS_TTL`, default 300s); the per-instance freshness gauge `parapet_edge_metrics_last_push_seconds{edge_id,edge_instance}` is deleted with the snapshot.
- DoS bounds (the instance header is self-reported): 8 MiB body → 413, 128-byte instance header → 400, **128 distinct instances per edge_id** with stalest-first eviction (`parapet_edge_metrics_instance_evicted_total`) — memory is bounded at tokens × cap × snapshot even against a compromised token.

Docs: EDGE.md (API entry, "Edge metrics push" section, fail-modes row); commented examples in `deploy/edge/{edge,controlplane}.yaml`.

## Verification

- `gofmt` clean, `go vet` clean, **631 tests pass** (`-race` on `edge`/`edgecp`).
- New tests: label injection + self-report override, replica coexistence under one edge_id, TTL eviction (injected clock), instance-cap eviction, merge validity **proven by re-parsing the merged output with expfmt**, all handler status arms (401/403/400/413/404/204), push-loop wire format.
- Live smoke: ran the CP locally (fs backend), pushed a snapshot with a spoofed `edge_id` → 204, scrape showed it overridden to the token's id with `edge_instance` attached and a single `# TYPE` block per family; missing instance header → 400.

Note: this `prometheus/common` version panics on a zero-value `expfmt.TextParser`; parsers are built with `expfmt.NewTextParser(model.UTF8Validation)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)