### PR TITLE
fix(edgecp): relist on every watch reconnect so a CP never serves stale config

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -356,6 +356,22 @@ CP knobs: `CP_EVENTS_MAX_SUBSCRIBERS` (default 1024) and
 each, so size it ≥ replicas-per-token); over-cap streams shed with 503 +
 `Retry-After: CP_EVENTS_RETRY_AFTER` (default 30s).
 
+**CP store freshness (relist on reconnect).** The version vector — and every
+fetch the edge makes — is only as fresh as the CP's own view of the cluster. The
+CP's reloaders (Secrets, WAF/ratelimit ConfigMaps, Ingresses, the CA Secret)
+watch with a bare k8s watch that carries no resourceVersion and never replays
+history, so a change landing in the gap between one watch closing (a server
+timeout, a 410 watch-cache compaction, a transient disconnect) and the next
+opening is never delivered as an event. Because each reload rebuilds the whole
+store and only fires on an event, such a change would otherwise persist until an
+unrelated later event or a CP restart — a replica serving stale content under an
+*honest* ETag, with `/v1/events` advertising a stale vector. The CP closes this
+by **relisting on every watch (re)connect** (`watchAndRelist`, mirroring the
+controller's `resyncStore`): the watch is established first, then the store is
+relisted, so anything missed while no watch was live is recovered and any change
+after that point is delivered on the live watch. Each store is content-gated, so
+a no-change relist neither bumps an ETag nor wakes the fleet over `/v1/events`.
+
 ## WAF at the edge
 
 Unchanged from the keyless design — the WAF half never depended on how TLS keys

--- a/edgecp/ingressreload.go
+++ b/edgecp/ingressreload.go
@@ -45,22 +45,12 @@ func (r *IngressReloader) WithRateLimit(rl *RateLimitStore) *IngressReloader {
 // LoadOnce does a single synchronous load (call before serving — see WafReloader).
 func (r *IngressReloader) LoadOnce(ctx context.Context) error { return r.reload(ctx) }
 
-// Watch re-establishes the Ingress watch and reloads on change. Run after LoadOnce.
+// Watch relists on every (re)connect (see watchAndRelist) and reloads on change.
+// Run after LoadOnce.
 func (r *IngressReloader) Watch(ctx context.Context) {
-	for ctx.Err() == nil {
-		w, err := k8s.WatchIngresses(ctx, r.watchNamespace)
-		if err != nil {
-			slog.Error("edgecp: watch ingresses failed; retrying", "err", err)
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(time.Second):
-			}
-			continue
-		}
-		r.drain(ctx, w.ResultChan())
-		w.Stop()
-	}
+	watchAndRelist(ctx, "ingresses",
+		func(ctx context.Context) (watch.Interface, error) { return k8s.WatchIngresses(ctx, r.watchNamespace) },
+		r.reload, r.drain)
 }
 
 func (r *IngressReloader) drain(ctx context.Context, ch <-chan watch.Event) {

--- a/edgecp/ratelimitreload.go
+++ b/edgecp/ratelimitreload.go
@@ -35,23 +35,15 @@ func NewRateLimitReloader(store *RateLimitStore, watchNamespace, podNamespace st
 // edge fetch sees a populated store (same startup ordering as the WafReloader).
 func (r *RateLimitReloader) LoadOnce(ctx context.Context) error { return r.reload(ctx) }
 
-// Watch re-establishes the ConfigMap watch and reloads (debounced) on change.
-// Blocks until ctx is cancelled; run it in a goroutine after LoadOnce.
+// Watch relists on every (re)connect (see watchAndRelist) and reloads
+// (debounced) on change. Blocks until ctx is cancelled; run it in a goroutine
+// after LoadOnce.
 func (r *RateLimitReloader) Watch(ctx context.Context) {
-	for ctx.Err() == nil {
-		w, err := k8s.WatchConfigMaps(ctx, r.watchNamespace, RateLimitLabelKey)
-		if err != nil {
-			slog.Error("edgecp: watch ratelimit configmaps failed; retrying", "err", err)
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(time.Second):
-			}
-			continue
-		}
-		r.drain(ctx, w.ResultChan())
-		w.Stop()
-	}
+	watchAndRelist(ctx, "ratelimit configmaps",
+		func(ctx context.Context) (watch.Interface, error) {
+			return k8s.WatchConfigMaps(ctx, r.watchNamespace, RateLimitLabelKey)
+		},
+		r.reload, r.drain)
 }
 
 func (r *RateLimitReloader) drain(ctx context.Context, ch <-chan watch.Event) {

--- a/edgecp/reload.go
+++ b/edgecp/reload.go
@@ -29,16 +29,51 @@ func NewReloader(store *CertStore, namespace, skipSecret string) *Reloader {
 	return &Reloader{store: store, namespace: namespace, skipSecret: skipSecret, debounce: 300 * time.Millisecond}
 }
 
-// Start does the initial load and then watches Secrets, reloading on change.
+// Start watches Secrets, relisting on every (re)connect and on change.
 // Blocks until ctx is cancelled; run it in a goroutine.
 func (r *Reloader) Start(ctx context.Context) {
-	if err := r.reload(ctx); err != nil {
-		slog.Error("edgecp: initial secret load failed", "err", err)
-	}
+	watchAndRelist(ctx, "secrets",
+		func(ctx context.Context) (watch.Interface, error) { return k8s.WatchSecrets(ctx, r.namespace) },
+		r.reload, r.drain)
+}
+
+// watchAndRelist is the relist-on-(re)connect watch loop every edgecp reloader
+// shares. On each iteration it (re)establishes the watch, RELISTS once via
+// reload, then drains events (each triggers a debounced reload) until the watch
+// closes — then reconnects.
+//
+// The relist is the fix for a silent-staleness bug: the bare k8s Watch carries
+// no resourceVersion and never replays history, so a change that lands in the
+// gap between one watch closing and the next opening is never delivered. Because
+// every reload is a full rebuild triggered only by a watch event, that missed
+// change would otherwise persist until some unrelated later event — or a process
+// restart (the "edge keeps stale config until restart" incident). Relisting once
+// the watch is live closes the gap: anything that changed while no watch was
+// established is captured by the list, and any change from this point on is
+// delivered as an event on w. This mirrors the controller's resyncStore
+// (controller.go), but is simpler here because each reload already rebuilds the
+// whole store, so events only need to act as a trigger — not be replayed in
+// order. Establishing the watch BEFORE the relist (rather than after, as the
+// controller does) leaves no residual gap: a change racing the relist still
+// delivers an event on the now-live watch.
+//
+// Every edgecp store is content-gated (cert version, WAF/ratelimit recompute,
+// the signer's ca_id/active-fp tuple), so a no-change relist is a true no-op —
+// no etag bump and no /v1/events wake of the edge fleet.
+//
+// drain blocks until the watch channel closes (so the loop reconnects) or ctx is
+// done; label names the resource in logs.
+func watchAndRelist(
+	ctx context.Context,
+	label string,
+	watchFn func(ctx context.Context) (watch.Interface, error),
+	reload func(ctx context.Context) error,
+	drain func(ctx context.Context, ch <-chan watch.Event),
+) {
 	for ctx.Err() == nil {
-		w, err := k8s.WatchSecrets(ctx, r.namespace)
+		w, err := watchFn(ctx)
 		if err != nil {
-			slog.Error("edgecp: watch secrets failed; retrying", "err", err)
+			slog.Error("edgecp: watch "+label+" failed; retrying", "err", err)
 			select {
 			case <-ctx.Done():
 				return
@@ -46,7 +81,10 @@ func (r *Reloader) Start(ctx context.Context) {
 			}
 			continue
 		}
-		r.drain(ctx, w.ResultChan())
+		if err := reload(ctx); err != nil {
+			slog.Error("edgecp: "+label+" relist on watch (re)connect failed; keeping last-good", "err", err)
+		}
+		drain(ctx, w.ResultChan())
 		w.Stop()
 	}
 }

--- a/edgecp/reload_test.go
+++ b/edgecp/reload_test.go
@@ -11,6 +11,23 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
+// drainUntilClosedOrDone mirrors the real reloader drains: it returns when the
+// watch channel closes (so the loop reconnects) OR when ctx is cancelled (so the
+// helper goroutine shuts down cleanly at test end instead of parking on a
+// watcher nobody stops).
+func drainUntilClosedOrDone(ctx context.Context, ch <-chan watch.Event) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-ch:
+			if !ok {
+				return
+			}
+		}
+	}
+}
+
 // watchAndRelist must relist via reload on EVERY watch (re)connect — including
 // reconnects that deliver zero events. This is the fix for the silent-staleness
 // bug: a change that lands in the gap between one watch closing and the next
@@ -33,13 +50,8 @@ func TestWatchAndRelistRelistsOnEveryReconnect(t *testing.T) {
 		relists.Add(1)
 		return nil
 	}
-	// drain mirrors the real reloaders: return when the watch channel closes.
-	drain := func(_ context.Context, ch <-chan watch.Event) {
-		for range ch {
-		}
-	}
 
-	go watchAndRelist(ctx, "test", watchFn, reload, drain)
+	go watchAndRelist(ctx, "test", watchFn, reload, drainUntilClosedOrDone)
 
 	waitRelists := func(want int32) {
 		t.Helper()
@@ -85,12 +97,8 @@ func TestWatchAndRelistRetriesWatchErrorThenRelists(t *testing.T) {
 		relists.Add(1)
 		return nil
 	}
-	drain := func(_ context.Context, ch <-chan watch.Event) {
-		for range ch {
-		}
-	}
 
-	go watchAndRelist(ctx, "test", watchFn, reload, drain)
+	go watchAndRelist(ctx, "test", watchFn, reload, drainUntilClosedOrDone)
 
 	// The first attempt errored (no relist); the retry establishes and relists.
 	w := <-established

--- a/edgecp/reload_test.go
+++ b/edgecp/reload_test.go
@@ -1,0 +1,101 @@
+package edgecp
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// watchAndRelist must relist via reload on EVERY watch (re)connect — including
+// reconnects that deliver zero events. This is the fix for the silent-staleness
+// bug: a change that lands in the gap between one watch closing and the next
+// opening is never delivered (a bare Watch carries no resourceVersion), so
+// without the reconnect relist it would persist until an unrelated later event
+// or a process restart.
+func TestWatchAndRelistRelistsOnEveryReconnect(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var relists atomic.Int32
+	established := make(chan *watch.FakeWatcher, 8)
+
+	watchFn := func(context.Context) (watch.Interface, error) {
+		w := watch.NewFake()
+		established <- w
+		return w, nil
+	}
+	reload := func(context.Context) error {
+		relists.Add(1)
+		return nil
+	}
+	// drain mirrors the real reloaders: return when the watch channel closes.
+	drain := func(_ context.Context, ch <-chan watch.Event) {
+		for range ch {
+		}
+	}
+
+	go watchAndRelist(ctx, "test", watchFn, reload, drain)
+
+	waitRelists := func(want int32) {
+		t.Helper()
+		require.Eventually(t, func() bool { return relists.Load() >= want },
+			2*time.Second, 5*time.Millisecond, "want >= %d relists, got %d", want, relists.Load())
+	}
+
+	// First watch establishes → relist happens with NO events delivered.
+	w1 := <-established
+	waitRelists(1)
+
+	// Close the watch with zero events in flight: drain returns, the loop
+	// reconnects, and the reconnect MUST relist again (the gap-closing fix).
+	w1.Stop()
+	w2 := <-established
+	waitRelists(2)
+
+	// And once more, to show it's every reconnect, not just the first.
+	w2.Stop()
+	<-established
+	waitRelists(3)
+}
+
+// A watchFn error must back off and retry without ever calling reload for that
+// failed attempt, then relist once the watch finally establishes.
+func TestWatchAndRelistRetriesWatchErrorThenRelists(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var relists atomic.Int32
+	var attempts atomic.Int32
+	established := make(chan *watch.FakeWatcher, 4)
+
+	watchFn := func(context.Context) (watch.Interface, error) {
+		if attempts.Add(1) == 1 {
+			return nil, errors.New("api down")
+		}
+		w := watch.NewFake()
+		established <- w
+		return w, nil
+	}
+	reload := func(context.Context) error {
+		relists.Add(1)
+		return nil
+	}
+	drain := func(_ context.Context, ch <-chan watch.Event) {
+		for range ch {
+		}
+	}
+
+	go watchAndRelist(ctx, "test", watchFn, reload, drain)
+
+	// The first attempt errored (no relist); the retry establishes and relists.
+	w := <-established
+	require.Eventually(t, func() bool { return relists.Load() == 1 },
+		3*time.Second, 5*time.Millisecond, "relist must run only after the watch establishes")
+	require.GreaterOrEqual(t, attempts.Load(), int32(2))
+	w.Stop()
+}

--- a/edgecp/signerreload.go
+++ b/edgecp/signerreload.go
@@ -54,23 +54,14 @@ func NewSignerReloader(server *Server, namespace, caSecret string, ttl, skew tim
 // until the bootstrap Job lands.
 func (r *SignerReloader) LoadOnce(ctx context.Context) error { return r.reload(ctx) }
 
-// Watch re-establishes a Secret watch and reloads (debounced) on every event that
-// touches the CA Secret. Blocks until ctx is cancelled; run it in a goroutine.
+// Watch relists on every (re)connect (see watchAndRelist) and reloads (debounced)
+// on every event that touches the CA Secret. The reconnect relist is tuple-gated
+// in reload (ca_id, active-fp), so it never churns the generation on a no-op.
+// Blocks until ctx is cancelled; run it in a goroutine.
 func (r *SignerReloader) Watch(ctx context.Context) {
-	for ctx.Err() == nil {
-		w, err := k8s.WatchSecrets(ctx, r.namespace)
-		if err != nil {
-			slog.Error("edgecp: signer watch secrets failed; retrying", "err", err)
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(time.Second):
-			}
-			continue
-		}
-		r.drain(ctx, w.ResultChan())
-		w.Stop()
-	}
+	watchAndRelist(ctx, "signer secrets",
+		func(ctx context.Context) (watch.Interface, error) { return k8s.WatchSecrets(ctx, r.namespace) },
+		r.reload, r.drain)
 }
 
 // isCASecret reports whether a watch event concerns the CA Secret by name (so

--- a/edgecp/wafreload.go
+++ b/edgecp/wafreload.go
@@ -36,23 +36,15 @@ func NewWafReloader(store *WafStore, watchNamespace, podNamespace string) *WafRe
 // an empty ruleset until the next refresh).
 func (r *WafReloader) LoadOnce(ctx context.Context) error { return r.reload(ctx) }
 
-// Watch re-establishes the ConfigMap watch and reloads (debounced) on change.
-// Blocks until ctx is cancelled; run it in a goroutine after LoadOnce.
+// Watch relists on every (re)connect (see watchAndRelist) and reloads
+// (debounced) on change. Blocks until ctx is cancelled; run it in a goroutine
+// after LoadOnce.
 func (r *WafReloader) Watch(ctx context.Context) {
-	for ctx.Err() == nil {
-		w, err := k8s.WatchConfigMaps(ctx, r.watchNamespace, WAFLabelKey)
-		if err != nil {
-			slog.Error("edgecp: watch configmaps failed; retrying", "err", err)
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(time.Second):
-			}
-			continue
-		}
-		r.drain(ctx, w.ResultChan())
-		w.Stop()
-	}
+	watchAndRelist(ctx, "waf configmaps",
+		func(ctx context.Context) (watch.Interface, error) {
+			return k8s.WatchConfigMaps(ctx, r.watchNamespace, WAFLabelKey)
+		},
+		r.reload, r.drain)
 }
 
 func (r *WafReloader) drain(ctx context.Context, ch <-chan watch.Event) {


### PR DESCRIPTION
## Problem

This is the **CP-side half** of the "edge keeps stale WAF/config until restart" incident (the edge-side half — missing `IdleConnTimeout` + the SSE accelerator — shipped in #148).

The control plane's reloaders (Secrets, WAF/ratelimit ConfigMaps, Ingresses, the CA Secret) watch with a **bare k8s watch — no `resourceVersion`, no history replay**. When the watch channel closed (a server timeout, a `410` watch-cache compaction, a transient disconnect), `drain` returned **without relisting**, and the fresh watch only fired on the *next* change. Because each `reload` rebuilds the whole store and only fires on a watch event, a change that landed in that gap **persisted until some unrelated later event — or a process restart**.

The result: a replica serving **stale content under an honest ETag**, and (since #148) advertising a **stale `/v1/events` version vector**, until restarted. No amount of edge-side polling could recover it, because the CP itself was wrong.

## Fix

Factor the five near-identical watch loops into one `watchAndRelist` helper (`edgecp/reload.go`) that **relists on every (re)connect**, mirroring the controller's `resyncStore` (`controller.go`). All five reloaders — cert `Reloader.Start`, and `Watch` on the WAF / ratelimit / Ingress / signer reloaders — now delegate to it.

Ordering: it establishes the watch **first**, then relists — so a change racing the relist still delivers an event on the live watch, leaving **no residual gap** (stricter than the controller's relist-after-close ordering). Unlike the controller it needs no reconcile pass: each `reload` is already a full rebuild, so events are only a *trigger* and their order doesn't matter.

**Churn-free:** every edgecp store is content-gated — the cert store's `version` fingerprint, the WAF/ratelimit `recompute` ETag, and the signer's `(ca_id, active-fp)` tuple gate. So a no-change relist is a true no-op: **no ETag bump, no `/v1/events` wake of the edge fleet.** Watches reconnect on the order of minutes, so the extra LIST is negligible. (The cert store was already commented as designed for exactly this: "a no-change relist of the cluster's secrets doesn't wake the fleet.")

## Tests

- `TestWatchAndRelistRelistsOnEveryReconnect` — a **zero-event** reconnect still relists (via `watch.NewFake`), proving the gap is closed even when no event ever arrives on the new watch.
- `TestWatchAndRelistRetriesWatchErrorThenRelists` — a watch-establish error backs off and relists only once the watch actually establishes (never on a failed attempt).

655 tests pass under `-race` across 23 packages; `gofmt`/`go vet` clean. EDGE.md gains a "CP store freshness (relist on reconnect)" note explaining why the version vector is only as fresh as the CP's own view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)