### PR TITLE
refactor(edge): unify zone bindings + known hosts into GET /v1/topology

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -64,6 +64,7 @@ client ──TLS──► edge (Go/parapet, outside k8s)                        
                   │     GET /v1/certs?sni=… → cert+key+ETag (allowed SNI) │
                   │     GET /v1/waf         → rules for edge domains      │
                   │     GET /v1/ratelimit   → limits for edge domains     │
+                  │     GET /v1/topology    → zone bindings + known hosts │
                   │   authz: bearer token → allowed domains/zones         │
                   │   reads: TLS Secrets, WAF + ratelimit ConfigMaps,     │
                   │          Ingresses                                    │
@@ -91,8 +92,8 @@ keys**, so it must never be on the public LoadBalancer. See
 - **`cmd/edge-controlplane/`** (Go) — in-cluster HTTPS REST server. Reuses the
   Go controller's k8s client (`k8s`), cert table (`cert`), WAF rule parser
   (`wafrule`), and route/zone logic. Serves `GET /v1/certs?sni=…` (cert+key),
-  `GET /v1/waf` (rules), and `GET /v1/ratelimit` (limits). Not on the request
-  path.
+  `GET /v1/waf` (rules), `GET /v1/ratelimit` (limits), and `GET /v1/topology`
+  (the unified zone bindings + known-host list). Not on the request path.
 - **`cmd/edge-proxy/` + `edge/`** (Go) — a parapet-framework proxy. Reuses
   `cert.Table` for SNI resolution (plugged into `tls.Config.GetCertificate`,
   self-signed fallback on a miss), `wafrule` + `parapet/pkg/waf` for CEL
@@ -115,8 +116,9 @@ catch-all entry in the domain list that authorizes the token for **every** host
 check gates both endpoints:
 
 - `GET /v1/certs/{sni}` → require `sni ∈ allowed(token)`.
-- `GET /v1/waf` → return only the zones / host-map entries for the token's domains.
-- `GET /v1/ratelimit` → same scoping (zones, host-map, known hosts) per token.
+- `GET /v1/waf` → return only the zone rulesets for the token's domains.
+- `GET /v1/ratelimit` → same scoping (zone limit sets) per token.
+- `GET /v1/topology` → only the WAF + rate-limit zone bindings and known hosts for the token's domains.
 
 Server-side TLS is mandatory here: it encrypts the token **and the returned
 private key** in flight and lets the edge authenticate the control plane. The
