### PR TITLE
feat(edge): CP /v1/events SSE wake-up stream + edge poke (ALB idle fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,10 @@ enforces the ConfigMap-driven global+zone rate limits (`edge/ratelimit.go`,
 per-edge counters, mounted after the WAF and before the cache), optionally
 caches responses via `parapet/pkg/cache` (memory or disk backend,
 selected by `EDGE_CACHE_BACKEND`), and forwards to parapet (`edge/forward.go`). Refresh loops are fail-static
-(`edge/refresh.go`, `edge/wafrefresh.go`, `edge/ratelimitrefresh.go`). It is **not** the controller — no k8s
+(`edge/refresh.go`, `edge/wafrefresh.go`, `edge/ratelimitrefresh.go`); by default the CP's `GET /v1/events`
+SSE change stream (`edge/events.go` + `edgecp/events.go`, `EDGE_EVENTS_ENABLED`/`CP_EVENTS_ENABLED`) pokes
+them on change — a version-vector wake-up signal only, so updates land in seconds while the jittered polls
+stay the correctness floor (stream failure / 404 from an old CP ⇒ pure polling). It is **not** the controller — no k8s
 client, no Ingress watch — so it lives beside, not inside, the controller. Like
 the controller it honors `TRUST_PROXY` (shared `trustcidr` package): default `""`
 keeps the first-hop distrust posture; set it (e.g. `cloudflare`) when the edge

--- a/EDGE.md
+++ b/EDGE.md
@@ -169,7 +169,10 @@ GET /v1/waf           Authorization: Bearer <token>   [If-None-Match: "<etag>"]
        host_zone_map  : host → zoneKey — LEGACY host-level binding, kept for
                         pre-path-aware edges; a current edge uses it only when
                         route_zone_map is absent (older CP), as whole-host patterns.
-       (ETag is over the *scoped* payload, so 304 revalidation is per-edge-correct)
+       (ETag is over the *scoped* payload, so 304 revalidation is per-edge-correct;
+        the generation is EXCLUDED from the validator — it is process-local, and
+        CP replicas must mint identical validators for identical content or an
+        edge rotating across replicas would never 304)
 
 GET /v1/ratelimit     Authorization: Bearer <token>   [If-None-Match: "<etag>"]
   200 {"generation": N, "global_limits":["…"], "zones":{"<ns>/<name>":["…"]},
@@ -185,7 +188,7 @@ GET /v1/ratelimit     Authorization: Bearer <token>   [If-None-Match: "<etag>"]
        (documents are ARRAYS of YAML strings, one per ConfigMap data value —
         ratelimitrule.Parse takes one document per string and does not split "---",
         so the WAF's concatenated format would silently drop trailing documents;
-        ETag over the scoped payload, like /v1/waf)
+        ETag over the scoped payload with the generation excluded, like /v1/waf)
   401 (no/invalid token)   404 (ratelimit distribution disabled)
 
 GET /v1/purges?since=<seq>   Authorization: Bearer <token>
@@ -217,6 +220,29 @@ POST /v1/purges       Authorization: Bearer <ADMIN token>   ← stronger cred th
        (the admin token is NOT host-scoped — it may purge any host; per-host scoping is
         applied on the read side, not at issue time)
   401 (no/invalid admin token)  400 (invalid scope/host/uri)  404 (purge distribution disabled)
+
+GET /v1/events        Authorization: Bearer <token>   (SSE; long-lived)
+  200 Content-Type: text/event-stream — change-notification stream. Each event:
+       event: change
+       data: {"waf":"<etag>","ratelimit":"<etag>","certs":"<fp>","purges":<seq>}
+       The payload is a VERSION VECTOR (opaque, CP-process-local) — a wake-up
+       signal only, never content. The first event is the current vector (a
+       reconnecting edge covers its disconnected window); after that, one event
+       per change, with `: ping` keepalive comments every CP_EVENTS_PING_INTERVAL
+       (default 20s — keep it under any fronting LB's idle timeout; Google ALB
+       drops idle streams at ~60s). On a change the edge POKES the matching
+       refresh loop, which re-fetches through the scoped, ETag-revalidated
+       endpoints above — authz scoping and fail-static apply are unchanged, and
+       the jittered poll timers remain the correctness floor (an edge without the
+       stream just converges at poll cadence). When the CP sits behind an LB,
+       size the LB's backend/response timeout above the ping interval; the LB
+       cutting the stream at its response timeout is fine — the edge reconnects
+       with backoff.
+  401 (no/invalid token)   404 (events disabled / older CP — edge falls back to polling)
+  503 + Retry-After (a subscriber cap reached — global CP_EVENTS_MAX_SUBSCRIBERS,
+       or per-token CP_EVENTS_MAX_PER_TOKEN so one stream-leaking edge can't
+       starve the rest of the fleet; each stream pins a goroutine+connection;
+       the edge falls back to polling and re-probes)
 
 POST /v1/metrics      Authorization: Bearer <token>   X-Edge-Instance: <instance>
   body: the edge's FULL Prometheus registry in text exposition format
@@ -282,6 +308,53 @@ The edge serves a cached cert. On rotation the new cert must reach the edge
 **before** the old one is distrusted, or handshakes fail in the gap. So: refresh
 on a timer with overlap, honor the ETag/version, and on a fetch failure
 **keep serving the cached cert** (fail-static) — never drop it.
+
+## Change notifications (SSE) — propagation in seconds, polling as the floor
+
+By default the edge also subscribes to `GET /v1/events` (`EDGE_EVENTS_ENABLED`,
+default `true`; `CP_EVENTS_ENABLED` on the CP, default `true`): a server-sent
+event stream whose payload is a **version vector** of the CP's stores (WAF etag,
+ratelimit etag, cert-index fingerprint, purge seq). On a change the edge **pokes
+the matching refresh loop**, which runs its normal ETag-revalidated fetch — so a
+WAF/cert/limit/purge edit propagates to the fleet in seconds instead of one
+`EDGE_REFRESH_INTERVAL`, while everything that matters stays where it was:
+
+- **Wake-up signal only.** No content rides the stream; the edge fetches through
+  the same scoped, authorized, fail-static endpoints. A spoofed/buggy event can
+  at worst trigger a redundant 304 fetch.
+- **Polling stays the correctness floor.** The jittered poll loops are
+  unchanged; the stream is an accelerator. Stream down / CP too old (404) /
+  subscriber cap (503) ⇒ pure polling, with reconnect-with-backoff (404
+  re-probes every ~5m).
+- **Single-flight preserved.** Pokes are buffered(1) channels consumed by each
+  resource's own loop goroutine — a poke never runs a refresh concurrently with
+  a timer tick.
+- **Gap coverage on (re)connect.** The first event of every stream is the
+  current vector, and the edge pokes all loops on connect — anything that
+  changed while disconnected is fetched immediately (steady state: one 304 per
+  resource).
+
+**Fronting LB notes (e.g. Google ALB).** The CP sends `: ping` keepalives every
+`CP_EVENTS_PING_INTERVAL` (default 20s) — keep it under the LB's idle timeout
+(ALB drops idle connections at ~60s). Set the LB's backend **response timeout**
+comfortably high (e.g. ≥ 10 min); the LB cutting a stream at that timeout is
+harmless — the edge reconnects and re-baselines. Separately, the edge's CP
+transport expires pooled idle connections after 30s (`IdleConnTimeout`), so a
+poll never reuses a connection the LB has already silently dropped, and bounds
+every pre-response phase (dial 10s, TLS handshake 10s, response headers 30s);
+the stream additionally arms its 90s silent-stream watchdog BEFORE connecting,
+so a half-dead LB can never wedge the subscriber goroutine. Stream connects are
+fleet-jittered (boot [0,5s); post-EOF reconnect [0,2s) — a CP restart EOFs every
+edge's stream at the same instant) and a 200 that ends before the initial event
+is treated as a failure (backoff), never a hot reconnect loop. Backoff growth is
+evidence-of-failure only: a stream that DELIVERED events resets it however it
+ended — LB response-timeout cuts are *unclean* (no terminal chunk), and treating
+them as failures would ratchet every edge to permanent max backoff.
+
+CP knobs: `CP_EVENTS_MAX_SUBSCRIBERS` (default 1024) and
+`CP_EVENTS_MAX_PER_TOKEN` (default 32 — replicas share one token, one stream
+each, so size it ≥ replicas-per-token); over-cap streams shed with 503 +
+`Retry-After: CP_EVENTS_RETRY_AFTER` (default 30s).
 
 ## WAF at the edge
 
@@ -833,6 +906,7 @@ edge *can* be co-located, prefer keyless (recoverable in git history).
 | CP restart / fresh replica (in-memory journal seq resets below the edge cursor, `since > max_seq`) | CP returns `flush_required` (the cursor-ahead-of-journal check) → edge flushes and realigns its cursor **down** to `max_seq`. The edge also independently flushes on `max_seq < cursor` as defense-in-depth against an older CP. Never silently under-invalidates. |
 | `purge-state` lost/corrupt | Cursor resets to 0 → next poll re-syncs (a trim gap or cursor-ahead → flush-all). Cursor + maps share **one atomic write** so they can't desync. |
 | `POST /v1/metrics` unreachable | Edge keeps serving traffic (**fail static** — push is pure observability); the CP serves the last snapshot until `CP_EDGE_METRICS_TTL`, then the instance's series disappear (its `last_push_seconds` series with them). The next successful push restores everything — counters are cumulative, nothing is lost. |
+| `GET /v1/events` stream down / 404 (old CP) / 503 (cap) | Edge degrades to **pure polling** (the unchanged correctness floor) and reconnects with backoff (404 re-probes ~5m). On reconnect it pokes every loop, covering anything that changed while disconnected. Updates are *slower, never lost*. |
 
 ## Conformance
 

--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -350,15 +350,52 @@ func main() {
 	// the per-edge bearer token (scoped to the edge's hosts); issuing a purge needs
 	// CP_PURGE_ADMIN_TOKEN — a stronger credential than the edges hold. Without that
 	// token, issuance is locked out, so refuse to enable an issue-less purge plane.
+	var purgeStore *edgecp.PurgeStore
 	if os.Getenv("CP_PURGE_ENABLED") == "true" {
 		adminToken := os.Getenv("CP_PURGE_ADMIN_TOKEN")
 		if adminToken == "" {
 			slog.Error("CP_PURGE_ENABLED=true requires CP_PURGE_ADMIN_TOKEN (the credential that gates POST /v1/purges)")
 			os.Exit(1)
 		}
-		purgeStore := edgecp.NewPurgeStore(envInt("CP_PURGE_MAX_ENTRIES", 0))
+		purgeStore = edgecp.NewPurgeStore(envInt("CP_PURGE_MAX_ENTRIES", 0))
 		server = server.WithPurge(purgeStore, adminToken)
 		slog.Info("edge control plane: cache-purge distribution enabled")
+	}
+
+	// Change-notification stream (GET /v1/events): a per-edge SSE wake-up signal
+	// so the fleet converges in ~seconds instead of one poll interval. The hub
+	// samples the stores' version vector and broadcasts on change; edges
+	// re-fetch through the scoped, ETag-revalidated endpoints, so authz and
+	// fail-static semantics are untouched. Keep the ping cadence under any
+	// fronting LB's idle timeout (Google ALB drops idle streams at ~60s), and
+	// size the LB's backend/response timeout well above it — the stream is cut
+	// at that timeout and the edge transparently reconnects.
+	if envOr("CP_EVENTS_ENABLED", "true") == "true" {
+		hub := edgecp.NewEventsHub(func() edgecp.EventsSnapshot {
+			var snap edgecp.EventsSnapshot
+			snap.Certs = store.Version()
+			if wafStore != nil {
+				snap.WAF = wafStore.Version()
+			}
+			if rlStore != nil {
+				snap.RateLimit = rlStore.Version()
+			}
+			if purgeStore != nil {
+				snap.Purges = purgeStore.LastSeq()
+			}
+			return snap
+		})
+		hub.PingInterval = time.Duration(envInt("CP_EVENTS_PING_INTERVAL", 20)) * time.Second
+		hub.MaxSubscribers = envInt("CP_EVENTS_MAX_SUBSCRIBERS", 1024)
+		// Per-token cap: replicas share one token (one stream each), so size it
+		// >= replicas-per-token. It exists so one edge in a stream-leaking
+		// reconnect loop can't eat the global cap and starve the rest of the fleet.
+		hub.MaxPerToken = envInt("CP_EVENTS_MAX_PER_TOKEN", 32)
+		hub.RetryAfterSecs = envInt("CP_EVENTS_RETRY_AFTER", 30)
+		go hub.Run(ctx)
+		server = server.WithEvents(hub)
+		slog.Info("edge control plane: change-event stream enabled",
+			"ping_interval", hub.PingInterval, "max_subscribers", hub.MaxSubscribers)
 	}
 
 	// Convergence /metrics on a SEPARATE, unauthenticated listener (never the

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -134,6 +134,20 @@ func main() {
 
 	ctx := context.Background()
 
+	// Change-notification stream (GET /v1/events): pokes the refresh loops the
+	// moment the CP's stores change, so updates propagate in ~seconds instead of
+	// one EDGE_REFRESH_INTERVAL. Pure accelerator — the jittered poll loops stay
+	// as the correctness floor, and an old CP (404) just means pure polling.
+	// Buffered(1) pokes coalesce; each loop consumes its own channel, keeping
+	// refreshes single-flight per resource.
+	eventsEnabled := envOr("EDGE_EVENTS_ENABLED", "true") == "true"
+	var pokes edge.EventPokes
+	var certPoke, wafPoke, rlPoke, purgePoke chan struct{}
+	if eventsEnabled {
+		certPoke = make(chan struct{}, 1)
+		pokes.Certs = certPoke
+	}
+
 	// Optional data-plane mTLS: fetch a CP-issued client cert (CA-only trust), hold it
 	// in memory (never on disk), and present it on the re-encrypt hop. The re-mint
 	// coordinator owns every re-mint path (proactive on a ca_id flip observed via the
@@ -169,7 +183,7 @@ func main() {
 		loaded := edge.RefreshCertsAll(cp, store, domains, remintCoord)
 		slog.Info("edge: initial cert load", "loaded", loaded, "total", len(domains))
 	}
-	go edge.RunCertRefresh(ctx, cp, store, domains, refreshInterval, remintCoord)
+	go edge.RunCertRefresh(ctx, cp, store, domains, refreshInterval, remintCoord, certPoke)
 
 	if dataplaneMTLS {
 		// Startup mint is direct + UN-jittered (readiness needs it fast); the periodic
@@ -196,7 +210,11 @@ func main() {
 	if wafEnabled {
 		ewaf = edge.NewEdgeWAF(country, asn)
 		edge.RefreshWafOnce(cp, ewaf, remintCoord)
-		go edge.RunWafRefresh(ctx, cp, ewaf, refreshInterval, remintCoord)
+		if eventsEnabled {
+			wafPoke = make(chan struct{}, 1)
+			pokes.WAF = wafPoke
+		}
+		go edge.RunWafRefresh(ctx, cp, ewaf, refreshInterval, remintCoord, wafPoke)
 	}
 
 	// Optional edge rate limiting (ConfigMap-driven global + zone sets fetched
@@ -206,7 +224,11 @@ func main() {
 	if ratelimitEnabled {
 		erl = edge.NewEdgeRateLimit(country, asn)
 		edge.RefreshRateLimitOnce(cp, erl)
-		go edge.RunRateLimitRefresh(ctx, cp, erl, refreshInterval)
+		if eventsEnabled {
+			rlPoke = make(chan struct{}, 1)
+			pokes.RateLimit = rlPoke
+		}
+		go edge.RunRateLimitRefresh(ctx, cp, erl, refreshInterval, rlPoke)
 	}
 
 	// Optional response cache (off by default), from parapet/pkg/cache. The
@@ -267,13 +289,24 @@ func main() {
 	if purgeTable != nil {
 		purgeInterval := time.Duration(envInt64("EDGE_CACHE_PURGE_POLL_INTERVAL", 10)) * time.Second
 		edge.RefreshPurgeOnce(cp, purgeTable) // best-effort initial sync; fail-static
-		go edge.RunPurgeRefresh(ctx, cp, purgeTable, purgeInterval)
+		if eventsEnabled {
+			purgePoke = make(chan struct{}, 1)
+			pokes.Purges = purgePoke
+		}
+		go edge.RunPurgeRefresh(ctx, cp, purgeTable, purgeInterval, purgePoke)
 		// The reaper physically reclaims invalidated entries off the serving path (the
 		// lazy lookup gate already guarantees correctness; this is just reclamation).
 		// Housekeeping cadence, jittered.
 		sweepInterval := time.Duration(envInt64("EDGE_CACHE_PURGE_SWEEP_INTERVAL", 300)) * time.Second
 		go edge.RunReaper(ctx, purgeStorage, purgeTable, sweepInterval)
 		slog.Info("edge cache: purge polling enabled", "poll_interval", purgeInterval, "sweep_interval", sweepInterval)
+	}
+
+	// All pokes are wired — subscribe to the CP's change stream. An old CP (no
+	// /v1/events) degrades to pure polling with an occasional re-probe.
+	if eventsEnabled {
+		go edge.RunEvents(ctx, cp, pokes)
+		slog.Info("edge: change-event stream enabled")
 	}
 
 	var getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error)

--- a/edge/cp.go
+++ b/edge/cp.go
@@ -2,11 +2,14 @@ package edge
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -28,9 +31,10 @@ const (
 // and the returned private key only ever travel over this connection.
 // GET /v1/certs?sni= and GET /v1/waf, fail-static.
 type CpClient struct {
-	http  *http.Client
-	base  string
-	token string
+	http   *http.Client
+	stream *http.Client // no overall Timeout — used for the long-lived /v1/events SSE stream
+	base   string
+	token  string
 }
 
 // NewCpClient builds a client for base (e.g. https://controlplane:8443). caPEM,
@@ -48,13 +52,39 @@ func NewCpClient(base, token string, caPEM []byte) (*CpClient, error) {
 			tlsConfig.RootCAs = pool
 		}
 	}
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+		// A zero-value Transport bounds NOTHING on the connect phase (the dial,
+		// TLS-handshake, and response-header timeouts below are DefaultTransport
+		// extras, not Transport defaults). The polling client is saved by its
+		// overall Client.Timeout, but the SSE stream client deliberately has none —
+		// without these, a half-dead LB that accepts the SYN and goes silent would
+		// hang the event stream's connect forever. Bound every pre-response phase
+		// here so both clients fail fast and retry/back off.
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		// An L7 LB in front of the CP (e.g. Google ALB) silently drops connections
+		// idle longer than its own timeout (~60s); reusing such a half-dead pooled
+		// connection makes the next poll fail (or pins this edge to one stale CP
+		// backend forever, since a poll cadence shorter than the pool's lifetime
+		// never lets the connection rotate). Expire idle connections well below
+		// that so every poll burst dials — and re-balances — fresh.
+		IdleConnTimeout: 30 * time.Second,
+	}
 	return &CpClient{
 		http: &http.Client{
 			Timeout:   30 * time.Second,
-			Transport: &http.Transport{TLSClientConfig: tlsConfig},
+			Transport: transport,
 		},
-		base:  strings.TrimRight(base, "/"),
-		token: token,
+		// The SSE stream must outlive any fixed Timeout (it is a deliberately
+		// long-lived response); cancellation rides the request context instead.
+		stream: &http.Client{Transport: transport},
+		base:   strings.TrimRight(base, "/"),
+		token:  token,
 	}, nil
 }
 
@@ -434,6 +464,41 @@ func (c *CpClient) FetchTrustBundleSignal() (caID, signerFP string, err error) {
 		return "", "", fmt.Errorf("decode: %w", err)
 	}
 	return body.CAID, body.SigningFP, nil
+}
+
+// ErrEventsUnsupported reports that the control plane does not serve
+// GET /v1/events (an older CP, or events disabled). The caller backs off much
+// longer than on a transient error — polling remains the floor either way.
+var ErrEventsUnsupported = errors.New("edge: control plane does not support /v1/events")
+
+// OpenEvents opens the change-notification SSE stream (GET /v1/events). The
+// returned body is the live stream; the caller must close it. Cancellation is
+// the caller's context (the stream client has no overall timeout — an SSE
+// response is deliberately long-lived). A 404 maps to ErrEventsUnsupported.
+func (c *CpClient) OpenEvents(ctx context.Context) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.base+"/v1/events", nil)
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := c.stream.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, ErrEventsUnsupported
+		}
+		return nil, fmt.Errorf("control plane returned %d for /v1/events", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		resp.Body.Close()
+		return nil, fmt.Errorf("control plane returned non-SSE content type %q for /v1/events", ct)
+	}
+	return resp, nil
 }
 
 // do issues an authorized GET, optionally with If-None-Match. The body must be

