### PR TITLE
fix(proxy): never forward the X-Parapet-Waf claim to the upstream backend

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -363,8 +363,10 @@ once a CP snapshot has landed, and the edge strips any client-supplied claim
 unconditionally — even with `EDGE_WAF_ENABLED=false` (`edge.StripWAFClaim`,
 mounted before the WAF so CEL rules never see a spoofed value either). On the
 core side, the claim is deleted from every request that is *not* skipped, so an
-unvalidated claim never reaches CEL rules, the zone WAF, or the backend; a
-skipped request's claim flows upstream, core-vouched. The claim is what lets
+unvalidated claim never reaches CEL rules or the zone WAF; and the core's proxy
+deletes it from **every** upstream request regardless of WAF config, so the
+backend never sees it — the claim is purely a core↔edge wire contract. It is
+also what lets
 the core tell edges apart **per request**: a WAF-disabled edge, or one still on
 its empty boot ruleset (booted while the CP was unreachable), forwards
 claimless requests — which simply get the full core WAF.

--- a/SPEC.md
+++ b/SPEC.md
@@ -102,8 +102,9 @@ only once a CP rules snapshot has landed, so an edge on its empty boot ruleset
 — or one with `EDGE_WAF_ENABLED=false` — forwards claimless requests that get
 the full core WAF. The edge strips client-supplied claims unconditionally; the
 core deletes the claim from any request it did not skip, so an unvalidated
-claim never reaches CEL rules, the zone WAF, or the upstream (a skipped
-request's claim flows upstream, core-vouched). Everything else (rate limits,
+claim never reaches CEL rules or the zone WAF, and the core's proxy deletes it
+from **every** upstream request regardless of WAF config — the claim is a
+core↔edge wire contract that backends never see. Everything else (rate limits,
 auth, routing, geo headers) is unchanged, and non-matching traffic still gets
 the full WAF. `true` is refused, and a bad spec (malformed CIDR, `edge-mtls`
 without `EDGE_TRUST_CP_ENDPOINT`) is fatal at startup. Edge images that predate

--- a/controller_waf.go
+++ b/controller_waf.go
@@ -90,8 +90,10 @@ func (ctrl *Controller) GlobalWAF() parapet.Middleware {
 				return
 			}
 			// Not validated: drop any claim header so it can't reach the CEL
-			// rules below (request.headers), the zone-WAF skip downstream, or
-			// the upstream backend. A validated request keeps it — core-vouched.
+			// rules below (request.headers) or the zone-WAF skip downstream. A
+			// validated request keeps it in-chain — the zone skip re-checks it —
+			// but it never reaches the backend either way: the proxy deletes it
+			// at the upstream boundary (proxy.New's Director).
 			r.Header.Del(wafclaim.Header)
 			wafH.ServeHTTP(w, r)
 		})

--- a/controller_waf_test.go
+++ b/controller_waf_test.go
@@ -103,13 +103,13 @@ rules:
 
 	rec, claim := serve(true)
 	assert.Equal(t, http.StatusOK, rec.Code, "validated-at-edge request bypasses the global WAF")
-	assert.Equal(t, "7", claim, "a validated claim is core-vouched and flows upstream")
+	assert.Equal(t, "7", claim, "a validated claim stays in-chain for the zone-WAF skip (the proxy strips it before the backend)")
 
 	rec, _ = serve(false)
 	assert.Equal(t, http.StatusForbidden, rec.Code, "other traffic still evaluates")
 
