### PR TITLE
feat(edge): default the edge→core hop to HTTP/2 (h2c / ALPN h2), opt-out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ caches responses via `parapet/pkg/cache` (memory or disk backend,
 selected by `EDGE_CACHE_BACKEND`; `EDGE_CACHE_CHUNKED` (default on) also caches
 no-`Content-Length` chunked/on-the-fly-compressed bodies by buffering to derive a
 length — safe because the `httputil.ReverseProxy` forwarder aborts on a truncated
-upstream so a partial body never commits), and forwards to parapet (`edge/forward.go`). Refresh loops are fail-static
+upstream so a partial body never commits), and forwards to parapet (`edge/forward.go`) — **HTTP/2 by default**: h2c on the plaintext `:80` hop, ALPN-negotiated h2 (HTTP/1.1 fallback) on the re-encrypt `:443` hop, `EDGE_UPSTREAM_HTTP2=false` forces HTTP/1.1; WebSocket/Upgrade always rides HTTP/1.1 (`H2CTransport` downgrades it, the re-encrypt path routes it to a dedicated h1 transport). Refresh loops are fail-static
 (`edge/refresh.go`, `edge/wafrefresh.go`, `edge/ratelimitrefresh.go`); by default the CP's `GET /v1/events`
 SSE change stream (`edge/events.go` + `edgecp/events.go`, `EDGE_EVENTS_ENABLED`/`CP_EVENTS_ENABLED`) pokes
 them on change — a version-vector wake-up signal only, so updates land in seconds while the jittered polls

--- a/EDGE.md
+++ b/EDGE.md
@@ -70,7 +70,7 @@ client ──TLS──► edge (Go/parapet, outside k8s)                        
                   │          Ingresses                                    │
                   │   refreshed on a timer; cached in memory only         │
                   │                                                       │
-                  └── data: HTTP/1.1 :80 / re-encrypt :443 ─► parapet ─► svc│
+                  └── data: h2c :80 / re-encrypt h2 :443 ─► parapet ─► svc│
                         (sets X-Forwarded-For/-Proto/-Country/-ASN)        │
                         parapet re-runs WAF authoritatively + routes       │
                               └──────────────────────────────────────────┘
@@ -80,7 +80,7 @@ client ──TLS──► edge (Go/parapet, outside k8s)                        
 
 | Channel | From → to | Protocol | Exposure |
 |---|---|---|---|
-| **Data plane** | edge → parapet `:80`/`:443` | HTTP/1.1 or re-encrypted TLS | private path |
+| **Data plane** | edge → parapet `:80`/`:443` | h2c, or re-encrypted TLS with ALPN h2 (`EDGE_UPSTREAM_HTTP2=false` ⇒ HTTP/1.1) | private path |
 | **Control plane** | edge → controlplane `:8443` | HTTPS GET (server-TLS + bearer token) | private path, edge sources only |
 
 Separate ports on separate Services. The control plane distributes **private
@@ -102,7 +102,10 @@ keys**, so it must never be on the public LoadBalancer. See
   `edge/cp.go`), runs global + zone WAF (`edge/waf.go`), optionally caches
   responses via `parapet/pkg/cache` (memory or disk, selected by
   `EDGE_CACHE_BACKEND`), and forwards to parapet with `X-Forwarded-*`
-  (`edge/forward.go`). Keys live in memory only, never on disk.
+  (`edge/forward.go`). The upstream hop is **HTTP/2 by default** — h2c on the
+  plaintext `:80` hop, ALPN-negotiated h2 (HTTP/1.1 fallback) on the re-encrypt
+  `:443` hop; `EDGE_UPSTREAM_HTTP2=false` forces HTTP/1.1. Keys live in memory
+  only, never on disk.
 
 ## Authorization (bearer token, two endpoints)
 
@@ -869,8 +872,8 @@ change is a natural later addition.
 ```
 edge           :443   public TLS (terminated locally)       EDGE_HTTPS_LISTEN
                :80    public plaintext (on; ""=disable)     EDGE_HTTP_LISTEN
-parapet        :80    data (HTTP/1.1 from edge)            unchanged role, now behind edge
-               :443   data (re-encrypt from edge)
+parapet        :80    data (h2c from edge; H2C=true)        unchanged role, now behind edge
+               :443   data (re-encrypt h2 from edge)
                :9187  metrics
 controlplane   :8443  HTTPS GET (server-TLS + bearer)       NEW — Go, own Service
                       (or plaintext HTTP on a trusted private network — TLS off)
@@ -879,6 +882,39 @@ controlplane   :8443  HTTPS GET (server-TLS + bearer)       NEW — Go, own Serv
                :9187  metrics (CP_METRICS_LISTEN) — the CP's own convergence
                       metrics MERGED with every pushed edge snapshot (below)
 ```