--- a/edge/events.go
+++ b/edge/events.go
@@ -1,0 +1,212 @@
+package edge
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// eventsSnapshot mirrors edgecp.EventsSnapshot: the version vector the CP pushes
+// on GET /v1/events. Values are opaque and process-local to the CP — they are
+// only ever compared for inequality against the previous event on the SAME
+// stream, never persisted or ordered.
+type eventsSnapshot struct {
+	WAF       string `json:"waf"`
+	RateLimit string `json:"ratelimit"`
+	Certs     string `json:"certs"`
+	Purges    uint64 `json:"purges"`
+}
+
+// EventPokes carries the wake-up channels for the resource refresh loops. Each
+// is optional (nil = that resource isn't running). Channels should be buffered
+// (size 1); sends are non-blocking, so a poke arriving while a refresh is
+// already pending coalesces.
+type EventPokes struct {
+	WAF       chan<- struct{}
+	RateLimit chan<- struct{}
+	Certs     chan<- struct{}
+	Purges    chan<- struct{}
+}
+
+func (p EventPokes) poke(ch chan<- struct{}) {
+	if ch == nil {
+		return
+	}
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}
+
+// pokeAll wakes every wired loop — used right after (re)connecting, when any
+// change during the disconnected window would otherwise wait for the poll floor.
+// Cheap: each refresh is an ETag-revalidated fetch (steady state one 304 each).
+func (p EventPokes) pokeAll() {
+	p.poke(p.WAF)
+	p.poke(p.RateLimit)
+	p.poke(p.Certs)
+	p.poke(p.Purges)
+}
+
+// Watchdog: with the CP pinging every ~20s, a stream silent this long is dead
+// (an LB that dropped the connection without FIN would otherwise block the read
+// forever) — close and reconnect.
+const eventsWatchdogTimeout = 90 * time.Second
+
+// On ErrEventsUnsupported (old CP / events disabled) re-probe this often —
+// rarely, since polling is doing the work meanwhile.
+const eventsUnsupportedRetry = 5 * time.Minute
+
+// Fleet-decorrelation jitter spans (vars so tests can zero them): the first
+// connect after boot, and the reconnect after a clean EOF (a CP restart EOFs
+// every edge's stream at the same instant).
+var (
+	eventsConnectJitter   = 5 * time.Second
+	eventsReconnectJitter = 2 * time.Second
+)
+
+// RunEvents subscribes to the CP's change-notification stream (GET /v1/events)
+// and pokes the matching refresh loop when a store's version changes. It is an
+// ACCELERATOR only: every refresh still happens on its loop's goroutine
+// (single-flight, fail-static, ETag-revalidated), and the jittered poll timers
+// remain the correctness floor — any stream failure just falls back to that
+// floor while this loop reconnects with backoff. Runs forever; fail-static.
+func RunEvents(ctx context.Context, cp *CpClient, pokes EventPokes) {
+	const backoffBase = time.Second
+	const backoffMax = time.Minute
+	// First connect is jittered like the poll loops: a fleet booted (or bounced)
+	// together must not open its streams in lockstep. Boot freshness doesn't
+	// suffer — main's synchronous initial fetches already ran.
+	if !sleepCtx(ctx, fullJitter(eventsConnectJitter)) {
+		return
+	}
+	backoff := backoffBase
+	for ctx.Err() == nil {
+		delivered, err := runEventsOnce(ctx, cp, pokes)
+		// A stream that delivered events was a HEALTHY subscription, however it
+		// ended — and in the documented fronting-LB deployment the common ending
+		// is unclean: an LB response-timeout (or a SIGKILLed CP) cuts the chunked
+		// response without the terminal 0-chunk, surfacing io.ErrUnexpectedEOF,
+		// not a clean EOF. Backoff growth is evidence-of-failure only: without
+		// this reset, every routine LB cut would double backoff and permanently
+		// ratchet the whole fleet to backoffMax, silently degrading the stream's
+		// ~seconds convergence to a fixed blind window per cut.
+		if delivered {
+			backoff = backoffBase
+		}
+		switch {
+		case ctx.Err() != nil:
+			return
+		case errors.Is(err, ErrEventsUnsupported):
+			slog.Info("edge: control plane has no /v1/events; relying on polling", "retry_in", eventsUnsupportedRetry)
+			if !sleepCtx(ctx, eventsUnsupportedRetry) {
+				return
+			}
+			backoff = backoffBase
+		case err != nil:
+			slog.Warn("edge: event stream ended; polling remains active; reconnecting", "error", err, "delivered", delivered, "backoff", backoff)
+			if !sleepCtx(ctx, backoff+fullJitter(backoffBase)) {
+				return
+			}
+			if !delivered {
+				backoff = minDur(backoff*2, backoffMax)
+			}
+		default:
+			// Clean EOF after a live stream (graceful CP handler return): reconnect
+			// promptly but jittered — a CP restart EOFs the WHOLE fleet's streams at
+			// once, and an unjittered reconnect would thunder.
+			if !sleepCtx(ctx, fullJitter(eventsReconnectJitter)) {
+				return
+			}
+		}
+	}
+}
+
+// runEventsOnce opens one stream and consumes it until it ends. delivered
+// reports whether at least one event arrived — the caller's backoff evidence:
+// a delivered stream was healthy however it ended (LB cuts are unclean), while
+// a 200 that ends before any event is an error (a misbehaving intermediary
+// must back off, never drive a sleepless reconnect loop).
+func runEventsOnce(ctx context.Context, cp *CpClient, pokes EventPokes) (delivered bool, err error) {
+	// The watchdog cancels only THIS request's context, forcing the blocked
+	// call to return when the stream goes silent past the ping cadence. It is
+	// armed BEFORE the connect: the transport bounds each pre-response phase,
+	// but the watchdog is the belt-and-suspenders ceiling on the whole connect
+	// (a connect that survives past it is canceled, not waited on forever).
+	reqCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	wd := time.AfterFunc(eventsWatchdogTimeout, cancel)
+	defer wd.Stop()
+
+	resp, err := cp.OpenEvents(reqCtx)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	wd.Reset(eventsWatchdogTimeout)
+	slog.Info("edge: event stream connected")
+
+	// Any change while disconnected has already happened — cover the gap now.
+	// The first received event then becomes the comparison baseline.
+	pokes.pokeAll()
+
+	var last eventsSnapshot
+	first := true
+	var data strings.Builder
+	sc := bufio.NewScanner(resp.Body)
+	sc.Buffer(make([]byte, 0, 4096), 1<<20)
+	for sc.Scan() {
+		wd.Reset(eventsWatchdogTimeout)
+		line := sc.Text()
+		switch {
+		case strings.HasPrefix(line, ":"): // keepalive comment
+		case strings.HasPrefix(line, "data:"):
+			data.WriteString(strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+		case line == "": // dispatch boundary
+			if data.Len() == 0 {
+				continue
+			}
+			var snap eventsSnapshot
+			if err := json.Unmarshal([]byte(data.String()), &snap); err != nil {
+				slog.Warn("edge: bad event payload; ignoring", "error", err)
+			} else {
+				if !first {
+					if snap.WAF != last.WAF {
+						pokes.poke(pokes.WAF)
+					}
+					if snap.RateLimit != last.RateLimit {
+						pokes.poke(pokes.RateLimit)
+					}
+					if snap.Certs != last.Certs {
+						pokes.poke(pokes.Certs)
+					}
+					if snap.Purges != last.Purges {
+						pokes.poke(pokes.Purges)
+					}
+				}
+				last = snap
+				first = false
+			}
+			data.Reset()
+		}
+	}
+	delivered = !first
+	if err := sc.Err(); err != nil && ctx.Err() == nil {
+		if reqCtx.Err() != nil {
+			return delivered, errors.New("stream silent past watchdog; closed")
+		}
+		return delivered, err
+	}
+	if !delivered && ctx.Err() == nil {
+		// Clean EOF with zero events: the CP always sends the current vector
+		// immediately, so this is a misbehaving intermediary (a buffering proxy,
+		// a synthesized 200, a CP dying mid-handshake). Surface it as an error so
+		// the caller backs off instead of hot-looping the reconnect.
+		return false, errors.New("stream ended before the initial event")
+	}
+	return delivered, nil
+}

--- a/edge/events_test.go
+++ b/edge/events_test.go
@@ -1,0 +1,216 @@
+package edge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// sseServer streams the snapshots sent on events as SSE change events, then
+// blocks until the request context ends.
+func sseServer(t *testing.T, events <-chan string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/events" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fl := w.(http.Flusher)
+		fl.Flush() // send headers now; the client unblocks on them
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case data, ok := <-events:
+				if !ok {
+					return
+				}
+				fmt.Fprintf(w, "event: change\ndata: %s\n\n", data)
+				fl.Flush()
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// zeroEventJitter removes the fleet-decorrelation connect jitter so tests are
+// fast and deterministic; the returned func restores it.
+func zeroEventJitter(t *testing.T) func() {
+	t.Helper()
+	prevConnect, prevReconnect := eventsConnectJitter, eventsReconnectJitter
+	eventsConnectJitter, eventsReconnectJitter = 0, 0
+	return func() { eventsConnectJitter, eventsReconnectJitter = prevConnect, prevReconnect }
+}
+
+func expectPoke(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("expected a %s poke", what)
+	}
+}
+
+func expectNoPoke(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatalf("unexpected %s poke", what)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestRunEventsPokesOnChange(t *testing.T) {
+	t.Cleanup(zeroEventJitter(t))
+	events := make(chan string, 8)
+	srv := sseServer(t, events)
+	cp, err := NewCpClient(srv.URL, "tok", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wafPoke := make(chan struct{}, 1)
+	certPoke := make(chan struct{}, 1)
+	purgePoke := make(chan struct{}, 1)
+	pokes := EventPokes{WAF: wafPoke, Certs: certPoke, Purges: purgePoke}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go RunEvents(ctx, cp, pokes)
+
+	// On connect every wired loop is poked once (gap coverage).
+	expectPoke(t, wafPoke, "connect waf")
+	expectPoke(t, certPoke, "connect certs")
+	expectPoke(t, purgePoke, "connect purges")
+
+	// First event is the baseline — no pokes.
+	events <- `{"waf":"a","certs":"c","purges":1}`
+	expectNoPoke(t, wafPoke, "baseline waf")
+
+	// Only the changed field pokes.
+	events <- `{"waf":"b","certs":"c","purges":1}`
+	expectPoke(t, wafPoke, "waf change")
+	expectNoPoke(t, certPoke, "certs unchanged")
+	expectNoPoke(t, purgePoke, "purges unchanged")
+
+	// A nil channel (resource not running) is skipped without panic.
+	events <- `{"waf":"b","certs":"c","purges":2,"ratelimit":"r"}`
+	expectPoke(t, purgePoke, "purge change")
+}
+
+func TestRunEventsOnceZeroEventEOFErrors(t *testing.T) {
+	// A 200 text/event-stream that ends before any event must be an ERROR (the
+	// reconnect loop backs off) — nil would drive a sleepless hot loop against a
+	// misbehaving intermediary.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.(http.Flusher).Flush()
+		// return: instant clean EOF, zero events
+	}))
+	t.Cleanup(srv.Close)
+	cp, err := NewCpClient(srv.URL, "tok", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	delivered, err := runEventsOnce(context.Background(), cp, EventPokes{})
+	if err == nil {
+		t.Fatal("zero-event EOF must return an error so the caller backs off")
+	}
+	if delivered {
+		t.Fatal("a zero-event stream must not count as delivered")
+	}
+}
+
+func TestRunEventsOnceDeliveredSurvivesUncleanCut(t *testing.T) {
+	// A stream that delivered events and is then cut WITHOUT the chunked
+	// terminal 0-chunk (an LB response-timeout, a SIGKILLed CP) must report
+	// delivered=true with the read error — the caller resets backoff on
+	// delivered streams, so routine LB cuts can't ratchet the fleet to
+	// permanent max backoff.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, buf, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			t.Errorf("hijack: %v", err)
+			return
+		}
+		defer conn.Close()
+		ev := "event: change\ndata: {\"waf\":\"a\"}\n\n"
+		buf.WriteString("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n")
+		fmt.Fprintf(buf, "%x\r\n%s\r\n", len(ev), ev)
+		buf.Flush()
+		// close without the terminal 0-chunk → io.ErrUnexpectedEOF at the client
+	}))
+	t.Cleanup(srv.Close)
+	cp, err := NewCpClient(srv.URL, "tok", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	delivered, err := runEventsOnce(context.Background(), cp, EventPokes{})
+	if err == nil {
+		t.Fatal("an unclean cut must surface a read error")
+	}
+	if !delivered {
+		t.Fatal("a stream that delivered an event must report delivered=true")
+	}
+}
+
+func TestOpenEventsUnsupported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(http.NotFound))
+	t.Cleanup(srv.Close)
+	cp, err := NewCpClient(srv.URL, "tok", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cp.OpenEvents(context.Background()); !errors.Is(err, ErrEventsUnsupported) {
+		t.Fatalf("err = %v, want ErrEventsUnsupported", err)
+	}
+}
+
+func TestOpenEventsRejectsNonSSE(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{}"))
+	}))
+	t.Cleanup(srv.Close)
+	cp, err := NewCpClient(srv.URL, "tok", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cp.OpenEvents(context.Background()); err == nil {
+		t.Fatal("a non-SSE 200 must be rejected")
+	}
+}
+
+func TestRunWafRefreshPoke(t *testing.T) {
+	hits := make(chan struct{}, 8)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/waf" {
+			hits <- struct{}{}
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	cp, err := NewCpClient(srv.URL, "tok", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	poke := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Interval far beyond the test deadline: any fetch can only come from the
+	// poke (honored even during the loop's initial jitter window).
+	go RunWafRefresh(ctx, cp, NewEdgeWAF(nil, nil), 10*time.Minute, nil, poke)
+	poke <- struct{}{}
+	select {
+	case <-hits:
+	case <-time.After(2 * time.Second):
+		t.Fatal("poke did not trigger a WAF fetch")
+	}
+}

--- a/edge/purgerefresh.go
+++ b/edge/purgerefresh.go
@@ -51,22 +51,11 @@ func RefreshPurgeOnce(cp *CpClient, table *PurgeTable) {
 // RunPurgeRefresh runs the periodic cache-purge poll forever. The first tick is
 // jittered by [0,interval] to decorrelate the fleet's poll instants. The cadence is
 // independent of (and typically faster than) the cert/WAF refresh, since purge
-// latency is operator-facing. Fail-static.
-func RunPurgeRefresh(ctx context.Context, cp *CpClient, table *PurgeTable, interval time.Duration) {
+// latency is operator-facing. Fail-static. poke (nil ok) wakes the loop
+// immediately on a /v1/events change signal; the timer remains the fallback floor.
+func RunPurgeRefresh(ctx context.Context, cp *CpClient, table *PurgeTable, interval time.Duration, poke <-chan struct{}) {
 	if interval <= 0 { // time.NewTicker panics on a non-positive interval
 		interval = 10 * time.Second
 	}
-	if !sleepCtx(ctx, fullJitter(interval)) {
-		return
-	}
-	t := time.NewTicker(interval)
-	defer t.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.C:
-			RefreshPurgeOnce(cp, table)
-		}
-	}
+	runRefreshLoop(ctx, interval, poke, func() { RefreshPurgeOnce(cp, table) })
 }

--- a/edge/ratelimitrefresh.go
+++ b/edge/ratelimitrefresh.go
@@ -30,21 +30,11 @@ func RefreshRateLimitOnce(cp *CpClient, e *EdgeRateLimit) {
 // RunRateLimitRefresh runs the periodic rate-limit refresh forever. The first
 // tick is jittered by [0,interval] (fleet poll-instant decorrelation). Same
 // cadence as the cert/WAF refresh (EDGE_REFRESH_INTERVAL); fail-static.
-func RunRateLimitRefresh(ctx context.Context, cp *CpClient, e *EdgeRateLimit, interval time.Duration) {
+// poke (nil ok) wakes the loop immediately on a /v1/events change signal; the
+// timer remains the fallback floor, and refreshes stay single-flight here.
+func RunRateLimitRefresh(ctx context.Context, cp *CpClient, e *EdgeRateLimit, interval time.Duration, poke <-chan struct{}) {
 	if interval <= 0 { // time.NewTicker panics on a non-positive interval
 		interval = 300 * time.Second
 	}
-	if !sleepCtx(ctx, fullJitter(interval)) {
-		return
-	}
-	t := time.NewTicker(interval)
-	defer t.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.C:
-			RefreshRateLimitOnce(cp, e)
-		}
-	}
+	runRefreshLoop(ctx, interval, poke, func() { RefreshRateLimitOnce(cp, e) })
 }

--- a/edge/refresh.go
+++ b/edge/refresh.go
@@ -11,6 +11,41 @@ import (
 	"time"
 )
 
+// runRefreshLoop runs fn forever: on a ticker (first tick offset by a [0,interval)
+// jitter so the fleet's poll instants decorrelate) and on every poke (nil ok — the
+// /v1/events wake-up). Pokes are honored DURING the initial jitter window too (a
+// change observed right after boot refreshes immediately), but the ticker phase
+// stays jitter-anchored — a fleet-wide broadcast must not phase-lock every edge's
+// poll timer into lockstep. All fn invocations happen on this goroutine, keeping
+// each resource's refresh single-flight.
+func runRefreshLoop(ctx context.Context, interval time.Duration, poke <-chan struct{}, fn func()) {
+	deadline := time.NewTimer(fullJitter(interval))
+	defer deadline.Stop()
+jitter:
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-deadline.C:
+			break jitter
+		case <-poke:
+			fn()
+		}
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			fn()
+		case <-poke:
+			fn()
+		}
+	}
+}
+
 // RefreshEdgeCertOnce generates a fresh in-memory keypair, builds a CSR, fetches a
 // signed leaf from the control plane, and atomically swaps the complete cert into
 // the store. Fail-static: on any error the prior cert is kept. The key is generated
