### PR TITLE
feat(cache): ConfigMap-driven cache overrides (CEL filter, global + zone) at the edge

### DIFF
--- a/CACHE.md
+++ b/CACHE.md
@@ -1,0 +1,381 @@
+# Cache overrides (ConfigMap-driven, global + zones)
+
+Per-request **cache policy overrides** at the edge response cache, with a
+**global** baseline set (platform-owned) plus opt-in **zones** (tenant-owned)
+that an ingress binds by reference — the same zone model as the [WAF](WAF.md)
+and [rate limiting](RATELIMIT.md), under its own marker label. A rule scopes
+itself with a CEL `filter` (the WAF's exact expression surface) and then either
+**forces** a caching policy onto an otherwise-uncacheable (or
+short-lived) origin response, or **bypasses** the cache entirely for matching
+requests. The runtime is `parapet/pkg/cache`'s own per-request hooks
+(`Options.Cacheable`, `Options.Override`); the parser lives in
+[`cacherule/`](cacherule/).
+
+> Status: **proposed** (design locked, pre-implementation). Edge-only — see
+> [Scope](#scope-and-non-goals). Gated by `EDGE_CACHE_OVERRIDE_ENABLED` on the
+> edge + `CP_CACHE_ENABLED` on the control plane (off by default — disabled
+> means no ConfigMap watch on the CP, no `/v1/cache` endpoint, no per-request
+> work on the edge). It requires `EDGE_CACHE_ENABLED=true`: an override only
+> steers the cache, so with no cache there is nothing to steer.
+
+> **Why this exists.** The edge cache is strictly **honor-origin** (see
+> [EDGE.md](EDGE.md#response-cache-at-the-edge)): it caches *only* when the
+> origin opts in with explicit `Cache-Control`/`Expires` freshness, and never
+> invents a TTL. That is the correct default, but it leaves two real gaps an
+> operator cannot close from the origin: an origin you **don't control** (or one
+> that forgot to send cache headers) is permanently uncacheable, and an origin
+> that **over-shares** (sends cacheable headers on a per-user or dynamic path)
+> can't be fenced off without an origin redeploy. Cache overrides are the edge's
+> escape hatch for both — *force* the first, *bypass* the second — scoped by CEL
+> so the policy lands only where the operator means it to.
+
+This complements, not replaces, the cache's built-in policy:
+
+| Layer | Configured by | What it decides |
+|---|---|---|
+| Honor-origin policy | origin response `Cache-Control`/`Expires` | the default: cache iff the origin opts in |
+| **Global overrides** | ConfigMap `…/cache: global` | force/bypass across **all** edge traffic |
+| **Zone overrides** | ConfigMap `…/cache: zone` + `cache-zone` annotation | force/bypass across a tenant's ingresses |
+
+## Override schema (the contract)
+
+Each ConfigMap `data` value is one `overrides:` document. Multiple keys (and
+multiple global ConfigMaps) are kept as a `[]string` and parsed one document
+each — **never `---`-joined** (the same wire rule as rate limits: `Parse` takes
+one document per string and would silently drop everything after the first
+`---`).
+
+```yaml
+overrides:
+  - id: static-assets       # required; unique in the set; [A-Za-z0-9._-], <= 63 chars
+    action: cache           # cache (default) | bypass
+    filter: |               # optional CEL — the override applies only when true
+      request.path.startsWith("/static/")
+    ttl: 1h                 # required for action=cache; forced freshness lifetime (Go duration, 1s..max)
+    policy: balanced        # conservative | balanced (default) | aggressive  — how far the force reaches
+    stale_while_revalidate: 30s   # optional; serve stale + refresh in background (rides the force, needs ttl)
+    stale_if_error: 1h            # optional; serve stale when a revalidation errors (needs ttl)
+    status: [200, 301, 404] # optional; only force these origin response statuses
+    mode: enforce           # enforce (default) | shadow
+    priority: 100           # ascending; first match wins among cache rules
+  - id: never-cache-account
+    action: bypass          # matching requests skip the cache entirely
+    filter: |
+      request.path.startsWith("/account/") || request.headers["authorization"] != ""
+    priority: 10
+```
+
+- **`action`** selects which of the cache's two per-request hooks the rule
+  drives:
+  - **`cache`** — on a cache fill, force a policy (`ttl`/`policy`/stale windows)
+    into the stored entry. Drives `parapet/pkg/cache`'s `Options.Override`.
+  - **`bypass`** — the matching request never touches the cache (served straight
+    from the origin, no `X-Cache` header, no egress accounting). Drives
+    `Options.Cacheable` → `false`. A bypass **takes precedence** over any
+    `cache` rule (the cache evaluates `Cacheable` before it ever considers a
+    fill), so a `bypass` is an absolute carve-out.
+- **`filter`** is an optional CEL expression that **scopes** the override: empty
+  means "every request", otherwise the rule applies only where it matches. It is
+  the **exact same surface as the [WAF](WAF.md)** — `request.method`,
+  `request.path`, `request.host`, `request.headers[...]`, `request.country`/
+  `request.asn`, the helpers (`ipInCidr`, `regexMatch`, `containsAny`, `lower`,
+  `urlDecode`, …) — compiled through the one shared `waf.Predicate`, identical to
+  the rate-limit `filter`, so the three CEL surfaces cannot drift. A `cache`
+  rule may additionally narrow by response `status` (below), which CEL can't see
+  at request time. Semantics that matter:
+  - **`request.body` is always `""`** — the cache runs late in the chain but
+    never buffers the request body, so a `filter` cannot inspect it. Everything
+    else in the request model is present.
+  - A geo reference (`request.country`/`request.asn`) **without the GeoIP
+    database** is not a load error — the field is just `""` / `0`, so the filter
+    simply never matches and the rule stays inert. Wire `WAF_GEOIP_DB`/
+    `WAF_ASN_DB` to make it match (the resolvers load when the edge WAF, rate
+    limiting, **or** cache overrides are enabled).
+  - **A runtime eval error biases toward NOT caching** — see
+    [the fail direction](#evaluation-precedence-and-the-fail-direction). This is
+    the one place this feature inverts the rate-limiter's fail-*open*: there, not
+    throttling is the safe action; here, not caching is.
+  - A bad expression is rejected at **load** (all-or-nothing, like every other
+    field): the set keeps its last-good overrides and the input is retried, so a
+    typo never silently changes caching at request time.
+- **`ttl`** is the forced freshness lifetime and is **required for
+  `action: cache`** — `parapet/pkg/cache` treats a non-positive TTL as "don't
+  force", so a `cache` rule without one would do nothing (rejected at load).
+  Already-cached entries keep the TTL that was baked in at *their* fill time;
+  changing a `ttl` re-policies only **future** fills (see
+  [Reload semantics](#reload-semantics-stateless-fills-bake-in)).
+- **`policy`** selects how far the force reaches over the origin's own
+  `Cache-Control` (it maps to `parapet/pkg/cache`'s `OverrideMode`; the forced
+  policy is baked into the **stored** entry only — the served `Cache-Control`
+  stays the origin's and does not propagate downstream):
+  - **`conservative`** — fill freshness only when the origin declares **none**;
+    otherwise honor the origin entirely (`no-cache`/`no-store`/`private` and any
+    explicit `max-age` are respected). Safest; the right choice for "cache what
+    the origin forgot to mark".
+  - **`balanced`** (default) — force freshness, overriding `no-cache`/`max-age`/
+    `Expires`, but still **refuse** a response that is unsafe to share:
+    `no-store`, `private`, `Set-Cookie`, `Vary: *`, a non-cacheable status, an
+    oversize body, or an `Authorization`-bearing request without a shared opt-in.
+    The correct default for forcing a TTL onto static assets.
+  - **`aggressive`** — override almost everything, **including the
+    `Authorization` gate**. ⚠️ **DANGER: cross-user leak.** The cache key ignores
+    `Cookie`/`Authorization`, so forcing past the `Authorization` gate stores one
+    user's authenticated response under a shared key and serves it to others.
+    Only use it for endpoints with **no per-user or secret data**, or where the
+    origin sends `Vary: Authorization`. A filter eval error **never** applies an
+    `aggressive` rule (the fail-safe below). Prefer `balanced` unless you are
+    certain.
+- **`stale_while_revalidate` / `stale_if_error`** force the RFC 5861 windows for
+  this rule's fills (serve stale immediately while a background refresh runs /
+  serve stale when a revalidation errors). They ride the same forced policy, so
+  they **require a `ttl`**. For fleet-wide stale serving **without** forcing a
+  TTL — i.e. applied to every honor-origin entry the cache already keeps — set
+  the `EDGE_CACHE_DEFAULT_SWR`/`EDGE_CACHE_DEFAULT_SIE` env defaults instead (an
+  explicit per-rule window wins over the default).
+- **`status`** narrows a `cache` rule to specific origin response statuses (the
+  `Override` hook sees the response, unlike CEL). Empty means "every cacheable
+  status the cache already accepts" (`200, 203, 204, 300, 301, 308, 404, 410`).
+  Ignored for `bypass` (there is no response yet when `Cacheable` runs).
+- **`mode: shadow`** evaluates the rule and **counts** it
+  (`parapet_cache_override_total{result="shadow"}`) but does **not** change
+  caching — ship shadow, watch the metric to confirm the rule matches what you
+  expect, then flip to `enforce`. The same rollout story as WAF `action: log`
+  and rate-limit `mode: shadow`.
+- **`priority`** orders `cache` rules; the **first** matching `cache` rule wins
+  (lower number first; ties break by `id`). `bypass` rules are not ordered
+  against each other — any matching bypass bypasses.
+
+## Delivery: ConfigMaps, one marker label
+
+The label key **`parapet.moonrhythm.io/cache`** marks a ConfigMap as
+cache-override input; the value selects the role — exactly the WAF's and
+rate-limit's model, under a separate key (a Kubernetes label selector can't OR
+two keys):
+
+| Label | Meaning | Where it's honored |
+|---|---|---|
+| `parapet.moonrhythm.io/cache: global` | contributes to the global set | only in the control plane's own namespace (`POD_NAMESPACE`) |
+| `parapet.moonrhythm.io/cache: zone` | one zone; zone ID = ConfigMap **name** | any watched namespace |
+
+Restricting `global` to `POD_NAMESPACE` is the security boundary: only the
+platform team can change caching for all traffic (force-caching is a
+correctness-sensitive lever). Tenants get RBAC `edit` on their own zone
+ConfigMaps. A ConfigMap carrying the `cache` label **and** a `waf`/`ratelimit`
+label is refused by the cache reload (one ConfigMap per feature).
+
+### Zone binding
+
+```yaml
+metadata:
+  annotations:
+    parapet.moonrhythm.io/cache-zone: assets        # bare id → ingress's own namespace
+    # parapet.moonrhythm.io/cache-zone: platform/assets   # ns/id → cross-namespace reference
+```
+
+Every domain/path on that ingress is matched against the `assets` zone's
+overrides (in addition to the global set).
+
+**Resolution allows cross-namespace references** (`ns/id`), following the
+**`waf-zone` model, not `ratelimit-zone`**. The distinction is deliberate and
+turns on shared state: a rate-limit zone carries **shared counter state**, so a
+cross-namespace bind would let one tenant burn another's budgets (a cross-tenant
+DoS) — hence same-namespace-only there. A cache-override zone, like a WAF zone,
+is **stateless config**: binding tenant A's override zone to tenant B's ingress
+applies A's policy to **B's own** traffic only — consensual, and it cannot harm
+A. So there is no tenancy reason to forbid it. (The one caveat is surrogate-key
+/ `Cache-Tag` purge, whose tag namespace is shared cross-tenant — but this
+feature sets no tags; see [Scope](#scope-and-non-goals).)
+
+A key that resolves to no zone — deleted, not yet created, or a **new** zone
+whose first config was rejected — applies no zone overrides (the global set
+still applies, and the origin's own policy still governs). Like the WAF's zone
+miss, this fails toward the honor-origin default by design.
+
+## Evaluation: precedence and the fail direction
+
+Per request, the edge resolves the request's bound zone (path-aware, on the same
+`http.ServeMux` route map as the edge WAF and rate limiter — see
+[edge zone routing](EDGE.md#rate-limiting-at-the-edge)) and evaluates the global
+set first, then the zone set:
+
+- **Bypass is a union, and authoritative.** If **any** matching `bypass` rule
+  fires in *either* the global or the zone set, the request bypasses the cache.
+  Most-restrictive wins, so a platform guardrail (`global` "never cache
+  `/admin`") can't be undone by a tenant, and a tenant can still add its own
+  carve-outs. Bypass is decided at `Cacheable` time, before any lookup or fill.
+- **Force is first-match, global before zone.** Among `cache` rules, evaluation
+  runs the global set (by `priority`) then the zone set (by `priority`), and the
+  **first** match wins — so a narrow global force is authoritative, and
+  everything the platform doesn't claim falls through to the tenant's zone. This
+  mirrors the WAF's "global first, authoritative" stance. (Write global `cache`
+  rules narrowly; broad global forces leave tenants no room.)
+
+**The fail direction — caching is the dangerous action, so errors bias *away*
+from it.** A filter eval error (timeout, cost-limit, panic, type error) is
+resolved toward **not caching**, never toward more caching:
+
+- a `bypass` rule whose filter errors → **bypass anyway** (treat as matched);
+- a `cache` rule whose filter errors → **skip the force** (honor the origin), and
+  an `aggressive` rule in particular is **never** applied on an error.
+
+The underlying principle is the same as the rate limiter's ("fail toward the
+non-disruptive action") — only the safe action differs: there it's *don't
+throttle* (fail open), here it's *don't serve shared/forced cache*. This matters
+most for `aggressive`, which removes parapet's `Authorization`/`Set-Cookie`/
+`private` backstops: a buggy expression must never be the reason a per-user
+response is force-cached under a shared key.
+
+The CEL surface, cost budget, and macro policy are **parapet's defaults**
+(cost `1e6`, macros on) — identical to the edge WAF and edge rate limiter, which
+also run on `waf` defaults. (The in-cluster `WAF_COST_LIMIT`/`WAF_DISABLE_MACROS`
+knobs are controller-only; the edge has no equivalent.) The request snapshot is
+built **once per request** and shared across all rules' filters; a set with no
+filtered rules pays nothing.
+
+### Per-request order at the edge
+
+The override hooks live **inside** the existing cache middleware, so they need
+no new chain position — the cache already sits after the WAF and rate limiter
+and before the forwarder:
+
+```
+edge WAF → edge rate limits → X-Forwarded-Country/-ASN
+→ RESPONSE CACHE (Cacheable: bypass rules · Override: cache rules) → forwarder
+```
+
+Consequences: a `bypass` is evaluated on every cacheable (`GET`/`HEAD`) request,
+so a cache **hit** still pays one zone-resolve + the bypass filters; a `cache`
+force is evaluated only on a **miss fill** (a hit already carries its baked
+policy), so steady hit traffic never re-evaluates `cache` rules.
+
+## Distribution: control plane → edge
+
+Cache overrides ride the **same machinery as the edge rate limits** (see
+[EDGE.md](EDGE.md#rate-limiting-at-the-edge)), so the wire contract, fail-static
+posture, and change-notification path are all reused, not reinvented:
+
+- The CP watches the `parapet.moonrhythm.io/cache` ConfigMaps (global honored
+  only from `POD_NAMESPACE`; multi-feature ConfigMaps refused) and derives the
+  `cache-zone` route→zone bindings from Ingresses on the shared Ingress watch —
+  **cross-namespace allowed** (the `waf-zone` rule, not `ratelimit-zone`'s).
+- It serves them at **`GET /v1/cache`**: `{ generation, global_overrides
+  []string, zones map[string][]string, route_zone_map }` plus the `ETag` header.
+  There is **no `host_zone_map`** — cache overrides are a new feature, so only the
+  path-aware route binding is shipped (no legacy host-level wire form to support).
+  Documents stay **`[]string` end to end** — one ConfigMap data value per
+  string — and the CP neither parses nor reserializes them, exactly as for
+  `/v1/ratelimit`. The `ETag` is computed with `generation` zeroed so
+  byte-identical content from any CP replica mints the same validator (304 across
+  replicas); payloads are per-token **scoped** to the edge's allowed hosts.
+- The edge polls on `EDGE_REFRESH_INTERVAL` (jittered, single-flight,
+  fail-static) and is **poked** by the `/v1/events` SSE stream (a new
+  `cache` field in the snapshot) so a change lands in seconds, with polling as
+  the correctness floor.
+- **Apply is all-or-nothing and withholds the etag on failure.** A parse or
+  compile error keeps the last-good set live and does **not** advance the
+  etag/generation, so the next poll re-fetches (200, not 304) and re-logs — the
+  twice-bitten edge gotcha: storing the etag on a rejected apply would 304 the
+  broken input forever and bury it after one warning.
+
+## Reload semantics (stateless; fills bake in)
+
+Cache overrides are **stateless** — unlike rate limits, a rule carries no live
+counter, so the reload story is just *all-or-nothing compile + keep last-good*,
+with none of the per-limit strategy/counter carry-over machinery:
+
+- An **unchanged** set (content fingerprint match) is not recompiled.
+- A **bad** set (YAML error, invalid rule, bad CEL) is rejected whole; that set
+  keeps its last-good overrides and the input is retried on the next reload.
+
+The one durable subtlety is **TTL is baked at fill time.** A `cache` rule forces
+its `ttl`/`policy` into an entry **when that entry is filled**; the stored entry
+then lives out that policy independently. Editing a rule's `ttl` therefore
+re-policies only **future** fills — already-cached entries keep their original
+forced lifetime until they expire or are **purged**. To force re-evaluation
+immediately, purge the affected URLs/prefix/host through the existing cache
+purge path (see [EDGE.md](EDGE.md#the-https-api-rest)). This is inherent to
+forcing-at-fill and is the same reason an origin `max-age` change doesn't
+retroactively shorten already-cached copies.
+
+## Configuration
+
+| Variable | Side | Default | Meaning |
+|---|---|---|---|
+| `EDGE_CACHE_ENABLED` | edge | `false` | the response cache (prerequisite) |
+| `EDGE_CACHE_OVERRIDE_ENABLED` | edge | `false` | fetch + apply cache overrides (no-op unless the cache is on) |
+| `CP_CACHE_ENABLED` | control plane | `false` | watch `…/cache` ConfigMaps and serve `GET /v1/cache` |
+| `EDGE_CACHE_DEFAULT_SWR` | edge | `0` (off) | fleet-wide RFC 5861 stale-while-revalidate floor for honor-origin entries |
+| `EDGE_CACHE_DEFAULT_SIE` | edge | `0` (off) | fleet-wide RFC 5861 stale-if-error floor for honor-origin entries |
+
+The canonical env-var and annotation entries live in [`SPEC.md`](SPEC.md); the
+edge-side detail lives in [`EDGE.md`](EDGE.md). `EDGE_CACHE_DEFAULT_SWR`/`_SIE`
+are independent of overrides (they wire `parapet/pkg/cache`'s
+`DefaultStaleWhileRevalidate`/`DefaultStaleIfError`, previously unwired at the
+edge) and are documented here because per-rule `stale_*` builds on the same
+RFC 5861 surface.
+
+## Metrics
+
+Every in-scope decision counts in
+**`parapet_cache_override_total{name,action,result}`** on the edge's `:9187`
+endpoint, alongside the existing `parapet_cache_total{result}` (HIT/MISS/…) and
+`parapet_cache_egress_bytes`:
+
+- `action` = `cache` | `bypass`.
+- `result` = `applied` | `shadow` | `error` (a rule whose filter excludes the
+  request is **not** counted — only in-scope decisions appear, like the rate
+  limiter).
+- `name`, collision-free with the rate limiter's identical scheme:
+
+  | name | source |
+  |---|---|
+  | `global:<id>` | global override `<id>` |
+  | `zone:<ns>/<name>:<id>` | zone override `<id>` in zone `<ns>/<name>` |
+
+A `cache` rule increments at **fill** time (it only shapes a miss); a `bypass`
+rule increments at **request** time. The `id` is bounded to `[A-Za-z0-9._-]`
+(no `/` or `:`) so it can't break the metric name.
+
+## Scope and non-goals
+
+- **Edge-only — the one asymmetry vs. WAF and rate limiting.** Those run in both
+  the in-cluster controller and the edge; caching exists **only at the edge**
+  (`parapet/pkg/cache`), so there is nothing to override in-cluster. This feature
+  therefore touches **`edge/` + `edgecp/` + `cacherule/` only** — no
+  `controller*.go`, and **no `plugin.CacheZone`**: the `cache-zone` annotation is
+  consumed solely by the CP to build the route→zone map for the edge, never by an
+  in-cluster enforcement path. Recorded as an edge divergence in
+  [`SPEC.md`](SPEC.md), like the cache itself.
+- **It steers the cache; it is not a second cache.** All the heavy lifting —
+  single-flight fills, `Vary` keying, the LRU byte cap, disk persistence, purge —
+  stays in `parapet/pkg/cache`. Overrides only feed its two decision hooks
+  (`Cacheable`, `Override`), so a force can never make the cache do something the
+  cache itself refuses (an oversize body, a `Set-Cookie`/`Vary: *` response under
+  `balanced`, a non-`GET`/`HEAD` method).
+- **No surrogate-key / `Cache-Tag` authoring (yet).** A rule cannot set a
+  `Cache-Tag` on the stored entry. This keeps the cross-tenant tag namespace
+  (which `Cache-Tag`-scoped purge shares — see
+  [EDGE.md](EDGE.md#the-https-api-rest)) out of tenant zones, which is what makes
+  cross-namespace zone binding safe. Tag authoring would have to reintroduce a
+  same-namespace constraint and is a deliberate non-goal here.
+- **No request-Cache-Control honoring.** Like a CDN, the cache ignores a
+  client's `no-cache`/`no-store` by design (a shared-cache DoS vector); overrides
+  don't change that — they are operator policy, not client-driven.
+- **No new CEL surface.** Request matching is the `filter` field, the WAF's
+  expression surface through the one shared `waf.Predicate`; response narrowing
+  is the non-CEL `status` list. There is no `response.*` CEL surface (the
+  `Override` hook's response access is exposed only as `status`).
+
+## Where the code will live
+
+| Concern | Mirror of | New |
+|---|---|---|
+| YAML DTO + parse + compile (filters via `waf.Predicate`) | `ratelimitrule/` | `cacherule/` |
+| CP store (global `[]string`, zones, route/host→zone, gen+etag) | `edgecp/ratelimitstore.go` | `edgecp/cachestore.go` |
+| CP ConfigMap reloader (cross-ns binding allowed) | `edgecp/ratelimitreload.go` | `edgecp/cachereload.go` |
+| CP endpoint `GET /v1/cache` + `EventsSnapshot.Cache` | `edgecp/server.go`, `events.go` | handler + field |
+| Edge fetch | `edge/cp.go` `FetchRateLimit` | `FetchCache` |
+| Edge runtime (compiled global+zone + matcher; `Cacheable`/`Override` hooks) | `edge/ratelimit.go` | `edge/cache_override.go` |
+| Edge refresh loop (jitter + ticker + poke, withhold etag on error) | `edge/ratelimitrefresh.go` | `edge/cacheoverriderefresh.go` |
+| Wire hooks into `cache.Options` + read `EDGE_CACHE_DEFAULT_SWR/_SIE` | — | `cmd/edge-proxy/main.go` |
+| Metric leaf (keeps edge off `metric`) | `metric/observe/ratelimit.go` | `metric/observe/cacheoverride.go` |

--- a/cacherule/cacherule.go
+++ b/cacherule/cacherule.go
@@ -1,0 +1,100 @@
+// Package cacherule parses the YAML override documents carried in cache
+// ConfigMaps (the global set and per-zone sets) and runs them against the edge
+// response cache.
+//
+// It mirrors ratelimitrule's split: Parse is the thin YAML-to-DTO layer, and
+// Ruleset.SetOverrides is the single source of truth for the heavier validation
+// (empty/duplicate/over-long id, bad enums, ttl bounds, CEL compilation) and for
+// the all-or-nothing compile — a bad batch keeps the last-good set live. Unlike
+// rate limiting the rules carry no live counter state, so there is no
+// counter-preservation machinery: a Ruleset is just a hot-swappable compiled set
+// that feeds parapet/pkg/cache's two per-request hooks (Options.Cacheable for
+// bypass rules, Options.Override for force rules).
+package cacherule
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Document is the YAML shape of a cache ConfigMap data value.
+type Document struct {
+	Overrides []Override `yaml:"overrides"`
+}
+
+// Override is one cache-policy override. Defaults and enums are
+// resolved/validated by Ruleset.SetOverrides, not here.
+type Override struct {
+	// ID identifies the override within its set and labels its metric series, so
+	// it must be unique, at most 63 chars, and use only [A-Za-z0-9._-] (a "/" or
+	// ":" would make the parapet_cache_override_total name ambiguous).
+	ID string `yaml:"id"`
+	// Action is "cache" (default; force a caching policy onto the fill via
+	// Options.Override) or "bypass" (the request skips the cache entirely via
+	// Options.Cacheable → false). A bypass takes precedence over any force, since
+	// the cache evaluates Cacheable before it considers a fill.
+	Action string `yaml:"action"`
+	// Filter is an optional CEL expression (the WAF's expression surface — same
+	// request.* variables and helper functions, via waf.NewPredicate) that scopes
+	// the override: empty means "every request", otherwise it applies only when
+	// the expression is true. request.body is always "" here (the cache does not
+	// buffer the request body); a geo reference (request.country/asn) without the
+	// GeoIP database simply never matches. A runtime eval error biases toward NOT
+	// caching (see Ruleset.MatchBypass / Force) — the deliberate inverse of the
+	// rate limiter's fail-open, because caching is the dangerous action. A bad
+	// expression is rejected at load (the whole batch).
+	Filter string `yaml:"filter"`
+	// TTL is the forced freshness lifetime (a Go duration, >= 1s). Required for
+	// action=cache (parapet treats a non-positive TTL as "don't force"); rejected
+	// for action=bypass.
+	TTL string `yaml:"ttl"`
+	// Policy selects how far the force reaches over the origin's Cache-Control
+	// (parapet's OverrideMode): "conservative" (fill only missing freshness),
+	// "balanced" (default; force but refuse unsafe-to-share responses), or
+	// "aggressive" (override almost everything, including the Authorization gate
+	// — a cross-user-leak risk; see CACHE.md). action=cache only.
+	Policy string `yaml:"policy"`
+	// StaleWhileRevalidate / StaleIfError force the RFC 5861 windows (Go
+	// durations) for this rule's fills. They ride the forced policy, so they
+	// require a ttl. action=cache only.
+	StaleWhileRevalidate string `yaml:"stale_while_revalidate"`
+	StaleIfError         string `yaml:"stale_if_error"`
+	// Status narrows a force to specific origin response statuses (the Override
+	// hook sees the response, unlike CEL). Empty means "every cacheable status
+	// the cache already accepts". Ignored for action=bypass (no response yet when
+	// Cacheable runs).
+	Status []int `yaml:"status"`
+	// Mode is "enforce" (default) or "shadow": shadow evaluates and counts the
+	// override (parapet_cache_override_total{result="shadow"}) but never changes
+	// caching, so a rule can be validated against live traffic before it takes
+	// effect.
+	Mode string `yaml:"mode"`
+	// Priority orders force rules; the first matching cache rule wins (lower
+	// number first, declaration order breaks ties). Default 100. Bypass rules are
+	// not ordered against each other.
+	Priority int `yaml:"priority"`
+}
+
+// Parse parses one or more YAML override documents (each ConfigMap data value is
+// one document) and returns the concatenated []Override. A YAML error in any
+// document is collected and returned joined; the caller (SetOverrides) rejects
+// the whole batch on any error, so a bad document never partially applies.
+func Parse(docs ...string) ([]Override, error) {
+	var out []Override
+	var errs []error
+	for _, doc := range docs {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		var d Document
+		if err := yaml.Unmarshal([]byte(doc), &d); err != nil {
+			errs = append(errs, fmt.Errorf("cache: parse document: %w", err))
+			continue
+		}
+		out = append(out, d.Overrides...)
+	}
+	return out, errors.Join(errs...)
+}

--- a/cacherule/ruleset.go
+++ b/cacherule/ruleset.go
@@ -1,0 +1,433 @@
+package cacherule
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/moonrhythm/parapet/pkg/cache"
+	"github.com/moonrhythm/parapet/pkg/waf"
+)
+
+const (
+	maxIDLen = 63
+
+	// minTTL bounds a forced freshness lifetime. A sub-second forced TTL is
+	// almost always a units mistake (e.g. "30" parsed as 30ns) and would store an
+	// entry that is already stale.
+	minTTL = time.Second
+
+	defaultPriority = 100
+)
+
+// metric result labels (parapet_cache_override_total{result}). applied = the
+// override changed caching for an in-scope request; shadow = matched but mode
+// withheld the effect; error = the filter eval errored (the override biased
+// toward not-caching). A rule the filter excludes is not counted at all.
+const (
+	resultApplied = "applied"
+	resultShadow  = "shadow"
+	resultError   = "error"
+)
+
+// ObserveFunc records one in-scope override decision. nil disables metrics.
+type ObserveFunc func(result string)
+
+type action uint8
+
+const (
+	actionCache action = iota
+	actionBypass
+)
+
+type mode uint8
+
+const (
+	modeEnforce mode = iota
+	modeShadow
+)
+
+// compiledOverride is one override ready for the request path: enums resolved,
+// CEL compiled, observe handle pre-resolved. Immutable after the set is
+// published.
+type compiledOverride struct {
+	id       string
+	action   action
+	filter   *waf.Predicate // nil ⇒ always matches (no CEL gate)
+	mode     mode
+	priority int
+	observe  ObserveFunc // nil when no Observe factory is wired
+
+	// force fields (action == actionCache only)
+	ttl    time.Duration
+	swr    time.Duration
+	sie    time.Duration
+	omode  cache.OverrideMode
+	status map[int]struct{} // nil ⇒ any cacheable status
+}
+
+// ruleset is one immutable compiled batch, swapped atomically into the Ruleset.
+// bypass keeps declaration order; force is sorted by priority. The request path
+// loads the pointer once and evaluates that whole set.
+type ruleset struct {
+	bypass      []compiledOverride // action == bypass
+	force       []compiledOverride // action == cache, priority-ordered
+	source      []Override         // normalized input, for introspection
+	needsFilter bool               // any rule carries a CEL filter
+}
+
+// Ruleset is a hot-swappable set of cache overrides — the runtime for both the
+// global instance and each zone. Configure the exported fields before the first
+// SetOverrides; they are read at compile time, not per request.
+//
+// An empty Ruleset (no SetOverrides yet, or an empty batch) matches nothing:
+// MatchBypass returns false and Force returns nil, so the cache honors the
+// origin exactly as if no overrides existed.
+type Ruleset struct {
+	set atomic.Pointer[ruleset]
+	mu  sync.Mutex // serializes SetOverrides (validate+compile+swap)
+
+	// NamePrefix scopes the metric name of every rule:
+	// parapet_cache_override_total{name="<NamePrefix>:<id>"}. The edge uses
+	// "global" and "zone:<ns>/<name>", disjoint name spaces.
+	NamePrefix string
+
+	// Observe builds the per-rule decision observer (e.g.
+	// metric/observe.CacheOverride). Resolved once per rule at SetOverrides, so
+	// the request path is lookup-free. nil disables decision metrics. The result
+	// type is the unnamed func(string) (not ObserveFunc) so a leaf metric package
+	// can supply it without importing this one — the same boundary the rate
+	// limiter keeps with parapet's ratelimit.ObserveFunc.
+	Observe func(name, action string) func(result string)
+
+	// FilterCostLimit caps CEL evaluator cost per filter evaluation (0 ⇒ the
+	// parapet WAF default). FilterDisableMacros refuses CEL macros. Both mirror
+	// the edge WAF's posture; read at SetOverrides, not per request.
+	FilterCostLimit     uint64
+	FilterDisableMacros bool
+}
+
+// Overrides returns the normalized overrides of the live set (defaults
+// resolved), in declaration order. Nil when nothing is loaded.
+func (rs *Ruleset) Overrides() []Override {
+	s := rs.set.Load()
+	if s == nil {
+		return nil
+	}
+	return s.source
+}
+
+// NeedsFilter reports whether the live set carries any CEL filter — the edge
+// uses it to skip building the request snapshot for filterless sets.
+func (rs *Ruleset) NeedsFilter() bool {
+	s := rs.set.Load()
+	return s != nil && s.needsFilter
+}
+
+// SetOverrides validates and compiles the batch, then atomically swaps it in.
+// All-or-nothing: any invalid override rejects the whole batch and the previous
+// good set stays live, so a bad ConfigMap edit can't change caching unexpectedly.
+func (rs *Ruleset) SetOverrides(overrides []Override) error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	var errs []error
+	seen := make(map[string]struct{}, len(overrides))
+	var bypass, force []compiledOverride
+	source := make([]Override, 0, len(overrides))
+	needsFilter := false
+
+	for i, ov := range overrides {
+		c, norm, err := rs.compile(ov)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("cache: override[%d] %q: %w", i, ov.ID, err))
+			continue
+		}
+		if _, dup := seen[c.id]; dup {
+			errs = append(errs, fmt.Errorf("cache: override[%d] %q: duplicate id", i, ov.ID))
+			continue
+		}
+		seen[c.id] = struct{}{}
+		if c.filter != nil {
+			needsFilter = true
+		}
+		if c.action == actionBypass {
+			bypass = append(bypass, c)
+		} else {
+			force = append(force, c)
+		}
+		source = append(source, norm)
+	}
+	if err := errors.Join(errs...); err != nil {
+		return err
+	}
+
+	// Stable sort keeps declaration order as the tie-break, so "first match wins"
+	// is deterministic for equal priorities.
+	sort.SliceStable(force, func(i, j int) bool { return force[i].priority < force[j].priority })
+
+	rs.set.Store(&ruleset{bypass: bypass, force: force, source: source, needsFilter: needsFilter})
+	return nil
+}
+
+// compile validates one override and builds its compiled form plus the
+// normalized (defaults-resolved) source copy.
+func (rs *Ruleset) compile(ov Override) (compiledOverride, Override, error) {
+	var errs []error
+
+	if err := validateID(ov.ID); err != nil {
+		errs = append(errs, err)
+	}
+
+	var act action
+	switch ov.Action {
+	case "", "cache":
+		act, ov.Action = actionCache, "cache"
+	case "bypass":
+		act = actionBypass
+	default:
+		errs = append(errs, fmt.Errorf("unknown action %q (want cache|bypass)", ov.Action))
+	}
+
+	var m mode
+	switch ov.Mode {
+	case "", "enforce":
+		m, ov.Mode = modeEnforce, "enforce"
+	case "shadow":
+		m = modeShadow
+	default:
+		errs = append(errs, fmt.Errorf("unknown mode %q (want enforce|shadow)", ov.Mode))
+	}
+
+	if ov.Priority == 0 {
+		ov.Priority = defaultPriority
+	}
+
+	c := compiledOverride{
+		id:       ov.ID,
+		action:   act,
+		mode:     m,
+		priority: ov.Priority,
+	}
+
+	if act == actionCache {
+		c.ttl, c.swr, c.sie, c.omode, c.status = rs.compileForce(ov, &errs)
+	} else {
+		// bypass: the force-only fields are meaningless and silently honoring them
+		// would mask an authoring mistake. Reject any that are set.
+		if strings.TrimSpace(ov.TTL) != "" || strings.TrimSpace(ov.Policy) != "" ||
+			strings.TrimSpace(ov.StaleWhileRevalidate) != "" || strings.TrimSpace(ov.StaleIfError) != "" ||
+			len(ov.Status) > 0 {
+			errs = append(errs, errors.New("ttl/policy/status/stale_* are not valid for action=bypass"))
+		}
+	}
+
+	// Filter compiles into a waf.Predicate over the WAF's request model. A bad
+	// expression joins errs, so an invalid filter rejects the whole batch.
+	var filter *waf.Predicate
+	ov.Filter = strings.TrimSpace(ov.Filter)
+	if ov.Filter != "" {
+		p, err := waf.NewPredicate(ov.Filter, rs.filterOptions()...)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("filter: %w", err))
+		} else {
+			filter = p
+		}
+	}
+	c.filter = filter
+
+	if err := errors.Join(errs...); err != nil {
+		return compiledOverride{}, Override{}, err
+	}
+
+	if rs.Observe != nil {
+		c.observe = rs.Observe(rs.NamePrefix+":"+ov.ID, ov.Action)
+	}
+	return c, ov, nil
+}
+
+// compileForce validates and resolves the action=cache fields. It appends to
+// errs and returns the resolved values (zero on error — the batch is rejected).
+func (rs *Ruleset) compileForce(ov Override, errs *[]error) (ttl, swr, sie time.Duration, omode cache.OverrideMode, status map[int]struct{}) {
+	if strings.TrimSpace(ov.TTL) == "" {
+		*errs = append(*errs, errors.New("ttl is required for action=cache"))
+	} else if d, err := time.ParseDuration(ov.TTL); err != nil {
+		*errs = append(*errs, fmt.Errorf("invalid ttl: %w", err))
+	} else if d < minTTL {
+		*errs = append(*errs, fmt.Errorf("ttl %s below minimum %s", d, minTTL))
+	} else {
+		ttl = d
+	}
+
+	switch ov.Policy {
+	case "", "balanced":
+		omode = cache.OverrideBalanced
+	case "conservative":
+		omode = cache.OverrideConservative
+	case "aggressive":
+		omode = cache.OverrideAggressive
+	default:
+		*errs = append(*errs, fmt.Errorf("unknown policy %q (want conservative|balanced|aggressive)", ov.Policy))
+	}
+
+	swr = parseStaleWindow("stale_while_revalidate", ov.StaleWhileRevalidate, errs)
+	sie = parseStaleWindow("stale_if_error", ov.StaleIfError, errs)
+
+	if len(ov.Status) > 0 {
+		status = make(map[int]struct{}, len(ov.Status))
+		for _, s := range ov.Status {
+			if s < 100 || s > 599 {
+				*errs = append(*errs, fmt.Errorf("invalid status %d (want 100..599)", s))
+				continue
+			}
+			status[s] = struct{}{}
+		}
+	}
+	return ttl, swr, sie, omode, status
+}
+
+func parseStaleWindow(field, raw string, errs *[]error) time.Duration {
+	if strings.TrimSpace(raw) == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		*errs = append(*errs, fmt.Errorf("invalid %s: %w", field, err))
+		return 0
+	}
+	if d < 0 {
+		*errs = append(*errs, fmt.Errorf("%s must be >= 0", field))
+		return 0
+	}
+	return d
+}
+
+// filterOptions builds the waf.NewPredicate options from the Ruleset's filter
+// knobs. Zero values leave the parapet WAF defaults, so an unconfigured Ruleset
+// compiles filters exactly like a default edge WAF rule.
+func (rs *Ruleset) filterOptions() []waf.PredicateOption {
+	var opts []waf.PredicateOption
+	if rs.FilterCostLimit > 0 {
+		opts = append(opts, waf.WithPredicateCostLimit(rs.FilterCostLimit))
+	}
+	if rs.FilterDisableMacros {
+		opts = append(opts, waf.WithPredicateDisableMacros())
+	}
+	return opts
+}
+
+// MatchBypass reports whether this set bypasses the cache for r. getInput
+// returns the shared request snapshot (built at most once per request by the
+// caller, across the global + zone sets). A bypass rule whose filter ERRORS is
+// treated as matched — the fail-safe direction: caching is the dangerous action,
+// so an error biases toward not caching. A shadow rule that would bypass is
+// counted but does not actually bypass.
+func (rs *Ruleset) MatchBypass(r *http.Request, getInput func() waf.Input) bool {
+	s := rs.set.Load()
+	if s == nil || len(s.bypass) == 0 {
+		return false
+	}
+	for i := range s.bypass {
+		b := &s.bypass[i]
+		matched, errored := true, false
+		if b.filter != nil {
+			ok, err := b.filter.Eval(r.Context(), getInput())
+			if err != nil {
+				matched, errored = true, true // fail toward not caching
+			} else {
+				matched = ok
+			}
+		}
+		if !matched {
+			continue
+		}
+		if b.mode == modeShadow {
+			observe(b.observe, resultShadow)
+			continue
+		}
+		if errored {
+			observe(b.observe, resultError)
+		} else {
+			observe(b.observe, resultApplied)
+		}
+		return true
+	}
+	return false
+}
+
+// Force returns the forced caching policy for r and the origin response status,
+// or (nil, false) to honor the origin. getInput is the shared request snapshot.
+// Rules are tried in priority order; the first clean match wins. A rule whose
+// filter ERRORS is SKIPPED (honor the origin) — the fail-safe direction for a
+// force, since applying a force on an error could cache shared/per-user content.
+// A shadow rule that would apply is counted and skipped (a lower-priority real
+// rule may still apply).
+func (rs *Ruleset) Force(r *http.Request, status int, getInput func() waf.Input) (*cache.Override, bool) {
+	s := rs.set.Load()
+	if s == nil || len(s.force) == 0 {
+		return nil, false
+	}
+	for i := range s.force {
+		f := &s.force[i]
+		if f.status != nil {
+			if _, ok := f.status[status]; !ok {
+				continue
+			}
+		}
+		matched := true
+		if f.filter != nil {
+			ok, err := f.filter.Eval(r.Context(), getInput())
+			if err != nil {
+				observe(f.observe, resultError)
+				continue // fail toward not caching: skip the force
+			}
+			matched = ok
+		}
+		if !matched {
+			continue
+		}
+		if f.mode == modeShadow {
+			observe(f.observe, resultShadow)
+			continue
+		}
+		observe(f.observe, resultApplied)
+		return &cache.Override{
+			TTL:                  f.ttl,
+			StaleWhileRevalidate: f.swr,
+			StaleIfError:         f.sie,
+			Mode:                 f.omode,
+		}, true
+	}
+	return nil, false
+}
+
+func observe(fn ObserveFunc, result string) {
+	if fn != nil {
+		fn(result)
+	}
+}
+
+func validateID(id string) error {
+	if id == "" {
+		return errors.New("id is required")
+	}
+	if len(id) > maxIDLen {
+		return fmt.Errorf("id longer than %d chars", maxIDLen)
+	}
+	for i := 0; i < len(id); i++ {
+		switch c := id[i]; {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9',
+			c == '-', c == '_', c == '.':
+		default:
+			// "/" or ":" would make the metric name ambiguous against the
+			// "<prefix>:<id>" scheme.
+			return fmt.Errorf("id contains %q (want [A-Za-z0-9._-])", c)
+		}
+	}
+	return nil
+}

--- a/cacherule/ruleset_test.go
+++ b/cacherule/ruleset_test.go
@@ -1,0 +1,267 @@
+package cacherule_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/moonrhythm/parapet/pkg/cache"
+	"github.com/moonrhythm/parapet/pkg/waf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet-ingress-controller/cacherule"
+)
+
+func req(method, target string) *http.Request {
+	return httptest.NewRequest(method, target, nil)
+}
+
+// snap returns the shared-snapshot closure the edge passes into the hooks.
+func snap(r *http.Request) func() waf.Input {
+	return func() waf.Input { return waf.NewInput(r, "", "", 0) }
+}
+
+func idsOf(rs *cacherule.Ruleset) []string {
+	var ids []string
+	for _, o := range rs.Overrides() {
+		ids = append(ids, o.ID)
+	}
+	return ids
+}
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+	ovs, err := cacherule.Parse(
+		"overrides:\n  - id: a\n    action: bypass\n",
+		"",
+		"overrides:\n  - id: b\n    ttl: 1h\n",
+	)
+	require.NoError(t, err)
+	require.Len(t, ovs, 2)
+	assert.Equal(t, "a", ovs[0].ID)
+	assert.Equal(t, "b", ovs[1].ID)
+}
+
+func TestSetOverrides_RejectsAndKeepsLastGood(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		ov   cacherule.Override
+	}{
+		{"empty id", cacherule.Override{ID: "", Action: "cache", TTL: "1h"}},
+		{"id with colon", cacherule.Override{ID: "a:b", Action: "cache", TTL: "1h"}},
+		{"id with slash", cacherule.Override{ID: "a/b", Action: "cache", TTL: "1h"}},
+		{"bad action", cacherule.Override{ID: "x", Action: "nope"}},
+		{"bad mode", cacherule.Override{ID: "x", Action: "cache", TTL: "1h", Mode: "audit"}},
+		{"missing ttl", cacherule.Override{ID: "x", Action: "cache"}},
+		{"ttl too small", cacherule.Override{ID: "x", Action: "cache", TTL: "100ms"}},
+		{"bad ttl", cacherule.Override{ID: "x", Action: "cache", TTL: "abc"}},
+		{"bad policy", cacherule.Override{ID: "x", Action: "cache", TTL: "1h", Policy: "nuke"}},
+		{"bad status", cacherule.Override{ID: "x", Action: "cache", TTL: "1h", Status: []int{99}}},
+		{"bypass with ttl", cacherule.Override{ID: "x", Action: "bypass", TTL: "1h"}},
+		{"bypass with status", cacherule.Override{ID: "x", Action: "bypass", Status: []int{200}}},
+		{"bypass with policy", cacherule.Override{ID: "x", Action: "bypass", Policy: "balanced"}},
+		{"non-bool filter", cacherule.Override{ID: "x", Action: "cache", TTL: "1h", Filter: "request.method"}},
+		{"bad filter syntax", cacherule.Override{ID: "x", Action: "cache", TTL: "1h", Filter: "request."}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rs := &cacherule.Ruleset{}
+			require.NoError(t, rs.SetOverrides([]cacherule.Override{{ID: "keep", Action: "cache", TTL: "1h"}}))
+			err := rs.SetOverrides([]cacherule.Override{c.ov})
+			assert.Error(t, err)
+			assert.Equal(t, []string{"keep"}, idsOf(rs), "last-good set must survive a rejected batch")
+		})
+	}
+}
+
+func TestSetOverrides_DuplicateID(t *testing.T) {
+	t.Parallel()
+	rs := &cacherule.Ruleset{}
+	err := rs.SetOverrides([]cacherule.Override{
+		{ID: "x", Action: "cache", TTL: "1h"},
+		{ID: "x", Action: "bypass"},
+	})
+	assert.Error(t, err)
+}
+
+func TestBypass_FilterScopeAndNoFilter(t *testing.T) {
+	t.Parallel()
+	rs := &cacherule.Ruleset{}
+	require.NoError(t, rs.SetOverrides([]cacherule.Override{
+		{ID: "admin", Action: "bypass", Filter: `request.path.startsWith("/admin")`},
+	}))
+	r1 := req("GET", "/admin/x")
+	assert.True(t, rs.MatchBypass(r1, snap(r1)), "filter matches ⇒ bypass")
+	r2 := req("GET", "/public")
+	assert.False(t, rs.MatchBypass(r2, snap(r2)), "filter excludes ⇒ no bypass")
+
+	all := &cacherule.Ruleset{}
+	require.NoError(t, all.SetOverrides([]cacherule.Override{{ID: "all", Action: "bypass"}}))
+	r3 := req("GET", "/anything")
+	assert.True(t, all.MatchBypass(r3, snap(r3)), "filterless bypass matches every request")
+}
+
+func TestBypass_FailsTowardNotCaching(t *testing.T) {
+	t.Parallel()
+	// Cost limit 1 makes every filter evaluation error. A bypass rule whose filter
+	// errors must still bypass — caching is the dangerous action.
+	rs := &cacherule.Ruleset{FilterCostLimit: 1}
+	require.NoError(t, rs.SetOverrides([]cacherule.Override{
+		{ID: "x", Action: "bypass", Filter: `request.method == "GET"`},
+	}))
+	r := req("GET", "/")
+	assert.True(t, rs.MatchBypass(r, snap(r)), "filter error ⇒ bypass anyway")
+}
+
+func TestBypass_ShadowDoesNotBypass(t *testing.T) {
+	t.Parallel()
+	rs := &cacherule.Ruleset{}
+	require.NoError(t, rs.SetOverrides([]cacherule.Override{
+		{ID: "x", Action: "bypass", Mode: "shadow", Filter: `request.path == "/p"`},
+	}))
+	r := req("GET", "/p")
+	assert.False(t, rs.MatchBypass(r, snap(r)), "shadow evaluates but never bypasses")
+}
+
+func TestForce_FirstMatchByPriority(t *testing.T) {
+	t.Parallel()
+	rs := &cacherule.Ruleset{}
+	require.NoError(t, rs.SetOverrides([]cacherule.Override{
+		{ID: "hi", Action: "cache", TTL: "1h", Priority: 200, Filter: `request.path.startsWith("/a")`},
+		{ID: "lo", Action: "cache", TTL: "10m", Priority: 50, Filter: `request.path.startsWith("/a")`},
+	}))
+	r := req("GET", "/a/x")
+	ov, ok := rs.Force(r, 200, snap(r))
+	require.True(t, ok)
+	assert.Equal(t, 10*time.Minute, ov.TTL, "lower priority number wins")
+}
+
+func TestForce_StatusGate(t *testing.T) {
+	t.Parallel()
+	rs := &cacherule.Ruleset{}
+	require.NoError(t, rs.SetOverrides([]cacherule.Override{
+		{ID: "s", Action: "cache", TTL: "1h", Status: []int{301, 404}},
+	}))
+	r := req("GET", "/x")
+	_, ok := rs.Force(r, 200, snap(r))
+	assert.False(t, ok, "200 not in the status list ⇒ no force")
+	_, ok = rs.Force(r, 301, snap(r))
+	assert.True(t, ok, "301 is in the status list ⇒ force")
+}
+
+func TestForce_FilterScope(t *testing.T) {
+	t.Parallel()
+	rs := &cacherule.Ruleset{}
+	require.NoError(t, rs.SetOverrides([]cacherule.Override{
+		{ID: "f", Action: "cache", TTL: "1h", Filter: `request.method == "GET"`},
+	}))
+	get := req("GET", "/x")
+	_, ok := rs.Force(get, 200, snap(get))
+	assert.True(t, ok)
+	post := req("POST", "/x")
+	_, ok = rs.Force(post, 200, snap(post))
+	assert.False(t, ok)
+}
+
+func TestForce_FailSkipsOnError(t *testing.T) {
+	t.Parallel()
+	// An aggressive force whose filter errors must NOT apply — applying a force on
+	// an error could cache shared/per-user content (the cross-user-leak risk).
+	rs := &cacherule.Ruleset{FilterCostLimit: 1}
+	require.NoError(t, rs.SetOverrides([]cacherule.Override{
+		{ID: "agg", Action: "cache", TTL: "1h", Policy: "aggressive", Filter: `request.method == "GET"`},
+	}))
+	r := req("GET", "/x")
+	_, ok := rs.Force(r, 200, snap(r))
+	assert.False(t, ok, "filter error ⇒ honor the origin (skip the force)")
+}
+
+func TestForce_ShadowSkipsToNextRealRule(t *testing.T) {
+	t.Parallel()
+	rs := &cacherule.Ruleset{}
+	require.NoError(t, rs.SetOverrides([]cacherule.Override{
+		{ID: "sh", Action: "cache", TTL: "10m", Priority: 10, Mode: "shadow", Filter: `request.path == "/a"`},
+		{ID: "real", Action: "cache", TTL: "1h", Priority: 20, Filter: `request.path == "/a"`},
+	}))
+	r := req("GET", "/a")
+	ov, ok := rs.Force(r, 200, snap(r))
+	require.True(t, ok)
+	assert.Equal(t, time.Hour, ov.TTL, "shadow match is counted but skipped; the next real rule applies")
+}
+
+func TestForce_PolicyMapping(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		policy string
+		want   cache.OverrideMode
+	}{
+		{"", cache.OverrideBalanced},
+		{"balanced", cache.OverrideBalanced},
+		{"conservative", cache.OverrideConservative},
+		{"aggressive", cache.OverrideAggressive},
+	}
+	for _, c := range cases {
+		rs := &cacherule.Ruleset{}
+		require.NoError(t, rs.SetOverrides([]cacherule.Override{
+			{ID: "p", Action: "cache", TTL: "1h", Policy: c.policy},
+		}))
+		r := req("GET", "/x")
+		ov, ok := rs.Force(r, 200, snap(r))
+		require.True(t, ok)
+		assert.Equal(t, c.want, ov.Mode, "policy %q", c.policy)
+	}
+}
+
+func TestForce_StaleWindowsRideTheForce(t *testing.T) {
+	t.Parallel()
+	rs := &cacherule.Ruleset{}
+	require.NoError(t, rs.SetOverrides([]cacherule.Override{
+		{ID: "s", Action: "cache", TTL: "1h", StaleWhileRevalidate: "30s", StaleIfError: "5m"},
+	}))
+	r := req("GET", "/x")
+	ov, ok := rs.Force(r, 200, snap(r))
+	require.True(t, ok)
+	assert.Equal(t, 30*time.Second, ov.StaleWhileRevalidate)
+	assert.Equal(t, 5*time.Minute, ov.StaleIfError)
+}
+
+func TestObserve_CountsInScopeDecisions(t *testing.T) {
+	t.Parallel()
+	counts := map[string]int{}
+	factory := func(name, action string) func(string) {
+		return func(result string) { counts[name+"|"+action+"|"+result]++ }
+	}
+	rs := &cacherule.Ruleset{NamePrefix: "global", Observe: factory}
+	require.NoError(t, rs.SetOverrides([]cacherule.Override{
+		{ID: "b", Action: "bypass", Filter: `request.path == "/admin"`},
+		{ID: "c", Action: "cache", TTL: "1h"},
+	}))
+
+	// In-scope bypass.
+	radmin := req("GET", "/admin")
+	assert.True(t, rs.MatchBypass(radmin, snap(radmin)))
+	// Out-of-scope bypass: not counted.
+	rother := req("GET", "/x")
+	assert.False(t, rs.MatchBypass(rother, snap(rother)))
+	// Force applies.
+	_, ok := rs.Force(rother, 200, snap(rother))
+	assert.True(t, ok)
+
+	assert.Equal(t, 1, counts["global:b|bypass|applied"])
+	assert.Equal(t, 1, counts["global:c|cache|applied"])
+	assert.Equal(t, 0, counts["global:b|bypass|shadow"], "out-of-scope decisions are not counted")
+}
+
+func TestNeedsFilter(t *testing.T) {
+	t.Parallel()
+	none := &cacherule.Ruleset{}
+	require.NoError(t, none.SetOverrides([]cacherule.Override{{ID: "x", Action: "cache", TTL: "1h"}}))
+	assert.False(t, none.NeedsFilter())
+
+	some := &cacherule.Ruleset{}
+	require.NoError(t, some.SetOverrides([]cacherule.Override{{ID: "x", Action: "bypass", Filter: `request.method == "GET"`}}))
+	assert.True(t, some.NeedsFilter())
+}

--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -96,6 +96,7 @@ func main() {
 	tokensFile := os.Getenv("CP_TOKENS_FILE")            // alternative: path to that JSON
 	wafEnabled := os.Getenv("CP_WAF_ENABLED") == "true"
 	ratelimitEnabled := os.Getenv("CP_RATELIMIT_ENABLED") == "true"
+	cacheEnabled := os.Getenv("CP_CACHE_ENABLED") == "true"
 	caCertPath := os.Getenv("EDGE_CA_CERT")                 // provided-mode edge CA cert (with EDGE_CA_KEY → enable issuance)
 	caKeyPath := os.Getenv("EDGE_CA_KEY")                   // provided-mode edge CA private key
 	caSecret := os.Getenv("EDGE_CA_SECRET")                 // managed-mode edge CA Secret in POD_NAMESPACE; "" + no provided files = issuance off
@@ -318,6 +319,7 @@ func main() {
 	// fetch sees the full payload, not a half-populated store.
 	var wafStore *edgecp.WafStore
 	var rlStore *edgecp.RateLimitStore
+	var cacheStore *edgecp.CacheStore
 	var hostsStore *edgecp.HostsStore
 	if wafEnabled {
 		wafStore = edgecp.NewWafStore()
@@ -339,6 +341,19 @@ func main() {
 		server = server.WithRateLimit(rlStore)
 		slog.Info("edge control plane: ratelimit distribution enabled", "pod_namespace", podNamespace)
 	}
+	// Cache-override distribution (GET /v1/cache): the same global+zone model
+	// under its own label/annotation, sharing the one Ingress watch (cross-namespace
+	// zone binding allowed — overrides are stateless config).
+	if cacheEnabled {
+		cacheStore = edgecp.NewCacheStore()
+		cacheReloader := edgecp.NewCacheReloader(cacheStore, watchNamespace, podNamespace)
+		if err := cacheReloader.LoadOnce(ctx); err != nil {
+			slog.Error("edgecp: initial cache load failed", "err", err)
+		}
+		go cacheReloader.Watch(ctx)
+		server = server.WithCache(cacheStore)
+		slog.Info("edge control plane: cache-override distribution enabled", "pod_namespace", podNamespace)
+	}
 	// Standalone known-host distribution (GET /v1/hosts) — the edge request
 	// metric's host oracle. On by default and independent of WAF/ratelimit, since
 	// the metric is always on; it only rides the same Ingress watch.
@@ -347,8 +362,8 @@ func main() {
 		server = server.WithHosts(hostsStore)
 		slog.Info("edge control plane: hosts distribution enabled")
 	}
-	if wafStore != nil || rlStore != nil || hostsStore != nil {
-		ingReloader := edgecp.NewIngressReloader(wafStore, watchNamespace).WithRateLimit(rlStore).WithHosts(hostsStore)
+	if wafStore != nil || rlStore != nil || cacheStore != nil || hostsStore != nil {
+		ingReloader := edgecp.NewIngressReloader(wafStore, watchNamespace).WithRateLimit(rlStore).WithCache(cacheStore).WithHosts(hostsStore)
 		if err := ingReloader.LoadOnce(ctx); err != nil {
 			slog.Error("edgecp: initial ingress load failed", "err", err)
 		}
@@ -388,6 +403,9 @@ func main() {
 			}
 			if rlStore != nil {
 				snap.RateLimit = rlStore.Version()
+			}
+			if cacheStore != nil {
+				snap.Cache = cacheStore.Version()
 			}
 			if hostsStore != nil {
 				snap.Hosts = hostsStore.Version()
@@ -457,7 +475,7 @@ func main() {
 	if tlsEnabled {
 		srv.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
 	}
-	slog.Info("edge control plane listening", "addr", addr, "tokens", len(tokens), "waf", wafEnabled, "ratelimit", ratelimitEnabled, "tls", tlsEnabled)
+	slog.Info("edge control plane listening", "addr", addr, "tokens", len(tokens), "waf", wafEnabled, "ratelimit", ratelimitEnabled, "cache", cacheEnabled, "tls", tlsEnabled)
 
 	if tlsEnabled {
 		err = srv.ListenAndServeTLS(tlsCert, tlsKey)

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -96,6 +96,13 @@ func main() {
 	}
 	wafEnabled := envOr("EDGE_WAF_ENABLED", "false") == "true"
 	ratelimitEnabled := envOr("EDGE_RATELIMIT_ENABLED", "false") == "true"
+	cacheEnabled := envOr("EDGE_CACHE_ENABLED", "false") == "true"
+	cacheOverrideEnabled := envOr("EDGE_CACHE_OVERRIDE_ENABLED", "false") == "true"
+	if cacheOverrideEnabled && !cacheEnabled {
+		// Overrides only steer the cache; with no cache there is nothing to steer.
+		slog.Warn("EDGE_CACHE_OVERRIDE_ENABLED=true has no effect without EDGE_CACHE_ENABLED=true; ignoring")
+		cacheOverrideEnabled = false
+	}
 	disableLog := envOr("DISABLE_LOG", "false") == "true"
 	waitBeforeShutdown := time.Duration(envInt64("WAIT_BEFORE_SHUTDOWN", 30)) * time.Second
 	domains := splitDomains(os.Getenv("EDGE_DOMAINS"))
@@ -216,7 +223,7 @@ func main() {
 	var ewaf *edge.EdgeWAF
 	var country func(*http.Request) string
 	var asn func(*http.Request) int64
-	if wafEnabled || ratelimitEnabled {
+	if wafEnabled || ratelimitEnabled || cacheOverrideEnabled {
 		country, asn = loadGeoResolvers()
 	}
 	if wafEnabled {
@@ -243,13 +250,29 @@ func main() {
 		go edge.RunRateLimitRefresh(ctx, cp, erl, refreshInterval, rlPoke)
 	}
 
+	// Optional cache overrides (ConfigMap-driven global + zone sets fetched from
+	// the control plane). They feed the response cache's two per-request hooks
+	// (Cacheable for bypass rules, Override for force rules); wired into the cache
+	// Options below. Requires EDGE_CACHE_ENABLED (validated above).
+	var eco *edge.EdgeCacheOverride
+	if cacheOverrideEnabled {
+		eco = edge.NewEdgeCacheOverride(country, asn)
+		edge.RefreshCacheOverrideOnce(cp, eco)
+		var cachePoke chan struct{}
+		if eventsEnabled {
+			cachePoke = make(chan struct{}, 1)
+			pokes.Cache = cachePoke
+		}
+		go edge.RunCacheOverrideRefresh(ctx, cp, eco, refreshInterval, cachePoke)
+	}
+
 	// Optional response cache (off by default), from parapet/pkg/cache. The
 	// backend is disk (default; survives restarts, bounded by on-disk bytes) or
 	// memory (EDGE_CACHE_BACKEND=memory; bodies in RAM, lost on restart).
 	var respCache *cache.Cache
 	var purgeTable *edge.PurgeTable
 	var purgeStorage cache.Storage // the live backend, for the reaper's Range sweep
-	if envOr("EDGE_CACHE_ENABLED", "false") == "true" {
+	if cacheEnabled {
 		maxSize := envInt64("EDGE_CACHE_MAX_SIZE", 1<<30)
 		maxFile := envInt64("EDGE_CACHE_MAX_FILE_SIZE", 8<<20)
 		var storage cache.Storage
@@ -288,6 +311,18 @@ func main() {
 					cacheMetrics(r, info)
 					cache.LogResult(r, info)
 				},
+			}
+			// Fleet-wide RFC 5861 stale serving for honor-origin entries that lack the
+			// directive (independent of overrides; an explicit response directive or a
+			// per-rule stale_* still wins). 0 forces nothing.
+			opts.DefaultStaleWhileRevalidate = time.Duration(envInt64("EDGE_CACHE_DEFAULT_SWR", 0)) * time.Second
+			opts.DefaultStaleIfError = time.Duration(envInt64("EDGE_CACHE_DEFAULT_SIE", 0)) * time.Second
+			// Cache overrides drive the two per-request decision hooks: Cacheable
+			// (bypass rules) and Override (force rules). nil when EDGE_CACHE_OVERRIDE_ENABLED
+			// is off, leaving the cache strictly honor-origin.
+			if eco != nil {
+				opts.Cacheable = eco.Cacheable
+				opts.Override = eco.Override
 			}
 			// Cache-purge: an invalidation table fed from the control plane gates each
 			// hit (parapet's Options.InvalidatedAfter). On by default with the cache; the

--- a/edge/cache_override.go
+++ b/edge/cache_override.go
@@ -1,0 +1,199 @@
+package edge
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/moonrhythm/parapet/pkg/cache"
+	"github.com/moonrhythm/parapet/pkg/waf"
+
+	"github.com/moonrhythm/parapet-ingress-controller/cacherule"
+	"github.com/moonrhythm/parapet-ingress-controller/metric/observe"
+)
+
+// EdgeCacheOverride holds the compiled global override set plus tenant zones
+// fetched from the control plane, and exposes them as the two per-request hooks
+// parapet/pkg/cache consults: Cacheable (bypass rules) and Override (force
+// rules). It reuses cacherule — the same parser/runtime the spec defines — so an
+// override shapes caching identically wherever it is evaluated.
+//
+// Eval order mirrors the WAF/rate limiter: global first (authoritative), then
+// the zone bound to the request route. Zone resolution is PATH-AWARE (the same
+// zoneMatcher: the controller's own route patterns on a real http.ServeMux).
+// Unlike the rate limiter, zone binding allows CROSS-NAMESPACE references (the
+// WAF model): an override set is stateless config, so binding tenant A's zone to
+// tenant B's ingress applies A's policy to B's own traffic only — there is no
+// shared counter state to abuse. Bypass is a union (global OR zone, most
+// restrictive wins); force is first-match global-before-zone.
+type EdgeCacheOverride struct {
+	global  *cacherule.Ruleset
+	zones   atomic.Pointer[map[string]*cacherule.Ruleset] // zoneKey -> compiled zone
+	matcher atomic.Pointer[zoneMatcher]                   // host+path -> zoneKey (core ServeMux semantics)
+
+	newZone func(key string) *cacherule.Ruleset
+	country func(*http.Request) string
+	asn     func(*http.Request) int64
+
+	generation atomic.Uint64
+
+	mu   sync.Mutex
+	etag string
+}
+
+// NewEdgeCacheOverride builds an empty edge cache-override runtime. country/asn
+// are the GeoIP resolvers (the same ones the edge WAF/rate limiter use) used to
+// populate request.country/request.asn for a filter; nil leaves those fields ""
+// / 0 (a geo reference simply never matches), never a load error.
+func NewEdgeCacheOverride(country func(*http.Request) string, asn func(*http.Request) int64) *EdgeCacheOverride {
+	e := &EdgeCacheOverride{country: country, asn: asn}
+	newRuleset := func(prefix string) *cacherule.Ruleset {
+		return &cacherule.Ruleset{
+			NamePrefix: prefix,
+			// observe (not metric) keeps the edge binaries off the metric package,
+			// the same boundary as the edge WAF/rate-limit observers.
+			Observe: observe.CacheOverride,
+		}
+	}
+	e.global = newRuleset("global")
+	e.newZone = func(key string) *cacherule.Ruleset { return newRuleset("zone:" + key) }
+	empty := map[string]*cacherule.Ruleset{}
+	e.zones.Store(&empty)
+	e.matcher.Store(newZoneMatcher(nil, nil))
+	return e
+}
+
+// Etag returns the ETag of the currently-loaded config (sent as If-None-Match).
+func (e *EdgeCacheOverride) Etag() string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.etag
+}
+
+// Update compiles and installs a fetched payload: the global override set, the
+// zones, and the path-aware route→zone bindings. All-or-nothing PER set
+// (SetOverrides keeps the last-good set on any invalid override); the zones map
+// and matcher are swapped wholesale. The etag + generation advance only on a
+// CLEAN apply, so a rejected set re-fetches (200, not 304) and re-warns each
+// poll — keeping the degraded state visible, exactly like the WAF/rate-limit
+// refreshers.
+func (e *EdgeCacheOverride) Update(generation uint64, globalDocs []string, zoneDocs map[string][]string, routeZone map[string]string, etag string) error {
+	var firstErr error
+	note := func(err error) {
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	// global
+	if ovs, err := cacherule.Parse(globalDocs...); err != nil {
+		note(fmt.Errorf("global: %w", err))
+	} else if err := e.global.SetOverrides(ovs); err != nil {
+		note(fmt.Errorf("global: %w", err))
+	}
+
+	// zones: reuse the existing instance per key so a bad edit keeps last-good
+	// without disturbing siblings.
+	cur := e.zones.Load()
+	newZones := make(map[string]*cacherule.Ruleset, len(zoneDocs))
+	for key, docs := range zoneDocs {
+		z := (*cur)[key]
+		if z == nil {
+			z = e.newZone(key)
+		}
+		if ovs, err := cacherule.Parse(docs...); err != nil {
+			note(fmt.Errorf("zone %s: %w", key, err))
+		} else if err := z.SetOverrides(ovs); err != nil {
+			note(fmt.Errorf("zone %s: %w", key, err))
+		}
+		newZones[key] = z
+	}
+	e.zones.Store(&newZones)
+
+	// No legacy host→zone map: cache overrides are a new feature, so every edge
+	// understands the path-aware routeZone format and there is no old wire form
+	// to fall back to.
+	e.matcher.Store(newZoneMatcher(routeZone, nil))
+
+	if firstErr == nil {
+		e.mu.Lock()
+		e.etag = etag
+		e.mu.Unlock()
+		e.generation.Store(generation)
+	}
+	return firstErr
+}
+
+// Cacheable implements parapet/pkg/cache's Options.Cacheable. It returns false
+// (bypass the cache) when any matching bypass rule fires in the global OR the
+// bound zone set. Runs on every GET/HEAD; a filterless set is a cheap pass.
+func (e *EdgeCacheOverride) Cacheable(r *http.Request) bool {
+	getInput := e.inputFor(r)
+	if e.global.MatchBypass(r, getInput) {
+		return false
+	}
+	if z := e.resolveZone(r); z != nil && z.MatchBypass(r, getInput) {
+		return false
+	}
+	return true
+}
+
+// Override implements parapet/pkg/cache's Options.Override. It returns the first
+// matching force policy — global rules before the bound zone's — or nil to honor
+// the origin. Runs on a fill (miss), with the origin response status. header is
+// part of the hook signature but unused: v1 narrows by status only.
+func (e *EdgeCacheOverride) Override(r *http.Request, status int, _ http.Header) *cache.Override {
+	getInput := e.inputFor(r)
+	if ov, ok := e.global.Force(r, status, getInput); ok {
+		return ov
+	}
+	if z := e.resolveZone(r); z != nil {
+		if ov, ok := z.Force(r, status, getInput); ok {
+			return ov
+		}
+	}
+	return nil
+}
+
+// inputFor returns a closure that builds the WAF request snapshot at most once
+// per hook call, shared across the global + zone evaluations. request.body is ""
+// (the cache does not buffer the body); country/asn resolve through the same
+// GeoIP funcs the edge WAF uses (nil ⇒ "" / 0).
+func (e *EdgeCacheOverride) inputFor(r *http.Request) func() waf.Input {
+	var input waf.Input
+	built := false
+	return func() waf.Input {
+		if !built {
+			var country string
+			if e.country != nil {
+				country = e.country(r)
+			}
+			var asn int64
+			if e.asn != nil {
+				asn = e.asn(r)
+			}
+			input = waf.NewInput(r, "", country, asn)
+			built = true
+		}
+		return input
+	}
+}
+
+// resolveZone returns the override set bound to the request's host+path, or nil.
+// Host must already be normalized (host.StripPort + host.ToLower upstream).
+func (e *EdgeCacheOverride) resolveZone(r *http.Request) *cacherule.Ruleset {
+	m := e.matcher.Load()
+	if m == nil {
+		return nil
+	}
+	key, ok := m.resolve(r)
+	if !ok {
+		return nil
+	}
+	zs := e.zones.Load()
+	if zs == nil {
+		return nil
+	}
+	return (*zs)[key]
+}

--- a/edge/cache_override_test.go
+++ b/edge/cache_override_test.go
@@ -1,0 +1,120 @@
+package edge
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getReq(target string) *http.Request {
+	return httptest.NewRequest(http.MethodGet, target, nil)
+}
+
+const cacheGlobalBypassAdmin = `overrides:
+  - id: g-admin
+    action: bypass
+    filter: request.path.startsWith("/admin")
+`
+
+const cacheGlobalForceShared = `overrides:
+  - id: g-shared
+    action: cache
+    ttl: 10m
+    filter: request.path.startsWith("/shared")
+`
+
+const cacheZoneForceAPI = `overrides:
+  - id: z-api
+    action: cache
+    ttl: 1h
+    filter: request.path.startsWith("/api")
+  - id: z-shared
+    action: cache
+    ttl: 1h
+    filter: request.path.startsWith("/shared")
+  - id: z-private
+    action: bypass
+    filter: request.path.startsWith("/private")
+`
+
+func TestEdgeCacheOverride_GlobalBypassAndZoneForce(t *testing.T) {
+	t.Parallel()
+	e := NewEdgeCacheOverride(nil, nil)
+	require.NoError(t, e.Update(1,
+		[]string{cacheGlobalBypassAdmin},
+		map[string][]string{"cust/z": {cacheZoneForceAPI}},
+		map[string]string{"t1.example.com/api/": "cust/z", "t1.example.com/private/": "cust/z"},
+		"v1",
+	))
+
+	// Global bypass: /admin anywhere is never cached.
+	assert.False(t, e.Cacheable(getReq("http://anything.example.com/admin/x")))
+	assert.True(t, e.Cacheable(getReq("http://anything.example.com/other")))
+
+	// Zone force: a request routed into the zone gets its TTL.
+	ov := e.Override(getReq("http://t1.example.com/api/widgets"), 200, nil)
+	require.NotNil(t, ov)
+	assert.Equal(t, time.Hour, ov.TTL)
+
+	// A request that resolves to no zone has no force (and no global force here).
+	assert.Nil(t, e.Override(getReq("http://t1.example.com/elsewhere"), 200, nil))
+	assert.Nil(t, e.Override(getReq("http://other.example.com/api/widgets"), 200, nil))
+}
+
+func TestEdgeCacheOverride_BypassUnion(t *testing.T) {
+	t.Parallel()
+	e := NewEdgeCacheOverride(nil, nil)
+	require.NoError(t, e.Update(1,
+		nil, // no global rules
+		map[string][]string{"cust/z": {cacheZoneForceAPI}},
+		map[string]string{"t1.example.com/private/": "cust/z"},
+		"v1",
+	))
+	// Zone bypass fires even with no global bypass (union).
+	assert.False(t, e.Cacheable(getReq("http://t1.example.com/private/data")))
+	assert.True(t, e.Cacheable(getReq("http://t1.example.com/private-ish")))
+}
+
+func TestEdgeCacheOverride_GlobalForceBeatsZone(t *testing.T) {
+	t.Parallel()
+	e := NewEdgeCacheOverride(nil, nil)
+	require.NoError(t, e.Update(1,
+		[]string{cacheGlobalForceShared},                   // global forces /shared to 10m
+		map[string][]string{"cust/z": {cacheZoneForceAPI}}, // zone would force /shared to 1h
+		map[string]string{"t1.example.com/shared/": "cust/z"},
+		"v1",
+	))
+	ov := e.Override(getReq("http://t1.example.com/shared/x"), 200, nil)
+	require.NotNil(t, ov)
+	assert.Equal(t, 10*time.Minute, ov.TTL, "global force is authoritative over the zone")
+}
+
+func TestEdgeCacheOverride_FailStaticEtagWithheld(t *testing.T) {
+	t.Parallel()
+	e := NewEdgeCacheOverride(nil, nil)
+	require.NoError(t, e.Update(1, []string{cacheGlobalBypassAdmin}, nil, nil, "v1"))
+	assert.Equal(t, "v1", e.Etag())
+
+	// A global set that fails to compile (cache action without ttl) is rejected;
+	// the etag must NOT advance so the next poll re-fetches and re-warns.
+	badDoc := "overrides:\n  - id: x\n    action: cache\n"
+	err := e.Update(2, []string{badDoc}, nil, nil, "v2")
+	require.Error(t, err)
+	assert.Equal(t, "v1", e.Etag(), "etag withheld on a rejected apply")
+
+	// Recovery: a clean apply advances the etag again.
+	require.NoError(t, e.Update(3, []string{cacheGlobalBypassAdmin}, nil, nil, "v3"))
+	assert.Equal(t, "v3", e.Etag())
+}
+
+func TestEdgeCacheOverride_EmptyIsHonorOrigin(t *testing.T) {
+	t.Parallel()
+	e := NewEdgeCacheOverride(nil, nil)
+	// No payload applied: every request is cacheable and nothing is forced.
+	assert.True(t, e.Cacheable(getReq("http://x.example.com/admin")))
+	assert.Nil(t, e.Override(getReq("http://x.example.com/api"), 200, nil))
+}

--- a/edge/cacheoverriderefresh.go
+++ b/edge/cacheoverriderefresh.go
@@ -1,0 +1,40 @@
+package edge
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// RefreshCacheOverrideOnce fetches the cache-override payload (ETag-revalidated)
+// and swaps it into the EdgeCacheOverride. A fetch failure or an invalid set is
+// fail-static — the edge keeps its last-good overrides and never starts forcing
+// or bypassing on a degraded fetch. Per-set keep-last-good means a bad zone
+// keeps its old overrides while other sets still update.
+func RefreshCacheOverrideOnce(cp *CpClient, e *EdgeCacheOverride) {
+	res, err := cp.FetchCache(e.Etag())
+	switch {
+	case err != nil:
+		slog.Warn("edge: cache-override fetch failed; keeping last-good overrides", "error", err)
+	case res.Unchanged:
+		// 304: cached config is current.
+	default:
+		if err := e.Update(res.Generation, res.GlobalOverrides, res.Zones, res.RouteZoneMap, res.Etag); err != nil {
+			slog.Warn("edge: a cache-override set was rejected; kept last-good (per set)", "error", err)
+		} else {
+			slog.Info("edge: cache overrides updated", "generation", res.Generation)
+		}
+	}
+}
+
+// RunCacheOverrideRefresh runs the periodic cache-override refresh forever. The
+// first tick is jittered by [0,interval] (fleet poll-instant decorrelation),
+// same cadence as the cert/WAF/ratelimit refresh (EDGE_REFRESH_INTERVAL);
+// fail-static. poke (nil ok) wakes the loop immediately on a /v1/events change
+// signal; the timer remains the fallback floor and refreshes stay single-flight.
+func RunCacheOverrideRefresh(ctx context.Context, cp *CpClient, e *EdgeCacheOverride, interval time.Duration, poke <-chan struct{}) {
+	if interval <= 0 { // time.NewTicker panics on a non-positive interval
+		interval = 300 * time.Second
+	}
+	runRefreshLoop(ctx, interval, poke, func() { RefreshCacheOverrideOnce(cp, e) })
+}

--- a/edge/cp.go
+++ b/edge/cp.go
@@ -273,6 +273,60 @@ func (c *CpClient) FetchRateLimit(currentEtag string) (RateLimitFetch, error) {
 	}
 }
 
+// CacheFetch is the outcome of a cache-override config fetch.
+type CacheFetch struct {
+	// Unchanged is true on a 304.
+	Unchanged bool
+	// On a 200: the generation, global override documents, per-zone documents,
+	// path-aware route→zone bindings, and the ETag. Documents are []string (one
+	// YAML document per ConfigMap data value — cacherule.Parse's contract; never
+	// "---"-joined). There is no legacy host→zone map: cache overrides are a new
+	// feature, so only the path-aware format is ever served.
+	Generation      uint64
+	GlobalOverrides []string
+	Zones           map[string][]string
+	RouteZoneMap    map[string]string
+	Etag            string
+}
+
+type cacheBody struct {
+	Generation      uint64              `json:"generation"`
+	GlobalOverrides []string            `json:"global_overrides"`
+	Zones           map[string][]string `json:"zones"`
+	RouteZoneMap    map[string]string   `json:"route_zone_map"`
+}
+
+// FetchCache fetches the cache-override payload (global documents + zones +
+// route→zone map) scoped to the edge's token, with ETag revalidation. A 404
+// ("cache distribution disabled") is treated like any other non-200/304: an
+// error the caller handles fail-static (keeps last-good).
+func (c *CpClient) FetchCache(currentEtag string) (CacheFetch, error) {
+	resp, err := c.do(c.base+"/v1/cache", currentEtag)
+	if err != nil {
+		return CacheFetch{}, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		return CacheFetch{Unchanged: true}, nil
+	case http.StatusOK:
+		var body cacheBody
+		if err := json.NewDecoder(io.LimitReader(resp.Body, maxWafBody)).Decode(&body); err != nil {
+			return CacheFetch{}, fmt.Errorf("decode: %w", err)
+		}
+		return CacheFetch{
+			Generation:      body.Generation,
+			GlobalOverrides: body.GlobalOverrides,
+			Zones:           body.Zones,
+			RouteZoneMap:    body.RouteZoneMap,
+			Etag:            resp.Header.Get("ETag"),
+		}, nil
+	default:
+		return CacheFetch{}, fmt.Errorf("control plane returned %d for /v1/cache", resp.StatusCode)
+	}
+}
+
 // HostsFetch is the outcome of a known-host fetch (the request metric's host
 // oracle). Scoped to the edge's token.
 type HostsFetch struct {

--- a/edge/events.go
+++ b/edge/events.go
@@ -17,6 +17,7 @@ import (
 type eventsSnapshot struct {
 	WAF       string `json:"waf"`
 	RateLimit string `json:"ratelimit"`
+	Cache     string `json:"cache"`
 	Hosts     string `json:"hosts"`
 	Certs     string `json:"certs"`
 	Purges    uint64 `json:"purges"`
@@ -29,6 +30,7 @@ type eventsSnapshot struct {
 type EventPokes struct {
 	WAF       chan<- struct{}
 	RateLimit chan<- struct{}
+	Cache     chan<- struct{}
 	Hosts     chan<- struct{}
 	Certs     chan<- struct{}
 	Purges    chan<- struct{}
@@ -50,6 +52,7 @@ func (p EventPokes) poke(ch chan<- struct{}) {
 func (p EventPokes) pokeAll() {
 	p.poke(p.WAF)
 	p.poke(p.RateLimit)
+	p.poke(p.Cache)
 	p.poke(p.Hosts)
 	p.poke(p.Certs)
 	p.poke(p.Purges)
@@ -183,6 +186,9 @@ func runEventsOnce(ctx context.Context, cp *CpClient, pokes EventPokes) (deliver
 					}
 					if snap.RateLimit != last.RateLimit {
 						pokes.poke(pokes.RateLimit)
+					}
+					if snap.Cache != last.Cache {
+						pokes.poke(pokes.Cache)
 					}
 					if snap.Hosts != last.Hosts {
 						pokes.poke(pokes.Hosts)

--- a/edgecp/cachereload.go
+++ b/edgecp/cachereload.go
@@ -1,0 +1,124 @@
+package edgecp
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/moonrhythm/parapet-ingress-controller/k8s"
+)
+
+// CacheReloader keeps the CacheStore's override sets in sync with the cluster's
+// cache ConfigMaps (label `parapet.moonrhythm.io/cache`). Global overrides are
+// honored only from podNamespace; zone overrides are collected from any watched
+// namespace, keyed "<ns>/<name>". Same list-on-change pattern as the
+// WafReloader / RateLimitReloader.
+type CacheReloader struct {
+	store          *CacheStore
+	watchNamespace string // "" = all namespaces (zones can live anywhere)
+	podNamespace   string // bounds the global override set
+	debounce       time.Duration
+}
+
+func NewCacheReloader(store *CacheStore, watchNamespace, podNamespace string) *CacheReloader {
+	return &CacheReloader{
+		store:          store,
+		watchNamespace: watchNamespace,
+		podNamespace:   podNamespace,
+		debounce:       300 * time.Millisecond,
+	}
+}
+
+// LoadOnce does a single synchronous load. Call it before serving so the first
+// edge fetch sees a populated store.
+func (r *CacheReloader) LoadOnce(ctx context.Context) error { return r.reload(ctx) }
+
+// Watch relists on every (re)connect (see watchAndRelist) and reloads
+// (debounced) on change. Blocks until ctx is cancelled; run it in a goroutine
+// after LoadOnce.
+func (r *CacheReloader) Watch(ctx context.Context) {
+	watchAndRelist(ctx, "cache configmaps",
+		func(ctx context.Context) (watch.Interface, error) {
+			return k8s.WatchConfigMaps(ctx, r.watchNamespace, CacheLabelKey)
+		},
+		r.reload, r.drain)
+}
+
+func (r *CacheReloader) drain(ctx context.Context, ch <-chan watch.Event) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-ch:
+			if !ok {
+				return
+			}
+			timer := time.NewTimer(r.debounce)
+		coalesce:
+			for {
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return
+				case _, ok := <-ch:
+					if !ok {
+						timer.Stop()
+						break coalesce
+					}
+					if !timer.Stop() {
+						<-timer.C
+					}
+					timer.Reset(r.debounce)
+				case <-timer.C:
+					break coalesce
+				}
+			}
+			if err := r.reload(ctx); err != nil {
+				slog.Error("edgecp: cache reload failed", "err", err)
+			}
+		}
+	}
+}
+
+// reload lists cache ConfigMaps across the watch namespace and rebuilds the
+// global set (podNamespace only) and the zone registry (any namespace). A
+// ConfigMap that also carries the WAF or rate-limit label is refused (one
+// ConfigMap per feature, mirroring the controller and the other reloaders: the
+// lenient YAML parsers would cross-parse the other feature's documents to zero
+// entries silently).
+func (r *CacheReloader) reload(ctx context.Context) error {
+	cms, err := k8s.GetConfigMaps(ctx, r.watchNamespace, CacheLabelKey)
+	if err != nil {
+		return err
+	}
+	projected := make([]wafConfigMap, 0, len(cms))
+	for i := range cms {
+		cm := &cms[i]
+		role := cm.Labels[CacheLabelKey]
+		if role == wafRoleGlobal || role == wafRoleZone {
+			if _, alsoWAF := cm.Labels[WAFLabelKey]; alsoWAF {
+				slog.Warn("edgecp: ignoring configmap that carries both the cache and waf labels; use one configmap per feature",
+					"configmap", cm.Namespace+"/"+cm.Name)
+				continue
+			}
+			if _, alsoRL := cm.Labels[RateLimitLabelKey]; alsoRL {
+				slog.Warn("edgecp: ignoring configmap that carries both the cache and ratelimit labels; use one configmap per feature",
+					"configmap", cm.Namespace+"/"+cm.Name)
+				continue
+			}
+		}
+		projected = append(projected, wafConfigMap{
+			namespace: cm.Namespace,
+			name:      cm.Name,
+			labels:    cm.Labels,
+			data:      cm.Data,
+		})
+	}
+	r.store.SetGlobal(collectGlobalCacheDocs(projected, r.podNamespace))
+	zones := collectZoneCacheDocs(projected)
+	r.store.SetZones(zones)
+	slog.Info("edgecp: cache store reloaded", "zones", len(zones))
+	return nil
+}

--- a/edgecp/cachestore.go
+++ b/edgecp/cachestore.go
@@ -1,0 +1,206 @@
+package edgecp
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// Cache-override ConfigMap markers. The role values ("global"/"zone") are shared
+// with the WAF and rate-limit labels.
+const (
+	CacheLabelKey = "parapet.moonrhythm.io/cache"
+	// CacheZoneAnnotation binds an Ingress to a cache-override zone — bare id or
+	// "ns/id". CROSS-NAMESPACE references are honored (the WAF model, NOT
+	// ratelimit's same-namespace rule): an override set is stateless config, so
+	// binding it cross-namespace applies the policy to the binding ingress's own
+	// traffic only — there is no shared counter state a cross-tenant bind could
+	// abuse.
+	CacheZoneAnnotation = "parapet.moonrhythm.io/cache-zone"
+)
+
+// CacheStore holds everything the edge needs to apply ConfigMap-driven cache
+// overrides: the global override documents (platform baseline, identical for
+// every edge), tenant zone documents (keyed "<ns>/<name>"), and the path-aware
+// route→zone bindings derived from Ingresses (cache-zone annotation). Documents
+// stay []string end to end, like RateLimitStore: cacherule.Parse treats each
+// ConfigMap data value as ONE YAML document and does not split "---".
+//
+// Unlike RateLimitStore there is no legacy host→zone map (cache overrides are a
+// new feature, so every edge speaks the path-aware format) and no known-host
+// list (overrides are stateless — there are no per-host buckets to collapse).
+//
+// Responses are scoped per edge by the caller (scoped()); same locking model as
+// the other stores: lock-free reads via atomic pointers, mu held by writers and
+// by scoped() for a consistent snapshot.
+type CacheStore struct {
+	mu        sync.RWMutex
+	global    atomic.Pointer[[]string]
+	zones     atomic.Pointer[map[string][]string] // zoneKey -> override documents
+	routeZone atomic.Pointer[map[string]string]   // route pattern ("host/path[/]") -> zoneKey
+	gen       atomic.Uint64
+	curEtag   atomic.Pointer[string]
+}
+
+func NewCacheStore() *CacheStore {
+	s := &CacheStore{}
+	var g []string
+	z := map[string][]string{}
+	rz := map[string]string{}
+	s.global.Store(&g)
+	s.zones.Store(&z)
+	s.routeZone.Store(&rz)
+	et := etagOfString("")
+	s.curEtag.Store(&et)
+	return s
+}
+
+// SetGlobal replaces the global override documents (one per ConfigMap data
+// value, deterministic order — see CacheReloader).
+func (s *CacheStore) SetGlobal(docs []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.global.Store(&docs)
+	s.recompute()
+}
+
+// SetZones replaces the full zone registry (zoneKey -> override documents).
+func (s *CacheStore) SetZones(zones map[string][]string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.zones.Store(&zones)
+	s.recompute()
+}
+
+// SetIngressDerived replaces the path-aware route→zone binding (the only
+// Ingress-derived input cache overrides need).
+func (s *CacheStore) SetIngressDerived(routeZone map[string]string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.routeZone.Store(&routeZone)
+	s.recompute()
+}
+
+// recompute bumps the generation + etag when the combined content changes.
+// Caller holds s.mu.
+func (s *CacheStore) recompute() {
+	et := etagOfString(s.fingerprint())
+	if prev := s.curEtag.Load(); prev != nil && *prev == et {
+		return
+	}
+	s.gen.Add(1)
+	s.curEtag.Store(&et)
+}
+
+// Version is the store's full-content etag — an opaque change signal for the
+// /v1/events stream (per-edge scoping happens at fetch time, not here).
+func (s *CacheStore) Version() string { return *s.curEtag.Load() }
+
+// fingerprint is a stable serialization of the full content. Documents are
+// length-prefixed so doc-slice boundaries are unambiguous, mirroring
+// RateLimitStore.fingerprint.
+func (s *CacheStore) fingerprint() string {
+	var b strings.Builder
+	writeDocs := func(docs []string) {
+		for _, d := range docs {
+			b.WriteString(strconv.Itoa(len(d)))
+			b.WriteByte(':')
+			b.WriteString(d)
+		}
+	}
+	writeDocs(*s.global.Load())
+	b.WriteByte(0)
+	zones := *s.zones.Load()
+	zoneKeys := make([]string, 0, len(zones))
+	for k := range zones {
+		zoneKeys = append(zoneKeys, k)
+	}
+	sort.Strings(zoneKeys)
+	for _, k := range zoneKeys {
+		b.WriteString(k)
+		b.WriteByte(1)
+		writeDocs(zones[k])
+		b.WriteByte(1)
+	}
+	b.WriteByte(0)
+	writeSortedMap(&b, *s.routeZone.Load())
+	return b.String()
+}
+
+// cacheScopedSnapshot is the per-edge cache-override payload: global (shared) +
+// only the zones and route bindings for hosts the edge may serve.
+type cacheScopedSnapshot struct {
+	generation uint64
+	global     []string
+	zones      map[string][]string
+	routeZone  map[string]string
+}
+
+// scoped builds the response for an edge, mirroring RateLimitStore.scoped: read
+// under the lock so the fields are one consistent snapshot.
+func (s *CacheStore) scoped(allow func(host string) bool) cacheScopedSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	allZones := *s.zones.Load()
+	allRouteZone := *s.routeZone.Load()
+
+	zones := map[string][]string{}
+	routeZone := map[string]string{}
+	for pattern, zoneKey := range allRouteZone {
+		if !allow(patternHost(pattern)) {
+			continue
+		}
+		routeZone[pattern] = zoneKey
+		if docs, ok := allZones[zoneKey]; ok {
+			zones[zoneKey] = docs
+		}
+	}
+	return cacheScopedSnapshot{
+		generation: s.gen.Load(),
+		global:     *s.global.Load(),
+		zones:      zones,
+		routeZone:  routeZone,
+	}
+}
+
+// collectGlobalCacheDocs collects the global override documents from the given
+// ConfigMaps: only those labeled `…/cache: global` AND living in podNamespace
+// (the platform-owned baseline boundary), in deterministic namespace/name +
+// data-key order.
+func collectGlobalCacheDocs(cms []wafConfigMap, podNamespace string) []string {
+	var globals []wafConfigMap
+	for _, cm := range cms {
+		if cm.labels[CacheLabelKey] != wafRoleGlobal || cm.namespace != podNamespace {
+			continue
+		}
+		globals = append(globals, cm)
+	}
+	sort.Slice(globals, func(i, j int) bool {
+		if globals[i].namespace != globals[j].namespace {
+			return globals[i].namespace < globals[j].namespace
+		}
+		return globals[i].name < globals[j].name
+	})
+	var docs []string
+	for _, cm := range globals {
+		docs = append(docs, sortedValues(cm.data)...)
+	}
+	return docs
+}
+
+// collectZoneCacheDocs collects zone ConfigMaps (any namespace) into
+// zoneKey ("<ns>/<name>") -> override documents.
+func collectZoneCacheDocs(cms []wafConfigMap) map[string][]string {
+	out := map[string][]string{}
+	for _, cm := range cms {
+		if cm.labels[CacheLabelKey] != wafRoleZone {
+			continue
+		}
+		key := cm.namespace + "/" + cm.name
+		out[key] = append(out[key], sortedValues(cm.data)...)
+	}
+	return out
+}

--- a/edgecp/cachestore_test.go
+++ b/edgecp/cachestore_test.go
@@ -1,0 +1,130 @@
+package edgecp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestCollectCacheDocs(t *testing.T) {
+	cms := []wafConfigMap{
+		{namespace: "platform", name: "b-global", labels: map[string]string{CacheLabelKey: "global"},
+			data: map[string]string{"z.yaml": "doc-b2", "a.yaml": "doc-b1"}},
+		{namespace: "platform", name: "a-global", labels: map[string]string{CacheLabelKey: "global"},
+			data: map[string]string{"l.yaml": "doc-a"}},
+		// global outside podNamespace is a tenant injection attempt — ignored
+		{namespace: "cust1", name: "evil-global", labels: map[string]string{CacheLabelKey: "global"},
+			data: map[string]string{"x": "evil"}},
+		{namespace: "cust1", name: "basic", labels: map[string]string{CacheLabelKey: "zone"},
+			data: map[string]string{"l.yaml": "zone-doc"}},
+	}
+
+	global := collectGlobalCacheDocs(cms, "platform")
+	want := []string{"doc-a", "doc-b1", "doc-b2"} // by namespace/name, then data key
+	if !reflect.DeepEqual(global, want) {
+		t.Errorf("global docs: got %v, want %v", global, want)
+	}
+
+	zones := collectZoneCacheDocs(cms)
+	if !reflect.DeepEqual(zones, map[string][]string{"cust1/basic": {"zone-doc"}}) {
+		t.Errorf("zone docs: got %v", zones)
+	}
+}
+
+func TestCacheStoreScopedAndGeneration(t *testing.T) {
+	s := NewCacheStore()
+	gen0 := s.gen.Load()
+	s.SetGlobal([]string{"gdoc"})
+	s.SetZones(map[string][]string{"cust1/basic": {"zdoc"}, "cust2/other": {"odoc"}})
+	s.SetIngressDerived(map[string]string{
+		"a.example.com/api/": "cust1/basic",
+		"d.example.com/":     "cust2/other",
+	})
+	if s.gen.Load() == gen0 {
+		t.Fatal("generation should bump on content change")
+	}
+
+	// scope to an edge allowed everything except d.example.com
+	snap := s.scoped(func(host string) bool { return host != "d.example.com" })
+	if !reflect.DeepEqual(snap.global, []string{"gdoc"}) {
+		t.Errorf("global always included: got %v", snap.global)
+	}
+	if !reflect.DeepEqual(snap.routeZone, map[string]string{"a.example.com/api/": "cust1/basic"}) {
+		t.Errorf("routeZone not scoped by pattern host: got %v", snap.routeZone)
+	}
+	if !reflect.DeepEqual(snap.zones, map[string][]string{"cust1/basic": {"zdoc"}}) {
+		t.Errorf("zones must include only referenced+allowed: got %v", snap.zones)
+	}
+
+	// unchanged content must not bump the generation (etag stability)
+	gen := s.gen.Load()
+	s.SetGlobal([]string{"gdoc"})
+	if s.gen.Load() != gen {
+		t.Error("generation bumped on identical content")
+	}
+}
+
+func TestServerCacheEndpoint(t *testing.T) {
+	store := NewCacheStore()
+	store.SetGlobal([]string{"gdoc"})
+	store.SetZones(map[string][]string{"cust1/basic": {"zdoc"}})
+	store.SetIngressDerived(map[string]string{
+		"acme.com/": "cust1/basic",
+		"evil.com/": "cust1/basic",
+	})
+
+	authz := NewAuthz(map[string][]string{"tok": {"acme.com"}})
+	h := NewServer(NewCertStore(), authz).WithCache(store).Handler()
+
+	// happy path, scoped to the token's domains
+	req := httptest.NewRequest("GET", "/v1/cache", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	var resp cacheResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(resp.GlobalOverrides, []string{"gdoc"}) {
+		t.Errorf("global: got %v", resp.GlobalOverrides)
+	}
+	if !reflect.DeepEqual(resp.RouteZoneMap, map[string]string{"acme.com/": "cust1/basic"}) {
+		t.Errorf("route_zone_map must exclude evil.com: got %v", resp.RouteZoneMap)
+	}
+	etag := rec.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("missing ETag")
+	}
+
+	// 304 on matching If-None-Match
+	req2 := httptest.NewRequest("GET", "/v1/cache", nil)
+	req2.Header.Set("Authorization", "Bearer tok")
+	req2.Header.Set("If-None-Match", etag)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusNotModified {
+		t.Errorf("want 304, got %d", rec2.Code)
+	}
+
+	// 401 without a token
+	rec3 := httptest.NewRecorder()
+	h.ServeHTTP(rec3, httptest.NewRequest("GET", "/v1/cache", nil))
+	if rec3.Code != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d", rec3.Code)
+	}
+
+	// 404 when distribution is disabled (no WithCache)
+	h2 := NewServer(NewCertStore(), authz).Handler()
+	rec4 := httptest.NewRecorder()
+	req4 := httptest.NewRequest("GET", "/v1/cache", nil)
+	req4.Header.Set("Authorization", "Bearer tok")
+	h2.ServeHTTP(rec4, req4)
+	if rec4.Code != http.StatusNotFound {
+		t.Errorf("want 404, got %d", rec4.Code)
+	}
+}

--- a/edgecp/events.go
+++ b/edgecp/events.go
@@ -14,9 +14,11 @@ import (
 // counter), so an edge must only ever compare them for INEQUALITY against the
 // previous event on the SAME stream — never persist or order them.
 type EventsSnapshot struct {
-	// WAF/RateLimit are the stores' content etags ("" when distribution is off).
+	// WAF/RateLimit/Cache are the stores' content etags ("" when distribution is
+	// off).
 	WAF       string `json:"waf,omitempty"`
 	RateLimit string `json:"ratelimit,omitempty"`
+	Cache     string `json:"cache,omitempty"`
 	// Hosts is the known-host store's content etag ("" when off). A host change
 	// pokes only the edge's hosts refresh — it doesn't affect WAF/ratelimit.
 	Hosts string `json:"hosts,omitempty"`

--- a/edgecp/ingressreload.go
+++ b/edgecp/ingressreload.go
@@ -27,6 +27,7 @@ import (
 type IngressReloader struct {
 	store          *WafStore       // optional (nil = WAF host→zone derivation off)
 	rl             *RateLimitStore // optional (nil = rate-limit derivation off)
+	cache          *CacheStore     // optional (nil = cache-override derivation off)
 	hosts          *HostsStore     // optional (nil = /v1/hosts distribution off)
 	watchNamespace string
 	debounce       time.Duration
@@ -40,6 +41,14 @@ func NewIngressReloader(store *WafStore, watchNamespace string) *IngressReloader
 // its host→zone binding and known-host list. Returns the reloader for chaining.
 func (r *IngressReloader) WithRateLimit(rl *RateLimitStore) *IngressReloader {
 	r.rl = rl
+	return r
+}
+
+// WithCache wires the cache-override store so the Ingress reload also derives
+// its path-aware route→zone binding (cache-zone annotation, cross-namespace
+// allowed — the WAF model). Returns the reloader for chaining.
+func (r *IngressReloader) WithCache(cache *CacheStore) *IngressReloader {
+	r.cache = cache
 	return r
 }
 
@@ -108,6 +117,12 @@ func (r *IngressReloader) reload(ctx context.Context) error {
 	}
 	if r.rl != nil {
 		r.rl.SetIngressDerived(buildRateLimitHostZone(ings), buildZoneRoutes(ings, RateLimitZoneAnnotation, true), collectIngressHosts(ings))
+	}
+	if r.cache != nil {
+		// Cross-namespace allowed (sameNamespaceOnly=false), the WAF model: an
+		// override set is stateless config, so a cross-namespace bind applies the
+		// policy to the binding ingress's own traffic only.
+		r.cache.SetIngressDerived(buildZoneRoutes(ings, CacheZoneAnnotation, false))
 	}
 	if r.hosts != nil {
 		r.hosts.SetHosts(collectIngressHosts(ings))

--- a/edgecp/server.go
+++ b/edgecp/server.go
@@ -27,6 +27,10 @@ type Server struct {
 	// /v1/ratelimit → 404). Same scoping/ETag model as the WAF endpoint.
 	ratelimit *RateLimitStore
 
+	// cache is the optional cache-override distribution store (nil = disabled,
+	// /v1/cache → 404). Same scoping/ETag model as the WAF endpoint.
+	cache *CacheStore
+
 	// hosts is the optional standalone known-host distribution store (nil =
 	// /v1/hosts → 404). It feeds the edge request metric's host oracle; same
 	// scoping/ETag model. Standalone because the metric is always on and a stale
@@ -143,6 +147,13 @@ func (s *Server) WithRateLimit(rl *RateLimitStore) *Server {
 	return s
 }
 
+// WithCache enables the cache-override distribution endpoint (GET /v1/cache).
+// Returns the server for chaining.
+func (s *Server) WithCache(c *CacheStore) *Server {
+	s.cache = c
+	return s
+}
+
 // WithHosts enables the standalone known-host endpoint (GET /v1/hosts). Returns
 // the server for chaining.
 func (s *Server) WithHosts(hosts *HostsStore) *Server {
@@ -232,6 +243,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /v1/certs", s.handleCert)
 	mux.HandleFunc("GET /v1/waf", s.handleWAF)
 	mux.HandleFunc("GET /v1/ratelimit", s.handleRateLimit)
+	mux.HandleFunc("GET /v1/cache", s.handleCache)
 	mux.HandleFunc("GET /v1/hosts", s.handleHosts)
 	mux.HandleFunc("GET /v1/purges", s.handlePurges)
 	mux.HandleFunc("GET /v1/events", s.handleEvents)
@@ -439,6 +451,62 @@ func (s *Server) handleRateLimit(w http.ResponseWriter, r *http.Request) {
 		RouteZoneMap: snap.routeZone,
 		HostZoneMap:  snap.hostZone,
 		Hosts:        snap.hosts,
+	}
+	body, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, "encode", http.StatusInternalServerError)
+		return
+	}
+	// Generation zeroed in the validator for the same reason as handleWAF:
+	// process-local counters must not defeat 304 revalidation across replicas.
+	etagResp := resp
+	etagResp.Generation = 0
+	etagBody, err := json.Marshal(etagResp)
+	if err != nil {
+		http.Error(w, "encode", http.StatusInternalServerError)
+		return
+	}
+	etag := etagOfString(string(etagBody))
+	w.Header().Set("ETag", etag)
+	if match := r.Header.Get("If-None-Match"); match != "" && etagMatch(match, etag) {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(body)
+}
+
+// cacheResponse is the GET /v1/cache payload. Documents are arrays of YAML
+// strings (one per ConfigMap data value) — cacherule.Parse takes one document
+// per string and does not split "---". No legacy host_zone_map: cache overrides
+// are a new feature, so only the path-aware route binding is served.
+type cacheResponse struct {
+	Generation      uint64              `json:"generation"`
+	GlobalOverrides []string            `json:"global_overrides"`
+	Zones           map[string][]string `json:"zones"`
+	RouteZoneMap    map[string]string   `json:"route_zone_map"`
+}
+
+// handleCache serves the cache-override payload scoped to the edge's allowed
+// domains: the global baseline (identical for every edge) plus only the zones
+// and route→zone bindings for hosts this token may serve. ETag is computed over
+// the scoped payload — the same model as handleRateLimit.
+func (s *Server) handleCache(w http.ResponseWriter, r *http.Request) {
+	token, ok := bearer(r)
+	if !ok || !s.authz.Known(token) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if s.cache == nil {
+		http.Error(w, "cache distribution disabled", http.StatusNotFound)
+		return
+	}
+	snap := s.cache.scoped(func(host string) bool { return s.authz.Allowed(token, host) })
+	resp := cacheResponse{
+		Generation:      snap.generation,
+		GlobalOverrides: snap.global,
+		Zones:           snap.zones,
+		RouteZoneMap:    snap.routeZone,
 	}
 	body, err := json.Marshal(resp)
 	if err != nil {

--- a/metric/observe/cacheoverride.go
+++ b/metric/observe/cacheoverride.go
@@ -1,0 +1,41 @@
+package observe
+
+import (
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var _cacheOverride struct {
+	vec *prometheus.CounterVec
+}
+
+func init() {
+	_cacheOverride.vec = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "cache_override_total",
+	}, []string{"name", "action", "result"})
+	prom.Registry().MustRegister(_cacheOverride.vec)
+}
+
+// CacheOverride returns a cacherule observe hook counting every in-scope
+// override decision as parapet_cache_override_total{name,action,result}
+// (action = cache|bypass, result = applied|shadow|error). The three counter
+// handles are resolved here, once per rule, so the per-request hook is alloc-
+// and lookup-free. name and action must be bounded: an operator-set override id
+// and its fixed action, never request input. A rule the filter excludes is not
+// counted (only in-scope decisions appear).
+func CacheOverride(name, action string) func(result string) {
+	applied := _cacheOverride.vec.With(prometheus.Labels{"name": name, "action": action, "result": "applied"})
+	shadow := _cacheOverride.vec.With(prometheus.Labels{"name": name, "action": action, "result": "shadow"})
+	errored := _cacheOverride.vec.With(prometheus.Labels{"name": name, "action": action, "result": "error"})
+	return func(result string) {
+		switch result {
+		case "applied":
+			applied.Inc()
+		case "shadow":
+			shadow.Inc()
+		case "error":
+			errored.Inc()
+		}
+	}
+}


### PR DESCRIPTION
## What

Per-request **cache-policy overrides** at the edge response cache, with a **global** baseline (platform-owned) plus opt-in **zones** (tenant-owned), each scoped by a CEL `filter`. Same global+zone + CEL model as the [WAF](../blob/main/WAF.md) and [rate limiter](../blob/main/RATELIMIT.md), under its own `parapet.moonrhythm.io/cache` label and `cache-zone` annotation. Full design in **[`CACHE.md`](../blob/feat/cache-override-spec/CACHE.md)**.

The spine: `parapet/pkg/cache` already ships two per-request hooks the edge didn't wire — `Options.Cacheable` (bypass) and `Options.Override` (force `ttl`/`policy`/RFC 5861 windows). This feature drives them from a ConfigMap-sourced, CEL-filtered, CP-distributed ruleset. The hard cache mechanics (single-flight, Vary, honor-origin, purge) are untouched.

## Shape

- **Edge-only** — the in-cluster controller has no cache, so there's nothing to override there. Touches `edge/`, `edgecp/`, and a new `cacherule/` package; **no controller plugin**.
- **`cacherule/`** — YAML DTO + stateless `Ruleset` runtime (all-or-nothing compile, keep-last-good); filters compile through the shared `waf.Predicate`, so the WAF / rate-limit / cache CEL surfaces can't drift.
- **Precedence & fail direction** (`edge/cache_override.go`) — force is first-match **global-before-zone**; bypass is a **union** (global OR zone). A filter eval error **biases toward NOT caching** — the deliberate inverse of the rate limiter's fail-open, since caching is the dangerous action (an `aggressive` force never applies on error).
- **CP→edge distribution** mirrors `/v1/ratelimit`: `CacheStore` + `CacheReloader`, `GET /v1/cache` (per-edge scoped, generation-zeroed ETag), `EventsSnapshot.Cache` SSE poke, withhold-etag-on-error fail-static apply. **Cross-namespace** zone binding allowed (overrides are stateless config — the `waf-zone` model, not `ratelimit-zone`'s same-ns rule).
- Also wires the previously-unwired **`EDGE_CACHE_DEFAULT_SWR`/`SIE`**.
- Metric `parapet_cache_override_total{name,action,result}`.

## Config

Gated by `EDGE_CACHE_OVERRIDE_ENABLED` (edge, requires `EDGE_CACHE_ENABLED`) + `CP_CACHE_ENABLED` (control plane). Off by default — no watch, no endpoint, no per-request work.

## Tests

`go test -race ./...` → **721 pass**; `go vet` + `gofmt` clean. New tests cover: cacherule validation/precedence/status-gate/fail-direction/shadow/policy-mapping/metrics; edge global+zone precedence, bypass union, fail-static etag-withhold; CP store scoping + `/v1/cache` 200/304/401/404.

Ran `/scrutinize` before opening: one finding (a `CACHE.md` wire-payload listing a `host_zone_map` the impl correctly omits) — fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)