+
+### Upstream protocol (edge → parapet)
+
+The edge→parapet hop runs **HTTP/2 by default**, matching the multiplexing the
+core already accepts (`edge/forward.go`):
+
+```
+EDGE_UPSTREAM_ADDR   parapet host:port (default parapet:80)
+EDGE_UPSTREAM_TLS    re-encrypt the hop with TLS (default false)
+EDGE_UPSTREAM_SNI    SNI/Host on the re-encrypt handshake (default: addr's host)
+EDGE_UPSTREAM_HTTP2  HTTP/2 on the hop (default true — opt-out)
+```
+
+- **Plaintext hop (`EDGE_UPSTREAM_TLS=false`)** → **h2c** prior-knowledge, via
+  parapet's `upstream.H2CTransport`. The core's `:80` server runs with `H2C=true`
+  (`p.SetHTTP1(true)` + `p.SetUnencryptedHTTP2(true)`), so it accepts the h2c
+  preface directly.
+- **Re-encrypt hop (`EDGE_UPSTREAM_TLS=true`)** → **ALPN-negotiated h2 with an
+  HTTP/1.1 fallback**. `net/http` won't auto-enable h2 alongside a custom
+  `tls.Config`/dialer, so the edge sets `ForceAttemptHTTP2` on the transport; the
+  core's `:443` server offers `h2` via ALPN and negotiation lands on h2 (falling
+  back to HTTP/1.1 if a core ever only offers it). Data-plane mTLS
+  (`EDGE_DATAPLANE_MTLS`) rides h2 or HTTP/1.1 identically — the client cert is
+  presented in the TLS handshake either way.
+
+**WebSocket / `Upgrade` requests always ride HTTP/1.1.** `httputil.ReverseProxy`
+has no HTTP/2 upgrade path (no RFC 8441) and an h2 connection rejects the
+`Connection`/`Upgrade` request headers: `H2CTransport` downgrades them itself, and
+the re-encrypt path routes them to a dedicated HTTP/1.1-over-TLS transport.
+
+**Opt-out (`EDGE_UPSTREAM_HTTP2=false`)** forces HTTP/1.1 on both hops. Use it for
+a core that predates `H2C=true` on `:80`, or a dumb L4 in front of `:443` that
+can't ALPN.
 
 ### Edge metrics push (scrape the CP, not the fleet)
 

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -71,6 +71,10 @@ func main() {
 	upstreamAddr := envOr("EDGE_UPSTREAM_ADDR", "parapet:80")
 	upstreamTLS := envOr("EDGE_UPSTREAM_TLS", "false") == "true"
 	upstreamSNI := envOr("EDGE_UPSTREAM_SNI", "")
+	// Default on: h2c on the plaintext hop, ALPN h2 (HTTP/1.1 fallback) on re-encrypt.
+	// Set EDGE_UPSTREAM_HTTP2=false to force HTTP/1.1 — e.g. a core that predates H2C
+	// on :80, or an L4 in front of :443 that can't ALPN.
+	upstreamHTTP2 := envOr("EDGE_UPSTREAM_HTTP2", "true") == "true"
 	dataplaneMTLS := envOr("EDGE_DATAPLANE_MTLS", "false") == "true"
 	if dataplaneMTLS && !upstreamTLS {
 		slog.Error("EDGE_DATAPLANE_MTLS=true requires EDGE_UPSTREAM_TLS=true (a client cert can only ride TLS)")
@@ -124,6 +128,7 @@ func main() {
 		"cp_endpoint", cpEndpoint,
 		"upstream_addr", upstreamAddr,
 		"upstream_tls", upstreamTLS,
+		"upstream_http2", upstreamHTTP2,
 		"serve_all", serveAll,
 		"domains", len(domains),
 		"waf_enabled", wafEnabled,
@@ -372,7 +377,7 @@ func main() {
 		// fires a (non-blocking) reactive re-mint. nil when mTLS is off.
 		onCertReject = func() { remintCoord.Trigger("reactive") }
 	}
-	forwarder := edge.NewForwarder(upstreamAddr, upstreamTLS, upstreamSNI, getClientCert, onCertReject)
+	forwarder := edge.NewForwarder(upstreamAddr, upstreamTLS, upstreamHTTP2, upstreamSNI, getClientCert, onCertReject)
 
 	if metricsListen != "" {
 		go func() {

--- a/deploy/edge/e2e/run.sh
+++ b/deploy/edge/e2e/run.sh
@@ -52,7 +52,7 @@ wait_for_port() {
   done
   # Surface the process logs so a startup crash is diagnosable in CI (not just a
   # bare "did not come up").
-  for log in "$WORK/cp.log" "$WORK/edge.log"; do
+  for log in "$WORK/cp.log" "$WORK/edge.log" "$WORK/upstream.log"; do
     [ -s "$log" ] && { echo "----- $(basename "$log") -----" >&2; cat "$log" >&2; }
   done
   fail "$name did not come up on :$port"
@@ -184,28 +184,14 @@ say "3. build binaries (Go edge + Go control plane)"
   || fail "go build control plane"
 ( cd "$REPO" && go build -o "$WORK/parapet-edge" ./cmd/edge-proxy ) \
   || fail "go build edge"
+# Dummy upstream is a Go h2c-capable origin (stands in for parapet's H2C=true :80),
+# so the edge's default h2c upstream hop is actually exercised end-to-end.
+( cd "$REPO" && go build -o "$WORK/upstream" ./deploy/edge/e2e/upstream ) \
+  || fail "go build upstream"
 
 # ---------------------------------------------------------------------------
-say "4. start dummy upstream (stands in for parapet)"
-python3 -c "
-import http.server, socketserver
-class H(http.server.BaseHTTPRequestHandler):
-    protocol_version = 'HTTP/1.1'
-    def do_GET(self):
-        if self.path == '/cacheme':
-            body=b'cacheable-body'
-            self.send_response(200); self.send_header('content-length',str(len(body)))
-            self.send_header('cache-control','public, max-age=60')
-            self.end_headers(); self.wfile.write(body); return
-        body=b'hello-from-upstream'
-        self.send_response(200); self.send_header('content-length',str(len(body)))
-        # Echo the proto the edge forwarded so the test can assert http vs https.
-        self.send_header('x-seen-forwarded-proto', self.headers.get('x-forwarded-proto',''))
-        self.end_headers()
-        self.wfile.write(body)
-    def log_message(self,*a): pass
-socketserver.TCPServer(('127.0.0.1',$UP_PORT),H).serve_forever()
-" & PIDS+=($!)
+say "4. start dummy upstream (Go h2c origin, stands in for parapet)"
+UPSTREAM_ADDR="127.0.0.1:$UP_PORT" "$WORK/upstream" > "$WORK/upstream.log" 2>&1 & PIDS+=($!)
 wait_for_port "$UP_PORT" upstream
 
 say "5. start the Go control plane (fs backend, WAF enabled)"
@@ -244,7 +230,11 @@ OUT="$(curl -sS -D "$WORK/https.hdr" --cacert "$WORK/ca.crt" --resolve "$DOMAIN:
 # The TLS listener must forward X-Forwarded-Proto: https (echoed back by upstream).
 grep -qiE "^x-seen-forwarded-proto: https[[:space:]]*$" "$WORK/https.hdr" \
   || { cat "$WORK/https.hdr" >&2; fail "TLS listener did not forward X-Forwarded-Proto: https"; }
-echo "  ✓ TLS terminated with control-plane-fetched cert; / forwarded to upstream (proto=https)"
+# The edge→upstream hop defaults to h2c (EDGE_UPSTREAM_HTTP2 unset ⇒ on); the upstream
+# echoes the HTTP major version it saw, so 2 proves h2c was negotiated by default.
+grep -qiE "^x-seen-proto-major: 2[[:space:]]*$" "$WORK/https.hdr" \
+  || { cat "$WORK/https.hdr" >&2; fail "edge did not forward to upstream over h2c (want proto-major 2)"; }
+echo "  ✓ TLS terminated with control-plane-fetched cert; / forwarded to upstream over h2c (proto=https)"
 
 # Phase 1b: the plaintext HTTP listener forwards to upstream WITHOUT redirecting,
 # tagging the hop X-Forwarded-Proto: http so the in-cluster core (not the edge)
@@ -255,7 +245,9 @@ HTTP_OUT="$(curl -sS -D "$WORK/http.hdr" -H "Host: $DOMAIN" \
 [ "$HTTP_OUT" = "hello-from-upstream" ] || fail "unexpected body over http: $HTTP_OUT"
 grep -qiE "^x-seen-forwarded-proto: http[[:space:]]*$" "$WORK/http.hdr" \
   || { cat "$WORK/http.hdr" >&2; fail "HTTP listener did not forward X-Forwarded-Proto: http"; }
-echo "  ✓ plaintext HTTP listener forwarded to upstream (proto=http, no edge redirect)"
+grep -qiE "^x-seen-proto-major: 2[[:space:]]*$" "$WORK/http.hdr" \
+  || { cat "$WORK/http.hdr" >&2; fail "edge did not forward to upstream over h2c (want proto-major 2)"; }
+echo "  ✓ plaintext HTTP listener forwarded to upstream over h2c (proto=http, no edge redirect)"
 
 # Phase 2: the global WAF rule blocks /blocked AT THE EDGE with 403 (never upstream).
 CODE="$(curl -s -o "$WORK/blocked.body" -w '%{http_code}' --cacert "$WORK/ca.crt" \

--- a/deploy/edge/e2e/upstream/main.go
+++ b/deploy/edge/e2e/upstream/main.go
@@ -1,0 +1,58 @@
+// Command upstream is the dummy origin for the edge e2e smoke test (deploy/edge/e2e/run.sh).
+// It stands in for the in-cluster parapet: a plaintext listener that accepts BOTH
+// HTTP/1.1 and h2c (unencrypted HTTP/2) — exactly what parapet's :80 server runs
+// with H2C=true — so the test exercises the edge's default h2c upstream hop.
+//
+// It echoes two things the test asserts on:
+//   - X-Seen-Forwarded-Proto: the inbound X-Forwarded-Proto (client scheme the edge tagged).
+//   - X-Seen-Proto-Major: the HTTP major version the request arrived as (2 ⇒ h2c worked).
+//
+// Pure stdlib, no module deps beyond the repo. Addr comes from UPSTREAM_ADDR.
+package main
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+)
+
+func main() {
+	addr := os.Getenv("UPSTREAM_ADDR")
+	if addr == "" {
+		addr = "127.0.0.1:18090"
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Seen-Forwarded-Proto", r.Header.Get("X-Forwarded-Proto"))
+		w.Header().Set("X-Seen-Proto-Major", strconv.Itoa(r.ProtoMajor))
+		if r.URL.Path == "/cacheme" {
+			body := []byte("cacheable-body")
+			w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+			w.Header().Set("Cache-Control", "public, max-age=60")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+			return
+		}
+		body := []byte("hello-from-upstream")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+
+	// Accept HTTP/1.1 and h2c on the same plaintext listener (parapet's H2C=true).
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+
+	srv := &http.Server{Handler: mux, Protocols: protocols}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Fatalf("upstream: listen %s: %v", addr, err)
+	}
+	if err := srv.Serve(ln); err != nil {
+		log.Fatalf("upstream: serve: %v", err)
+	}
+}

--- a/edge/forward.go
+++ b/edge/forward.go
@@ -5,20 +5,23 @@ import (
 	"crypto/tls"
 	"errors"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/moonrhythm/parapet"
 	"github.com/moonrhythm/parapet/pkg/upstream"
 )
 
 // Forwarder is the terminal middleware that forwards a request to the in-cluster
-// parapet. It uses plaintext h2c by default, or re-encrypts with TLS when
-// EDGE_UPSTREAM_TLS=true (presenting EDGE_UPSTREAM_SNI as the SNI/Host for the
-// handshake). It does NOT rewrite the HTTP Host — the original client Host is
-// forwarded.
+// parapet. By default it speaks h2c on the plaintext hop and ALPN-negotiated h2
+// (with HTTP/1.1 fallback) on the re-encrypt hop; set EDGE_UPSTREAM_HTTP2=false to
+// force HTTP/1.1 on either. It re-encrypts with TLS when EDGE_UPSTREAM_TLS=true
+// (presenting EDGE_UPSTREAM_SNI as the SNI/Host for the handshake). It does NOT
+// rewrite the HTTP Host — the original client Host is forwarded.
 //
 // The X-Forwarded-For / X-Real-Ip / X-Forwarded-Proto headers are set by the
 // parapet server's own inbound proxy layer. By default the edge is the first hop
@@ -31,22 +34,37 @@ type Forwarder struct {
 	rp *httputil.ReverseProxy
 }
 
-// NewForwarder builds a forwarder to addr (host:port). useTLS selects re-encrypt
-// (TLS) vs plaintext HTTP/1.1; sni is the SNI/Host presented when re-encrypting
-// (ignored otherwise; "" lets the transport default to addr's host). getClientCert,
-// when non-nil (and useTLS), presents the edge's data-plane mTLS client cert on the
-// re-encrypt handshake so the core can CA-only-trust this edge (EDGE_DATAPLANE_MTLS).
+// NewForwarder builds a forwarder to addr (host:port).
 //
-// The plaintext hop is HTTP/1.1 (not h2c); parapet's :80 accepts it.
-// Re-encrypt uses TLS with InsecureSkipVerify (a cluster-internal hop,
-// matching the controller's upstream posture) — the edge authenticates ITSELF to
-// the core with its client cert; it does not yet verify the core's server cert.
-// onCertReject, when non-nil, fires when the CORE rejects the edge's data-plane client
-// cert in the re-encrypt TLS handshake — the reactive force-re-mint floor. It is the
-// coordinator's reactive Trigger; nil when data-plane mTLS is off.
-func NewForwarder(addr string, useTLS bool, sni string, getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error), onCertReject func()) *Forwarder {
+// useTLS selects re-encrypt (TLS) vs plaintext; sni is the SNI/Host presented when
+// re-encrypting (ignored otherwise; "" lets the transport default to addr's host).
+//
+// enableHTTP2 (default on; EDGE_UPSTREAM_HTTP2) picks the upstream protocol within
+// each mode. The core accepts both upgraded protocols out of the box — parapet's :80
+// server runs with H2C=true and its :443 server offers h2 via ALPN:
+//   - plaintext  → h2c prior-knowledge via parapet's upstream.H2CTransport;
+//     HTTP/1.1 when disabled.
+//   - re-encrypt → ALPN-negotiated h2 with HTTP/1.1 fallback via a ForceAttemptHTTP2
+//     http.Transport (h2TLSTransport); HTTP/1.1-over-TLS when disabled.
+//
+// WebSocket/Upgrade requests always ride HTTP/1.1 regardless: httputil.ReverseProxy
+// has no HTTP/2 upgrade path (no RFC 8441) and an h2 connection rejects the
+// Connection/Upgrade request headers. H2CTransport downgrades them itself; the
+// re-encrypt path routes them to a dedicated HTTP/1.1-over-TLS transport.
+//
+// getClientCert, when non-nil (and useTLS), presents the edge's data-plane mTLS
+// client cert on the re-encrypt handshake so the core can CA-only-trust this edge
+// (EDGE_DATAPLANE_MTLS); it rides h2 or HTTP/1.1 identically. Re-encrypt uses TLS
+// with InsecureSkipVerify (a cluster-internal hop, matching the controller's upstream
+// posture) — the edge authenticates ITSELF to the core with its client cert; it does
+// not yet verify the core's server cert. onCertReject, when non-nil, fires when the
+// CORE rejects the edge's data-plane client cert in the re-encrypt TLS handshake — the
+// reactive force-re-mint floor. It is the coordinator's reactive Trigger; nil when
+// data-plane mTLS is off.
+func NewForwarder(addr string, useTLS, enableHTTP2 bool, sni string, getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error), onCertReject func()) *Forwarder {
 	var tr http.RoundTripper
-	if useTLS {
+	switch {
+	case useTLS:
 		tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true} //nolint:gosec // cluster-internal hop, matches the controller's upstream posture
 		if sni != "" {
 			tlsConfig.ServerName = sni
@@ -54,19 +72,36 @@ func NewForwarder(addr string, useTLS bool, sni string, getClientCert func(*tls.
 		if getClientCert != nil {
 			tlsConfig.GetClientCertificate = getClientCert
 		}
-		// HTTPSTransport sets r.URL.Scheme = "https" and dials r.URL.Host with TLS.
-		tr = &upstream.HTTPSTransport{TLSClientConfig: tlsConfig}
-	} else {
+		// HTTPSTransport sets r.URL.Scheme = "https" and dials r.URL.Host with TLS,
+		// HTTP/1.1 only (net/http won't auto-enable h2 with a custom TLS config).
+		h1 := &upstream.HTTPSTransport{TLSClientConfig: tlsConfig}
+		if enableHTTP2 {
+			tr = newH2TLSTransport(tlsConfig, h1)
+		} else {
+			tr = h1
+		}
+	case enableHTTP2:
+		// Plaintext h2c (prior-knowledge) to the core's H2C=true :80 listener.
+		// H2CTransport sets r.URL.Scheme = "http" and downgrades Upgrade/WebSocket
+		// requests to HTTP/1.1.
+		tr = &upstream.H2CTransport{}
+	default:
 		// HTTPTransport sets r.URL.Scheme = "http" and speaks HTTP/1.1.
 		tr = &upstream.HTTPTransport{}
 	}
 
+	scheme := "http"
+	if useTLS {
+		scheme = "https"
+	}
+
 	rp := &httputil.ReverseProxy{
-		// The transport sets the scheme; the Director only needs the host. The
-		// path/query and Host header are forwarded verbatim (parapet routes on
-		// them). RemoteAddr is cleared in ServeHandler so ReverseProxy doesn't
+		// The Director sets the scheme + host. The upstream.* transports also set the
+		// scheme, but the plain http.Transport behind h2TLSTransport does not, so the
+		// Director must. The path/query and Host header are forwarded verbatim (parapet
+		// routes on them). RemoteAddr is cleared in ServeHandler so ReverseProxy doesn't
 		// re-append X-Forwarded-For — the parapet server already set the true one.
-		Director:   func(r *http.Request) { r.URL.Host = addr },
+		Director:   func(r *http.Request) { r.URL.Scheme = scheme; r.URL.Host = addr },
 		Transport:  tr,
 		BufferPool: bufferPool,
 		ErrorLog:   slog.NewLogLogger(slog.Default().Handler(), slog.LevelWarn),
@@ -124,6 +159,49 @@ func isClientCertRejected(err error) bool {
 		}
 	}
 	return false
+}
+
+// h2TLSTransport forwards over re-encrypted TLS, preferring ALPN-negotiated HTTP/2
+// for ordinary requests while keeping WebSocket/Upgrade requests on HTTP/1.1 — an
+// HTTP/2 connection rejects the Connection/Upgrade request headers, so they need a
+// dedicated HTTP/1.1 transport (this mirrors parapet's upstream.H2CTransport for the
+// plaintext hop). Both transports share one tls.Config (same mTLS client cert / SNI),
+// so the data-plane-mTLS handshake is identical on either protocol.
+type h2TLSTransport struct {
+	h2 http.RoundTripper // ForceAttemptHTTP2: negotiates h2, falls back to HTTP/1.1
+	h1 http.RoundTripper // HTTP/1.1-over-TLS, for Upgrade requests
+}
+
+func newH2TLSTransport(tlsConfig *tls.Config, h1 http.RoundTripper) *h2TLSTransport {
+	return &h2TLSTransport{
+		// ForceAttemptHTTP2 makes net/http wire up the bundled http2 transport even
+		// though we supply a custom TLSClientConfig + DialContext (which otherwise trips
+		// net/http's conservative "don't surprise me" opt-out — see Transport.protocols).
+		// ALPN then negotiates h2, falling back to HTTP/1.1 if the core only offers it.
+		// Fields mirror upstream.HTTPSTransport's defaults so only the protocol changes;
+		// DisableCompression keeps the proxy hop byte-transparent (no auto-gzip).
+		h2: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
+			TLSClientConfig:       tlsConfig,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConnsPerHost:   32,
+			IdleConnTimeout:       10 * time.Minute,
+			TLSHandshakeTimeout:   5 * time.Second,
+			ResponseHeaderTimeout: time.Minute,
+			DisableCompression:    true,
+		},
+		h1: h1,
+	}
+}
+
+// RoundTrip routes Upgrade requests to HTTP/1.1 and everything else to the
+// h2-preferring transport. r.URL.Scheme is already "https" (set by the Director).
+func (t *h2TLSTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.Header.Get("Upgrade") != "" {
+		return t.h1.RoundTrip(r)
+	}
+	return t.h2.RoundTrip(r)
 }
 
 // ServeHandler implements parapet.Middleware. It is terminal — the next handler

--- a/edge/forward_http2_test.go
+++ b/edge/forward_http2_test.go
@@ -1,0 +1,124 @@
+package edge
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// protoHandler reports the HTTP major version the upstream actually saw — the wire
+// outcome of the edge→core hop (2 = h2c/h2, 1 = HTTP/1.1).
+func protoHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "proto=%d", r.ProtoMajor)
+	})
+}
+
+// forwardThrough drives one request through the forwarder and returns the response
+// body (which carries proto=N from protoHandler).
+func forwardThrough(t *testing.T, f *Forwarder) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://core.example/", nil)
+	f.ServeHandler(nil).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q", rec.Code, rec.Body.String())
+	}
+	return rec.Body.String()
+}
+
+func addrOf(t *testing.T, rawURL string) string {
+	t.Helper()
+	return strings.TrimPrefix(strings.TrimPrefix(rawURL, "https://"), "http://")
+}
+
+// Plaintext hop: enableHTTP2=true must negotiate h2c to the core's H2C listener;
+// enableHTTP2=false must stay on HTTP/1.1.
+func TestForwarder_Plaintext_H2COptOut(t *testing.T) {
+	// Plaintext listener that accepts both HTTP/1.1 and h2c (unencrypted HTTP/2) —
+	// exactly what parapet's :80 server runs with H2C=true.
+	srv := httptest.NewUnstartedServer(protoHandler())
+	p := new(http.Protocols)
+	p.SetHTTP1(true)
+	p.SetUnencryptedHTTP2(true)
+	srv.Config.Protocols = p
+	srv.Start()
+	defer srv.Close()
+	addr := addrOf(t, srv.URL)
+
+	if got := forwardThrough(t, NewForwarder(addr, false, true, "", nil, nil)); got != "proto=2" {
+		t.Errorf("h2c default: want proto=2, got %q", got)
+	}
+	if got := forwardThrough(t, NewForwarder(addr, false, false, "", nil, nil)); got != "proto=1" {
+		t.Errorf("opt-out: want proto=1 (HTTP/1.1), got %q", got)
+	}
+}
+
+// Re-encrypt hop: enableHTTP2=true must ALPN-negotiate h2 to an h2-capable core;
+// enableHTTP2=false must stay on HTTP/1.1 over TLS. (InsecureSkipVerify makes the
+// edge accept the httptest cert, matching the cluster-internal posture.)
+func TestForwarder_TLS_H2OptOut(t *testing.T) {
+	srv := httptest.NewUnstartedServer(protoHandler())
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	defer srv.Close()
+	addr := addrOf(t, srv.URL)
+
+	if got := forwardThrough(t, NewForwarder(addr, true, true, "", nil, nil)); got != "proto=2" {
+		t.Errorf("h2 default: want proto=2, got %q", got)
+	}
+	if got := forwardThrough(t, NewForwarder(addr, true, false, "", nil, nil)); got != "proto=1" {
+		t.Errorf("opt-out: want proto=1 (HTTP/1.1 over TLS), got %q", got)
+	}
+}
+
+// A core that only offers HTTP/1.1 over TLS (no h2 ALPN) must still work with
+// enableHTTP2=true — ForceAttemptHTTP2 offers h2 but falls back to HTTP/1.1.
+func TestForwarder_TLS_H2FallsBackToHTTP1(t *testing.T) {
+	srv := httptest.NewUnstartedServer(protoHandler())
+	srv.EnableHTTP2 = false // server offers only http/1.1 in ALPN
+	srv.StartTLS()
+	defer srv.Close()
+	addr := addrOf(t, srv.URL)
+
+	if got := forwardThrough(t, NewForwarder(addr, true, true, "", nil, nil)); got != "proto=1" {
+		t.Errorf("h2 requested, http/1.1-only core: want graceful proto=1, got %q", got)
+	}
+}
+
+// recordRT records that it was used and returns a trivial 200.
+type recordRT struct{ used bool }
+
+func (r *recordRT) RoundTrip(*http.Request) (*http.Response, error) {
+	r.used = true
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+}
+
+// The re-encrypt h2 transport must route Upgrade/WebSocket requests to the HTTP/1.1
+// transport (an h2 connection rejects Connection/Upgrade headers) and everything
+// else to the h2-preferring transport.
+func TestH2TLSTransport_UpgradeRoutesToHTTP1(t *testing.T) {
+	h1, h2 := &recordRT{}, &recordRT{}
+	tr := &h2TLSTransport{h1: h1, h2: h2}
+
+	up := httptest.NewRequest(http.MethodGet, "https://core/", nil)
+	up.Header.Set("Connection", "Upgrade")
+	up.Header.Set("Upgrade", "websocket")
+	if _, err := tr.RoundTrip(up); err != nil {
+		t.Fatal(err)
+	}
+	if !h1.used || h2.used {
+		t.Errorf("upgrade request: want h1, got h1=%v h2=%v", h1.used, h2.used)
+	}
+
+	h1.used, h2.used = false, false
+	normal := httptest.NewRequest(http.MethodGet, "https://core/", nil)
+	if _, err := tr.RoundTrip(normal); err != nil {
+		t.Fatal(err)
+	}
+	if h1.used || !h2.used {
+		t.Errorf("normal request: want h2, got h1=%v h2=%v", h1.used, h2.used)
+	}
+}


