### PR TITLE
feat(edge): per-edge request metric + GET /v1/hosts known-host oracle

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -64,6 +64,7 @@ client ──TLS──► edge (Go/parapet, outside k8s)                        
                   │     GET /v1/certs?sni=… → cert+key+ETag (allowed SNI) │
                   │     GET /v1/waf         → rules for edge domains      │
                   │     GET /v1/ratelimit   → limits for edge domains     │
+                  │     GET /v1/hosts       → known hosts (metric oracle) │
                   │   authz: bearer token → allowed domains/zones         │
                   │   reads: TLS Secrets, WAF + ratelimit ConfigMaps,     │
                   │          Ingresses                                    │
@@ -117,6 +118,7 @@ check gates both endpoints:
 - `GET /v1/certs/{sni}` → require `sni ∈ allowed(token)`.
 - `GET /v1/waf` → return only the zones / host-map entries for the token's domains.
 - `GET /v1/ratelimit` → same scoping (zones, host-map, known hosts) per token.
+- `GET /v1/hosts` → only the known hosts for the token's domains (the request metric's host oracle).
 
 Server-side TLS is mandatory here: it encrypts the token **and the returned
 private key** in flight and lets the edge authenticate the control plane. The
@@ -191,6 +193,23 @@ GET /v1/ratelimit     Authorization: Bearer <token>   [If-None-Match: "<etag>"]
         ETag over the scoped payload with the generation excluded, like /v1/waf)
   401 (no/invalid token)   404 (ratelimit distribution disabled)
 
+GET /v1/hosts         Authorization: Bearer <token>   [If-None-Match: "<etag>"]
+  200 {"generation": N, "hosts":["…"]}
+       hosts          : every Ingress-declared host the edge may serve, scoped to
+                        the token's domains (sorted, deduped). The edge wires it as
+                        the request metric's host oracle: parapet_requests's `host`
+                        label is bounded to this set (an unknown host collapses to
+                        "other"), giving EXACT per-host labels while keeping series
+                        cardinality bounded under a random-Host flood.
+       STANDALONE — not folded into /v1/waf or /v1/ratelimit — because the metric is
+       always on (even with WAF + rate-limiting off) and a stale/empty list only
+       over-collapses the label to "other" (a cardinality bound, never a WAF/limit
+       correctness signal), so it has NO atomicity coupling with those payloads.
+       Served by default (CP_HOSTS_ENABLED, default true); it rides the same Ingress
+       watch as the WAF/ratelimit binding derivation.
+       (ETag over the scoped payload with the generation excluded, like /v1/waf)
+  401 (no/invalid token)   404 (hosts distribution disabled / older CP)
+
 GET /v1/purges?since=<seq>   Authorization: Bearer <token>
   200 {"entries":[{"seq":N,"scope":"url|host|prefix|tag|flush-all","host":"…","uri":"…","tag":"…"}],
        "max_seq": N, "flush_required": false}
@@ -224,7 +243,7 @@ POST /v1/purges       Authorization: Bearer <ADMIN token>   ← stronger cred th
 GET /v1/events        Authorization: Bearer <token>   (SSE; long-lived)
   200 Content-Type: text/event-stream — change-notification stream. Each event:
        event: change
-       data: {"waf":"<etag>","ratelimit":"<etag>","certs":"<fp>","purges":<seq>}
+       data: {"waf":"<etag>","ratelimit":"<etag>","hosts":"<etag>","certs":"<fp>","purges":<seq>}
        The payload is a VERSION VECTOR (opaque, CP-process-local) — a wake-up
        signal only, never content. The first event is the current vector (a
        reconnecting edge covers its disconnected window); after that, one event