@@ -155,41 +157,55 @@ GET /v1/certs?sni=<host>   Authorization: Bearer <token>   [If-None-Match: "<eta
   400 (missing sni)  401 (no/invalid token)  403 (sni ∉ allowed(token))  404 (no cert for sni)
 
 GET /v1/waf           Authorization: Bearer <token>   [If-None-Match: "<etag>"]
-  200 {"generation": N, "global_rules":"…", "zones":{…}, "route_zone_map":{…},
-       "host_zone_map":{…}}
+  200 {"generation": N, "global_rules":"…", "zones":{…}}
        global_rules   : the platform baseline YAML (identical for every edge)
        zones          : zoneKey ("<ns>/<name>") → rules YAML, scoped to the edge's hosts
-       route_zone_map : route pattern → zoneKey — PATH-AWARE binding. Patterns are
-                        byte-identical to the controller's route keys (Prefix →
-                        "host/path" + "host/path/", Exact → trailing slash stripped,
-                        ImplementationSpecific → as-is); the edge loads them into a
-                        real http.ServeMux, so zone resolution matches the core
-                        exactly (incl. two ingresses sharing a host with different
-                        paths and different zones). Scoped to the edge's hosts.
-       host_zone_map  : host → zoneKey — LEGACY host-level binding, kept for
-                        pre-path-aware edges; a current edge uses it only when
-                        route_zone_map is absent (older CP), as whole-host patterns.
-       (ETag is over the *scoped* payload, so 304 revalidation is per-edge-correct;
+                        (only the zones the edge's allowed hosts bind to — the CP
+                        intersects against the bindings it also holds)
+       (the zone BINDINGS that select these zones ship from /v1/topology, not here;
+        ETag is over the *scoped* payload, so 304 revalidation is per-edge-correct;
         the generation is EXCLUDED from the validator — it is process-local, and
         CP replicas must mint identical validators for identical content or an
         edge rotating across replicas would never 304)
 
 GET /v1/ratelimit     Authorization: Bearer <token>   [If-None-Match: "<etag>"]
-  200 {"generation": N, "global_limits":["…"], "zones":{"<ns>/<name>":["…"]},
-       "route_zone_map":{…}, "host_zone_map":{…}, "hosts":["…"]}
+  200 {"generation": N, "global_limits":["…"], "zones":{"<ns>/<name>":["…"]}}
        global_limits  : the platform baseline limit DOCUMENTS (identical for every edge)
        zones          : zoneKey → limit documents, scoped to the edge's hosts
-       route_zone_map : route pattern → zoneKey (`ratelimit-zone`, same-namespace
-                        only) — same path-aware model as /v1/waf
-       host_zone_map  : host → zoneKey (legacy, as in /v1/waf), scoped
-       hosts          : every Ingress-declared host the edge may serve — wired as the
-                        Limiter's KnownHost so host-keyed buckets for undeclared hosts
-                        collapse into one (cardinality bound under a random-Host flood)
-       (documents are ARRAYS of YAML strings, one per ConfigMap data value —
+       (the zone bindings + known-host list ship from /v1/topology, not here;
+        documents are ARRAYS of YAML strings, one per ConfigMap data value —
         ratelimitrule.Parse takes one document per string and does not split "---",
         so the WAF's concatenated format would silently drop trailing documents;
         ETag over the scoped payload with the generation excluded, like /v1/waf)
   401 (no/invalid token)   404 (ratelimit distribution disabled)
+
+GET /v1/topology      Authorization: Bearer <token>   [If-None-Match: "<etag>"]
+  200 {"generation": N, "waf_route_zone":{…}, "waf_host_zone":{…},
+       "rl_route_zone":{…}, "rl_host_zone":{…}, "hosts":["…"]}
+       The UNIFIED Ingress-derived topology — the single home for the zone bindings
+       and the known-host list that /v1/waf and /v1/ratelimit used to embed. The
+       edge feeds it to its WAF matcher, its rate-limit matcher, and the request
+       metric's host-cardinality bound.
+       waf_route_zone : route pattern → WAF zoneKey — PATH-AWARE binding. Patterns are
+                        byte-identical to the controller's route keys (Prefix →
+                        "host/path" + "host/path/", Exact → trailing slash stripped,
+                        ImplementationSpecific → as-is); the edge loads them into a
+                        real http.ServeMux, so zone resolution matches the core
+                        exactly. Scoped to the edge's hosts.
+       waf_host_zone  : host → WAF zoneKey — LEGACY host-level binding, used only when
+                        waf_route_zone is absent, as whole-host subtree patterns.
+       rl_route_zone / rl_host_zone : the same, for `ratelimit-zone` bindings
+                        (same-namespace only). Independent of the WAF maps — a route
+                        can be in a WAF zone, a different rate-limit zone, or neither.
+       hosts          : every Ingress-declared host the edge may serve — the edge's
+                        IsKnownHost set (rate-limit host-key collapse + the request
+                        metric's host bound; undeclared hosts collapse to one bucket /
+                        the "other" label, a cardinality bound under a random-Host flood)
+       (ETag over the scoped payload with the generation excluded, like /v1/waf. A
+        binding change here bumps the topology version on /v1/events; the edge then
+        also re-fetches /v1/waf + /v1/ratelimit, since a binding change can alter
+        which zone rulesets/limit sets it should receive — cheap 304s when unchanged.)
+  401 (no/invalid token)   404 (topology distribution disabled)
 
 GET /v1/purges?since=<seq>   Authorization: Bearer <token>
   200 {"entries":[{"seq":N,"scope":"url|host|prefix|tag|flush-all","host":"…","uri":"…","tag":"…"}],
@@ -224,7 +240,7 @@ POST /v1/purges       Authorization: Bearer <ADMIN token>   ← stronger cred th
 GET /v1/events        Authorization: Bearer <token>   (SSE; long-lived)
   200 Content-Type: text/event-stream — change-notification stream. Each event:
        event: change
-       data: {"waf":"<etag>","ratelimit":"<etag>","certs":"<fp>","purges":<seq>}
+       data: {"waf":"<etag>","ratelimit":"<etag>","topology":"<etag>","certs":"<fp>","purges":<seq>}
        The payload is a VERSION VECTOR (opaque, CP-process-local) — a wake-up
        signal only, never content. The first event is the current vector (a
        reconnecting edge covers its disconnected window); after that, one event

--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -318,6 +318,7 @@ func main() {
 	// fetch sees the full payload, not a half-populated store.
 	var wafStore *edgecp.WafStore
 	var rlStore *edgecp.RateLimitStore
+	var topoStore *edgecp.TopologyStore
 	if wafEnabled {
 		wafStore = edgecp.NewWafStore()
 		wafReloader := edgecp.NewWafReloader(wafStore, watchNamespace, podNamespace)
@@ -339,11 +340,16 @@ func main() {
 		slog.Info("edge control plane: ratelimit distribution enabled", "pod_namespace", podNamespace)
 	}
 	if wafStore != nil || rlStore != nil {
-		ingReloader := edgecp.NewIngressReloader(wafStore, watchNamespace).WithRateLimit(rlStore)
+		// Topology distribution rides the same Ingress watch: one reload feeds the
+		// WAF store, the rate-limit store, and the unified /v1/topology store.
+		topoStore = edgecp.NewTopologyStore()
+		server = server.WithTopology(topoStore)
+		ingReloader := edgecp.NewIngressReloader(wafStore, watchNamespace).WithRateLimit(rlStore).WithTopology(topoStore)
 		if err := ingReloader.LoadOnce(ctx); err != nil {
 			slog.Error("edgecp: initial ingress load failed", "err", err)
 		}
 		go ingReloader.Watch(ctx)
+		slog.Info("edge control plane: topology distribution enabled")
 	}
 
 	// Optional cache-purge distribution (GET/POST /v1/purges). The read side rides
@@ -376,6 +382,9 @@ func main() {
 			snap.Certs = store.Version()
 			if wafStore != nil {
 				snap.WAF = wafStore.Version()
+			}
+			if topoStore != nil {
+				snap.Topology = topoStore.Version()
 			}
 			if rlStore != nil {
 				snap.RateLimit = rlStore.Version()

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -142,7 +142,7 @@ func main() {
 	// refreshes single-flight per resource.
 	eventsEnabled := envOr("EDGE_EVENTS_ENABLED", "true") == "true"
 	var pokes edge.EventPokes
-	var certPoke, wafPoke, rlPoke, purgePoke chan struct{}
+	var certPoke, wafPoke, rlPoke, topoPoke, purgePoke chan struct{}
 	if eventsEnabled {
 		certPoke = make(chan struct{}, 1)
 		pokes.Certs = certPoke
@@ -207,8 +207,23 @@ func main() {
 	if wafEnabled || ratelimitEnabled {
 		country, asn = loadGeoResolvers()
 	}
+
+	// Unified zone-binding + known-host topology (GET /v1/topology), shared by the
+	// edge WAF matcher and the rate-limit matcher (and the request-metric host
+	// bound). Fetched whenever either feature is on; fail-static like the others.
+	var topo *edge.EdgeTopology
+	if wafEnabled || ratelimitEnabled {
+		topo = edge.NewEdgeTopology()
+		edge.RefreshTopologyOnce(cp, topo)
+		if eventsEnabled {
+			topoPoke = make(chan struct{}, 1)
+			pokes.Topology = topoPoke
+		}
+		go edge.RunTopologyRefresh(ctx, cp, topo, refreshInterval, topoPoke)
+	}
+
 	if wafEnabled {
-		ewaf = edge.NewEdgeWAF(country, asn)
+		ewaf = edge.NewEdgeWAF(country, asn, topo)
 		edge.RefreshWafOnce(cp, ewaf, remintCoord)
 		if eventsEnabled {
 			wafPoke = make(chan struct{}, 1)
@@ -222,7 +237,7 @@ func main() {
 	// controller's are per pod; the core still enforces its own limits.
 	var erl *edge.EdgeRateLimit
 	if ratelimitEnabled {
-		erl = edge.NewEdgeRateLimit(country, asn)
+		erl = edge.NewEdgeRateLimit(country, asn, topo)
 		edge.RefreshRateLimitOnce(cp, erl)
 		if eventsEnabled {
 			rlPoke = make(chan struct{}, 1)

--- a/edge/cp.go
+++ b/edge/cp.go
@@ -152,34 +152,29 @@ func (c *CpClient) FetchCert(sni, currentEtag string) (CertFetch, error) {
 	}
 }
 
-// WafFetch is the outcome of a WAF ruleset fetch.
+// WafFetch is the outcome of a WAF ruleset fetch. Zone BINDINGS now ride
+// /v1/topology (see FetchTopology), not this payload.
 type WafFetch struct {
 	// Unchanged is true on a 304.
 	Unchanged bool
-	// On a 200: the generation, global YAML, per-zone YAML, zone bindings
-	// (path-aware route patterns, plus the legacy host map an older CP serves),
-	// and the ETag.
-	Generation   uint64
-	GlobalRules  string
-	Zones        map[string]string
-	RouteZoneMap map[string]string
-	HostZoneMap  map[string]string
-	Etag         string
-	CAID         string // signer target ca_id (secondary force-re-mint confirmer; 200 only)
-	SignerFP     string // active signing fp (200 only)
+	// On a 200: the generation, global YAML, per-zone YAML, and the ETag.
+	Generation  uint64
+	GlobalRules string
+	Zones       map[string]string
+	Etag        string
+	CAID        string // signer target ca_id (secondary force-re-mint confirmer; 200 only)
+	SignerFP    string // active signing fp (200 only)
 }
 
 type wafBody struct {
-	Generation   uint64            `json:"generation"`
-	GlobalRules  string            `json:"global_rules"`
-	Zones        map[string]string `json:"zones"`
-	RouteZoneMap map[string]string `json:"route_zone_map"`
-	HostZoneMap  map[string]string `json:"host_zone_map"`
-	CAID         string            `json:"ca_id"`
-	SigningFP    string            `json:"signing_cert_fp"`
+	Generation  uint64            `json:"generation"`
+	GlobalRules string            `json:"global_rules"`
+	Zones       map[string]string `json:"zones"`
+	CAID        string            `json:"ca_id"`
+	SigningFP   string            `json:"signing_cert_fp"`
 }
 
-// FetchWaf fetches the WAF payload (global YAML + zones + host->zone map) scoped
+// FetchWaf fetches the WAF ruleset payload (global YAML + zone rulesets) scoped
 // to the edge's token, with ETag revalidation. A 404 ("waf distribution
 // disabled") is treated like any other non-200/304: an error the caller handles
 // fail-static (keeps last-good).
@@ -199,35 +194,29 @@ func (c *CpClient) FetchWaf(currentEtag string) (WafFetch, error) {
 			return WafFetch{}, fmt.Errorf("decode: %w", err)
 		}
 		return WafFetch{
-			Generation:   body.Generation,
-			GlobalRules:  body.GlobalRules,
-			Zones:        body.Zones,
-			RouteZoneMap: body.RouteZoneMap,
-			HostZoneMap:  body.HostZoneMap,
-			Etag:         resp.Header.Get("ETag"),
-			CAID:         body.CAID,
-			SignerFP:     body.SigningFP,
+			Generation:  body.Generation,
+			GlobalRules: body.GlobalRules,
+			Zones:       body.Zones,
+			Etag:        resp.Header.Get("ETag"),
+			CAID:        body.CAID,
+			SignerFP:    body.SigningFP,
 		}, nil
 	default:
 		return WafFetch{}, fmt.Errorf("control plane returned %d for /v1/waf", resp.StatusCode)
 	}
 }
 
-// RateLimitFetch is the outcome of a rate-limit config fetch.
+// RateLimitFetch is the outcome of a rate-limit config fetch. Zone BINDINGS and
+// the known-host list now ride /v1/topology (see FetchTopology), not this payload.
 type RateLimitFetch struct {
 	// Unchanged is true on a 304.
 	Unchanged bool
-	// On a 200: the generation, global limit documents, per-zone documents,
-	// zone bindings (path-aware route patterns, plus the legacy host map an
-	// older CP serves), known hosts, and the ETag. Documents are []string
-	// (one YAML document per ConfigMap data value — ratelimitrule.Parse's
-	// contract; never "---"-joined).
+	// On a 200: the generation, global limit documents, per-zone documents, and
+	// the ETag. Documents are []string (one YAML document per ConfigMap data
+	// value — ratelimitrule.Parse's contract; never "---"-joined).
 	Generation   uint64
 	GlobalLimits []string
 	Zones        map[string][]string
-	RouteZoneMap map[string]string
-	HostZoneMap  map[string]string
-	Hosts        []string
 	Etag         string
 }
 
@@ -235,15 +224,12 @@ type rateLimitBody struct {
 	Generation   uint64              `json:"generation"`
 	GlobalLimits []string            `json:"global_limits"`
 	Zones        map[string][]string `json:"zones"`
-	RouteZoneMap map[string]string   `json:"route_zone_map"`
-	HostZoneMap  map[string]string   `json:"host_zone_map"`
-	Hosts        []string            `json:"hosts"`
 }
 
-// FetchRateLimit fetches the rate-limit payload (global documents + zones +
-// host->zone map + known hosts) scoped to the edge's token, with ETag
-// revalidation. A 404 ("ratelimit distribution disabled") is treated like any
-// other non-200/304: an error the caller handles fail-static (keeps last-good).
+// FetchRateLimit fetches the rate-limit limit-set payload (global documents +
+// zone limit sets) scoped to the edge's token, with ETag revalidation. A 404
+// ("ratelimit distribution disabled") is treated like any other non-200/304: an
+// error the caller handles fail-static (keeps last-good).
 func (c *CpClient) FetchRateLimit(currentEtag string) (RateLimitFetch, error) {
 	resp, err := c.do(c.base+"/v1/ratelimit", currentEtag)
 	if err != nil {
@@ -263,13 +249,67 @@ func (c *CpClient) FetchRateLimit(currentEtag string) (RateLimitFetch, error) {
 			Generation:   body.Generation,
 			GlobalLimits: body.GlobalLimits,
 			Zones:        body.Zones,
-			RouteZoneMap: body.RouteZoneMap,
-			HostZoneMap:  body.HostZoneMap,
-			Hosts:        body.Hosts,
 			Etag:         resp.Header.Get("ETag"),
 		}, nil
 	default:
 		return RateLimitFetch{}, fmt.Errorf("control plane returned %d for /v1/ratelimit", resp.StatusCode)
+	}
+}
+
+// TopologyFetch is the outcome of a topology fetch: the unified WAF + rate-limit
+// zone bindings (path-aware route maps plus legacy host maps) and the known-host
+// list, scoped to the edge's token.
+type TopologyFetch struct {
+	// Unchanged is true on a 304.
+	Unchanged    bool
+	Generation   uint64
+	WAFRouteZone map[string]string
+	WAFHostZone  map[string]string
+	RLRouteZone  map[string]string
+	RLHostZone   map[string]string
+	Hosts        []string
+	Etag         string
+}
+
+type topologyBody struct {
+	Generation   uint64            `json:"generation"`
+	WAFRouteZone map[string]string `json:"waf_route_zone"`
+	WAFHostZone  map[string]string `json:"waf_host_zone"`
+	RLRouteZone  map[string]string `json:"rl_route_zone"`
+	RLHostZone   map[string]string `json:"rl_host_zone"`
+	Hosts        []string          `json:"hosts"`
+}
+
+// FetchTopology fetches the unified zone-binding + known-host topology scoped to
+// the edge's token, with ETag revalidation. A 404 ("topology distribution
+// disabled") is treated like any other non-200/304: an error the caller handles
+// fail-static (keeps last-good).
+func (c *CpClient) FetchTopology(currentEtag string) (TopologyFetch, error) {
+	resp, err := c.do(c.base+"/v1/topology", currentEtag)
+	if err != nil {
+		return TopologyFetch{}, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		return TopologyFetch{Unchanged: true}, nil
+	case http.StatusOK:
+		var body topologyBody
+		if err := json.NewDecoder(io.LimitReader(resp.Body, maxWafBody)).Decode(&body); err != nil {
+			return TopologyFetch{}, fmt.Errorf("decode: %w", err)
+		}
+		return TopologyFetch{
+			Generation:   body.Generation,
+			WAFRouteZone: body.WAFRouteZone,
+			WAFHostZone:  body.WAFHostZone,
+			RLRouteZone:  body.RLRouteZone,
+			RLHostZone:   body.RLHostZone,
+			Hosts:        body.Hosts,
+			Etag:         resp.Header.Get("ETag"),
+		}, nil
+	default:
+		return TopologyFetch{}, fmt.Errorf("control plane returned %d for /v1/topology", resp.StatusCode)
 	}
 }
 

--- a/edge/cp_test.go
+++ b/edge/cp_test.go
@@ -77,7 +77,7 @@ func TestCpClient_FetchWaf200ParsesPayload(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/v1/waf", r.URL.Path)
 		w.Header().Set("ETag", `"w1"`)
-		_, _ = w.Write([]byte(`{"generation":7,"global_rules":"G","zones":{"ns/z":"ZY"},"route_zone_map":{"acme.com/api/":"ns/z"},"host_zone_map":{"acme.com":"ns/z"}}`))
+		_, _ = w.Write([]byte(`{"generation":7,"global_rules":"G","zones":{"ns/z":"ZY"}}`))
 	}))
 	defer srv.Close()
 	cp, _ := NewCpClient(srv.URL, "t", nil)
@@ -87,8 +87,6 @@ func TestCpClient_FetchWaf200ParsesPayload(t *testing.T) {
 	assert.EqualValues(t, 7, res.Generation)
 	assert.Equal(t, "G", res.GlobalRules)
 	assert.Equal(t, "ZY", res.Zones["ns/z"])
-	assert.Equal(t, "ns/z", res.RouteZoneMap["acme.com/api/"])
-	assert.Equal(t, "ns/z", res.HostZoneMap["acme.com"])
 	assert.Equal(t, `"w1"`, res.Etag)
 }
 
@@ -96,7 +94,7 @@ func TestCpClient_FetchRateLimit200ParsesPayload(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/v1/ratelimit", r.URL.Path)
 		w.Header().Set("ETag", `"r1"`)
-		_, _ = w.Write([]byte(`{"generation":4,"global_limits":["G1","G2"],"zones":{"ns/z":["Z"]},"route_zone_map":{"acme.com/":"ns/z"},"host_zone_map":{"acme.com":"ns/z"},"hosts":["acme.com"]}`))
+		_, _ = w.Write([]byte(`{"generation":4,"global_limits":["G1","G2"],"zones":{"ns/z":["Z"]}}`))
 	}))
 	defer srv.Close()
 	cp, _ := NewCpClient(srv.URL, "t", nil)
@@ -106,9 +104,6 @@ func TestCpClient_FetchRateLimit200ParsesPayload(t *testing.T) {
 	assert.EqualValues(t, 4, res.Generation)
 	assert.Equal(t, []string{"G1", "G2"}, res.GlobalLimits)
 	assert.Equal(t, []string{"Z"}, res.Zones["ns/z"])
-	assert.Equal(t, "ns/z", res.RouteZoneMap["acme.com/"])
-	assert.Equal(t, "ns/z", res.HostZoneMap["acme.com"])
-	assert.Equal(t, []string{"acme.com"}, res.Hosts)
 	assert.Equal(t, `"r1"`, res.Etag)
 }
 

--- a/edge/events.go
+++ b/edge/events.go
@@ -17,6 +17,7 @@ import (
 type eventsSnapshot struct {
 	WAF       string `json:"waf"`
 	RateLimit string `json:"ratelimit"`
+	Topology  string `json:"topology"`
 	Certs     string `json:"certs"`
 	Purges    uint64 `json:"purges"`
 }
@@ -28,6 +29,7 @@ type eventsSnapshot struct {
 type EventPokes struct {
 	WAF       chan<- struct{}
 	RateLimit chan<- struct{}
+	Topology  chan<- struct{}
 	Certs     chan<- struct{}
 	Purges    chan<- struct{}
 }
@@ -48,6 +50,7 @@ func (p EventPokes) poke(ch chan<- struct{}) {
 func (p EventPokes) pokeAll() {
 	p.poke(p.WAF)
 	p.poke(p.RateLimit)
+	p.poke(p.Topology)
 	p.poke(p.Certs)
 	p.poke(p.Purges)
 }
@@ -179,6 +182,14 @@ func runEventsOnce(ctx context.Context, cp *CpClient, pokes EventPokes) (deliver
 						pokes.poke(pokes.WAF)
 					}
 					if snap.RateLimit != last.RateLimit {
+						pokes.poke(pokes.RateLimit)
+					}
+					if snap.Topology != last.Topology {
+						pokes.poke(pokes.Topology)
+						// A binding change can alter which zone rulesets/limit sets a
+						// token receives, so also re-fetch WAF + rate-limit — cheap 304s
+						// when their own content is unchanged.
+						pokes.poke(pokes.WAF)
 						pokes.poke(pokes.RateLimit)
 					}
 					if snap.Certs != last.Certs {

--- a/edge/events_test.go
+++ b/edge/events_test.go
@@ -206,7 +206,7 @@ func TestRunWafRefreshPoke(t *testing.T) {
 	defer cancel()
 	// Interval far beyond the test deadline: any fetch can only come from the
 	// poke (honored even during the loop's initial jitter window).
-	go RunWafRefresh(ctx, cp, NewEdgeWAF(nil, nil), 10*time.Minute, nil, poke)
+	go RunWafRefresh(ctx, cp, NewEdgeWAF(nil, nil, NewEdgeTopology()), 10*time.Minute, nil, poke)
 	poke <- struct{}{}
 	select {
 	case <-hits:

--- a/edge/ratelimit.go
+++ b/edge/ratelimit.go
@@ -29,10 +29,9 @@ import (
 // traffic never burns rate budget, and BEFORE the response cache so
 // edge-enforced limits apply to cache hits too.
 type EdgeRateLimit struct {
-	global     *ratelimitrule.Limiter
-	zones      atomic.Pointer[map[string]*ratelimitrule.Limiter] // zoneKey -> compiled zone
-	matcher    atomic.Pointer[zoneMatcher]                       // host+path -> zoneKey (core ServeMux semantics)
-	knownHosts atomic.Pointer[map[string]struct{}]               // Ingress-declared hosts (host-key collapse)
+	global *ratelimitrule.Limiter
+	zones  atomic.Pointer[map[string]*ratelimitrule.Limiter] // zoneKey -> compiled zone
+	topo   *EdgeTopology                                     // shared: host+path -> zoneKey + known-host set (from /v1/topology)
 
 	newZone func(key string) *ratelimitrule.Limiter
 
@@ -46,28 +45,19 @@ type EdgeRateLimit struct {
 // resolvers (the same ones the edge WAF uses); nil makes SetLimits reject
 // country/asn-keyed limits — all-or-nothing, so a geo-keyed limit set requires
 // the GeoIP databases at the edge (same parity note as the WAF, see EDGE.md).
-func NewEdgeRateLimit(country func(*http.Request) string, asn func(*http.Request) int64) *EdgeRateLimit {
-	e := &EdgeRateLimit{}
-	// knownHost reads the live Ingress-declared host set per request, so a host
-	// added by a later fetch is honored without recompiling limits. A host not
-	// in the set collapses (also before the first payload — there are no limits
-	// to evaluate then anyway), mirroring the controller's IsKnownHost.
-	knownHost := func(host string) bool {
-		m := e.knownHosts.Load()
-		if m == nil {
-			return false
-		}
-		_, ok := (*m)[host]
-		return ok
-	}
+func NewEdgeRateLimit(country func(*http.Request) string, asn func(*http.Request) int64, topo *EdgeTopology) *EdgeRateLimit {
+	e := &EdgeRateLimit{topo: topo}
 	newLimiter := func(namePrefix string) *ratelimitrule.Limiter {
 		return &ratelimitrule.Limiter{
 			NamePrefix: namePrefix,
 			// observe (not metric) keeps the controller's init-materialized
 			// core-trust series off the edge's /metrics — same boundary as the
 			// edge WAF's eval observer.
-			Observe:   observe.RateLimit,
-			KnownHost: knownHost,
+			Observe: observe.RateLimit,
+			// Host-key collapse reads the live Ingress-declared host set (shared
+			// EdgeTopology), so a host added by a later topology fetch is honored
+			// without recompiling limits, mirroring the controller's IsKnownHost.
+			KnownHost: topo.IsKnownHost,
 			Country:   country,
 			ASN:       asn,
 		}
@@ -76,9 +66,6 @@ func NewEdgeRateLimit(country func(*http.Request) string, asn func(*http.Request
 	e.newZone = func(key string) *ratelimitrule.Limiter { return newLimiter("zone:" + key) }
 	empty := map[string]*ratelimitrule.Limiter{}
 	e.zones.Store(&empty)
-	e.matcher.Store(newZoneMatcher(nil, nil))
-	emptyHosts := map[string]struct{}{}
-	e.knownHosts.Store(&emptyHosts)
 	return e
 }
 
@@ -89,33 +76,22 @@ func (e *EdgeRateLimit) Etag() string {
 	return e.etag
 }
 
-// Update compiles and installs a fetched payload: the global limit set, the
-// zones, the zone bindings, and the known-host list. routeZone is the
-// path-aware binding (route pattern -> zoneKey); hostZone is the legacy
-// host-level binding an older CP serves, used only when routeZone is empty
-// (see newZoneMatcher). All-or-nothing PER set (SetLimits keeps the last-good
-// set on any invalid limit); the zones map, the matcher, and the known-host set
-// are swapped wholesale. An existing zone instance is reused when present so
-// its counters survive the swap (SetLimits additionally carries strategies over
-// for limits whose shaping config didn't change — the same counter-preservation
-// the controller's reload has). Returns the first error encountered (the rest
-// still apply — fail-static per set).
-func (e *EdgeRateLimit) Update(generation uint64, globalDocs []string, zoneDocs map[string][]string, routeZone, hostZone map[string]string, hosts []string, etag string) error {
+// Update compiles and installs a fetched payload: the global limit set and the
+// zone limit sets. The zone BINDINGS and the known-host list come from
+// EdgeTopology now, not from this payload. All-or-nothing PER set (SetLimits
+// keeps the last-good set on any invalid limit); the zones map is swapped
+// wholesale. An existing zone instance is reused when present so its counters
+// survive the swap (SetLimits additionally carries strategies over for limits
+// whose shaping config didn't change — the same counter-preservation the
+// controller's reload has). Returns the first error encountered (the rest still
+// apply — fail-static per set).
+func (e *EdgeRateLimit) Update(generation uint64, globalDocs []string, zoneDocs map[string][]string, etag string) error {
 	var firstErr error
 	note := func(err error) {
 		if firstErr == nil {
 			firstErr = err
 		}
 	}
-
-	// Swap the known-host set BEFORE applying limits: SetLimits compiles
-	// against the live closure, and a request racing the swap just collapses
-	// (or not) against whichever set is current — both are sound snapshots.
-	hs := make(map[string]struct{}, len(hosts))
-	for _, h := range hosts {
-		hs[h] = struct{}{}
-	}
-	e.knownHosts.Store(&hs)
 
 	// global
 	if limits, err := ratelimitrule.Parse(globalDocs...); err != nil {
@@ -141,8 +117,6 @@ func (e *EdgeRateLimit) Update(generation uint64, globalDocs []string, zoneDocs 
 		newZones[key] = z
 	}
 	e.zones.Store(&newZones)
-
-	e.matcher.Store(newZoneMatcher(routeZone, hostZone))
 
 	// Advance the etag + generation only on a CLEAN apply. Storing the etag on
 	// a failed apply would 304 every later poll: the rejection would be warned
@@ -176,13 +150,11 @@ func (e *EdgeRateLimit) Global() parapet.Middleware {
 func (e *EdgeRateLimit) Zone() parapet.Middleware {
 	return parapet.MiddlewareFunc(func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-			if m := e.matcher.Load(); m != nil {
-				if key, ok := m.resolve(r); ok {
-					if zs := e.zones.Load(); zs != nil {
-						if z := (*zs)[key]; z != nil {
-							z.Serve(rw, r, h)
-							return
-						}
+			if key, ok := e.topo.resolveRLZone(r); ok {
+				if zs := e.zones.Load(); zs != nil {
+					if z := (*zs)[key]; z != nil {
+						z.Serve(rw, r, h)
+						return
 					}
 				}
 			}

--- a/edge/ratelimit_test.go
+++ b/edge/ratelimit_test.go
@@ -37,9 +37,18 @@ func rlServe(mw http.Handler, host, ip string) int {
 	return rec.Code
 }
 
+// rlWithRLZones builds an EdgeRateLimit whose shared topology binds the given
+// rate-limit route/host maps and known-host list (these now live in
+// EdgeTopology, not the rate-limit payload).
+func rlWithRLZones(routeZone, hostZone map[string]string, hosts []string) *EdgeRateLimit {
+	topo := NewEdgeTopology()
+	topo.Update(1, nil, nil, routeZone, hostZone, hosts, `"t1"`)
+	return NewEdgeRateLimit(nil, nil, topo)
+}
+
 func TestEdgeRateLimit_GlobalEnforces(t *testing.T) {
-	e := NewEdgeRateLimit(nil, nil)
-	require.NoError(t, e.Update(1, []string{ipLimitDoc}, nil, nil, nil, nil, `"e1"`))
+	e := NewEdgeRateLimit(nil, nil, NewEdgeTopology())
+	require.NoError(t, e.Update(1, []string{ipLimitDoc}, nil, `"e1"`))
 
 	h := e.Global().ServeHandler(passed())
 	assert.Equal(t, 200, rlServe(h, "acme.com", "10.1.1.1"), "first request within rate")
@@ -49,12 +58,8 @@ func TestEdgeRateLimit_GlobalEnforces(t *testing.T) {
 
 func TestEdgeRateLimit_ZoneBoundByHost(t *testing.T) {
 	// Legacy host-level binding (route_zone_map absent — an older CP).
-	e := NewEdgeRateLimit(nil, nil)
-	require.NoError(t, e.Update(1, nil,
-		map[string][]string{"cust1/basic": {ipLimitDoc}},
-		nil,
-		map[string]string{"acme.com": "cust1/basic"},
-		[]string{"acme.com"}, `"e1"`))
+	e := rlWithRLZones(nil, map[string]string{"acme.com": "cust1/basic"}, []string{"acme.com"})
+	require.NoError(t, e.Update(1, nil, map[string][]string{"cust1/basic": {ipLimitDoc}}, `"e1"`))
 
 	h := e.Zone().ServeHandler(passed())
 	assert.Equal(t, 200, rlServe(h, "acme.com", "10.2.2.2"))
@@ -76,17 +81,14 @@ func TestEdgeRateLimit_ZonePathAware(t *testing.T) {
 	// Two ingresses share a host with different paths and different zones: each
 	// path burns its OWN zone's budget, and an unbound path burns none — the
 	// resolution the controller's per-route binding gives.
-	e := NewEdgeRateLimit(nil, nil)
+	e := rlWithRLZones(map[string]string{
+		"acme.com/api":  "cust1/a",
+		"acme.com/api/": "cust1/a",
+		"acme.com/web":  "cust2/b",
+		"acme.com/web/": "cust2/b",
+	}, nil, []string{"acme.com"})
 	require.NoError(t, e.Update(1, nil,
-		map[string][]string{"cust1/a": {ipLimitDoc}, "cust2/b": {ipLimitDoc}},
-		map[string]string{
-			"acme.com/api":  "cust1/a",
-			"acme.com/api/": "cust1/a",
-			"acme.com/web":  "cust2/b",
-			"acme.com/web/": "cust2/b",
-		},
-		nil,
-		[]string{"acme.com"}, `"e1"`))
+		map[string][]string{"cust1/a": {ipLimitDoc}, "cust2/b": {ipLimitDoc}}, `"e1"`))
 
 	h := e.Zone().ServeHandler(passed())
 	assert.Equal(t, 200, rlServePath(h, "acme.com", "/api/x", "10.9.9.9"))
@@ -97,8 +99,8 @@ func TestEdgeRateLimit_ZonePathAware(t *testing.T) {
 }
 
 func TestEdgeRateLimit_KeepLastGoodAndCountersOnBadUpdate(t *testing.T) {
-	e := NewEdgeRateLimit(nil, nil)
-	require.NoError(t, e.Update(1, []string{ipLimitDoc}, nil, nil, nil, nil, `"e1"`))
+	e := NewEdgeRateLimit(nil, nil, NewEdgeTopology())
+	require.NoError(t, e.Update(1, []string{ipLimitDoc}, nil, `"e1"`))
 
 	h := e.Global().ServeHandler(passed())
 	assert.Equal(t, 200, rlServe(h, "acme.com", "10.3.3.3"))
@@ -107,30 +109,31 @@ func TestEdgeRateLimit_KeepLastGoodAndCountersOnBadUpdate(t *testing.T) {
 	// live counters — stay in force, and the etag is NOT advanced so the bad
 	// input is re-fetched and retried (re-warned) on the next poll instead of
 	// 304ing forever.
-	err := e.Update(2, []string{"limits:\n  - id: bad\n    key: ip\n    rate: -1\n    window: 1m\n"}, nil, nil, nil, nil, `"e2"`)
+	err := e.Update(2, []string{"limits:\n  - id: bad\n    key: ip\n    rate: -1\n    window: 1m\n"}, nil, `"e2"`)
 	assert.Error(t, err)
 	assert.Equal(t, `"e1"`, e.Etag(), "etag must not advance on a failed apply")
 	assert.Equal(t, 429, rlServe(h, "acme.com", "10.3.3.3"), "last-good set still enforcing with its counters")
 }
 
 func TestEdgeRateLimit_CountersSurviveUnchangedUpdate(t *testing.T) {
-	e := NewEdgeRateLimit(nil, nil)
+	e := NewEdgeRateLimit(nil, nil, NewEdgeTopology())
 	doc := "limits:\n  - id: ip-2\n    key: ip\n    rate: 2\n    window: 1m\n"
-	require.NoError(t, e.Update(1, []string{doc}, nil, nil, nil, nil, `"e1"`))
+	require.NoError(t, e.Update(1, []string{doc}, nil, `"e1"`))
 
 	h := e.Global().ServeHandler(passed())
 	assert.Equal(t, 200, rlServe(h, "acme.com", "10.4.4.4"))
 
 	// Re-applying an unchanged limit carries the strategy — and its counters —
 	// over (SetLimits' cfgKey match), so the budget is NOT reset by a refresh.
-	require.NoError(t, e.Update(2, []string{doc}, nil, nil, nil, nil, `"e2"`))
+	require.NoError(t, e.Update(2, []string{doc}, nil, `"e2"`))
 	assert.Equal(t, 200, rlServe(h, "acme.com", "10.4.4.4"), "2/2 after carry-over")
 	assert.Equal(t, 429, rlServe(h, "acme.com", "10.4.4.4"), "3rd request over the carried budget")
 }
 
 func TestEdgeRateLimit_KnownHostCollapse(t *testing.T) {
-	e := NewEdgeRateLimit(nil, nil)
-	require.NoError(t, e.Update(1, []string{hostLimitDoc}, nil, nil, nil, []string{"a.com"}, `"e1"`))
+	// The known-host set now comes from the shared topology.
+	e := rlWithRLZones(nil, nil, []string{"a.com"})
+	require.NoError(t, e.Update(1, []string{hostLimitDoc}, nil, `"e1"`))
 
 	h := e.Global().ServeHandler(passed())
 	// Hosts no Ingress declares collapse into ONE shared bucket: a random-Host
@@ -141,8 +144,8 @@ func TestEdgeRateLimit_KnownHostCollapse(t *testing.T) {
 }
 
 func TestEdgeRateLimit_EtagRoundtrips(t *testing.T) {
-	e := NewEdgeRateLimit(nil, nil)
+	e := NewEdgeRateLimit(nil, nil, NewEdgeTopology())
 	assert.Equal(t, "", e.Etag())
-	require.NoError(t, e.Update(3, nil, nil, nil, nil, nil, `"e9"`))
+	require.NoError(t, e.Update(3, nil, nil, `"e9"`))
 	assert.Equal(t, `"e9"`, e.Etag())
 }

--- a/edge/ratelimitrefresh.go
+++ b/edge/ratelimitrefresh.go
@@ -19,7 +19,7 @@ func RefreshRateLimitOnce(cp *CpClient, e *EdgeRateLimit) {
 	case res.Unchanged:
 		// 304: cached config is current.
 	default:
-		if err := e.Update(res.Generation, res.GlobalLimits, res.Zones, res.RouteZoneMap, res.HostZoneMap, res.Hosts, res.Etag); err != nil {
+		if err := e.Update(res.Generation, res.GlobalLimits, res.Zones, res.Etag); err != nil {
 			slog.Warn("edge: a rate-limit set was rejected; kept last-good (per set)", "error", err)
 		} else {
 			slog.Info("edge: rate limits updated", "generation", res.Generation)

--- a/edge/topology.go
+++ b/edge/topology.go
@@ -1,0 +1,101 @@
+package edge
+
+import (
+	"net/http"
+	"sync"
+	"sync/atomic"
+)
+
+// EdgeTopology holds the Ingress-derived topology fetched from the control
+// plane's GET /v1/topology: the WAF zone matcher, the rate-limit zone matcher,
+// and the known-host set. It is the single source the edge WAF, the edge rate
+// limiter, and the request metric read — replacing the per-feature bindings the
+// /v1/waf and /v1/ratelimit payloads used to embed.
+//
+// Zone resolution is PATH-AWARE: the CP ships the controller's own route
+// patterns and the matcher runs them through a real http.ServeMux, so the edge
+// resolves a request's zone exactly as the core does. The known-host set bounds
+// the request metric's host label and the rate limiter's host-key collapse to
+// the controller's IsKnownHost set.
+type EdgeTopology struct {
+	wafMatcher atomic.Pointer[zoneMatcher]         // host+path -> waf zoneKey
+	rlMatcher  atomic.Pointer[zoneMatcher]         // host+path -> ratelimit zoneKey
+	knownHosts atomic.Pointer[map[string]struct{}] // Ingress-declared hosts
+
+	// generation of the currently-loaded snapshot (0 until the first fetch applies).
+	generation atomic.Uint64
+
+	mu   sync.Mutex
+	etag string
+}
+
+// NewEdgeTopology returns an empty topology (no bindings, no known hosts) — every
+// request resolves to no zone and every host is unknown until the first fetch.
+func NewEdgeTopology() *EdgeTopology {
+	t := &EdgeTopology{}
+	t.wafMatcher.Store(newZoneMatcher(nil, nil))
+	t.rlMatcher.Store(newZoneMatcher(nil, nil))
+	empty := map[string]struct{}{}
+	t.knownHosts.Store(&empty)
+	return t
+}
+
+// Etag returns the ETag of the currently-loaded topology (sent as If-None-Match).
+func (t *EdgeTopology) Etag() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.etag
+}
+
+// Generation returns the currently-loaded snapshot's generation (0 until the
+// first fetch applies).
+func (t *EdgeTopology) Generation() uint64 { return t.generation.Load() }
+
+// Update installs a fetched topology snapshot. The two matchers and the
+// known-host set are swapped wholesale (each an independent atomic swap; a
+// request racing the swap reads a consistent prior-or-next snapshot of each).
+// Unlike the WAF/rate-limit Updates there is no compile step — the maps are
+// already-validated wire data — so it always applies and advances the
+// etag/generation.
+func (t *EdgeTopology) Update(generation uint64, wafRouteZone, wafHostZone, rlRouteZone, rlHostZone map[string]string, hosts []string, etag string) {
+	t.wafMatcher.Store(newZoneMatcher(wafRouteZone, wafHostZone))
+	t.rlMatcher.Store(newZoneMatcher(rlRouteZone, rlHostZone))
+	hs := make(map[string]struct{}, len(hosts))
+	for _, h := range hosts {
+		hs[h] = struct{}{}
+	}
+	t.knownHosts.Store(&hs)
+
+	t.mu.Lock()
+	t.etag = etag
+	t.mu.Unlock()
+	t.generation.Store(generation)
+}
+
+// resolveWAFZone returns the WAF zone key bound to the request's host+path.
+func (t *EdgeTopology) resolveWAFZone(r *http.Request) (string, bool) {
+	if m := t.wafMatcher.Load(); m != nil {
+		return m.resolve(r)
+	}
+	return "", false
+}
+
+// resolveRLZone returns the rate-limit zone key bound to the request's host+path.
+func (t *EdgeTopology) resolveRLZone(r *http.Request) (string, bool) {
+	if m := t.rlMatcher.Load(); m != nil {
+		return m.resolve(r)
+	}
+	return "", false
+}
+
+// IsKnownHost reports whether host is one an Ingress declares. A host not in the
+// set collapses (the request metric's "other" bucket, the rate limiter's shared
+// host-key bucket), mirroring the controller's IsKnownHost cardinality bound.
+func (t *EdgeTopology) IsKnownHost(host string) bool {
+	m := t.knownHosts.Load()
+	if m == nil {
+		return false
+	}
+	_, ok := (*m)[host]
+	return ok
+}

--- a/edge/topology_test.go
+++ b/edge/topology_test.go
@@ -1,0 +1,68 @@
+package edge
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func topoReq(host, path string) *http.Request {
+	return httptest.NewRequest(http.MethodGet, "https://"+host+path, nil)
+}
+
+func TestEdgeTopology_Empty(t *testing.T) {
+	tp := NewEdgeTopology()
+	_, ok := tp.resolveWAFZone(topoReq("acme.com", "/x"))
+	assert.False(t, ok)
+	_, ok = tp.resolveRLZone(topoReq("acme.com", "/x"))
+	assert.False(t, ok)
+	assert.False(t, tp.IsKnownHost("acme.com"))
+	assert.Equal(t, "", tp.Etag())
+	assert.EqualValues(t, 0, tp.Generation())
+}
+
+// The WAF matcher, the rate-limit matcher, and the known-host set are independent:
+// a request resolves to its WAF zone and its (possibly different) rate-limit zone
+// from the one fetched topology.
+func TestEdgeTopology_UpdateResolvesIndependently(t *testing.T) {
+	tp := NewEdgeTopology()
+	tp.Update(5,
+		map[string]string{"acme.com/api": "ns/waf", "acme.com/api/": "ns/waf"}, nil, // waf route map
+		map[string]string{"acme.com/": "ns/rl"}, nil, // rl route map (whole-host subtree)
+		[]string{"acme.com"}, `"t1"`)
+
+	k, ok := tp.resolveWAFZone(topoReq("acme.com", "/api/x"))
+	assert.True(t, ok)
+	assert.Equal(t, "ns/waf", k)
+	k, ok = tp.resolveRLZone(topoReq("acme.com", "/api/x"))
+	assert.True(t, ok)
+	assert.Equal(t, "ns/rl", k)
+
+	// /web has no WAF binding, but the rate-limit "/" subtree covers it.
+	_, ok = tp.resolveWAFZone(topoReq("acme.com", "/web"))
+	assert.False(t, ok, "no waf route for /web")
+	_, ok = tp.resolveRLZone(topoReq("acme.com", "/web"))
+	assert.True(t, ok, "rl subtree / covers /web")
+
+	assert.True(t, tp.IsKnownHost("acme.com"))
+	assert.False(t, tp.IsKnownHost("evil.com"))
+	assert.Equal(t, `"t1"`, tp.Etag())
+	assert.EqualValues(t, 5, tp.Generation())
+}
+
+// route maps absent (an older CP would only have sent host maps) → synthesized
+// into whole-host "host/" subtree patterns, same as the WAF/RL matchers did.
+func TestEdgeTopology_LegacyHostZoneFallback(t *testing.T) {
+	tp := NewEdgeTopology()
+	tp.Update(1, nil, map[string]string{"acme.com": "ns/waf"},
+		nil, map[string]string{"acme.com": "ns/rl"}, []string{"acme.com"}, `"t1"`)
+
+	k, ok := tp.resolveWAFZone(topoReq("acme.com", "/anything"))
+	assert.True(t, ok)
+	assert.Equal(t, "ns/waf", k)
+	k, ok = tp.resolveRLZone(topoReq("acme.com", "/anything"))
+	assert.True(t, ok)
+	assert.Equal(t, "ns/rl", k)
+}

--- a/edge/topologyrefresh.go
+++ b/edge/topologyrefresh.go
@@ -1,0 +1,37 @@
+package edge
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// RefreshTopologyOnce fetches the unified topology (ETag-revalidated) and swaps
+// it into the EdgeTopology. A fetch failure is fail-static — the edge keeps its
+// last-good bindings + known-host set and never falls back to "no topology"
+// (which would unbind every zone and collapse every host). There is no compile
+// step, so a 200 always applies.
+func RefreshTopologyOnce(cp *CpClient, t *EdgeTopology) {
+	res, err := cp.FetchTopology(t.Etag())
+	switch {
+	case err != nil:
+		slog.Warn("edge: topology fetch failed; keeping last-good bindings", "error", err)
+	case res.Unchanged:
+		// 304: cached topology is current.
+	default:
+		t.Update(res.Generation, res.WAFRouteZone, res.WAFHostZone, res.RLRouteZone, res.RLHostZone, res.Hosts, res.Etag)
+		slog.Info("edge: topology updated", "generation", res.Generation, "hosts", len(res.Hosts))
+	}
+}
+
+// RunTopologyRefresh runs the periodic topology refresh forever. The first tick
+// is jittered by [0,interval] (fleet poll-instant decorrelation); same cadence
+// as the cert/WAF refresh; fail-static. poke (nil ok) wakes the loop immediately
+// on the /v1/events topology change signal, so the timer is only the fallback
+// floor. All refreshes run on THIS goroutine, keeping them single-flight.
+func RunTopologyRefresh(ctx context.Context, cp *CpClient, t *EdgeTopology, interval time.Duration, poke <-chan struct{}) {
+	if interval <= 0 { // time.NewTicker panics on a non-positive interval
+		interval = 300 * time.Second
+	}
+	runRefreshLoop(ctx, interval, poke, func() { RefreshTopologyOnce(cp, t) })
+}

--- a/edge/waf.go
+++ b/edge/waf.go
@@ -30,9 +30,9 @@ import (
 // a host with different paths and different zones resolve exactly as they do at
 // the core.
 type EdgeWAF struct {
-	global  *waf.WAF
-	zones   atomic.Pointer[map[string]*waf.WAF] // zoneKey -> compiled zone
-	matcher atomic.Pointer[zoneMatcher]         // host+path -> zoneKey (core ServeMux semantics)
+	global *waf.WAF
+	zones  atomic.Pointer[map[string]*waf.WAF] // zoneKey -> compiled zone
+	topo   *EdgeTopology                       // shared: host+path -> zoneKey (from /v1/topology)
 
 	newZone func() *waf.WAF // factory wiring Country/ASN/Logger onto a fresh zone
 
@@ -48,7 +48,7 @@ type EdgeWAF struct {
 // (nil = request.country empty / request.asn 0); they are wired onto the global
 // ruleset and every zone, so the edge — the first hop — resolves both from the
 // true client IP.
-func NewEdgeWAF(country func(*http.Request) string, asn func(*http.Request) int64) *EdgeWAF {
+func NewEdgeWAF(country func(*http.Request) string, asn func(*http.Request) int64, topo *EdgeTopology) *EdgeWAF {
 	newWAF := func(scope string) *waf.WAF {
 		w := waf.New()
 		w.Country = country
@@ -65,11 +65,10 @@ func NewEdgeWAF(country func(*http.Request) string, asn func(*http.Request) int6
 		w.Observe = observe.WAFEval(scope)
 		return w
 	}
-	w := &EdgeWAF{newZone: func() *waf.WAF { return newWAF("zone") }}
+	w := &EdgeWAF{newZone: func() *waf.WAF { return newWAF("zone") }, topo: topo}
 	w.global = newWAF("global")
 	empty := map[string]*waf.WAF{}
 	w.zones.Store(&empty)
-	w.matcher.Store(newZoneMatcher(nil, nil))
 	return w
 }
 
@@ -80,16 +79,15 @@ func (w *EdgeWAF) Etag() string {
 	return w.etag
 }
 
-// Update compiles and installs a fetched payload: the global ruleset, the
-// zones, and the zone bindings. routeZone is the path-aware binding (route
-// pattern -> zoneKey); hostZone is the legacy host-level binding an older CP
-// serves, used only when routeZone is empty (see newZoneMatcher). All-or-nothing
-// PER ruleset (parapet's SetRules keeps the last-good ruleset on a compile
-// error); the zones map and the matcher are swapped wholesale. An existing zone
-// instance is reused when present so a bad zone edit keeps its last-good rules
-// (mirrors the controller). Returns the first compile error encountered (the
-// rest still apply — fail-static per ruleset).
-func (w *EdgeWAF) Update(generation uint64, globalYAML string, zonesYAML, routeZone, hostZone map[string]string, etag string) error {
+// Update compiles and installs a fetched payload: the global ruleset and the
+// zone rulesets. The zone BINDINGS (which route resolves to which zone) come
+// from EdgeTopology now, not from this payload. All-or-nothing PER ruleset
+// (parapet's SetRules keeps the last-good ruleset on a compile error); the zones
+// map is swapped wholesale. An existing zone instance is reused when present so
+// a bad zone edit keeps its last-good rules (mirrors the controller). Returns
+// the first compile error encountered (the rest still apply — fail-static per
+// ruleset).
+func (w *EdgeWAF) Update(generation uint64, globalYAML string, zonesYAML map[string]string, etag string) error {
 	var firstErr error
 	note := func(err error) {
 		if firstErr == nil {
@@ -120,8 +118,6 @@ func (w *EdgeWAF) Update(generation uint64, globalYAML string, zonesYAML, routeZ
 		newZones[key] = z
 	}
 	w.zones.Store(&newZones)
-
-	w.matcher.Store(newZoneMatcher(routeZone, hostZone))
 
 	// Advance the etag + generation only on a CLEAN apply. Storing the etag on
 	// a failed compile would 304 every later poll and the bad input would never
@@ -196,13 +192,11 @@ func StripWAFClaim() parapet.Middleware {
 func (w *EdgeWAF) Zone() parapet.Middleware {
 	return parapet.MiddlewareFunc(func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-			if m := w.matcher.Load(); m != nil {
-				if key, ok := m.resolve(r); ok {
-					if zs := w.zones.Load(); zs != nil {
-						if z := (*zs)[key]; z != nil {
-							z.ServeHandler(h).ServeHTTP(rw, r)
-							return
-						}
+			if key, ok := w.topo.resolveWAFZone(r); ok {
+				if zs := w.zones.Load(); zs != nil {
+					if z := (*zs)[key]; z != nil {
+						z.ServeHandler(h).ServeHTTP(rw, r)
+						return
 					}
 				}
 			}

--- a/edge/waf_test.go
+++ b/edge/waf_test.go
@@ -45,9 +45,17 @@ func passed() http.Handler {
 	})
 }
 
+// wafWithWAFZones builds an EdgeWAF whose shared topology binds the given WAF
+// route/host maps (the bindings now live in EdgeTopology, not the WAF payload).
+func wafWithWAFZones(routeZone, hostZone map[string]string) *EdgeWAF {
+	topo := NewEdgeTopology()
+	topo.Update(1, routeZone, hostZone, nil, nil, nil, `"t1"`)
+	return NewEdgeWAF(nil, nil, topo)
+}
+
 func TestEdgeWAF_GlobalBlocksMatchingPath(t *testing.T) {
-	w := NewEdgeWAF(nil, nil)
-	require.NoError(t, w.Update(1, globalRulesYAML, nil, nil, nil, `"e1"`))
+	w := NewEdgeWAF(nil, nil, NewEdgeTopology())
+	require.NoError(t, w.Update(1, globalRulesYAML, nil, `"e1"`))
 
 	h := w.Global().ServeHandler(passed())
 	blocked := run(h, "GET", "https://acme.com/blocked")
@@ -61,13 +69,10 @@ func TestEdgeWAF_GlobalBlocksMatchingPath(t *testing.T) {
 
 func TestEdgeWAF_ZoneBlocksWhenHostBound(t *testing.T) {
 	// Legacy host-level binding (route_zone_map absent — an older CP): the host
-	// map is synthesized into whole-host subtree patterns.
-	w := NewEdgeWAF(nil, nil)
-	require.NoError(t, w.Update(1, "",
-		map[string]string{"ns/z": zoneRulesYAML},
-		nil,
-		map[string]string{"acme.com": "ns/z"},
-		`"e1"`))
+	// map is synthesized into whole-host subtree patterns (in newZoneMatcher,
+	// which EdgeTopology builds the matcher with).
+	w := wafWithWAFZones(nil, map[string]string{"acme.com": "ns/z"})
+	require.NoError(t, w.Update(1, "", map[string]string{"ns/z": zoneRulesYAML}, `"e1"`))
 
 	h := w.Zone().ServeHandler(passed())
 
@@ -100,16 +105,14 @@ func TestEdgeWAF_ZonePathAware(t *testing.T) {
 	// request.path == "/zoneblocked"). Route patterns are the controller's
 	// route keys, so the edge resolves each path to its own zone — the case
 	// host-level binding could not represent.
-	w := NewEdgeWAF(nil, nil)
+	w := wafWithWAFZones(map[string]string{
+		"acme.com/api":  "ns/z2",
+		"acme.com/api/": "ns/z2",
+		"acme.com/web":  "ns/z1",
+		"acme.com/web/": "ns/z1",
+	}, nil)
 	require.NoError(t, w.Update(1, "",
-		map[string]string{"ns/z1": zoneRulesYAML, "ns/z2": blockAllZoneYAML},
-		map[string]string{
-			"acme.com/api":  "ns/z2",
-			"acme.com/api/": "ns/z2",
-			"acme.com/web":  "ns/z1",
-			"acme.com/web/": "ns/z1",
-		},
-		nil, `"e1"`))
+		map[string]string{"ns/z1": zoneRulesYAML, "ns/z2": blockAllZoneYAML}, `"e1"`))
 
 	h := w.Zone().ServeHandler(passed())
 
@@ -132,20 +135,16 @@ func TestEdgeWAF_ZonePathAware(t *testing.T) {
 func TestEdgeWAF_RouteZonePreferredOverHostZone(t *testing.T) {
 	// When the CP ships route_zone_map, the legacy host map is ignored — the
 	// edge must not blend the two models.
-	w := NewEdgeWAF(nil, nil)
-	require.NoError(t, w.Update(1, "",
-		map[string]string{"ns/z": zoneRulesYAML},
-		map[string]string{"acme.com/api/": "ns/z"},
-		map[string]string{"acme.com": "ns/z"},
-		`"e1"`))
+	w := wafWithWAFZones(map[string]string{"acme.com/api/": "ns/z"}, map[string]string{"acme.com": "ns/z"})
+	require.NoError(t, w.Update(1, "", map[string]string{"ns/z": zoneRulesYAML}, `"e1"`))
 
 	h := w.Zone().ServeHandler(passed())
 	assert.Equal(t, 200, run(h, "GET", "https://acme.com/zoneblocked").Code, "host-level binding ignored when route map present")
 }
 
 func TestEdgeWAF_KeepLastGoodOnBadRuleset(t *testing.T) {
-	w := NewEdgeWAF(nil, nil)
-	require.NoError(t, w.Update(1, globalRulesYAML, nil, nil, nil, `"e1"`))
+	w := NewEdgeWAF(nil, nil, NewEdgeTopology())
+	require.NoError(t, w.Update(1, globalRulesYAML, nil, `"e1"`))
 
 	// A ruleset that fails to compile (non-bool expression) is rejected; the
 	// previous good global ruleset stays live, and the etag + generation are
@@ -156,7 +155,7 @@ func TestEdgeWAF_KeepLastGoodOnBadRuleset(t *testing.T) {
   - id: bad
     expression: "1 + 1"
     action: block
-`, nil, nil, nil, `"e2"`)
+`, nil, `"e2"`)
 	assert.Error(t, err)
 	assert.Equal(t, `"e1"`, w.Etag(), "etag must not advance on a failed apply")
 
@@ -169,12 +168,12 @@ func TestEdgeWAF_BadFirstSnapshotNeverClaims(t *testing.T) {
 	// An edge whose FIRST snapshot fails to compile keeps the empty boot
 	// ruleset — it must not claim WAF validation, or a WAF_VALIDATED_PROXY
 	// core would skip its own WAF for traffic that was screened by nothing.
-	w := NewEdgeWAF(nil, nil)
+	w := NewEdgeWAF(nil, nil, NewEdgeTopology())
 	err := w.Update(1, `rules:
   - id: bad
     expression: "1 + 1"
     action: block
-`, nil, nil, nil, `"e1"`)
+`, nil, `"e1"`)
 	assert.Error(t, err)
 
 	var got string
@@ -191,14 +190,14 @@ func TestEdgeWAF_BadFirstSnapshotNeverClaims(t *testing.T) {
 
 func TestEdgeWAF_CountryResolverWired(t *testing.T) {
 	country := func(_ *http.Request) string { return "XX" }
-	w := NewEdgeWAF(country, nil)
+	w := NewEdgeWAF(country, nil, NewEdgeTopology())
 	require.NoError(t, w.Update(1, `rules:
   - id: geo
     expression: request.country == "XX"
     action: block
     status: 403
     message: blocked-by-geo
-`, nil, nil, nil, `"e1"`))
+`, nil, `"e1"`))
 
 	h := w.Global().ServeHandler(passed())
 	rec := run(h, "GET", "https://acme.com/anything")
@@ -207,14 +206,14 @@ func TestEdgeWAF_CountryResolverWired(t *testing.T) {
 }
 
 func TestEdgeWAF_EtagRoundtrips(t *testing.T) {
-	w := NewEdgeWAF(nil, nil)
+	w := NewEdgeWAF(nil, nil, NewEdgeTopology())
 	assert.Equal(t, "", w.Etag())
-	require.NoError(t, w.Update(3, globalRulesYAML, nil, nil, nil, `"e9"`))
+	require.NoError(t, w.Update(3, globalRulesYAML, nil, `"e9"`))
 	assert.Equal(t, `"e9"`, w.Etag())
 }
 
 func TestEdgeWAF_ClaimStamp(t *testing.T) {
-	w := NewEdgeWAF(nil, nil)
+	w := NewEdgeWAF(nil, nil, NewEdgeTopology())
 
 	var got string
 	sentinel := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
@@ -231,7 +230,7 @@ func TestEdgeWAF_ClaimStamp(t *testing.T) {
 
 	// Once a snapshot lands, the claim is the generation — Set overwrites any
 	// inbound value even without StripWAFClaim upstream.
-	require.NoError(t, w.Update(7, globalRulesYAML, nil, nil, nil, `"e1"`))
+	require.NoError(t, w.Update(7, globalRulesYAML, nil, `"e1"`))
 	req := httptest.NewRequest(http.MethodGet, "https://acme.com/x", nil)
 	req.Header.Set(wafclaim.Header, "spoofed")
 	h.ServeHTTP(httptest.NewRecorder(), req)
@@ -251,20 +250,20 @@ func TestStripWAFClaim(t *testing.T) {
 }
 
 func TestEdgeWAF_ZoneRemovedOnNextUpdateButKeptOnBadEdit(t *testing.T) {
-	w := NewEdgeWAF(nil, nil)
-	require.NoError(t, w.Update(1, "",
-		map[string]string{"ns/z": zoneRulesYAML},
-		map[string]string{"acme.com/": "ns/z"}, nil, `"e1"`))
+	// Binding lives in the shared topology; the zone RULESETS come from the WAF
+	// payload. A dropped ruleset stops being evaluated even though the binding
+	// remains.
+	w := wafWithWAFZones(map[string]string{"acme.com/": "ns/z"}, nil)
+	require.NoError(t, w.Update(1, "", map[string]string{"ns/z": zoneRulesYAML}, `"e1"`))
 
 	// A bad edit to the zone keeps its last-good rules.
 	_ = w.Update(2, "",
-		map[string]string{"ns/z": "rules:\n  - id: bad\n    expression: \"1+1\"\n    action: block\n"},
-		map[string]string{"acme.com/": "ns/z"}, nil, `"e2"`)
+		map[string]string{"ns/z": "rules:\n  - id: bad\n    expression: \"1+1\"\n    action: block\n"}, `"e2"`)
 	h := w.Zone().ServeHandler(passed())
 	assert.Equal(t, 403, run(h, "GET", "https://acme.com/zoneblocked").Code, "bad zone edit keeps last-good")
 
 	// A zone absent from the next payload is dropped.
-	require.NoError(t, w.Update(3, "", nil, nil, nil, `"e3"`))
+	require.NoError(t, w.Update(3, "", nil, `"e3"`))
 	h2 := w.Zone().ServeHandler(passed())
 	assert.Equal(t, 200, run(h2, "GET", "https://acme.com/zoneblocked").Code, "dropped zone no longer evaluated")
 }

--- a/edge/wafrefresh.go
+++ b/edge/wafrefresh.go
@@ -18,7 +18,7 @@ func RefreshWafOnce(cp *CpClient, w *EdgeWAF, coord *RemintCoordinator) {
 	case res.Unchanged:
 		// 304: cached ruleset is current.
 	default:
-		if err := w.Update(res.Generation, res.GlobalRules, res.Zones, res.RouteZoneMap, res.HostZoneMap, res.Etag); err != nil {
+		if err := w.Update(res.Generation, res.GlobalRules, res.Zones, res.Etag); err != nil {
 			slog.Warn("edge: a WAF ruleset was rejected; kept last-good (per ruleset)", "error", err)
 		} else {
 			slog.Info("edge: WAF rulesets updated", "generation", res.Generation)

--- a/edgecp/events.go
+++ b/edgecp/events.go
@@ -17,6 +17,11 @@ type EventsSnapshot struct {
 	// WAF/RateLimit are the stores' content etags ("" when distribution is off).
 	WAF       string `json:"waf,omitempty"`
 	RateLimit string `json:"ratelimit,omitempty"`
+	// Topology is the topology store's content etag ("" when off). A binding/host
+	// change bumps it; the edge re-fetches /v1/topology (and, since a binding
+	// change can alter which zone rulesets a token receives, also /v1/waf and
+	// /v1/ratelimit — those are cheap 304s when their own content is unchanged).
+	Topology string `json:"topology,omitempty"`
 	// Certs is a fingerprint over the cert store's full (name, etag) index.
 	Certs string `json:"certs,omitempty"`
 	// Purges is the purge journal's last issued seq (0 = none/off).

--- a/edgecp/ingressreload.go
+++ b/edgecp/ingressreload.go
@@ -27,6 +27,7 @@ import (
 type IngressReloader struct {
 	store          *WafStore       // optional (nil = WAF host→zone derivation off)
 	rl             *RateLimitStore // optional (nil = rate-limit derivation off)
+	topo           *TopologyStore  // optional (nil = unified topology distribution off)
 	watchNamespace string
 	debounce       time.Duration
 }
@@ -39,6 +40,14 @@ func NewIngressReloader(store *WafStore, watchNamespace string) *IngressReloader
 // its host→zone binding and known-host list. Returns the reloader for chaining.
 func (r *IngressReloader) WithRateLimit(rl *RateLimitStore) *IngressReloader {
 	r.rl = rl
+	return r
+}
+
+// WithTopology wires the unified topology store (served at /v1/topology) so the
+// same Ingress reload also feeds the single binding+host distribution the edge
+// consumes. Returns the reloader for chaining.
+func (r *IngressReloader) WithTopology(topo *TopologyStore) *IngressReloader {
+	r.topo = topo
 	return r
 }
 
@@ -94,11 +103,24 @@ func (r *IngressReloader) reload(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Derive every binding/host input once from this one Ingress snapshot, then
+	// fan out to the WAF store + rate-limit store (which keep their own copy to
+	// scope which zone rulesets a token receives) and the topology store (the
+	// single wire home for the bindings + hosts). One snapshot ⇒ the three never
+	// diverge mid-update.
+	wafHostZone := buildHostZone(ings)
+	wafRouteZone := buildZoneRoutes(ings, WAFZoneAnnotation, false)
+	rlHostZone := buildRateLimitHostZone(ings)
+	rlRouteZone := buildZoneRoutes(ings, RateLimitZoneAnnotation, true)
+	hosts := collectIngressHosts(ings)
 	if r.store != nil {
-		r.store.SetIngressDerived(buildHostZone(ings), buildZoneRoutes(ings, WAFZoneAnnotation, false))
+		r.store.SetIngressDerived(wafHostZone, wafRouteZone)
 	}
 	if r.rl != nil {
-		r.rl.SetIngressDerived(buildRateLimitHostZone(ings), buildZoneRoutes(ings, RateLimitZoneAnnotation, true), collectIngressHosts(ings))
+		r.rl.SetIngressDerived(rlHostZone, rlRouteZone, hosts)
+	}
+	if r.topo != nil {
+		r.topo.SetIngressDerived(wafHostZone, wafRouteZone, rlHostZone, rlRouteZone, hosts)
 	}
 	return nil
 }

--- a/edgecp/ratelimitstore_test.go
+++ b/edgecp/ratelimitstore_test.go
@@ -151,15 +151,11 @@ func TestServerRateLimitEndpoint(t *testing.T) {
 	if !reflect.DeepEqual(resp.GlobalLimits, []string{"gdoc"}) {
 		t.Errorf("global: got %v", resp.GlobalLimits)
 	}
-	if !reflect.DeepEqual(resp.HostZoneMap, map[string]string{"acme.com": "cust1/basic"}) {
-		t.Errorf("host_zone_map must exclude evil.com: got %v", resp.HostZoneMap)
+	if !reflect.DeepEqual(resp.Zones, map[string][]string{"cust1/basic": {"zdoc"}}) {
+		t.Errorf("zones must include only referenced+allowed: got %v", resp.Zones)
 	}
-	if !reflect.DeepEqual(resp.RouteZoneMap, map[string]string{"acme.com/": "cust1/basic"}) {
-		t.Errorf("route_zone_map must exclude evil.com: got %v", resp.RouteZoneMap)
-	}
-	if !reflect.DeepEqual(resp.Hosts, []string{"acme.com"}) {
-		t.Errorf("hosts must be scoped: got %v", resp.Hosts)
-	}
+	// The zone bindings + known-host list now ship from /v1/topology — see
+	// TestServerTopologyEndpointScopesBindings.
 	etag := rec.Header().Get("ETag")
 	if etag == "" {
 		t.Fatal("missing ETag")

--- a/edgecp/server.go
+++ b/edgecp/server.go
@@ -27,6 +27,12 @@ type Server struct {
 	// /v1/ratelimit → 404). Same scoping/ETag model as the WAF endpoint.
 	ratelimit *RateLimitStore
 
+	// topology is the optional unified zone-binding + known-host distribution store
+	// (nil = /v1/topology → 404). It carries the bindings + hosts that /v1/waf and
+	// /v1/ratelimit no longer embed; the edge consumes it for its WAF matcher,
+	// rate-limit matcher, and request-metric host bound. Same scoping/ETag model.
+	topology *TopologyStore
+
 	// purge is the optional cache-purge journal (nil = purge distribution disabled,
 	// /v1/purges → 404). purgeAdminToken gates POST /v1/purges — a STRONGER credential
 	// than the per-edge read tokens (an edge can read its purges but not issue them).
@@ -137,6 +143,13 @@ func (s *Server) WithRateLimit(rl *RateLimitStore) *Server {
 	return s
 }
 
+// WithTopology enables the unified zone-binding + known-host endpoint
+// (GET /v1/topology). Returns the server for chaining.
+func (s *Server) WithTopology(topo *TopologyStore) *Server {
+	s.topology = topo
+	return s
+}
+
 // WithEvents enables the change-notification stream (GET /v1/events). Returns
 // the server for chaining; the caller runs hub.Run in its own goroutine.
 func (s *Server) WithEvents(hub *EventsHub) *Server {
@@ -219,6 +232,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /v1/certs", s.handleCert)
 	mux.HandleFunc("GET /v1/waf", s.handleWAF)
 	mux.HandleFunc("GET /v1/ratelimit", s.handleRateLimit)
+	mux.HandleFunc("GET /v1/topology", s.handleTopology)
 	mux.HandleFunc("GET /v1/purges", s.handlePurges)
 	mux.HandleFunc("GET /v1/events", s.handleEvents)
 	mux.HandleFunc("POST /v1/purges", s.handlePurgeAdmin)
@@ -313,21 +327,16 @@ func (s *Server) handleCert(w http.ResponseWriter, r *http.Request) {
 type wafResponse struct {
 	Generation  uint64            `json:"generation"`
 	GlobalRules string            `json:"global_rules"`
-	Zones       map[string]string `json:"zones"` // zoneKey -> rules YAML
-	// RouteZoneMap is the path-aware zone binding: route pattern (the
-	// controller's own route keys, "host/path[/]") -> zoneKey. HostZoneMap is
-	// the legacy host-level binding kept for pre-path-aware edges; a current
-	// edge prefers RouteZoneMap.
-	RouteZoneMap map[string]string `json:"route_zone_map"`
-	HostZoneMap  map[string]string `json:"host_zone_map"`             // host -> zoneKey (legacy)
-	CAID         string            `json:"ca_id,omitempty"`           // signer target ca_id (best-effort SECONDARY force-re-mint confirmer)
-	SigningFP    string            `json:"signing_cert_fp,omitempty"` // active signing fp (the tuple's other half)
+	Zones       map[string]string `json:"zones"`                     // zoneKey -> rules YAML
+	CAID        string            `json:"ca_id,omitempty"`           // signer target ca_id (best-effort SECONDARY force-re-mint confirmer)
+	SigningFP   string            `json:"signing_cert_fp,omitempty"` // active signing fp (the tuple's other half)
 }
 
-// handleWAF serves the WAF payload scoped to the edge's allowed domains: the
-// global baseline (identical for every edge) plus only the zones and host→zone
-// bindings for hosts this token may serve. ETag is computed over the *scoped*
-// payload, so revalidation is correct per edge.
+// handleWAF serves the WAF RULESET payload scoped to the edge's allowed domains:
+// the global baseline (identical for every edge) plus only the zone rulesets for
+// hosts this token may serve. The zone BINDINGS that select those zones now ship
+// from /v1/topology (the store still keeps its own copy to scope here). ETag is
+// computed over the *scoped* payload, so revalidation is correct per edge.
 func (s *Server) handleWAF(w http.ResponseWriter, r *http.Request) {
 	token, ok := bearer(r)
 	if !ok || !s.authz.Known(token) {
@@ -341,11 +350,9 @@ func (s *Server) handleWAF(w http.ResponseWriter, r *http.Request) {
 	snap := s.waf.scoped(func(host string) bool { return s.authz.Allowed(token, host) })
 	caID, activeFP := s.currentSignerKey()
 	resp := wafResponse{
-		Generation:   snap.generation,
-		GlobalRules:  snap.global,
-		Zones:        snap.zones,
-		RouteZoneMap: snap.routeZone,
-		HostZoneMap:  snap.hostZone,
+		Generation:  snap.generation,
+		GlobalRules: snap.global,
+		Zones:       snap.zones,
 		// In-body ca_id + signing fp bust the ETag on the 200 arm for free (the WAF
 		// snapshot is signer-independent). The steady-state 304 arm carries NOTHING, so
 		// /v1/waf is only a SECONDARY confirmer; the /v1/certs headers are the guaranteed
@@ -390,23 +397,14 @@ type rateLimitResponse struct {
 	Generation   uint64              `json:"generation"`
 	GlobalLimits []string            `json:"global_limits"`
 	Zones        map[string][]string `json:"zones"`
-	// RouteZoneMap is the path-aware zone binding (route pattern -> zoneKey);
-	// HostZoneMap is the legacy host-level binding kept for pre-path-aware
-	// edges. Same model as wafResponse.
-	RouteZoneMap map[string]string `json:"route_zone_map"`
-	HostZoneMap  map[string]string `json:"host_zone_map"`
-	// Hosts is every Ingress-declared host the edge may serve — the edge wires
-	// it as the Limiter's KnownHost so host-keyed buckets for undeclared hosts
-	// collapse into one (cardinality bound under a random-Host flood).
-	Hosts []string `json:"hosts"`
 }
 
-// handleRateLimit serves the rate-limit payload scoped to the edge's allowed
-// domains: the global baseline (identical for every edge) plus only the zones,
-// host→zone bindings, and known hosts for hosts this token may serve. ETag is
-// computed over the scoped payload, so revalidation is correct per edge —
-// the same model as handleWAF. No signer confirmer fields: /v1/certs (and
-// /v1/waf) already carry that signal.
+// handleRateLimit serves the rate-limit LIMIT-SET payload scoped to the edge's
+// allowed domains: the global baseline (identical for every edge) plus only the
+// zone limit sets for hosts this token may serve. The zone bindings that select
+// those zones and the known-host list now ship from /v1/topology (the store
+// still keeps its own copy to scope here). ETag is computed over the scoped
+// payload, so revalidation is correct per edge — the same model as handleWAF.
 func (s *Server) handleRateLimit(w http.ResponseWriter, r *http.Request) {
 	token, ok := bearer(r)
 	if !ok || !s.authz.Known(token) {
@@ -422,9 +420,6 @@ func (s *Server) handleRateLimit(w http.ResponseWriter, r *http.Request) {
 		Generation:   snap.generation,
 		GlobalLimits: snap.global,
 		Zones:        snap.zones,
-		RouteZoneMap: snap.routeZone,
-		HostZoneMap:  snap.hostZone,
-		Hosts:        snap.hosts,
 	}
 	body, err := json.Marshal(resp)
 	if err != nil {
@@ -433,6 +428,63 @@ func (s *Server) handleRateLimit(w http.ResponseWriter, r *http.Request) {
 	}
 	// Generation zeroed in the validator for the same reason as handleWAF:
 	// process-local counters must not defeat 304 revalidation across replicas.
+	etagResp := resp
+	etagResp.Generation = 0
+	etagBody, err := json.Marshal(etagResp)
+	if err != nil {
+		http.Error(w, "encode", http.StatusInternalServerError)
+		return
+	}
+	etag := etagOfString(string(etagBody))
+	w.Header().Set("ETag", etag)
+	if match := r.Header.Get("If-None-Match"); match != "" && etagMatch(match, etag) {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(body)
+}
+
+// topologyResponse is the GET /v1/topology payload: the WAF + rate-limit zone
+// bindings (path-aware route maps plus legacy host maps) and the known-host
+// list, scoped per edge. It is the single wire home for what /v1/waf and
+// /v1/ratelimit used to embed.
+type topologyResponse struct {
+	Generation   uint64            `json:"generation"`
+	WAFRouteZone map[string]string `json:"waf_route_zone"`
+	WAFHostZone  map[string]string `json:"waf_host_zone"`
+	RLRouteZone  map[string]string `json:"rl_route_zone"`
+	RLHostZone   map[string]string `json:"rl_host_zone"`
+	Hosts        []string          `json:"hosts"`
+}
+
+// handleTopology serves the unified zone-binding + known-host topology scoped to
+// the edge's allowed domains. ETag is computed over the scoped payload (with the
+// generation zeroed for cross-replica 304s), the same model as handleWAF.
+func (s *Server) handleTopology(w http.ResponseWriter, r *http.Request) {
+	token, ok := bearer(r)
+	if !ok || !s.authz.Known(token) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if s.topology == nil {
+		http.Error(w, "topology distribution disabled", http.StatusNotFound)
+		return
+	}
+	snap := s.topology.scoped(func(host string) bool { return s.authz.Allowed(token, host) })
+	resp := topologyResponse{
+		Generation:   snap.generation,
+		WAFRouteZone: snap.wafRouteZone,
+		WAFHostZone:  snap.wafHostZone,
+		RLRouteZone:  snap.rlRouteZone,
+		RLHostZone:   snap.rlHostZone,
+		Hosts:        snap.hosts,
+	}
+	body, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, "encode", http.StatusInternalServerError)
+		return
+	}
 	etagResp := resp
 	etagResp.Generation = 0
 	etagBody, err := json.Marshal(etagResp)

--- a/edgecp/topologystore.go
+++ b/edgecp/topologystore.go
@@ -1,0 +1,152 @@
+package edgecp
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// TopologyStore holds the Ingress-derived edge topology distributed ONCE via
+// GET /v1/topology: the WAF zone bindings, the rate-limit zone bindings (both as
+// the path-aware routeZone map plus a legacy host→zoneKey map), and the
+// known-host list. It supersedes the per-feature bindings/hosts that /v1/waf and
+// /v1/ratelimit used to embed — the edge fetches the binding topology and the
+// host set from one place and feeds it to its WAF matcher, rate-limit matcher,
+// and the request metric's host-cardinality bound.
+//
+// The WAF and rate-limit RULE/limit sets still come from /v1/waf and
+// /v1/ratelimit (and those stores still hold their own copy of the bindings to
+// scope which zone rulesets a token receives — tenant isolation); this store is
+// the single wire home for the bindings + hosts, fed by the same IngressReloader
+// snapshot so the three never diverge mid-update.
+//
+// Lock-free reads via atomic pointers; mu held by the writer and by scoped() for
+// a consistent snapshot, matching WafStore/RateLimitStore.
+type TopologyStore struct {
+	mu           sync.RWMutex
+	wafHostZone  atomic.Pointer[map[string]string] // lowercased host -> waf zoneKey (legacy)
+	wafRouteZone atomic.Pointer[map[string]string] // route pattern -> waf zoneKey
+	rlHostZone   atomic.Pointer[map[string]string] // lowercased host -> ratelimit zoneKey (legacy)
+	rlRouteZone  atomic.Pointer[map[string]string] // route pattern -> ratelimit zoneKey
+	hosts        atomic.Pointer[[]string]          // sorted known hosts (IsKnownHost)
+	gen          atomic.Uint64
+	curEtag      atomic.Pointer[string]
+}
+
+func NewTopologyStore() *TopologyStore {
+	s := &TopologyStore{}
+	wh := map[string]string{}
+	wr := map[string]string{}
+	rh := map[string]string{}
+	rr := map[string]string{}
+	var hosts []string
+	s.wafHostZone.Store(&wh)
+	s.wafRouteZone.Store(&wr)
+	s.rlHostZone.Store(&rh)
+	s.rlRouteZone.Store(&rr)
+	s.hosts.Store(&hosts)
+	et := etagOfString("")
+	s.curEtag.Store(&et)
+	return s
+}
+
+// SetIngressDerived replaces every Ingress-derived input in one recompute, so a
+// single Ingress reload can't be observed half-applied.
+func (s *TopologyStore) SetIngressDerived(wafHostZone, wafRouteZone, rlHostZone, rlRouteZone map[string]string, hosts []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.wafHostZone.Store(&wafHostZone)
+	s.wafRouteZone.Store(&wafRouteZone)
+	s.rlHostZone.Store(&rlHostZone)
+	s.rlRouteZone.Store(&rlRouteZone)
+	s.hosts.Store(&hosts)
+	s.recompute()
+}
+
+func (s *TopologyStore) recompute() {
+	et := etagOfString(s.fingerprint())
+	if prev := s.curEtag.Load(); prev != nil && *prev == et {
+		return
+	}
+	s.gen.Add(1)
+	s.curEtag.Store(&et)
+}
+
+func (s *TopologyStore) fingerprint() string {
+	var b strings.Builder
+	writeSortedMap(&b, *s.wafHostZone.Load())
+	b.WriteByte(0)
+	writeSortedMap(&b, *s.wafRouteZone.Load())
+	b.WriteByte(0)
+	writeSortedMap(&b, *s.rlHostZone.Load())
+	b.WriteByte(0)
+	writeSortedMap(&b, *s.rlRouteZone.Load())
+	b.WriteByte(0)
+	for _, h := range *s.hosts.Load() {
+		b.WriteString(h)
+		b.WriteByte(1)
+	}
+	return b.String()
+}
+
+// Version is the store's full-content etag — the opaque change signal for the
+// /v1/events stream (per-edge scoping happens at fetch time).
+func (s *TopologyStore) Version() string { return *s.curEtag.Load() }
+
+// topologySnapshot is the per-edge topology payload: only the bindings and hosts
+// the edge may serve (per allow).
+type topologySnapshot struct {
+	generation   uint64
+	wafHostZone  map[string]string
+	wafRouteZone map[string]string
+	rlHostZone   map[string]string
+	rlRouteZone  map[string]string
+	hosts        []string
+}
+
+// scoped builds the per-edge topology, including only host bindings whose host
+// the edge may serve, route bindings whose pattern-host the edge may serve, and
+// the allowed hosts. Read under the lock so all five form one consistent
+// snapshot (mirrors WafStore.scoped).
+func (s *TopologyStore) scoped(allow func(host string) bool) topologySnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	filterHostMap := func(m map[string]string) map[string]string {
+		out := map[string]string{}
+		for host, key := range m {
+			if allow(host) {
+				out[host] = key
+			}
+		}
+		return out
+	}
+	filterRouteMap := func(m map[string]string) map[string]string {
+		out := map[string]string{}
+		for pattern, key := range m {
+			if allow(patternHost(pattern)) {
+				out[pattern] = key
+			}
+		}
+		return out
+	}
+
+	allHosts := *s.hosts.Load()
+	hosts := make([]string, 0, len(allHosts))
+	for _, h := range allHosts {
+		if allow(h) {
+			hosts = append(hosts, h)
+		}
+	}
+	sort.Strings(hosts)
+
+	return topologySnapshot{
+		generation:   s.gen.Load(),
+		wafHostZone:  filterHostMap(*s.wafHostZone.Load()),
+		wafRouteZone: filterRouteMap(*s.wafRouteZone.Load()),
+		rlHostZone:   filterHostMap(*s.rlHostZone.Load()),
+		rlRouteZone:  filterRouteMap(*s.rlRouteZone.Load()),
+		hosts:        hosts,
+	}
+}

--- a/edgecp/topologystore_test.go
+++ b/edgecp/topologystore_test.go
@@ -1,0 +1,80 @@
+package edgecp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+// The /v1/topology endpoint scopes every binding map and the known-host list to
+// the token's allowed hosts — the per-edge isolation that used to live on the
+// WAF and rate-limit endpoints.
+func TestServerTopologyEndpointScopesBindings(t *testing.T) {
+	store := NewTopologyStore()
+	store.SetIngressDerived(
+		map[string]string{"acme.com": "cust1/waf", "evil.com": "cust2/waf"},       // wafHostZone
+		map[string]string{"acme.com/api/": "cust1/waf", "evil.com/": "cust2/waf"}, // wafRouteZone
+		map[string]string{"acme.com": "cust1/rl", "evil.com": "cust2/rl"},         // rlHostZone
+		map[string]string{"acme.com/": "cust1/rl", "evil.com/": "cust2/rl"},       // rlRouteZone
+		[]string{"acme.com", "evil.com"},                                          // hosts
+	)
+
+	authz := NewAuthz(map[string][]string{"tok": {"acme.com"}})
+	h := NewServer(NewCertStore(), authz).WithTopology(store).Handler()
+
+	req := httptest.NewRequest("GET", "/v1/topology", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	var resp topologyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(resp.WAFRouteZone, map[string]string{"acme.com/api/": "cust1/waf"}) {
+		t.Errorf("waf_route_zone must exclude evil.com: got %v", resp.WAFRouteZone)
+	}
+	if !reflect.DeepEqual(resp.WAFHostZone, map[string]string{"acme.com": "cust1/waf"}) {
+		t.Errorf("waf_host_zone must exclude evil.com: got %v", resp.WAFHostZone)
+	}
+	if !reflect.DeepEqual(resp.RLRouteZone, map[string]string{"acme.com/": "cust1/rl"}) {
+		t.Errorf("rl_route_zone must exclude evil.com: got %v", resp.RLRouteZone)
+	}
+	if !reflect.DeepEqual(resp.RLHostZone, map[string]string{"acme.com": "cust1/rl"}) {
+		t.Errorf("rl_host_zone must exclude evil.com: got %v", resp.RLHostZone)
+	}
+	if !reflect.DeepEqual(resp.Hosts, []string{"acme.com"}) {
+		t.Errorf("hosts must be scoped: got %v", resp.Hosts)
+	}
+
+	// ETag present, and an If-None-Match match 304s.
+	etag := rec.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("missing ETag")
+	}
+	req2 := httptest.NewRequest("GET", "/v1/topology", nil)
+	req2.Header.Set("Authorization", "Bearer tok")
+	req2.Header.Set("If-None-Match", etag)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusNotModified {
+		t.Fatalf("want 304 on matching ETag, got %d", rec2.Code)
+	}
+}
+
+// A disabled topology store 404s (no skew fallback — the edge handles it fail-static).
+func TestServerTopologyDisabled(t *testing.T) {
+	authz := NewAuthz(map[string][]string{"tok": {"acme.com"}})
+	h := NewServer(NewCertStore(), authz).Handler() // no WithTopology
+	req := httptest.NewRequest("GET", "/v1/topology", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("want 404 when topology disabled, got %d", rec.Code)
+	}
+}

--- a/edgecp/wafstore_test.go
+++ b/edgecp/wafstore_test.go
@@ -8,7 +8,11 @@ import (
 	"testing"
 )
 
-func TestServerWAFEndpointScopesBindings(t *testing.T) {
+// The WAF endpoint scopes the zone RULESETS to the zones the token's allowed
+// hosts bind to (the store still keeps its own copy of the bindings to do this).
+// The bindings themselves now ship from /v1/topology — see
+// TestServerTopologyEndpointScopesBindings.
+func TestServerWAFEndpointScopesZones(t *testing.T) {
 	store := NewWafStore()
 	store.SetGlobal("global-rules")
 	store.SetZones(map[string]string{"cust1/z": "zone-rules", "cust2/other": "other-rules"})
@@ -33,12 +37,6 @@ func TestServerWAFEndpointScopesBindings(t *testing.T) {
 	}
 	if resp.GlobalRules != "global-rules" {
 		t.Errorf("global always included: got %q", resp.GlobalRules)
-	}
-	if !reflect.DeepEqual(resp.RouteZoneMap, map[string]string{"acme.com/api/": "cust1/z"}) {
-		t.Errorf("route_zone_map must exclude evil.com: got %v", resp.RouteZoneMap)
-	}
-	if !reflect.DeepEqual(resp.HostZoneMap, map[string]string{"acme.com": "cust1/z"}) {
-		t.Errorf("host_zone_map must exclude evil.com: got %v", resp.HostZoneMap)
 	}
 	if !reflect.DeepEqual(resp.Zones, map[string]string{"cust1/z": "zone-rules"}) {
 		t.Errorf("zones must include only referenced+allowed: got %v", resp.Zones)


### PR DESCRIPTION
## What

The WAF zone bindings, the rate-limit zone bindings, and the known-host list were each shipped **redundantly** inside `/v1/waf` and `/v1/ratelimit`. This consolidates them into a single new endpoint — **`GET /v1/topology`** — leaving `/v1/waf` to carry only WAF rulesets and `/v1/ratelimit` only limit sets.

The edge consumes the bindings + hosts from one place: a shared **`EdgeTopology`** that backs its WAF zone matcher, its rate-limit zone matcher, and a single controller-faithful `IsKnownHost` set (per-token, scoped to the token's domains) available regardless of which features are enabled. That `IsKnownHost` set is the exact-parity oracle the request-count metric (#151) needs — this PR lands first; #151 will rebase to consume it.

## Design

- **Wire unified, scoping preserved.** The WAF/rate-limit stores still keep their own copy of the bindings *internally*, used only to scope which zone rulesets/limit sets a token receives (tenant isolation). The bindings/hosts are no longer on those wires — they're on `/v1/topology`. One `IngressReloader` snapshot feeds all three stores, so they never diverge mid-update.
- **WAF and rate-limit zone maps stay independent.** A route can be in a WAF zone, a different rate-limit zone, or neither — `/v1/topology` carries `waf_route_zone`/`waf_host_zone` and `rl_route_zone`/`rl_host_zone` separately.
- **SSE.** A binding change bumps the new `topology` version on `/v1/events`; the edge re-fetches `/v1/topology` **and** `/v1/waf`+`/v1/ratelimit` (a binding change can alter which zone sets a token should receive — cheap 304s when their own content is unchanged).

## No version-skew support

Per the edge fleet having no production traffic yet, this is a **clean breaking change** to the CP↔edge contract: the binding/host fields are *removed* from `/v1/waf` and `/v1/ratelimit`, not dual-served, and the edge has no fallback. `EDGE.md` updated to match.

## Files

| Area | Change |
|---|---|
| CP | `edgecp/topologystore.go` (new), `server.go` (`/v1/topology` + `WithTopology`, drop binding fields from WAF/RL responses), `ingressreload.go` (feed topology), `events.go` (topology version) |
| Edge | `edge/topology.go` + `edge/topologyrefresh.go` (new), `cp.go` (`FetchTopology`, trim WAF/RL fetch structs), `waf.go`/`ratelimit.go` (consume shared matcher, slimmer `Update`), `events.go` (topology poke) |
| Wiring | both `main.go`s |
| Docs/tests | `EDGE.md`; new topology store/unit tests + reworked WAF/RL/cp tests |

## Testing

- `go build`/`go vet`/`go test ./...` green — **660 pass, 23 packages**
- `go test -race ./edge/... ./edgecp/...` green (concurrent atomic matcher/host swaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)