### PR DESCRIPTION
## What

Default the edge→parapet forward hop to **HTTP/2**, with an opt-out:

| `EDGE_UPSTREAM_TLS` | `EDGE_UPSTREAM_HTTP2` (default `true`) | Wire protocol |
|---|---|---|
| `false` | `true` | **h2c** prior-knowledge |
| `false` | `false` | HTTP/1.1 |
| `true`  | `true` | **ALPN-negotiated h2** (HTTP/1.1 fallback) |
| `true`  | `false` | HTTP/1.1 over TLS |

Previously the hop was HTTP/1.1 in both modes.

## Why it's safe — the core already accepts both

No core change needed:
- parapet's `:80` server runs `H2C: true` (`p.SetHTTP1` + `p.SetUnencryptedHTTP2`) → accepts the h2c preface.
- parapet's `:443` server uses Go `ServeTLS` with no `NextProtos` override → Go auto-enables `h2` ALPN by default.

## Implementation notes

- **`net/http` won't auto-enable h2 with a custom `TLSClientConfig`/`DialContext`** (its conservative `Transport.protocols()` gate). The re-encrypt path uses a `ForceAttemptHTTP2` `http.Transport` (`h2TLSTransport`) mirroring `upstream.HTTPSTransport`'s defaults, incl. `DisableCompression: true` to keep the proxy hop byte-transparent. Plaintext reuses parapet's `upstream.H2CTransport`.
- **WebSocket/Upgrade always rides HTTP/1.1** — an h2 connection rejects `Connection`/`Upgrade` headers and `httputil.ReverseProxy` has no RFC 8441 path. `H2CTransport` downgrades them itself; the re-encrypt path routes them to a dedicated HTTP/1.1-over-TLS transport.
- **Data-plane mTLS** (`EDGE_DATAPLANE_MTLS`) rides h2 or HTTP/1.1 identically — the client cert is presented in the TLS handshake either way.

## Opt-out

`EDGE_UPSTREAM_HTTP2=false` forces HTTP/1.1 on both hops — for a core that predates `H2C=true` on `:80`, or a dumb L4 in front of `:443` that can't ALPN.

## Tests

- **`edge/forward_http2_test.go`** (new): real h2c / h2 / h1-fallback negotiation through the `Forwarder`, plus the `h2TLSTransport` Upgrade-routing split.
- **e2e** (`deploy/edge/e2e/run.sh`): the dummy upstream was Python (HTTP/1.1-only) and would break the default h2c hop, so it's replaced with a Go h2c-capable origin (`deploy/edge/e2e/upstream/main.go`) that echoes the HTTP major version it saw; the e2e now asserts the hop is actually h2c (`X-Seen-Proto-Major: 2`) on both the TLS-terminated and plaintext-listener paths.
- Verified locally: `gofmt -l .` clean · `go vet ./...` clean · `go test -race ./...` → 725 passed · e2e PASSED.

## Docs

`EDGE.md` (diagram, channel table, ports block, new "Upstream protocol" subsection) and `CLAUDE.md` edge note updated. SPEC.md unchanged (tabulates only controller env vars; WAF-claim hop semantics are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)