-	// An unvalidated claim must be deleted before rules/zone/upstream see it —
-	// use a rule that passes so the inner handler can observe the headers.
+	// An unvalidated claim must be deleted before rules and the zone skip see
+	// it — use a rule that passes so the inner handler can observe the headers.
 	ctrl.watchedConfigMaps.Store("ctrl-ns/waf-global", wafCM("ctrl-ns", "waf-global", roleGlobal, `
 rules:
   - id: block-nothing
@@ -119,7 +119,7 @@ rules:
 	ctrl.reloadWAFDebounced()
 	rec, claim = serve(false)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Empty(t, claim, "an unvalidated claim is stripped before the ruleset and upstream")
+	assert.Empty(t, claim, "an unvalidated claim is stripped before the ruleset and the zone skip")
 }
 
 func TestReloadWAF(t *testing.T) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"time"
+
+	"github.com/moonrhythm/parapet-ingress-controller/wafclaim"
 )
 
 type Proxy struct {
@@ -31,7 +33,14 @@ func New() *Proxy {
 		H2C:     p.h2cTransport,
 	}
 	p.reverseProxy = httputil.ReverseProxy{
-		Director:   func(_ *http.Request) {},
+		// The edge→core WAF claim is consumed in-process (GlobalWAF / WAFZone
+		// read it for the WAF_VALIDATED_PROXY skip); it is never the backend's
+		// business, so it is dropped here at the upstream boundary regardless of
+		// WAF config. ReverseProxy clones the request before calling Director,
+		// so the in-chain request — including the retry path — is untouched.
+		Director: func(r *http.Request) {
+			r.Header.Del(wafclaim.Header)
+		},
 		BufferPool: newBufferPool(),
 		Transport:  p.gw,
 		// No ModifyResponse: an upstream that responded — including with 502/503 —

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/moonrhythm/parapet-ingress-controller/wafclaim"
 )
 
 func TestProxy(t *testing.T) {
@@ -30,6 +32,33 @@ func TestProxy(t *testing.T) {
 		assert.True(t, called)
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, "OK", w.Body.String())
+	})
+
+	t.Run("strips the WAF claim header upstream", func(t *testing.T) {
+		t.Parallel()
+
+		// The claim header is the edge→core wire contract: the core consumes it
+		// in-process (the WAF_VALIDATED_PROXY skip) and must never forward it to
+		// a backend — validated or not, WAF on or off.
+		var claimSeen, otherSeen string
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			claimSeen = r.Header.Get(wafclaim.Header)
+			otherSeen = r.Header.Get("X-Other")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+
+		proxy := New()
+		r := httptest.NewRequest(http.MethodGet, ts.URL, nil)
+		r.Header.Set(wafclaim.Header, "7")
+		r.Header.Set("X-Other", "kept")
+		w := httptest.NewRecorder()
+		proxy.ServeHTTP(w, r)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Empty(t, claimSeen, "the claim header must not reach the upstream backend")
+		assert.Equal(t, "kept", otherSeen, "other headers pass through")
+		assert.Equal(t, "7", r.Header.Get(wafclaim.Header),
+			"the in-chain request is untouched (Director mutates the outbound clone)")
 	})
 
 	t.Run("upstream 5xx passes through unchanged", func(t *testing.T) {

--- a/wafclaim/wafclaim.go
+++ b/wafclaim/wafclaim.go
@@ -13,8 +13,9 @@ package wafclaim
 // peer the core verified (edge client cert / listed CIDR); the edge strips
 // client-supplied values unconditionally, and a core with the skip enabled
 // (WAF_ENABLED + WAF_VALIDATED_PROXY) drops the header from any request it
-// did not skip, so an unvalidated claim never reaches CEL rules, the zone
-// WAF, or the upstream backend there. A core with the skip DISABLED never
-// reads nor strips it (disabled features do no per-request work) — backends
-// must not trust the header unless the core in front of them has it enabled.
+// did not skip, so an unvalidated claim never reaches CEL rules or the zone
+// WAF there. The header is a core↔edge wire contract, never the backend's:
+// the core's proxy deletes it from every upstream request (proxy.New's
+// Director), regardless of WAF config — backends behind a current core never
+// see it and must not trust it.
 const Header = "X-Parapet-Waf"


### PR DESCRIPTION
## Problem

The `X-Parapet-Waf` claim header is the edge→core wire contract for `WAF_VALIDATED_PROXY`. The core consumed it in-process (the global/zone WAF skip), but a **validated** request kept the header all the way to the upstream backend ("core-vouched"), and with the skip disabled (or WAF off) a claim was forwarded untouched. Backends have no business seeing it.

## Fix

The proxy's `ReverseProxy` Director (previously a no-op) now deletes `wafclaim.Header` from the outbound request, unconditionally:

- `httputil.ReverseProxy` clones the request before calling the Director, so the **in-chain** request is untouched — the zone-WAF skip (which re-checks the claim after `GlobalWAF`) and the retry path still work exactly as before.
- Stripping happens regardless of WAF config — like hop-by-hop header hygiene; the cost is one constant-key header delete.
- The edge is unaffected: it forwards via its own `edge.Forwarder` (`parapet/pkg/upstream`), not this package, so its stamped claim still reaches the core.

## Changes

- `proxy/proxy.go` — strip `wafclaim.Header` in the Director
- `proxy/proxy_test.go` — pins: claim absent at upstream, other headers pass, in-chain request untouched
- `controller_waf.go` / `controller_waf_test.go` — comments/assertions no longer claim "flows upstream, core-vouched"
- `wafclaim/wafclaim.go`, `SPEC.md`, `EDGE.md` — contract docs updated: the claim is a core↔edge wire contract; backends never see it

## Testing

`gofmt` clean, `go vet` clean, full `go test ./...` — 638 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)