### PR TITLE
feat(edge): cache chunked (no-Content-Length) responses; bump parapet

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -692,6 +692,12 @@ EDGE_CACHE_BACKEND       disk | memory (default disk)
 EDGE_CACHE_DIR           cache root, disk backend only (default /var/cache/parapet-edge)
 EDGE_CACHE_MAX_SIZE      total bytes cap, LRU-evicted (default 1073741824 = 1 GiB)
 EDGE_CACHE_MAX_FILE_SIZE per-object bytes cap (default 8388608 = 8 MiB)
+EDGE_CACHE_CHUNKED       cache GET responses with no Content-Length (chunked /
+                         on-the-fly-compressed bodies — gzip/br/zstd) by buffering
+                         to derive a length (default true; the cap is enforced
+                         mid-stream, SSE is never buffered, and a truncated upstream
+                         is never committed since the forwarder aborts on it). Set
+                         false to cache only Content-Length'd responses.
 EDGE_CACHE_PURGE_ENABLED         poll for + apply cache purges (default true; needs
                                  CP_PURGE_ENABLED on the control plane)
 EDGE_CACHE_PURGE_POLL_INTERVAL   poll GET /v1/purges (default 10s; lower than the

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -276,6 +276,14 @@ func main() {
 			cacheMetrics := observe.CacheResult()
 			opts := cache.Options{
 				MaxFileSize: maxFile,
+				// Cache GET responses that arrive chunked with no Content-Length —
+				// on-the-fly-compressed assets (gzip/br/zstd) are the common case, and
+				// without this they're permanently uncacheable. Safe here: the edge
+				// forwarder is httputil.ReverseProxy, which panics http.ErrAbortHandler
+				// on a truncated upstream body, so a partial body is never committed
+				// (the cap is still enforced mid-stream, SSE is never buffered). On by
+				// default; EDGE_CACHE_CHUNKED=false reverts to Content-Length-only.
+				CacheChunked: envOr("EDGE_CACHE_CHUNKED", "true") == "true",
 				OnResult: func(r *http.Request, info cache.ResultInfo) {
 					cacheMetrics(r, info)
 					cache.LogResult(r, info)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/profiler v0.6.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.32.0
 	github.com/acoshift/configfile v1.9.0
-	github.com/moonrhythm/parapet v0.18.1
+	github.com/moonrhythm/parapet v0.18.2-0.20260611220738-3bc535d49de6
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moonrhythm/parapet v0.18.1 h1:+5bQqSY14RUTRenTnCKheGN8ymyU8JN1+6RRtM9vjzM=
-github.com/moonrhythm/parapet v0.18.1/go.mod h1:mfLCzU9zBm6vn05mnOgO0G8/+pArndciyLv3BYM9HJA=
+github.com/moonrhythm/parapet v0.18.2-0.20260611220738-3bc535d49de6 h1:XyuTXezoQpUeUvGfQvIelQNTc1rIuN5gAdIN4E8iZXA=
+github.com/moonrhythm/parapet v0.18.2-0.20260611220738-3bc535d49de6/go.mod h1:mfLCzU9zBm6vn05mnOgO0G8/+pArndciyLv3BYM9HJA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=


### PR DESCRIPTION
## What

Bumps `parapet` to `master` (adds `Options.CacheChunked`, parapet#247) and **enables it on the edge response cache**.

This closes the original **issue 2**: the edge cache worked for a direct `curl` (no `Accept-Encoding` → identity body with `Content-Length`) but never for the browser's asset requests. The diagnosis: Grafana (and any on-the-fly compressor) serves gzip/br/zstd **chunked, with no `Content-Length`**, and parapet's honor-origin cache refused to store a GET without one — so every compressed asset was a permanent `MISS`. `CacheChunked` buffers the body to derive a length, so those responses cache and serve compressed.

## Safety

Enabled unconditionally-by-default because it's safe on the edge specifically: the forwarder is `httputil.ReverseProxy`, which **panics `http.ErrAbortHandler` on a truncated upstream body**, so the cache's deferred cleanup aborts the entry — a partial body is never committed. The `MaxFileSize` cap is still enforced mid-stream (oversize → served in full, uncached) and `text/event-stream` is never buffered. (parapet#247 carries the full safety model + tests; it was scrutinized twice including the background stale-while-revalidate path.)

`EDGE_CACHE_CHUNKED=false` reverts to Content-Length-only.

## Changes

- `go.mod`/`go.sum`: parapet → `master` pseudo-version (includes `CacheChunked`).
- `cmd/edge-proxy/main.go`: `cache.Options{CacheChunked: EDGE_CACHE_CHUNKED (default true)}`.
- `EDGE.md`: document `EDGE_CACHE_CHUNKED`.

## Testing

- `go build`/`vet`/`test ./...` — **664 pass, 23 packages**.
- End-to-end repro is upstream behavior (chunked compressed asset); parapet#247's tests cover cached-when-enabled / SSE-excluded / over-cap / truncation-not-committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)