@@ -129,28 +164,20 @@ func RefreshCertsAll(cp *CpClient, store *CertStore, domains []string, coord *Re
 // every edge at once; un-jittered loops would hammer GET /v1/certs in lockstep). Each
 // tick refreshes the configured domains PLUS whatever is currently cached (deduped), so
 // on-demand-fetched domains (serve-all mode) keep rotating and observing. Fail-static.
-func RunCertRefresh(ctx context.Context, cp *CpClient, store *CertStore, domains []string, interval time.Duration, coord *RemintCoordinator) {
+// poke (nil ok) wakes the loop immediately on a /v1/events change signal; the steady
+// state of a poked sweep is one cheap 304 per domain. The timer remains the floor.
+func RunCertRefresh(ctx context.Context, cp *CpClient, store *CertStore, domains []string, interval time.Duration, coord *RemintCoordinator, poke <-chan struct{}) {
 	if interval <= 0 { // time.NewTicker panics on a non-positive interval
 		interval = 300 * time.Second
 	}
-	if !sleepCtx(ctx, fullJitter(interval)) {
-		return
-	}
-	t := time.NewTicker(interval)
-	defer t.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.C:
-			seen := map[string]struct{}{}
-			for _, d := range append(append([]string{}, domains...), store.Keys()...) {
-				if _, dup := seen[d]; dup {
-					continue
-				}
-				seen[d] = struct{}{}
-				RefreshCertOnce(cp, store, d, coord)
+	runRefreshLoop(ctx, interval, poke, func() {
+		seen := map[string]struct{}{}
+		for _, d := range append(append([]string{}, domains...), store.Keys()...) {
+			if _, dup := seen[d]; dup {
+				continue
 			}
+			seen[d] = struct{}{}
+			RefreshCertOnce(cp, store, d, coord)
 		}
-	}
+	})
 }

--- a/edge/wafrefresh.go
+++ b/edge/wafrefresh.go
@@ -32,22 +32,12 @@ func RefreshWafOnce(cp *CpClient, w *EdgeWAF, coord *RemintCoordinator) {
 
 // RunWafRefresh runs the periodic WAF refresh forever. The first tick is jittered by
 // [0,interval] (fleet poll-instant decorrelation). Same cadence as the cert refresh
-// (EDGE_REFRESH_INTERVAL); fail-static.
-func RunWafRefresh(ctx context.Context, cp *CpClient, w *EdgeWAF, interval time.Duration, coord *RemintCoordinator) {
+// (EDGE_REFRESH_INTERVAL); fail-static. poke (nil ok) wakes the loop immediately —
+// the /v1/events stream's change signal — so the timer is only the fallback floor.
+// All refreshes run on THIS goroutine, keeping them single-flight per resource.
+func RunWafRefresh(ctx context.Context, cp *CpClient, w *EdgeWAF, interval time.Duration, coord *RemintCoordinator, poke <-chan struct{}) {
 	if interval <= 0 { // time.NewTicker panics on a non-positive interval
 		interval = 300 * time.Second
 	}
-	if !sleepCtx(ctx, fullJitter(interval)) {
-		return
-	}
-	t := time.NewTicker(interval)
-	defer t.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.C:
-			RefreshWafOnce(cp, w, coord)
-		}
-	}
+	runRefreshLoop(ctx, interval, poke, func() { RefreshWafOnce(cp, w, coord) })
 }

--- a/edgecp/certstore.go
+++ b/edgecp/certstore.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -32,11 +33,22 @@ type CertStore struct {
 	// loaded flips true after the first Set (the reloader's initial cluster list
 	// completed), so the control plane can report readiness via /healthz?ready=1.
 	loaded atomic.Bool
+	// version fingerprints the full (name, etag) index — the /v1/events change
+	// signal. Content-derived (not a Set counter), so a no-change relist of the
+	// cluster's secrets doesn't wake the fleet.
+	version atomic.Pointer[string]
 }
 
 func NewCertStore() *CertStore {
-	return &CertStore{byName: map[string]*certEntry{}}
+	s := &CertStore{byName: map[string]*certEntry{}}
+	v := etagOfString("")
+	s.version.Store(&v)
+	return s
 }
+
+// Version is the store's full-index fingerprint — an opaque change signal for
+// the /v1/events stream (per-edge scoping happens at fetch time, not here).
+func (s *CertStore) Version() string { return *s.version.Load() }
 
 // Loaded reports whether the store has completed at least one load (readiness).
 func (s *CertStore) Loaded() bool { return s.loaded.Load() }
@@ -60,9 +72,24 @@ func (s *CertStore) Set(pairs []PEMPair) {
 			byName[strings.ToLower(n)] = e
 		}
 	}
+	names := make([]string, 0, len(byName))
+	for n := range byName {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	var fp strings.Builder
+	for _, n := range names {
+		fp.WriteString(n)
+		fp.WriteByte('=')
+		fp.WriteString(byName[n].etag)
+		fp.WriteByte('\n')
+	}
+	v := etagOfString(fp.String())
+
 	s.mu.Lock()
 	s.byName = byName
 	s.mu.Unlock()
+	s.version.Store(&v)
 	s.loaded.Store(true)
 }
 

--- a/edgecp/etag_test.go
+++ b/edgecp/etag_test.go
@@ -1,0 +1,100 @@
+package edgecp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The WAF/ratelimit generation is a PROCESS-LOCAL counter: two CP replicas
+// serving byte-identical content sit at different generations (different boot
+// times / reload counts). The ETag must therefore be computed over the content
+// WITHOUT the generation — otherwise an edge whose polls rotate across replicas
+// (IdleConnTimeout redials every poll) never gets a 304 and re-downloads +
+// recompiles the full bundle forever.
+
+func TestWafEtagExcludesProcessLocalGeneration(t *testing.T) {
+	store := NewWafStore()
+	store.SetGlobal("rules-a") // generation 1
+	srv := NewServer(NewCertStore(), NewAuthz(map[string][]string{"tok": {"example.com"}})).WithWAF(store)
+	h := srv.Handler()
+
+	get := func(ifNoneMatch string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest("GET", "/v1/waf", nil)
+		req.Header.Set("Authorization", "Bearer tok")
+		if ifNoneMatch != "" {
+			req.Header.Set("If-None-Match", ifNoneMatch)
+		}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec
+	}
+
+	first := get("")
+	if first.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", first.Code)
+	}
+	etag1 := first.Header().Get("ETag")
+	if etag1 == "" {
+		t.Fatal("no ETag on 200")
+	}
+
+	// Same content at a higher generation (simulates another replica, or an
+	// edit cycled back): identical validator, and revalidation 304s.
+	store.SetGlobal("rules-b") // generation 2
+	store.SetGlobal("rules-a") // generation 3, content identical to generation 1
+	second := get("")
+	if got := second.Header().Get("ETag"); got != etag1 {
+		t.Fatalf("ETag changed with content identical: %s -> %s (generation leaked into the validator)", etag1, got)
+	}
+	var resp wafResponse
+	if err := json.Unmarshal(second.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Generation != 3 {
+		t.Fatalf("generation = %d, want 3 (the REAL generation must still ride the body)", resp.Generation)
+	}
+	if rec := get(etag1); rec.Code != http.StatusNotModified {
+		t.Fatalf("revalidation status = %d, want 304", rec.Code)
+	}
+
+	// A real content change must still bust the validator.
+	store.SetGlobal("rules-c")
+	if rec := get(etag1); rec.Code != http.StatusOK {
+		t.Fatalf("changed content with stale validator: status = %d, want 200", rec.Code)
+	}
+}
+
+func TestRateLimitEtagExcludesProcessLocalGeneration(t *testing.T) {
+	store := NewRateLimitStore()
+	store.SetGlobal([]string{"limits-a"}) // generation 1
+	srv := NewServer(NewCertStore(), NewAuthz(map[string][]string{"tok": {"example.com"}})).WithRateLimit(store)
+	h := srv.Handler()
+
+	get := func(ifNoneMatch string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest("GET", "/v1/ratelimit", nil)
+		req.Header.Set("Authorization", "Bearer tok")
+		if ifNoneMatch != "" {
+			req.Header.Set("If-None-Match", ifNoneMatch)
+		}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec
+	}
+
+	first := get("")
+	if first.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", first.Code)
+	}
+	etag1 := first.Header().Get("ETag")
+
+	store.SetGlobal([]string{"limits-b"}) // generation 2
+	store.SetGlobal([]string{"limits-a"}) // generation 3, content identical
+	if got := get("").Header().Get("ETag"); got != etag1 {
+		t.Fatalf("ETag changed with content identical: %s -> %s (generation leaked into the validator)", etag1, got)
+	}
+	if rec := get(etag1); rec.Code != http.StatusNotModified {
+		t.Fatalf("revalidation status = %d, want 304", rec.Code)
+	}
+}