--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -318,6 +318,7 @@ func main() {
 	// fetch sees the full payload, not a half-populated store.
 	var wafStore *edgecp.WafStore
 	var rlStore *edgecp.RateLimitStore
+	var hostsStore *edgecp.HostsStore
 	if wafEnabled {
 		wafStore = edgecp.NewWafStore()
 		wafReloader := edgecp.NewWafReloader(wafStore, watchNamespace, podNamespace)
@@ -338,8 +339,16 @@ func main() {
 		server = server.WithRateLimit(rlStore)
 		slog.Info("edge control plane: ratelimit distribution enabled", "pod_namespace", podNamespace)
 	}
-	if wafStore != nil || rlStore != nil {
-		ingReloader := edgecp.NewIngressReloader(wafStore, watchNamespace).WithRateLimit(rlStore)
+	// Standalone known-host distribution (GET /v1/hosts) — the edge request
+	// metric's host oracle. On by default and independent of WAF/ratelimit, since
+	// the metric is always on; it only rides the same Ingress watch.
+	if envOr("CP_HOSTS_ENABLED", "true") == "true" {
+		hostsStore = edgecp.NewHostsStore()
+		server = server.WithHosts(hostsStore)
+		slog.Info("edge control plane: hosts distribution enabled")
+	}
+	if wafStore != nil || rlStore != nil || hostsStore != nil {
+		ingReloader := edgecp.NewIngressReloader(wafStore, watchNamespace).WithRateLimit(rlStore).WithHosts(hostsStore)
 		if err := ingReloader.LoadOnce(ctx); err != nil {
 			slog.Error("edgecp: initial ingress load failed", "err", err)
 		}
@@ -379,6 +388,9 @@ func main() {
 			}
 			if rlStore != nil {
 				snap.RateLimit = rlStore.Version()
+			}
+			if hostsStore != nil {
+				snap.Hosts = hostsStore.Version()
 			}
 			if purgeStore != nil {
 				snap.Purges = purgeStore.LastSeq()

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -142,11 +142,23 @@ func main() {
 	// refreshes single-flight per resource.
 	eventsEnabled := envOr("EDGE_EVENTS_ENABLED", "true") == "true"
 	var pokes edge.EventPokes
-	var certPoke, wafPoke, rlPoke, purgePoke chan struct{}
+	var certPoke, wafPoke, rlPoke, hostsPoke, purgePoke chan struct{}
 	if eventsEnabled {
 		certPoke = make(chan struct{}, 1)
 		pokes.Certs = certPoke
 	}
+
+	// Known-host set (GET /v1/hosts) — the request metric's host oracle. Always
+	// fetched (the metric is always mounted), independent of WAF/ratelimit;
+	// fail-static, and a 404 from a CP without the endpoint just leaves the metric
+	// collapsing every host to "other".
+	edgeHosts := edge.NewEdgeHosts()
+	edge.RefreshHostsOnce(cp, edgeHosts)
+	if eventsEnabled {
+		hostsPoke = make(chan struct{}, 1)
+		pokes.Hosts = hostsPoke
+	}
+	go edge.RunHostsRefresh(ctx, cp, edgeHosts, refreshInterval, hostsPoke)
 
 	// Optional data-plane mTLS: fetch a CP-issued client cert (CA-only trust), hold it
 	// in memory (never on disk), and present it on the re-encrypt hop. The re-mint
@@ -354,6 +366,14 @@ func main() {
 	m.Use(health)
 	m.Use(host.StripPort())
 	m.Use(host.ToLower())
+	// Per-request counter (parapet_requests{host,status,method,edge_id}); the same
+	// family the in-cluster controller exports. Outermost (past host
+	// normalization) so the counted status is the one the client sees — WAF
+	// blocks, rate-limit rejects, and cache hits alike. host is bounded to the
+	// Ingress-declared known-host set (EdgeHosts), so a random-Host flood in
+	// serve-all mode can't grow series cardinality, while real hosts keep EXACT
+	// per-host labels for the observation system.
+	m.Use(edge.Requests(edgeHosts.IsKnownHost))
 	if !disableLog {
 		m.Use(logger.Stdout())
 	}

--- a/edge/cp.go
+++ b/edge/cp.go
@@ -273,6 +273,50 @@ func (c *CpClient) FetchRateLimit(currentEtag string) (RateLimitFetch, error) {
 	}
 }
 
+// HostsFetch is the outcome of a known-host fetch (the request metric's host
+// oracle). Scoped to the edge's token.
+type HostsFetch struct {
+	// Unchanged is true on a 304.
+	Unchanged  bool
+	Generation uint64
+	Hosts      []string
+	Etag       string
+}
+
+type hostsBody struct {
+	Generation uint64   `json:"generation"`
+	Hosts      []string `json:"hosts"`
+}
+
+// FetchHosts fetches the known-host list scoped to the edge's token, with ETag
+// revalidation. A 404 ("hosts distribution disabled" — an old CP, or CP_HOSTS_
+// ENABLED=false) is treated like any other non-200/304: an error the caller
+// handles fail-static (keeps last-good; the metric just keeps its current bound).
+func (c *CpClient) FetchHosts(currentEtag string) (HostsFetch, error) {
+	resp, err := c.do(c.base+"/v1/hosts", currentEtag)
+	if err != nil {
+		return HostsFetch{}, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		return HostsFetch{Unchanged: true}, nil
+	case http.StatusOK:
+		var body hostsBody
+		if err := json.NewDecoder(io.LimitReader(resp.Body, maxWafBody)).Decode(&body); err != nil {
+			return HostsFetch{}, fmt.Errorf("decode: %w", err)
+		}
+		return HostsFetch{
+			Generation: body.Generation,
+			Hosts:      body.Hosts,
+			Etag:       resp.Header.Get("ETag"),
+		}, nil
+	default:
+		return HostsFetch{}, fmt.Errorf("control plane returned %d for /v1/hosts", resp.StatusCode)
+	}
+}
+
 // PurgeFetch is the outcome of a cache-purge poll.
 type PurgeFetch struct {
 	// Disabled is true on a 404 ("purge distribution disabled" at the CP): a clean,

--- a/edge/events.go
+++ b/edge/events.go
@@ -17,6 +17,7 @@ import (
 type eventsSnapshot struct {
 	WAF       string `json:"waf"`
 	RateLimit string `json:"ratelimit"`
+	Hosts     string `json:"hosts"`
 	Certs     string `json:"certs"`
 	Purges    uint64 `json:"purges"`
 }
@@ -28,6 +29,7 @@ type eventsSnapshot struct {
 type EventPokes struct {
 	WAF       chan<- struct{}
 	RateLimit chan<- struct{}
+	Hosts     chan<- struct{}
 	Certs     chan<- struct{}
 	Purges    chan<- struct{}
 }
@@ -48,6 +50,7 @@ func (p EventPokes) poke(ch chan<- struct{}) {
 func (p EventPokes) pokeAll() {
 	p.poke(p.WAF)
 	p.poke(p.RateLimit)
+	p.poke(p.Hosts)
 	p.poke(p.Certs)
 	p.poke(p.Purges)
 }
@@ -180,6 +183,9 @@ func runEventsOnce(ctx context.Context, cp *CpClient, pokes EventPokes) (deliver
 					}
 					if snap.RateLimit != last.RateLimit {
 						pokes.poke(pokes.RateLimit)
+					}
+					if snap.Hosts != last.Hosts {
+						pokes.poke(pokes.Hosts)
 					}
 					if snap.Certs != last.Certs {
 						pokes.poke(pokes.Certs)

--- a/edge/hosts.go
+++ b/edge/hosts.go
@@ -1,0 +1,73 @@
+package edge
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// EdgeHosts holds the Ingress-declared known-host set fetched from the control
+// plane's GET /v1/hosts. It is the request metric's host oracle: the metric
+// bounds the parapet_requests `host` label to this set (unknown hosts collapse
+// to "other"), giving EXACT per-host labels for an observation system while
+// keeping series cardinality bounded under a random-Host flood.
+//
+// Always-on (the metric is always mounted) and standalone: a stale or empty set
+// only over-collapses the label, never a WAF/limit signal, so it has no
+// atomicity coupling with the WAF/ratelimit payloads. Lock-free reads via the
+// atomic pointer.
+type EdgeHosts struct {
+	hosts atomic.Pointer[map[string]struct{}]
+
+	// generation of the currently-loaded snapshot (0 until the first fetch applies).
+	generation atomic.Uint64
+
+	mu   sync.Mutex
+	etag string
+}
+
+// NewEdgeHosts returns an empty host set — every host is unknown (collapses to
+// "other") until the first fetch lands.
+func NewEdgeHosts() *EdgeHosts {
+	h := &EdgeHosts{}
+	empty := map[string]struct{}{}
+	h.hosts.Store(&empty)
+	return h
+}
+
+// Etag returns the ETag of the currently-loaded set (sent as If-None-Match).
+func (h *EdgeHosts) Etag() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.etag
+}
+
+// Generation returns the currently-loaded snapshot's generation (0 until the
+// first fetch applies).
+func (h *EdgeHosts) Generation() uint64 { return h.generation.Load() }
+
+// Update swaps in a fetched host set wholesale. There is no compile step — the
+// list is already-validated wire data — so it always applies and advances the
+// etag/generation.
+func (h *EdgeHosts) Update(generation uint64, hosts []string, etag string) {
+	hs := make(map[string]struct{}, len(hosts))
+	for _, host := range hosts {
+		hs[host] = struct{}{}
+	}
+	h.hosts.Store(&hs)
+
+	h.mu.Lock()
+	h.etag = etag
+	h.mu.Unlock()
+	h.generation.Store(generation)
+}
+
+// IsKnownHost reports whether host is one an Ingress declares. A host not in the
+// set collapses to the metric's "other" bucket, bounding series cardinality.
+func (h *EdgeHosts) IsKnownHost(host string) bool {
+	m := h.hosts.Load()
+	if m == nil {
+		return false
+	}
+	_, ok := (*m)[host]
+	return ok
+}

--- a/edge/hosts_test.go
+++ b/edge/hosts_test.go
@@ -1,0 +1,32 @@
+package edge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEdgeHosts_Empty(t *testing.T) {
+	h := NewEdgeHosts()
+	assert.False(t, h.IsKnownHost("acme.com"))
+	assert.Equal(t, "", h.Etag())
+	assert.EqualValues(t, 0, h.Generation())
+}
+
+func TestEdgeHosts_Update(t *testing.T) {
+	h := NewEdgeHosts()
+	h.Update(5, []string{"acme.com", "app.acme.com"}, `"h1"`)
+
+	assert.True(t, h.IsKnownHost("acme.com"))
+	assert.True(t, h.IsKnownHost("app.acme.com"))
+	assert.False(t, h.IsKnownHost("evil.com"), "undeclared host is unknown (collapses to \"other\")")
+	assert.False(t, h.IsKnownHost("other.acme.com"), "a wildcard cert subdomain is NOT known unless an Ingress declares it")
+	assert.Equal(t, `"h1"`, h.Etag())
+	assert.EqualValues(t, 5, h.Generation())
+
+	// A later update swaps the set wholesale.
+	h.Update(6, []string{"new.com"}, `"h2"`)
+	assert.True(t, h.IsKnownHost("new.com"))
+	assert.False(t, h.IsKnownHost("acme.com"), "removed host is no longer known")
+	assert.EqualValues(t, 6, h.Generation())
+}

--- a/edge/hostsrefresh.go
+++ b/edge/hostsrefresh.go
@@ -1,0 +1,34 @@
+package edge
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// RefreshHostsOnce fetches the known-host list (ETag-revalidated) and swaps it
+// into EdgeHosts. A fetch failure is fail-static — the metric keeps its current
+// host bound. There is no compile step, so a 200 always applies.
+func RefreshHostsOnce(cp *CpClient, h *EdgeHosts) {
+	res, err := cp.FetchHosts(h.Etag())
+	switch {
+	case err != nil:
+		slog.Warn("edge: hosts fetch failed; keeping last-good known-host set", "error", err)
+	case res.Unchanged:
+		// 304: cached set is current.
+	default:
+		h.Update(res.Generation, res.Hosts, res.Etag)
+		slog.Info("edge: known-host set updated", "generation", res.Generation, "hosts", len(res.Hosts))
+	}
+}
+
+// RunHostsRefresh runs the periodic known-host refresh forever. The first tick is
+// jittered by [0,interval] (fleet poll-instant decorrelation); same cadence as
+// the cert/WAF refresh; fail-static. poke (nil ok) wakes the loop on the
+// /v1/events hosts change signal, so the timer is only the fallback floor.
+func RunHostsRefresh(ctx context.Context, cp *CpClient, h *EdgeHosts, interval time.Duration, poke <-chan struct{}) {
+	if interval <= 0 { // time.NewTicker panics on a non-positive interval
+		interval = 300 * time.Second
+	}
+	runRefreshLoop(ctx, interval, poke, func() { RefreshHostsOnce(cp, h) })
+}

--- a/edge/requests.go
+++ b/edge/requests.go
@@ -1,0 +1,162 @@
+package edge
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+
+	"github.com/moonrhythm/parapet"
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// parapet_requests is the per-request counter the in-cluster controller already
+// exports (metric.Requests). The edge can't import that package — it would
+// materialize the controller's core-trust alerting series (see metric/observe
+// and import_boundary_test.go) — and parapet's own prom.Requests carries an
+// UNBOUNDED host label, which a serve-all edge (any client Host) must not export.
+// So the edge registers the SAME family name here with a host label of its own
+// bounding. It merges into the controller's parapet_requests family at the
+// control plane (edgecp.mergeFamilies, by family name + matching counter type);
+// edge series are told apart by the edge_id/edge_instance labels the CP stamps
+// at ingest, and by carrying neither the ingress_* nor service_* labels.
+//
+// All three input-derived labels are bounded so request input can't grow series
+// cardinality (the OOM class the controller's metric.Requests guards the same
+// way): host collapses to "other" for any host the edge doesn't serve, method to
+// "other" outside the registered HTTP methods (any RFC7230 token is a valid
+// method), and status to "other" outside 100–599 (an upstream can write any code).
+var (
+	requestsOnce sync.Once
+	requestsVec  *prometheus.CounterVec
+)
+
+func requestsRegister() {
+	requestsOnce.Do(func() {
+		requestsVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: prom.Namespace,
+			Name:      "requests",
+			Help:      "Requests served by the edge, by host (collapsed to \"other\" when not served), status, method.",
+		}, []string{"host", "status", "method", "edge_id"})
+		prom.Registry().MustRegister(requestsVec)
+	})
+}
+
+// Requests returns middleware counting every served request as
+// parapet_requests{host,status,method,edge_id}. knownHost (may be nil — then the
+// host passes through, as in tests) bounds the host label: a host it reports
+// false for collapses to the "other" sentinel. Mount it outermost so the counted
+// status is the one the client sees — WAF blocks, rate-limit rejects, cache hits,
+// and proxied responses alike.
+func Requests(knownHost func(host string) bool) parapet.Middleware {
+	requestsRegister()
+	return &requestsMiddleware{knownHost: knownHost}
+}
+
+type requestsMiddleware struct {
+	knownHost func(host string) bool
+}
+
+func (p *requestsMiddleware) ServeHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nw := requestTrackRW{ResponseWriter: w}
+		defer func() {
+			requestsVec.WithLabelValues(
+				hostLabel(r.Host, p.knownHost),
+				statusLabel(nw.status),
+				methodLabel(r.Method),
+				edgeID,
+			).Inc()
+		}()
+		h.ServeHTTP(&nw, r)
+	})
+}
+
+// unknownHostLabel substitutes for a host the edge doesn't serve, so a flood of
+// random Host headers can't create unbounded host-labeled series. Matches
+// metric.HostLabel's "other" so edge and controller series share one bucket.
+const unknownHostLabel = "other"
+
+func hostLabel(host string, knownHost func(string) bool) string {
+	if knownHost == nil || knownHost(host) {
+		return host
+	}
+	return unknownHostLabel
+}
+
+// methodLabel collapses the client-controlled method to a bounded set; only the
+// registered HTTP methods pass through, anything else becomes "other".
+func methodLabel(method string) string {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodConnect,
+		http.MethodOptions, http.MethodTrace:
+		return method
+	default:
+		return "other"
+	}
+}
+
+// statusLabel bounds the response status: valid HTTP codes (100–599) pass
+// through, anything else (including 0 — a hijacked/empty response) is "other".
+func statusLabel(status int) string {
+	if status >= 100 && status <= 599 {
+		return strconv.Itoa(status)
+	}
+	return "other"
+}
+
+// requestTrackRW captures the response status while preserving the optional
+// ResponseWriter interfaces the chain relies on (Flush for SSE, Hijack for
+// websockets/upgrades, Push), mirroring parapet's prom.Requests writer.
+type requestTrackRW struct {
+	http.ResponseWriter
+
+	wroteHeader bool
+	status      int
+}
+
+func (w *requestTrackRW) WriteHeader(code int) {
+	if w.wroteHeader {
+		return
+	}
+	w.wroteHeader = true
+	w.status = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *requestTrackRW) Write(p []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(p)
+}
+
+func (w *requestTrackRW) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+// Push implements the http.Pusher interface.
+func (w *requestTrackRW) Push(target string, opts *http.PushOptions) error {
+	if p, ok := w.ResponseWriter.(http.Pusher); ok {
+		return p.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}
+
+// Flush implements the http.Flusher interface.
+func (w *requestTrackRW) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack implements the http.Hijacker interface.
+func (w *requestTrackRW) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, http.ErrNotSupported
+}

--- a/edge/requests_test.go
+++ b/edge/requests_test.go
@@ -1,0 +1,95 @@
+package edge
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// serve drives one request through the Requests middleware and returns it.
+func serveRequest(t *testing.T, mw interface {
+	ServeHandler(http.Handler) http.Handler
+}, method, host string, write func(http.ResponseWriter)) {
+	t.Helper()
+	h := mw.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		write(w)
+	}))
+	r := httptest.NewRequest(method, "http://"+host+"/x", nil)
+	r.Host = host
+	h.ServeHTTP(httptest.NewRecorder(), r)
+}
+
+func count(host, status, method string) float64 {
+	return testutil.ToFloat64(requestsVec.WithLabelValues(host, status, method, edgeID))
+}
+
+func TestRequestsCountsAndCollapsesHost(t *testing.T) {
+	known := map[string]struct{}{"app.example.com": {}}
+	mw := Requests(func(h string) bool { _, ok := known[h]; return ok })
+
+	// Known host: labeled verbatim, status taken from WriteHeader.
+	before := count("app.example.com", "418", "GET")
+	serveRequest(t, mw, http.MethodGet, "app.example.com", func(w http.ResponseWriter) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	if got := count("app.example.com", "418", "GET"); got != before+1 {
+		t.Errorf("known host: %v -> %v, want +1", before, got)
+	}
+
+	// Unknown host collapses to "other" so a random-Host flood can't grow series.
+	before = count("other", "418", "GET")
+	serveRequest(t, mw, http.MethodGet, "evil.example.net", func(w http.ResponseWriter) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	if got := count("other", "418", "GET"); got != before+1 {
+		t.Errorf("unknown host: %v -> %v, want +1 under \"other\"", before, got)
+	}
+	// ...and never under its raw name.
+	if c := testutil.CollectAndCount(requestsVec); c == 0 {
+		t.Fatal("expected series registered")
+	}
+}
+
+func TestRequestsDefaultStatusAndBounding(t *testing.T) {
+	mw := Requests(func(string) bool { return true })
+
+	// Body written without WriteHeader => 200.
+	before := count("h.example.com", "200", "GET")
+	serveRequest(t, mw, http.MethodGet, "h.example.com", func(w http.ResponseWriter) {
+		_, _ = w.Write([]byte("ok"))
+	})
+	if got := count("h.example.com", "200", "GET"); got != before+1 {
+		t.Errorf("default status: %v -> %v, want +1 under 200", before, got)
+	}
+
+	// Unregistered method token collapses to "other".
+	before = count("h.example.com", "200", "other")
+	serveRequest(t, mw, "WEIRDVERB", "h.example.com", func(w http.ResponseWriter) {
+		w.WriteHeader(http.StatusOK)
+	})
+	if got := count("h.example.com", "200", "other"); got != before+1 {
+		t.Errorf("method bounding: %v -> %v, want +1 under \"other\"", before, got)
+	}
+}
+
+func TestRequestsNilKnownHostPassesThrough(t *testing.T) {
+	mw := Requests(nil) // nil knownHost: host passes through unchanged (test convenience)
+	before := count("verbatim.example.com", "200", "GET")
+	serveRequest(t, mw, http.MethodGet, "verbatim.example.com", func(w http.ResponseWriter) {
+		w.WriteHeader(http.StatusOK)
+	})
+	if got := count("verbatim.example.com", "200", "GET"); got != before+1 {
+		t.Errorf("nil knownHost: %v -> %v, want +1 verbatim", before, got)
+	}
+}
+
+func TestStatusLabelBounds(t *testing.T) {
+	cases := map[int]string{0: "other", 99: "other", 100: "100", 200: "200", 599: "599", 600: "other", 700: "other"}
+	for code, want := range cases {
+		if got := statusLabel(code); got != want {
+			t.Errorf("statusLabel(%d) = %q, want %q", code, got, want)
+		}
+	}
+}

--- a/edgecp/events.go
+++ b/edgecp/events.go
@@ -17,6 +17,9 @@ type EventsSnapshot struct {
 	// WAF/RateLimit are the stores' content etags ("" when distribution is off).
 	WAF       string `json:"waf,omitempty"`
 	RateLimit string `json:"ratelimit,omitempty"`
+	// Hosts is the known-host store's content etag ("" when off). A host change
+	// pokes only the edge's hosts refresh — it doesn't affect WAF/ratelimit.
+	Hosts string `json:"hosts,omitempty"`
 	// Certs is a fingerprint over the cert store's full (name, etag) index.
 	Certs string `json:"certs,omitempty"`
 	// Purges is the purge journal's last issued seq (0 = none/off).

--- a/edgecp/hoststore.go
+++ b/edgecp/hoststore.go
@@ -1,0 +1,82 @@
+package edgecp
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// HostsStore holds the per-token known-host list (every Ingress-declared host),
+// distributed via GET /v1/hosts. It is the edge request metric's host oracle:
+// the edge bounds the parapet_requests `host` label to this set so a random-Host
+// flood can't grow series cardinality, with EXACT per-host labels — unlike a
+// cert-derived bound, which would bucket every subdomain of a wildcard cert
+// under one series.
+//
+// It is deliberately STANDALONE — not bundled into /v1/waf or /v1/ratelimit —
+// for two reasons: the metric is always on (even with WAF + rate-limiting off),
+// and a stale host list only over-collapses the metric label to "other" (a
+// cardinality bound, never a WAF/limit correctness signal), so it has no
+// atomicity coupling with those payloads. Same scoping/ETag model as the other
+// stores: lock-free reads via the atomic pointer, mu held by the writer and by
+// scoped() for a consistent snapshot.
+type HostsStore struct {
+	mu      sync.RWMutex
+	hosts   atomic.Pointer[[]string] // sorted, deduped known hosts
+	gen     atomic.Uint64
+	curEtag atomic.Pointer[string]
+}
+
+func NewHostsStore() *HostsStore {
+	s := &HostsStore{}
+	var h []string
+	s.hosts.Store(&h)
+	et := etagOfString("")
+	s.curEtag.Store(&et)
+	return s
+}
+
+// SetHosts replaces the full known-host list (sorted, deduped — see
+// collectIngressHosts).
+func (s *HostsStore) SetHosts(hosts []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hosts.Store(&hosts)
+	s.recompute()
+}
+
+// recompute bumps the generation + etag when the content changes. Caller holds mu.
+func (s *HostsStore) recompute() {
+	var b strings.Builder
+	for _, h := range *s.hosts.Load() {
+		b.WriteString(h)
+		b.WriteByte(0)
+	}
+	et := etagOfString(b.String())
+	if prev := s.curEtag.Load(); prev != nil && *prev == et {
+		return
+	}
+	s.gen.Add(1)
+	s.curEtag.Store(&et)
+}
+
+// Version is the store's full-content etag — the opaque change signal for the
+// /v1/events stream (per-edge scoping happens at fetch time).
+func (s *HostsStore) Version() string { return *s.curEtag.Load() }
+
+// scoped returns the generation and only the hosts the edge may serve (per allow),
+// read under the lock so the pair is a consistent snapshot.
+func (s *HostsStore) scoped(allow func(host string) bool) (generation uint64, hosts []string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	all := *s.hosts.Load()
+	out := make([]string, 0, len(all))
+	for _, h := range all {
+		if allow(h) {
+			out = append(out, h)
+		}
+	}
+	sort.Strings(out)
+	return s.gen.Load(), out
+}

--- a/edgecp/hoststore_test.go
+++ b/edgecp/hoststore_test.go
@@ -1,0 +1,70 @@
+package edgecp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+// The /v1/hosts endpoint scopes the known-host list to the token's allowed hosts.
+func TestServerHostsEndpointScopes(t *testing.T) {
+	store := NewHostsStore()
+	store.SetHosts([]string{"acme.com", "evil.com", "app.acme.com"})
+
+	authz := NewAuthz(map[string][]string{"tok": {"acme.com", "app.acme.com"}})
+	h := NewServer(NewCertStore(), authz).WithHosts(store).Handler()
+
+	req := httptest.NewRequest("GET", "/v1/hosts", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	var resp hostsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(resp.Hosts, []string{"acme.com", "app.acme.com"}) {
+		t.Errorf("hosts must exclude evil.com and be sorted: got %v", resp.Hosts)
+	}
+
+	// ETag present, and a matching If-None-Match 304s.
+	etag := rec.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("missing ETag")
+	}
+	req2 := httptest.NewRequest("GET", "/v1/hosts", nil)
+	req2.Header.Set("Authorization", "Bearer tok")
+	req2.Header.Set("If-None-Match", etag)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusNotModified {
+		t.Fatalf("want 304 on matching ETag, got %d", rec2.Code)
+	}
+}
+
+func TestServerHostsDisabled(t *testing.T) {
+	authz := NewAuthz(map[string][]string{"tok": {"acme.com"}})
+	h := NewServer(NewCertStore(), authz).Handler() // no WithHosts
+	req := httptest.NewRequest("GET", "/v1/hosts", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("want 404 when hosts disabled, got %d", rec.Code)
+	}
+}
+
+// Identical content must not bump the generation (etag-stable across re-derives).
+func TestHostsStoreGenerationStableOnIdenticalContent(t *testing.T) {
+	s := NewHostsStore()
+	s.SetHosts([]string{"a.com", "b.com"})
+	gen := s.gen.Load()
+	s.SetHosts([]string{"a.com", "b.com"})
+	if s.gen.Load() != gen {
+		t.Error("generation bumped on identical content")
+	}
+}

--- a/edgecp/ingressreload.go
+++ b/edgecp/ingressreload.go
@@ -27,6 +27,7 @@ import (
 type IngressReloader struct {
 	store          *WafStore       // optional (nil = WAF host→zone derivation off)
 	rl             *RateLimitStore // optional (nil = rate-limit derivation off)
+	hosts          *HostsStore     // optional (nil = /v1/hosts distribution off)
 	watchNamespace string
 	debounce       time.Duration
 }
@@ -39,6 +40,14 @@ func NewIngressReloader(store *WafStore, watchNamespace string) *IngressReloader
 // its host→zone binding and known-host list. Returns the reloader for chaining.
 func (r *IngressReloader) WithRateLimit(rl *RateLimitStore) *IngressReloader {
 	r.rl = rl
+	return r
+}
+
+// WithHosts wires the standalone known-host store (served at /v1/hosts) so the
+// same Ingress reload also feeds the edge request metric's host oracle. Returns
+// the reloader for chaining.
+func (r *IngressReloader) WithHosts(hosts *HostsStore) *IngressReloader {
+	r.hosts = hosts
 	return r
 }
 
@@ -99,6 +108,9 @@ func (r *IngressReloader) reload(ctx context.Context) error {
 	}
 	if r.rl != nil {
 		r.rl.SetIngressDerived(buildRateLimitHostZone(ings), buildZoneRoutes(ings, RateLimitZoneAnnotation, true), collectIngressHosts(ings))
+	}
+	if r.hosts != nil {
+		r.hosts.SetHosts(collectIngressHosts(ings))
 	}
 	return nil
 }

--- a/edgecp/server.go
+++ b/edgecp/server.go
@@ -27,6 +27,12 @@ type Server struct {
 	// /v1/ratelimit → 404). Same scoping/ETag model as the WAF endpoint.
 	ratelimit *RateLimitStore
 
+	// hosts is the optional standalone known-host distribution store (nil =
+	// /v1/hosts → 404). It feeds the edge request metric's host oracle; same
+	// scoping/ETag model. Standalone because the metric is always on and a stale
+	// list only over-collapses the metric label (no atomicity with waf/ratelimit).
+	hosts *HostsStore
+
 	// purge is the optional cache-purge journal (nil = purge distribution disabled,
 	// /v1/purges → 404). purgeAdminToken gates POST /v1/purges — a STRONGER credential
 	// than the per-edge read tokens (an edge can read its purges but not issue them).
@@ -137,6 +143,13 @@ func (s *Server) WithRateLimit(rl *RateLimitStore) *Server {
 	return s
 }
 
+// WithHosts enables the standalone known-host endpoint (GET /v1/hosts). Returns
+// the server for chaining.
+func (s *Server) WithHosts(hosts *HostsStore) *Server {
+	s.hosts = hosts
+	return s
+}
+
 // WithEvents enables the change-notification stream (GET /v1/events). Returns
 // the server for chaining; the caller runs hub.Run in its own goroutine.
 func (s *Server) WithEvents(hub *EventsHub) *Server {
@@ -219,6 +232,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /v1/certs", s.handleCert)
 	mux.HandleFunc("GET /v1/waf", s.handleWAF)
 	mux.HandleFunc("GET /v1/ratelimit", s.handleRateLimit)
+	mux.HandleFunc("GET /v1/hosts", s.handleHosts)
 	mux.HandleFunc("GET /v1/purges", s.handlePurges)
 	mux.HandleFunc("GET /v1/events", s.handleEvents)
 	mux.HandleFunc("POST /v1/purges", s.handlePurgeAdmin)
@@ -433,6 +447,50 @@ func (s *Server) handleRateLimit(w http.ResponseWriter, r *http.Request) {
 	}
 	// Generation zeroed in the validator for the same reason as handleWAF:
 	// process-local counters must not defeat 304 revalidation across replicas.
+	etagResp := resp
+	etagResp.Generation = 0
+	etagBody, err := json.Marshal(etagResp)
+	if err != nil {
+		http.Error(w, "encode", http.StatusInternalServerError)
+		return
+	}
+	etag := etagOfString(string(etagBody))
+	w.Header().Set("ETag", etag)
+	if match := r.Header.Get("If-None-Match"); match != "" && etagMatch(match, etag) {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(body)
+}
+
+// hostsResponse is the GET /v1/hosts payload: the known-host list scoped to the
+// token's domains. It is the edge request metric's host oracle.
+type hostsResponse struct {
+	Generation uint64   `json:"generation"`
+	Hosts      []string `json:"hosts"`
+}
+
+// handleHosts serves the known-host list scoped to the edge's allowed domains.
+// ETag is over the scoped payload with the generation zeroed, the same model as
+// handleWAF.
+func (s *Server) handleHosts(w http.ResponseWriter, r *http.Request) {
+	token, ok := bearer(r)
+	if !ok || !s.authz.Known(token) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if s.hosts == nil {
+		http.Error(w, "hosts distribution disabled", http.StatusNotFound)
+		return
+	}
+	generation, hosts := s.hosts.scoped(func(host string) bool { return s.authz.Allowed(token, host) })
+	resp := hostsResponse{Generation: generation, Hosts: hosts}
+	body, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, "encode", http.StatusInternalServerError)
+		return
+	}
 	etagResp := resp
 	etagResp.Generation = 0
 	etagBody, err := json.Marshal(etagResp)


### PR DESCRIPTION
## What

Exports `parapet_requests{host,status,method,edge_id}` from the edge so its metric pushes carry per-request counts (the family was absent — the edge mounted no request counter). The `host` label is bounded to the controller's **exact** `IsKnownHost` set, so a random-`Host` flood can't grow series cardinality **and** real hosts keep **exact per-host labels** for a tenant-facing observation system.

The host oracle is distributed via a **new standalone `GET /v1/hosts`**: the CP serves the per-token known-host list (`HostsStore`, fed by the same Ingress watch), and the edge consumes it into `EdgeHosts` (fetch + fail-static refresh + a `/v1/events` `hosts` topic). On by default (`CP_HOSTS_ENABLED`).

## Why standalone (and why this replaces #152)

`/v1/hosts` is deliberately **not** folded into `/v1/waf` or `/v1/ratelimit`:
- The metric is **always on** (even with WAF + rate-limiting off), so the oracle must be independently available.
- A stale/empty host list only **over-collapses the metric label to `"other"`** — a cardinality bound, never a WAF/limit correctness signal — so it has **no atomicity coupling** with those payloads.

This supersedes the closed **#152**, which unified the WAF/RL **zone bindings** into one endpoint. The scrutiny on #152 showed that breaks `WAF_VALIDATED_PROXY`: when the core skips its WAF and trusts the edge's claim, the edge's **zone matcher must stay atomic with its zone rules** — so the bindings stay in `/v1/waf`/`/v1/ratelimit`, **untouched here**. Only the always-safe known-host list is centralized.

It also supersedes the earlier **cert-store** host oracle (`store.Has`), which bucketed every subdomain of a wildcard cert under one series — no good for per-tenant observability.

## Surface (purely additive, +726/−4)

| Area | Change |
|---|---|
| CP | `edgecp/hoststore.go` (new) + `/v1/hosts` handler/`WithHosts` (`server.go`) + Ingress-watch feed (`ingressreload.go`) + `hosts` event topic (`events.go`) + wiring (`cmd/edge-controlplane`) |
| Edge | `edge/hosts.go` + `edge/hostsrefresh.go` (new), `FetchHosts` (`cp.go`), `hosts` poke (`events.go`), `edge/requests.go` metric middleware, wiring (`cmd/edge-proxy`) |
| Docs/tests | `EDGE.md` `/v1/hosts` contract; host-store/`EdgeHosts`/metric tests |

WAF/RL bindings and the rate-limiter's own host list are **unchanged from `main`** (atomic with their rules/limits).

## Testing

- `go build`/`vet`/`test ./...` — **664 pass, 23 packages** (incl. the edge import-boundary guard: the metric stays off the `metric` package)
- `go test -race ./edge/... ./edgecp/...` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)