--- a/edgecp/events.go
+++ b/edgecp/events.go
@@ -1,0 +1,150 @@
+package edgecp
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// EventsSnapshot is the version vector pushed on the GET /v1/events SSE stream.
+// It is a WAKE-UP SIGNAL only: opaque per-store versions, never content. On a
+// change the edge re-runs its existing ETag-revalidated fetch for that store,
+// so authorization scoping, fail-static apply, and keep-last-good semantics all
+// stay exactly where they are today. The versions are process-local (a hash or
+// counter), so an edge must only ever compare them for INEQUALITY against the
+// previous event on the SAME stream — never persist or order them.
+type EventsSnapshot struct {
+	// WAF/RateLimit are the stores' content etags ("" when distribution is off).
+	WAF       string `json:"waf,omitempty"`
+	RateLimit string `json:"ratelimit,omitempty"`
+	// Certs is a fingerprint over the cert store's full (name, etag) index.
+	Certs string `json:"certs,omitempty"`
+	// Purges is the purge journal's last issued seq (0 = none/off).
+	Purges uint64 `json:"purges,omitempty"`
+}
+
+// EventsHub samples a version snapshot of the distribution stores and fans a
+// change event out to every subscribed /v1/events stream. Sampling (instead of
+// hooking every store mutation) keeps the stores untouched and is cheap: one
+// atomic/RLock read per store per SampleInterval.
+type EventsHub struct {
+	// SampleInterval is how often the snapshot is polled for change (default 1s).
+	SampleInterval time.Duration
+	// PingInterval is the SSE keepalive-comment cadence (default 20s). Keep it
+	// well under any fronting LB's idle timeout (Google ALB drops at ~60s idle).
+	PingInterval time.Duration
+	// MaxSubscribers bounds concurrent streams; each pins one goroutine and one
+	// connection, and the endpoint is reachable per edge token, so a runaway
+	// fleet (or a token in a reconnect loop) must shed instead of exhausting the
+	// CP (default 1024). Over-limit gets 503 + Retry-After:RetryAfterSecs.
+	MaxSubscribers int
+	// MaxPerToken bounds streams per bearer token, so one misbehaving edge (a
+	// reconnect loop that leaks streams) can't consume the GLOBAL cap and starve
+	// every other edge's stream. Replicas may share one token (one stream each),
+	// so size it >= replicas-per-token; default 32. <= 0 disables the per-token
+	// bound (the global cap still applies).
+	MaxPerToken int
+	// RetryAfterSecs is the Retry-After on a shed 503 (default 30).
+	RetryAfterSecs int
+
+	snapshot func() EventsSnapshot
+
+	mu       sync.Mutex
+	subs     map[chan EventsSnapshot]string // chan -> subscribing token
+	perToken map[string]int
+}
+
+// NewEventsHub builds a hub over the given snapshot source. Tune the exported
+// fields before Run/Subscribe; zero values get the documented defaults.
+func NewEventsHub(snapshot func() EventsSnapshot) *EventsHub {
+	return &EventsHub{
+		SampleInterval: time.Second,
+		PingInterval:   20 * time.Second,
+		MaxSubscribers: 1024,
+		MaxPerToken:    32,
+		RetryAfterSecs: 30,
+		snapshot:       snapshot,
+		subs:           map[chan EventsSnapshot]string{},
+		perToken:       map[string]int{},
+	}
+}
+
+// Current returns the live snapshot (sent as the first event of every stream,
+// so a reconnecting edge immediately covers whatever changed while it was
+// disconnected).
+func (h *EventsHub) Current() EventsSnapshot { return h.snapshot() }
+
+// Subscribe registers a stream for the given bearer token. ok=false means a
+// cap is reached — global (MaxSubscribers) or per-token (MaxPerToken) — and the
+// handler sheds with 503. The returned cancel must be called exactly once.
+// The channel is buffered; a slow consumer keeps only the LATEST undelivered
+// snapshot (each event carries the full vector, so intermediate ones are
+// redundant) — the hub never blocks on a subscriber.
+func (h *EventsHub) Subscribe(token string) (ch <-chan EventsSnapshot, cancel func(), ok bool) {
+	c := make(chan EventsSnapshot, 1)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.MaxSubscribers > 0 && len(h.subs) >= h.MaxSubscribers {
+		return nil, nil, false
+	}
+	if h.MaxPerToken > 0 && h.perToken[token] >= h.MaxPerToken {
+		return nil, nil, false
+	}
+	h.subs[c] = token
+	h.perToken[token]++
+	return c, func() {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if _, registered := h.subs[c]; !registered {
+			return // idempotent: a double cancel must not double-decrement the token count
+		}
+		delete(h.subs, c)
+		if n := h.perToken[token]; n <= 1 {
+			delete(h.perToken, token) // don't leak an entry per ever-seen token
+		} else {
+			h.perToken[token] = n - 1
+		}
+	}, true
+}
+
+// Run samples the snapshot and broadcasts on change, until ctx is done. Run it
+// in a goroutine; one per process.
+func (h *EventsHub) Run(ctx context.Context) {
+	interval := h.SampleInterval
+	if interval <= 0 {
+		interval = time.Second
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	last := h.snapshot()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			cur := h.snapshot()
+			if cur == last {
+				continue
+			}
+			last = cur
+			h.broadcast(cur)
+		}
+	}
+}
+
+func (h *EventsHub) broadcast(snap EventsSnapshot) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for c := range h.subs {
+		// Latest-wins, never block: drop the stale undelivered snapshot (if any),
+		// then enqueue the current one.
+		select {
+		case <-c:
+		default:
+		}
+		select {
+		case c <- snap:
+		default:
+		}
+	}
+}

--- a/edgecp/events_test.go
+++ b/edgecp/events_test.go
@@ -1,0 +1,256 @@
+package edgecp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestEventsHubBroadcastOnChange(t *testing.T) {
+	var version atomic.Value
+	version.Store("v1")
+	hub := NewEventsHub(func() EventsSnapshot { return EventsSnapshot{WAF: version.Load().(string)} })
+	hub.SampleInterval = 5 * time.Millisecond
+
+	ch, cancel, ok := hub.Subscribe("tok")
+	if !ok {
+		t.Fatal("subscribe should succeed under the cap")
+	}
+	defer cancel()
+
+	ctx, stop := context.WithCancel(context.Background())
+	defer stop()
+	go hub.Run(ctx)
+	// Let Run take its v1 baseline before flipping (it samples on start).
+	time.Sleep(50 * time.Millisecond)
+	version.Store("v2")
+	select {
+	case snap := <-ch:
+		if snap.WAF != "v2" {
+			t.Fatalf("snapshot WAF = %q, want v2", snap.WAF)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no broadcast after a version change")
+	}
+
+	// No change → no event.
+	select {
+	case snap := <-ch:
+		t.Fatalf("unexpected broadcast without change: %+v", snap)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestEventsHubSubscriberCapAndLatestWins(t *testing.T) {
+	hub := NewEventsHub(func() EventsSnapshot { return EventsSnapshot{} })
+	hub.MaxSubscribers = 1
+
+	ch, cancel, ok := hub.Subscribe("tok")
+	if !ok {
+		t.Fatal("first subscribe should succeed")
+	}
+	if _, _, ok := hub.Subscribe("other"); ok {
+		t.Fatal("second subscribe should be rejected at the global cap")
+	}
+
+	// A slow consumer keeps only the latest snapshot.
+	hub.broadcast(EventsSnapshot{Purges: 1})
+	hub.broadcast(EventsSnapshot{Purges: 2})
+	if snap := <-ch; snap.Purges != 2 {
+		t.Fatalf("slow consumer got %d, want the latest (2)", snap.Purges)
+	}
+
+	cancel()
+	if _, cancel2, ok := hub.Subscribe("tok"); !ok {
+		t.Fatal("subscribe should succeed again after cancel freed the slot")
+	} else {
+		cancel2()
+	}
+}
+
+func TestEventsHubPerTokenCap(t *testing.T) {
+	hub := NewEventsHub(func() EventsSnapshot { return EventsSnapshot{} })
+	hub.MaxSubscribers = 10
+	hub.MaxPerToken = 1
+
+	_, cancelA, ok := hub.Subscribe("a")
+	if !ok {
+		t.Fatal("first subscribe for token a should succeed")
+	}
+	if _, _, ok := hub.Subscribe("a"); ok {
+		t.Fatal("second subscribe for token a should be rejected at the per-token cap")
+	}
+	// Another token is unaffected: the cap is per token, not global.
+	if _, cancelB, ok := hub.Subscribe("b"); !ok {
+		t.Fatal("token b should not be starved by token a's cap")
+	} else {
+		defer cancelB()
+	}
+
+	// Double cancel must not double-decrement (idempotent), and the freed slot
+	// must be reusable.
+	cancelA()
+	cancelA()
+	if _, cancelA2, ok := hub.Subscribe("a"); !ok {
+		t.Fatal("token a should subscribe again after cancel")
+	} else {
+		cancelA2()
+	}
+}
+
+// eventsTestServer wires a real Server + hub on an httptest server (SSE needs a
+// real flusher; httptest.NewRecorder can't stream).
+func eventsTestServer(t *testing.T, hub *EventsHub) *httptest.Server {
+	t.Helper()
+	srv := NewServer(NewCertStore(), NewAuthz(map[string][]string{"tok": {"example.com"}}))
+	if hub != nil {
+		srv = srv.WithEvents(hub)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestHandleEventsAuthAndDisabled(t *testing.T) {
+	ts := eventsTestServer(t, nil) // events disabled
+
+	req, _ := http.NewRequest("GET", ts.URL+"/v1/events", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("no token: status = %d, want 401", resp.StatusCode)
+	}
+
+	req.Header.Set("Authorization", "Bearer tok")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("events disabled: status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestHandleEventsStreamsInitialAndChange(t *testing.T) {
+	var version atomic.Value
+	version.Store("v1")
+	hub := NewEventsHub(func() EventsSnapshot { return EventsSnapshot{WAF: version.Load().(string)} })
+	hub.SampleInterval = 5 * time.Millisecond
+	ctx, stop := context.WithCancel(context.Background())
+	defer stop()
+	go hub.Run(ctx)
+	time.Sleep(50 * time.Millisecond) // let Run take its v1 baseline
+
+	ts := eventsTestServer(t, hub)
+	req, _ := http.NewRequest("GET", ts.URL+"/v1/events", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("content type = %q", ct)
+	}
+
+	sc := bufio.NewScanner(resp.Body) // one scanner: its buffer may hold the next event
+	readEvent := func() EventsSnapshot {
+		t.Helper()
+		var data string
+		for sc.Scan() {
+			line := sc.Text()
+			if strings.HasPrefix(line, "data:") {
+				data = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			}
+			if line == "" && data != "" {
+				break
+			}
+		}
+		if data == "" {
+			t.Fatalf("stream ended without an event: %v", sc.Err())
+		}
+		var snap EventsSnapshot
+		if err := json.Unmarshal([]byte(data), &snap); err != nil {
+			t.Fatal(err)
+		}
+		return snap
+	}
+
+	if snap := readEvent(); snap.WAF != "v1" {
+		t.Fatalf("initial event WAF = %q, want v1", snap.WAF)
+	}
+	version.Store("v2")
+	if snap := readEvent(); snap.WAF != "v2" {
+		t.Fatalf("change event WAF = %q, want v2", snap.WAF)
+	}
+}
+
+func TestHandleEventsPingIntervalFloor(t *testing.T) {
+	hub := NewEventsHub(func() EventsSnapshot { return EventsSnapshot{WAF: "v"} })
+	hub.PingInterval = 0 // a zeroed env knob must degrade to the default, not panic NewTicker
+	ts := eventsTestServer(t, hub)
+
+	req, _ := http.NewRequest("GET", ts.URL+"/v1/events", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	// The initial event must arrive (the handler survived the zero interval).
+	buf := make([]byte, 16)
+	if _, err := resp.Body.Read(buf); err != nil {
+		t.Fatalf("initial event not readable: %v", err)
+	}
+}
+
+func TestHandleEventsShedsOverCap(t *testing.T) {
+	hub := NewEventsHub(func() EventsSnapshot { return EventsSnapshot{} })
+	hub.MaxSubscribers = 1
+	ts := eventsTestServer(t, hub)
+
+	open := func() *http.Response {
+		req, _ := http.NewRequest("GET", ts.URL+"/v1/events", nil)
+		req.Header.Set("Authorization", "Bearer tok")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return resp
+	}
+	first := open()
+	defer first.Body.Close()
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("first stream status = %d, want 200", first.StatusCode)
+	}
+	// Wait for the first stream's initial event so its Subscribe has happened.
+	buf := make([]byte, 1)
+	if _, err := first.Body.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	second := open()
+	defer second.Body.Close()
+	if second.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("over-cap stream status = %d, want 503", second.StatusCode)
+	}
+	if second.Header.Get("Retry-After") == "" {
+		t.Fatal("shed 503 must carry Retry-After")
+	}
+}

--- a/edgecp/purgestore.go
+++ b/edgecp/purgestore.go
@@ -76,6 +76,14 @@ func NewPurgeStore(maxEntries int) *PurgeStore {
 	return &PurgeStore{minSeq: 1, maxKeep: maxEntries}
 }
 
+// LastSeq returns the highest issued seq (0 = none yet) — the /v1/events change
+// signal for the purge journal.
+func (s *PurgeStore) LastSeq() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastSeq
+}
+
 // Add appends a purge and returns its seq. scope must be one of flush-all / host /
 // url / prefix / tag. host is required (and normalized) for host/url/prefix; uri is
 // required for url (the exact on-the-wire path+query) and prefix (the path prefix),

--- a/edgecp/ratelimitstore.go
+++ b/edgecp/ratelimitstore.go
@@ -102,6 +102,10 @@ func (s *RateLimitStore) recompute() {
 	s.curEtag.Store(&et)
 }
 
+// Version is the store's full-content etag — an opaque change signal for the
+// /v1/events stream (per-edge scoping happens at fetch time, not here).
+func (s *RateLimitStore) Version() string { return *s.curEtag.Load() }
+
 // fingerprint is a stable serialization of the full content. Documents are
 // length-prefixed so doc-slice boundaries are unambiguous (["a","bc"] vs
 // ["ab","c"]), mirroring the controller's fingerprintDocs.

--- a/edgecp/server.go
+++ b/edgecp/server.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // Server is the edge control-plane HTTP API. It authorizes each request by the
@@ -36,6 +37,11 @@ type Server struct {
 	// disabled, POST /v1/metrics → 404). Serving happens on the separate
 	// CP_METRICS_LISTEN via MetricsHandler, not on this API mux.
 	metricsStore *MetricsStore
+
+	// events is the optional change-notification hub (nil = /v1/events → 404 and
+	// edges fall back to pure polling). The stream is a wake-up signal only; the
+	// edge still fetches through the scoped, ETag-revalidated endpoints above.
+	events *EventsHub
 
 	// signerState is the (signer, generation) snapshot, replaced WHOLESALE by
 	// SetSigner so a reader Loads both halves coherently (never a torn signer-from-A
@@ -131,6 +137,13 @@ func (s *Server) WithRateLimit(rl *RateLimitStore) *Server {
 	return s
 }
 
+// WithEvents enables the change-notification stream (GET /v1/events). Returns
+// the server for chaining; the caller runs hub.Run in its own goroutine.
+func (s *Server) WithEvents(hub *EventsHub) *Server {
+	s.events = hub
+	return s
+}
+
 // WithPurge enables cache-purge distribution: GET /v1/purges (per-edge bearer,
 // scoped) and POST /v1/purges (gated by adminToken). An empty adminToken leaves
 // POST locked out (every issue attempt 401s) — read distribution still works.
@@ -207,6 +220,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /v1/waf", s.handleWAF)
 	mux.HandleFunc("GET /v1/ratelimit", s.handleRateLimit)
 	mux.HandleFunc("GET /v1/purges", s.handlePurges)
+	mux.HandleFunc("GET /v1/events", s.handleEvents)
 	mux.HandleFunc("POST /v1/purges", s.handlePurgeAdmin)
 	mux.HandleFunc("POST /v1/metrics", s.handleMetricsPush)
 	mux.HandleFunc("POST /v1/edge-cert", s.handleEdgeCert)
@@ -344,8 +358,21 @@ func (s *Server) handleWAF(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "encode", http.StatusInternalServerError)
 		return
 	}
-	// ETag over the scoped bytes (per-edge content differs, so per-edge etag).
-	etag := etagOfString(string(body))
+	// ETag over the scoped bytes (per-edge content differs, so per-edge etag) —
+	// with the GENERATION ZEROED: it is a process-local counter, so two CP
+	// replicas serving byte-identical content would otherwise mint different
+	// validators and an edge whose polls rotate across replicas would never
+	// 304 (full bundle + recompile every poll). The real generation still rides
+	// the 200 body; the in-body ca_id/signing fp stay in the validator (they are
+	// replica-identical — derived from the shared CA Secret).
+	etagResp := resp
+	etagResp.Generation = 0
+	etagBody, err := json.Marshal(etagResp)
+	if err != nil {
+		http.Error(w, "encode", http.StatusInternalServerError)
+		return
+	}
+	etag := etagOfString(string(etagBody))
 	w.Header().Set("ETag", etag)
 	if match := r.Header.Get("If-None-Match"); match != "" && etagMatch(match, etag) {
 		w.WriteHeader(http.StatusNotModified)
@@ -404,7 +431,16 @@ func (s *Server) handleRateLimit(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "encode", http.StatusInternalServerError)
 		return
 	}
-	etag := etagOfString(string(body))
+	// Generation zeroed in the validator for the same reason as handleWAF:
+	// process-local counters must not defeat 304 revalidation across replicas.
+	etagResp := resp
+	etagResp.Generation = 0
+	etagBody, err := json.Marshal(etagResp)
+	if err != nil {
+		http.Error(w, "encode", http.StatusInternalServerError)
+		return
+	}
+	etag := etagOfString(string(etagBody))
 	w.Header().Set("ETag", etag)
 	if match := r.Header.Get("If-None-Match"); match != "" && etagMatch(match, etag) {
 		w.WriteHeader(http.StatusNotModified)
@@ -440,6 +476,87 @@ func (s *Server) handlePurges(w http.ResponseWriter, r *http.Request) {
 	res := s.purge.Since(since, func(host string) bool { return s.authz.Allowed(token, host) })
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(res)
+}
+
+// handleEvents serves the change-notification SSE stream (GET /v1/events),
+// authorized by the per-edge bearer token. Each event is the full version
+// vector (EventsSnapshot) — an opaque wake-up signal; the edge re-fetches
+// changed material through the scoped, ETag-revalidated endpoints, so nothing
+// here bypasses authorization or fail-static apply. The first event is the
+// current snapshot (a reconnecting edge immediately covers its gap), then one
+// event per change, with `: ping` keepalive comments between (sized to stay
+// under a fronting LB's idle timeout). Subscribers are capped (503 +
+// Retry-After when full — the edge falls back to polling, its floor anyway).
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	token, ok := bearer(r)
+	if !ok || !s.authz.Known(token) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if s.events == nil {
+		http.Error(w, "events disabled", http.StatusNotFound)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	ch, cancel, ok := s.events.Subscribe(token)
+	if !ok {
+		retryAfter := s.events.RetryAfterSecs
+		if retryAfter <= 0 {
+			retryAfter = 30
+		}
+		w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+		http.Error(w, "too many event subscribers", http.StatusServiceUnavailable)
+		return
+	}
+	defer cancel()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("X-Accel-Buffering", "no") // tell buffering proxies to pass events through
+
+	writeEvent := func(snap EventsSnapshot) bool {
+		body, err := json.Marshal(snap)
+		if err != nil {
+			return false
+		}
+		if _, err := w.Write([]byte("event: change\ndata: " + string(body) + "\n\n")); err != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+	if !writeEvent(s.events.Current()) {
+		return
+	}
+
+	// Floor the ping cadence: time.NewTicker panics on <= 0 (a hub configured
+	// from a zeroed env var must degrade, not break every stream), and the ping
+	// exists to beat a fronting LB's idle timeout — 20s matches the default.
+	pingInterval := s.events.PingInterval
+	if pingInterval <= 0 {
+		pingInterval = 20 * time.Second
+	}
+	ping := time.NewTicker(pingInterval)
+	defer ping.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case snap := <-ch:
+			if !writeEvent(snap) {
+				return
+			}
+		case <-ping.C:
+			if _, err := w.Write([]byte(": ping\n\n")); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
 }
 
 // handlePurgeAdmin issues a cache purge (POST /v1/purges), gated by the purge admin

--- a/edgecp/wafstore.go
+++ b/edgecp/wafstore.go
@@ -103,6 +103,10 @@ func (s *WafStore) fingerprint() string {
 	return b.String()
 }
 
+// Version is the store's full-content etag — an opaque change signal for the
+// /v1/events stream (per-edge scoping happens at fetch time, not here).
+func (s *WafStore) Version() string { return *s.curEtag.Load() }
+
 // scopedSnapshot is the per-edge WAF payload: global (shared) + only the zones
 // and host bindings for hosts the edge is allowed to serve.
 type scopedSnapshot struct {


### PR DESCRIPTION
## Problem

The edge fronts the control plane through a Google ALB that drops connections idle for >60s. The `CpClient` transport had **no `IdleConnTimeout`**, so half-dead pooled connections survived the drop and the edge kept serving **stale WAF / ratelimit / cert config until restarted**. Polls were also fully jittered, so a missed change could persist for up to a full interval.

Reported symptoms this addresses:
- "edge proxy stop pull waf config and keep using stale config until restart"
- `WARN edge: purge poll failed; keeping applied epochs error="control plane returned 503 for /v1/purges"` (the fronting LB / an unready CP, not `handlePurges`)

## Fix

**Transport bounds** — every pre-response phase now has a timeout (Dial 10s, TLS 10s, ResponseHeader 30s) plus `IdleConnTimeout: 30s`, comfortably under the ALB's ~60s idle drop, so no pooled connection outlives the LB's view of it.

**SSE wake-up stream** — updates now land in seconds while **polling stays the correctness floor**:

- **edgecp** `GET /v1/events` streams a **version vector only** (waf etag, ratelimit etag, certstore fingerprint, purge lastSeq) — never content. `EventsHub` samples stores every 1s, broadcasts latest-wins on change, pings every 20s (< ALB idle). Bearer-authed; 404 when disabled; 503 + `Retry-After` over the global / per-token subscriber caps. Knobs: `CP_EVENTS_ENABLED`, `CP_EVENTS_PING_INTERVAL`, `CP_EVENTS_MAX_SUBSCRIBERS`, `CP_EVENTS_MAX_PER_TOKEN`, `CP_EVENTS_RETRY_AFTER`.
- **edge** `RunEvents` subscribes and **pokes the existing refresh loops** (buffered(1) chans → single-flight preserved); all fetches stay scoped, ETag-revalidated, and fail-static. `404` → 5m re-probe (old CP) and clean fallback to pure polling. `EDGE_EVENTS_ENABLED` (default on).

## Hardening (from review + adversarial workflow)

- **Connect jitter** decorrelates the fleet (a CP restart EOFs everyone at once); boot `[0,5s)`, post-EOF reconnect `[0,2s)`.
- **Delivered-stream backoff reset** — LB response-timeout cuts arrive as unclean `io.ErrUnexpectedEOF` (no terminal 0-chunk), so an error-only backoff would ratchet the whole fleet to permanent max backoff. Any stream that delivered events resets backoff regardless of how it ended.
- **Watchdog armed before `OpenEvents`** + transport timeouts so a half-dead LB can't wedge the subscriber goroutine.
- **WAF/ratelimit ETag excludes the process-local generation** — byte-identical CP replicas now mint identical validators, so an edge whose polls rotate across replicas (per the new `IdleConnTimeout`) still gets 304s instead of re-downloading + recompiling every poll. The real generation still rides the 200 body; the core checks the WAF claim by presence, so this is wire-compatible. (Same bug class previously fixed for the signer generation in `resourceversion.go`; the WAF/RL stores had been missed.)

## Tests

653 tests pass under `-race` across 23 packages; `gofmt`/`go vet` clean. New regression coverage: hub broadcast-on-change + caps + idempotent cancel, SSE stream init/change events, ping-interval floor, 503 shed; edge poke-on-change, zero-event-EOF → backoff, unclean-cut → delivered=true, `OpenEvents` unsupported/non-SSE rejection; ETag-excludes-generation pinning 304s across generation churn.

## Follow-up (not in this PR)

`edgecp/*reload.go` watchers re-establish a closed k8s watch **without relisting**, so events in the gap are lost (the controller's `watchResource` has `resyncStore` for exactly this). Without it a replica can serve stale content with an honest ETag — and SSE would then stream a stale version vector. Recommended as the next change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)