### PR TITLE
Bypass edge response cache for forward-auth-gated hosts (deployment access PR-6)

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -213,6 +213,24 @@ GET /v1/hosts         Authorization: Bearer <token>   [If-None-Match: "<etag>"]
        (ETag over the scoped payload with the generation excluded, like /v1/waf)
   401 (no/invalid token)   404 (hosts distribution disabled / older CP)
 
+GET /v1/gated-hosts   Authorization: Bearer <token>   [If-None-Match: "<etag>"]
+  200 {"generation": N, "hosts":["…"]}
+       hosts          : every host of an Ingress carrying the
+                        `parapet.moonrhythm.io/forward-auth` annotation (non-empty),
+                        scoped to the token's domains (sorted, deduped). The edge-proxy
+                        bypasses its RESPONSE CACHE for these hosts — never serves from
+                        nor stores a response — because the cache key ignores Cookie, so
+                        a cached 200 for a forward-auth-gated host would leak pre-auth
+                        content to anonymous users (Options.Cacheable → false).
+       STANDALONE and CP-DERIVED from the same Ingress watch (the apiserver does NOT
+       push it; the forward-auth annotation the deployer renders IS the signal). The
+       in-cluster forward-auth gate stays authoritative regardless, so a stale/empty
+       set or an older CP (404) cannot bypass AUTH — only briefly serve a cached copy
+       until the next poll/events poke; the change wakes edges via the events `gatedHosts`
+       vector. Served by default (CP_GATED_HOSTS_ENABLED, default true).
+       (ETag over the scoped payload with the generation excluded, like /v1/hosts)
+  401 (no/invalid token)   404 (gated-hosts distribution disabled / older CP)
+
 GET /v1/purges?since=<seq>   Authorization: Bearer <token>
   200 {"entries":[{"seq":N,"scope":"url|host|prefix|tag|flush-all","host":"…","uri":"…","tag":"…"}],
        "max_seq": N, "flush_required": false}
@@ -246,7 +264,7 @@ POST /v1/purges       Authorization: Bearer <ADMIN token>   ← stronger cred th
 GET /v1/events        Authorization: Bearer <token>   (SSE; long-lived)
   200 Content-Type: text/event-stream — change-notification stream. Each event:
        event: change
-       data: {"waf":"<etag>","ratelimit":"<etag>","hosts":"<etag>","certs":"<fp>","purges":<seq>}
+       data: {"waf":"<etag>","ratelimit":"<etag>","hosts":"<etag>","gatedHosts":"<etag>","certs":"<fp>","purges":<seq>}
        The payload is a VERSION VECTOR (opaque, CP-process-local) — a wake-up
        signal only, never content. The first event is the current vector (a
        reconnecting edge covers its disconnected window); after that, one event

--- a/cmd/edge-controlplane/main.go
+++ b/cmd/edge-controlplane/main.go
@@ -321,6 +321,7 @@ func main() {
 	var rlStore *edgecp.RateLimitStore
 	var cacheStore *edgecp.CacheStore
 	var hostsStore *edgecp.HostsStore
+	var gatedHostsStore *edgecp.GatedHostsStore
 	if wafEnabled {
 		wafStore = edgecp.NewWafStore()
 		wafReloader := edgecp.NewWafReloader(wafStore, watchNamespace, podNamespace)
@@ -362,8 +363,18 @@ func main() {
 		server = server.WithHosts(hostsStore)
 		slog.Info("edge control plane: hosts distribution enabled")
 	}
-	if wafStore != nil || rlStore != nil || cacheStore != nil || hostsStore != nil {
-		ingReloader := edgecp.NewIngressReloader(wafStore, watchNamespace).WithRateLimit(rlStore).WithCache(cacheStore).WithHosts(hostsStore)
+	// Forward-auth-gated host distribution (GET /v1/gated-hosts) — the edge-proxy
+	// bypasses its response cache for these hosts so a cached copy can't leak
+	// pre-auth content. ON BY DEFAULT (a security feature): the in-cluster
+	// forward-auth gate stays authoritative, but with this off a cached 200 for a
+	// gated host would be served to anonymous users. Rides the same Ingress watch.
+	if envOr("CP_GATED_HOSTS_ENABLED", "true") == "true" {
+		gatedHostsStore = edgecp.NewGatedHostsStore()
+		server = server.WithGatedHosts(gatedHostsStore)
+		slog.Info("edge control plane: gated-hosts distribution enabled")
+	}
+	if wafStore != nil || rlStore != nil || cacheStore != nil || hostsStore != nil || gatedHostsStore != nil {
+		ingReloader := edgecp.NewIngressReloader(wafStore, watchNamespace).WithRateLimit(rlStore).WithCache(cacheStore).WithHosts(hostsStore).WithGatedHosts(gatedHostsStore)
 		if err := ingReloader.LoadOnce(ctx); err != nil {
 			slog.Error("edgecp: initial ingress load failed", "err", err)
 		}
@@ -409,6 +420,9 @@ func main() {
 			}
 			if hostsStore != nil {
 				snap.Hosts = hostsStore.Version()
+			}
+			if gatedHostsStore != nil {
+				snap.GatedHosts = gatedHostsStore.Version()
 			}
 			if purgeStore != nil {
 				snap.Purges = purgeStore.LastSeq()

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -154,7 +154,7 @@ func main() {
 	// refreshes single-flight per resource.
 	eventsEnabled := envOr("EDGE_EVENTS_ENABLED", "true") == "true"
 	var pokes edge.EventPokes
-	var certPoke, wafPoke, rlPoke, hostsPoke, purgePoke chan struct{}
+	var certPoke, wafPoke, rlPoke, hostsPoke, gatedHostsPoke, purgePoke chan struct{}
 	if eventsEnabled {
 		certPoke = make(chan struct{}, 1)
 		pokes.Certs = certPoke
@@ -171,6 +171,21 @@ func main() {
 		pokes.Hosts = hostsPoke
 	}
 	go edge.RunHostsRefresh(ctx, cp, edgeHosts, refreshInterval, hostsPoke)
+
+	// Forward-auth-gated host set (GET /v1/gated-hosts) — the edge response-cache
+	// bypass set. The cache key ignores Cookie, so a cached 200 for a forward-auth-
+	// gated host would leak pre-auth content; the cache MUST never serve-from or
+	// store a response for these hosts. Always fetched (the bypass is a security
+	// invariant), independent of WAF/ratelimit; fail-static (keeps last-good), and a
+	// 404 from a CP without the endpoint just leaves no host bypassing — the
+	// in-cluster forward-auth gate stays authoritative regardless.
+	edgeGatedHosts := edge.NewEdgeGatedHosts()
+	edge.RefreshGatedHostsOnce(cp, edgeGatedHosts)
+	if eventsEnabled {
+		gatedHostsPoke = make(chan struct{}, 1)
+		pokes.GatedHosts = gatedHostsPoke
+	}
+	go edge.RunGatedHostsRefresh(ctx, cp, edgeGatedHosts, refreshInterval, gatedHostsPoke)
 
 	// Optional data-plane mTLS: fetch a CP-issued client cert (CA-only trust), hold it
 	// in memory (never on disk), and present it on the re-encrypt hop. The re-mint
@@ -325,9 +340,22 @@ func main() {
 			// Cache overrides drive the two per-request decision hooks: Cacheable
 			// (bypass rules) and Override (force rules). nil when EDGE_CACHE_OVERRIDE_ENABLED
 			// is off, leaving the cache strictly honor-origin.
+			//
+			// Gated hosts (forward-auth) must NEVER be served from or stored in the
+			// edge cache: the cache key ignores Cookie, so a cached copy would leak
+			// pre-auth content. The in-cluster forward-auth gate stays authoritative;
+			// this closes the edge-cache bypass of that gate. Active whenever the
+			// cache is on, independent of cache overrides.
+			ecoCacheable := func(r *http.Request) bool { return true }
 			if eco != nil {
-				opts.Cacheable = eco.Cacheable
+				ecoCacheable = eco.Cacheable
 				opts.Override = eco.Override
+			}
+			opts.Cacheable = func(r *http.Request) bool {
+				if edgeGatedHosts.IsGatedHost(r.Host) {
+					return false
+				}
+				return ecoCacheable(r)
 			}
 			// Cache-purge: an invalidation table fed from the control plane gates each
 			// hit (parapet's Options.InvalidatedAfter). On by default with the cache; the

--- a/edge/cp.go
+++ b/edge/cp.go
@@ -371,6 +371,51 @@ func (c *CpClient) FetchHosts(currentEtag string) (HostsFetch, error) {
 	}
 }
 
+// GatedHostsFetch is the outcome of a forward-auth-gated host fetch (the edge
+// response-cache bypass set). Scoped to the edge's token.
+type GatedHostsFetch struct {
+	// Unchanged is true on a 304.
+	Unchanged  bool
+	Generation uint64
+	Hosts      []string
+	Etag       string
+}
+
+type gatedHostsBody struct {
+	Generation uint64   `json:"generation"`
+	Hosts      []string `json:"hosts"`
+}
+
+// FetchGatedHosts fetches the forward-auth-gated host list scoped to the edge's
+// token, with ETag revalidation. A 404 ("gated-hosts distribution disabled" — an
+// old CP, or CP_GATED_HOSTS_ENABLED=false) is treated like any other non-200/304:
+// an error the caller handles fail-static (keeps last-good — the edge keeps
+// bypassing the cache for the hosts it already knows are gated).
+func (c *CpClient) FetchGatedHosts(currentEtag string) (GatedHostsFetch, error) {
+	resp, err := c.do(c.base+"/v1/gated-hosts", currentEtag)
+	if err != nil {
+		return GatedHostsFetch{}, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		return GatedHostsFetch{Unchanged: true}, nil
+	case http.StatusOK:
+		var body gatedHostsBody
+		if err := json.NewDecoder(io.LimitReader(resp.Body, maxWafBody)).Decode(&body); err != nil {
+			return GatedHostsFetch{}, fmt.Errorf("decode: %w", err)
+		}
+		return GatedHostsFetch{
+			Generation: body.Generation,
+			Hosts:      body.Hosts,
+			Etag:       resp.Header.Get("ETag"),
+		}, nil
+	default:
+		return GatedHostsFetch{}, fmt.Errorf("control plane returned %d for /v1/gated-hosts", resp.StatusCode)
+	}
+}
+
 // PurgeFetch is the outcome of a cache-purge poll.
 type PurgeFetch struct {
 	// Disabled is true on a 404 ("purge distribution disabled" at the CP): a clean,

--- a/edge/events.go
+++ b/edge/events.go
@@ -15,12 +15,13 @@ import (
 // only ever compared for inequality against the previous event on the SAME
 // stream, never persisted or ordered.
 type eventsSnapshot struct {
-	WAF       string `json:"waf"`
-	RateLimit string `json:"ratelimit"`
-	Cache     string `json:"cache"`
-	Hosts     string `json:"hosts"`
-	Certs     string `json:"certs"`
-	Purges    uint64 `json:"purges"`
+	WAF        string `json:"waf"`
+	RateLimit  string `json:"ratelimit"`
+	Cache      string `json:"cache"`
+	Hosts      string `json:"hosts"`
+	GatedHosts string `json:"gatedHosts"`
+	Certs      string `json:"certs"`
+	Purges     uint64 `json:"purges"`
 }
 
 // EventPokes carries the wake-up channels for the resource refresh loops. Each
@@ -28,12 +29,13 @@ type eventsSnapshot struct {
 // (size 1); sends are non-blocking, so a poke arriving while a refresh is
 // already pending coalesces.
 type EventPokes struct {
-	WAF       chan<- struct{}
-	RateLimit chan<- struct{}
-	Cache     chan<- struct{}
-	Hosts     chan<- struct{}
-	Certs     chan<- struct{}
-	Purges    chan<- struct{}
+	WAF        chan<- struct{}
+	RateLimit  chan<- struct{}
+	Cache      chan<- struct{}
+	Hosts      chan<- struct{}
+	GatedHosts chan<- struct{}
+	Certs      chan<- struct{}
+	Purges     chan<- struct{}
 }
 
 func (p EventPokes) poke(ch chan<- struct{}) {
@@ -54,6 +56,7 @@ func (p EventPokes) pokeAll() {
 	p.poke(p.RateLimit)
 	p.poke(p.Cache)
 	p.poke(p.Hosts)
+	p.poke(p.GatedHosts)
 	p.poke(p.Certs)
 	p.poke(p.Purges)
 }
@@ -192,6 +195,9 @@ func runEventsOnce(ctx context.Context, cp *CpClient, pokes EventPokes) (deliver
 					}
 					if snap.Hosts != last.Hosts {
 						pokes.poke(pokes.Hosts)
+					}
+					if snap.GatedHosts != last.GatedHosts {
+						pokes.poke(pokes.GatedHosts)
 					}
 					if snap.Certs != last.Certs {
 						pokes.poke(pokes.Certs)

--- a/edge/gatedhosts.go
+++ b/edge/gatedhosts.go
@@ -1,0 +1,74 @@
+package edge
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// EdgeGatedHosts holds the forward-auth-gated host set fetched from the control
+// plane's GET /v1/gated-hosts — every Ingress host whose Ingress carries the
+// `parapet.moonrhythm.io/forward-auth` annotation. The edge-proxy bypasses its
+// response cache (never serve-from, never store) for these hosts: the cache key
+// ignores Cookie, so a cached 200 for a forward-auth-gated host would leak
+// pre-auth content to anonymous users. The in-cluster forward-auth gate stays
+// authoritative regardless; this only closes the edge-cache bypass of it.
+//
+// Lock-free reads via the atomic pointer. A stale or empty set fails toward
+// caching (the edge briefly does NOT bypass for a newly-gated host), so the
+// /v1/events poke keeps it timely.
+type EdgeGatedHosts struct {
+	hosts atomic.Pointer[map[string]struct{}]
+
+	// generation of the currently-loaded snapshot (0 until the first fetch applies).
+	generation atomic.Uint64
+
+	mu   sync.Mutex
+	etag string
+}
+
+// NewEdgeGatedHosts returns an empty gated-host set — no host bypasses the cache
+// until the first fetch lands.
+func NewEdgeGatedHosts() *EdgeGatedHosts {
+	h := &EdgeGatedHosts{}
+	empty := map[string]struct{}{}
+	h.hosts.Store(&empty)
+	return h
+}
+
+// Etag returns the ETag of the currently-loaded set (sent as If-None-Match).
+func (h *EdgeGatedHosts) Etag() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.etag
+}
+
+// Generation returns the currently-loaded snapshot's generation (0 until the
+// first fetch applies).
+func (h *EdgeGatedHosts) Generation() uint64 { return h.generation.Load() }
+
+// Update swaps in a fetched gated-host set wholesale. There is no compile step —
+// the list is already-validated wire data — so it always applies and advances the
+// etag/generation.
+func (h *EdgeGatedHosts) Update(generation uint64, hosts []string, etag string) {
+	hs := make(map[string]struct{}, len(hosts))
+	for _, host := range hosts {
+		hs[host] = struct{}{}
+	}
+	h.hosts.Store(&hs)
+
+	h.mu.Lock()
+	h.etag = etag
+	h.mu.Unlock()
+	h.generation.Store(generation)
+}
+
+// IsGatedHost reports whether host is forward-auth-gated. The edge-proxy bypasses
+// its response cache for a host this returns true for.
+func (h *EdgeGatedHosts) IsGatedHost(host string) bool {
+	m := h.hosts.Load()
+	if m == nil {
+		return false
+	}
+	_, ok := (*m)[host]
+	return ok
+}

--- a/edge/gatedhosts_test.go
+++ b/edge/gatedhosts_test.go
@@ -1,0 +1,31 @@
+package edge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEdgeGatedHosts_Empty(t *testing.T) {
+	h := NewEdgeGatedHosts()
+	assert.False(t, h.IsGatedHost("acme.com"))
+	assert.Equal(t, "", h.Etag())
+	assert.EqualValues(t, 0, h.Generation())
+}
+
+func TestEdgeGatedHosts_Update(t *testing.T) {
+	h := NewEdgeGatedHosts()
+	h.Update(5, []string{"acme.com", "app.acme.com"}, `"g1"`)
+
+	assert.True(t, h.IsGatedHost("acme.com"))
+	assert.True(t, h.IsGatedHost("app.acme.com"))
+	assert.False(t, h.IsGatedHost("public.com"), "an un-gated host is not bypassed")
+	assert.Equal(t, `"g1"`, h.Etag())
+	assert.EqualValues(t, 5, h.Generation())
+
+	// A later update swaps the set wholesale.
+	h.Update(6, []string{"new.com"}, `"g2"`)
+	assert.True(t, h.IsGatedHost("new.com"))
+	assert.False(t, h.IsGatedHost("acme.com"), "a no-longer-gated host stops bypassing")
+	assert.EqualValues(t, 6, h.Generation())
+}

--- a/edge/gatedhostsrefresh.go
+++ b/edge/gatedhostsrefresh.go
@@ -1,0 +1,36 @@
+package edge
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// RefreshGatedHostsOnce fetches the forward-auth-gated host list (ETag-revalidated)
+// and swaps it into EdgeGatedHosts. A fetch failure is fail-static — the edge
+// keeps bypassing the cache for the hosts it already knows are gated. There is no
+// compile step, so a 200 always applies.
+func RefreshGatedHostsOnce(cp *CpClient, h *EdgeGatedHosts) {
+	res, err := cp.FetchGatedHosts(h.Etag())
+	switch {
+	case err != nil:
+		slog.Warn("edge: gated-hosts fetch failed; keeping last-good gated-host set", "error", err)
+	case res.Unchanged:
+		// 304: cached set is current.
+	default:
+		h.Update(res.Generation, res.Hosts, res.Etag)
+		slog.Info("edge: gated-host set updated", "generation", res.Generation, "hosts", len(res.Hosts))
+	}
+}
+
+// RunGatedHostsRefresh runs the periodic gated-host refresh forever. The first
+// tick is jittered by [0,interval] (fleet poll-instant decorrelation); same
+// cadence as the cert/WAF refresh; fail-static. poke (nil ok) wakes the loop on
+// the /v1/events gated-hosts change signal, so the timer is only the fallback
+// floor.
+func RunGatedHostsRefresh(ctx context.Context, cp *CpClient, h *EdgeGatedHosts, interval time.Duration, poke <-chan struct{}) {
+	if interval <= 0 { // time.NewTicker panics on a non-positive interval
+		interval = 300 * time.Second
+	}
+	runRefreshLoop(ctx, interval, poke, func() { RefreshGatedHostsOnce(cp, h) })
+}

--- a/edgecp/events.go
+++ b/edgecp/events.go
@@ -22,6 +22,10 @@ type EventsSnapshot struct {
 	// Hosts is the known-host store's content etag ("" when off). A host change
 	// pokes only the edge's hosts refresh — it doesn't affect WAF/ratelimit.
 	Hosts string `json:"hosts,omitempty"`
+	// GatedHosts is the forward-auth-gated host store's content etag ("" when off).
+	// A change pokes only the edge's gated-hosts refresh, which drives the edge
+	// response-cache bypass — it doesn't affect WAF/ratelimit.
+	GatedHosts string `json:"gatedHosts,omitempty"`
 	// Certs is a fingerprint over the cert store's full (name, etag) index.
 	Certs string `json:"certs,omitempty"`
 	// Purges is the purge journal's last issued seq (0 = none/off).

--- a/edgecp/gatedhoststore.go
+++ b/edgecp/gatedhoststore.go
@@ -1,0 +1,84 @@
+package edgecp
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// GatedHostsStore holds the per-token forward-auth-gated host set: every Ingress
+// host whose Ingress carries the `parapet.moonrhythm.io/forward-auth` annotation
+// (non-empty value), distributed via GET /v1/gated-hosts. The edge-proxy bypasses
+// its response cache for these hosts — the cache key ignores Cookie, so a cached
+// 200 for a forward-auth-gated host would leak pre-auth content to anonymous
+// users.
+//
+// Unlike the known-host oracle, this set fails toward CACHING: a stale or empty
+// set means the edge briefly does NOT bypass the cache for a newly-gated host, so
+// timeliness matters — it is paired with the /v1/events poke so the fleet
+// converges in ~seconds, not one poll interval. The in-cluster forward-auth gate
+// stays authoritative regardless: a brief propagation window can never let the
+// edge bypass auth, only briefly serve a cached copy of an already-public-looking
+// response. Same scoping/ETag model as the other stores: lock-free reads via the
+// atomic pointer, mu held by the writer and by scoped() for a consistent
+// snapshot.
+type GatedHostsStore struct {
+	mu      sync.RWMutex
+	hosts   atomic.Pointer[[]string] // sorted, deduped gated hosts
+	gen     atomic.Uint64
+	curEtag atomic.Pointer[string]
+}
+
+func NewGatedHostsStore() *GatedHostsStore {
+	s := &GatedHostsStore{}
+	var h []string
+	s.hosts.Store(&h)
+	et := etagOfString("")
+	s.curEtag.Store(&et)
+	return s
+}
+
+// SetHosts replaces the full gated-host list (sorted, deduped — see
+// collectGatedHosts).
+func (s *GatedHostsStore) SetHosts(hosts []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hosts.Store(&hosts)
+	s.recompute()
+}
+
+// recompute bumps the generation + etag when the content changes. Caller holds mu.
+func (s *GatedHostsStore) recompute() {
+	var b strings.Builder
+	for _, h := range *s.hosts.Load() {
+		b.WriteString(h)
+		b.WriteByte(0)
+	}
+	et := etagOfString(b.String())
+	if prev := s.curEtag.Load(); prev != nil && *prev == et {
+		return
+	}
+	s.gen.Add(1)
+	s.curEtag.Store(&et)
+}
+
+// Version is the store's full-content etag — the opaque change signal for the
+// /v1/events stream (per-edge scoping happens at fetch time).
+func (s *GatedHostsStore) Version() string { return *s.curEtag.Load() }
+
+// scoped returns the generation and only the gated hosts the edge may serve (per
+// allow), read under the lock so the pair is a consistent snapshot.
+func (s *GatedHostsStore) scoped(allow func(host string) bool) (generation uint64, hosts []string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	all := *s.hosts.Load()
+	out := make([]string, 0, len(all))
+	for _, h := range all {
+		if allow(h) {
+			out = append(out, h)
+		}
+	}
+	sort.Strings(out)
+	return s.gen.Load(), out
+}

--- a/edgecp/gatedhoststore_test.go
+++ b/edgecp/gatedhoststore_test.go
@@ -1,0 +1,70 @@
+package edgecp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+// The /v1/gated-hosts endpoint scopes the gated-host list to the token's allowed hosts.
+func TestServerGatedHostsEndpointScopes(t *testing.T) {
+	store := NewGatedHostsStore()
+	store.SetHosts([]string{"acme.com", "evil.com", "app.acme.com"})
+
+	authz := NewAuthz(map[string][]string{"tok": {"acme.com", "app.acme.com"}})
+	h := NewServer(NewCertStore(), authz).WithGatedHosts(store).Handler()
+
+	req := httptest.NewRequest("GET", "/v1/gated-hosts", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	var resp hostsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(resp.Hosts, []string{"acme.com", "app.acme.com"}) {
+		t.Errorf("hosts must exclude evil.com and be sorted: got %v", resp.Hosts)
+	}
+
+	// ETag present, and a matching If-None-Match 304s.
+	etag := rec.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("missing ETag")
+	}
+	req2 := httptest.NewRequest("GET", "/v1/gated-hosts", nil)
+	req2.Header.Set("Authorization", "Bearer tok")
+	req2.Header.Set("If-None-Match", etag)
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusNotModified {
+		t.Fatalf("want 304 on matching ETag, got %d", rec2.Code)
+	}
+}
+
+func TestServerGatedHostsDisabled(t *testing.T) {
+	authz := NewAuthz(map[string][]string{"tok": {"acme.com"}})
+	h := NewServer(NewCertStore(), authz).Handler() // no WithGatedHosts
+	req := httptest.NewRequest("GET", "/v1/gated-hosts", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("want 404 when gated-hosts disabled, got %d", rec.Code)
+	}
+}
+
+// Identical content must not bump the generation (etag-stable across re-derives).
+func TestGatedHostsStoreGenerationStableOnIdenticalContent(t *testing.T) {
+	s := NewGatedHostsStore()
+	s.SetHosts([]string{"a.com", "b.com"})
+	gen := s.gen.Load()
+	s.SetHosts([]string{"a.com", "b.com"})
+	if s.gen.Load() != gen {
+		t.Error("generation bumped on identical content")
+	}
+}

--- a/edgecp/ingressreload.go
+++ b/edgecp/ingressreload.go
@@ -13,6 +13,12 @@ import (
 	"github.com/moonrhythm/parapet-ingress-controller/k8s"
 )
 
+// ForwardAuthAnnotation marks an Ingress as forward-auth-gated (a non-empty value
+// enables the in-cluster forward-auth plugin — see plugin/auth.go). The edge-proxy
+// bypasses its response cache for every host of such an Ingress, so a cached copy
+// can't leak pre-auth content (the cache key ignores Cookie).
+const ForwardAuthAnnotation = "parapet.moonrhythm.io/forward-auth"
+
 // IngressReloader derives the zone bindings from Ingress objects: for each
 // Ingress carrying the `parapet.moonrhythm.io/waf-zone` annotation, every route
 // pattern its rules register at the controller maps to the resolved zone key
@@ -25,10 +31,11 @@ import (
 // known-host list the edge wires as its host-key collapser. store may be
 // nil when only the rate-limit side is enabled.
 type IngressReloader struct {
-	store          *WafStore       // optional (nil = WAF host→zone derivation off)
-	rl             *RateLimitStore // optional (nil = rate-limit derivation off)
-	cache          *CacheStore     // optional (nil = cache-override derivation off)
-	hosts          *HostsStore     // optional (nil = /v1/hosts distribution off)
+	store          *WafStore        // optional (nil = WAF host→zone derivation off)
+	rl             *RateLimitStore  // optional (nil = rate-limit derivation off)
+	cache          *CacheStore      // optional (nil = cache-override derivation off)
+	hosts          *HostsStore      // optional (nil = /v1/hosts distribution off)
+	gated          *GatedHostsStore // optional (nil = /v1/gated-hosts distribution off)
 	watchNamespace string
 	debounce       time.Duration
 }
@@ -57,6 +64,14 @@ func (r *IngressReloader) WithCache(cache *CacheStore) *IngressReloader {
 // the reloader for chaining.
 func (r *IngressReloader) WithHosts(hosts *HostsStore) *IngressReloader {
 	r.hosts = hosts
+	return r
+}
+
+// WithGatedHosts wires the forward-auth-gated host store (served at
+// /v1/gated-hosts) so the same Ingress reload also derives the host set the
+// edge-proxy bypasses its response cache for. Returns the reloader for chaining.
+func (r *IngressReloader) WithGatedHosts(gated *GatedHostsStore) *IngressReloader {
+	r.gated = gated
 	return r
 }
 
@@ -127,6 +142,9 @@ func (r *IngressReloader) reload(ctx context.Context) error {
 	if r.hosts != nil {
 		r.hosts.SetHosts(collectIngressHosts(ings))
 	}
+	if r.gated != nil {
+		r.gated.SetHosts(collectGatedHosts(ings))
+	}
 	return nil
 }
 
@@ -191,6 +209,34 @@ func buildRateLimitHostZone(ings []networking.Ingress) map[string]string {
 func collectIngressHosts(ings []networking.Ingress) []string {
 	seen := map[string]struct{}{}
 	for i := range ings {
+		for _, rule := range ings[i].Spec.Rules {
+			host := strings.ToLower(strings.TrimSpace(rule.Host))
+			if host == "" {
+				continue
+			}
+			seen[host] = struct{}{}
+		}
+	}
+	hosts := make([]string, 0, len(seen))
+	for h := range seen {
+		hosts = append(hosts, h)
+	}
+	sort.Strings(hosts)
+	return hosts
+}
+
+// collectGatedHosts returns every host declared by an Ingress that carries a
+// non-empty `parapet.moonrhythm.io/forward-auth` annotation (lowercased, deduped,
+// sorted — the order feeds the store fingerprint, exactly like
+// collectIngressHosts). The edge-proxy bypasses its response cache for these
+// hosts so a cached copy can't leak pre-auth content (the cache key ignores
+// Cookie); the in-cluster forward-auth gate stays authoritative.
+func collectGatedHosts(ings []networking.Ingress) []string {
+	seen := map[string]struct{}{}
+	for i := range ings {
+		if strings.TrimSpace(ings[i].Annotations[ForwardAuthAnnotation]) == "" {
+			continue // not forward-auth-gated
+		}
 		for _, rule := range ings[i].Spec.Rules {
 			host := strings.ToLower(strings.TrimSpace(rule.Host))
 			if host == "" {

--- a/edgecp/ingressreload_test.go
+++ b/edgecp/ingressreload_test.go
@@ -73,6 +73,28 @@ func TestBuildZoneRoutes(t *testing.T) {
 	}
 }
 
+// collectGatedHosts returns the hosts of ingresses carrying a non-empty
+// forward-auth annotation only — lowercased, deduped, sorted.
+func TestCollectGatedHosts(t *testing.T) {
+	ings := []networking.Ingress{
+		// Forward-auth-gated: contributes its hosts (lowercased).
+		routedIngress("cust1", "gated", map[string]string{ForwardAuthAnnotation: "http://authz/auth"},
+			httpRule("GATED.com", networking.HTTPIngressPath{Path: "/", PathType: pt(networking.PathTypePrefix)}),
+			httpRule("app.gated.com", networking.HTTPIngressPath{Path: "/", PathType: pt(networking.PathTypePrefix)})),
+		// No forward-auth annotation: contributes nothing.
+		routedIngress("cust2", "public", map[string]string{WAFZoneAnnotation: "z"},
+			httpRule("public.com", networking.HTTPIngressPath{Path: "/", PathType: pt(networking.PathTypePrefix)})),
+		// Forward-auth annotation present but whitespace-only (disabled): nothing.
+		routedIngress("cust3", "blank", map[string]string{ForwardAuthAnnotation: "  "},
+			httpRule("blank.com", networking.HTTPIngressPath{Path: "/", PathType: pt(networking.PathTypePrefix)})),
+	}
+	got := collectGatedHosts(ings)
+	want := []string{"app.gated.com", "gated.com"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
 func TestBuildZoneRoutesSameNamespaceOnly(t *testing.T) {
 	ings := []networking.Ingress{
 		routedIngress("cust1", "own", map[string]string{RateLimitZoneAnnotation: "basic"},

--- a/edgecp/server.go
+++ b/edgecp/server.go
@@ -37,6 +37,13 @@ type Server struct {
 	// list only over-collapses the metric label (no atomicity with waf/ratelimit).
 	hosts *HostsStore
 
+	// gatedHosts is the optional forward-auth-gated host distribution store (nil =
+	// /v1/gated-hosts → 404). The edge-proxy bypasses its response cache for these
+	// hosts so a cached copy can't leak pre-auth content (the cache key ignores
+	// Cookie); the in-cluster forward-auth gate stays authoritative. Same
+	// scoping/ETag model.
+	gatedHosts *GatedHostsStore
+
 	// purge is the optional cache-purge journal (nil = purge distribution disabled,
 	// /v1/purges → 404). purgeAdminToken gates POST /v1/purges — a STRONGER credential
 	// than the per-edge read tokens (an edge can read its purges but not issue them).
@@ -161,6 +168,13 @@ func (s *Server) WithHosts(hosts *HostsStore) *Server {
 	return s
 }
 
+// WithGatedHosts enables the forward-auth-gated host endpoint (GET /v1/gated-hosts).
+// Returns the server for chaining.
+func (s *Server) WithGatedHosts(gatedHosts *GatedHostsStore) *Server {
+	s.gatedHosts = gatedHosts
+	return s
+}
+
 // WithEvents enables the change-notification stream (GET /v1/events). Returns
 // the server for chaining; the caller runs hub.Run in its own goroutine.
 func (s *Server) WithEvents(hub *EventsHub) *Server {
@@ -245,6 +259,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /v1/ratelimit", s.handleRateLimit)
 	mux.HandleFunc("GET /v1/cache", s.handleCache)
 	mux.HandleFunc("GET /v1/hosts", s.handleHosts)
+	mux.HandleFunc("GET /v1/gated-hosts", s.handleGatedHosts)
 	mux.HandleFunc("GET /v1/purges", s.handlePurges)
 	mux.HandleFunc("GET /v1/events", s.handleEvents)
 	mux.HandleFunc("POST /v1/purges", s.handlePurgeAdmin)
@@ -553,6 +568,45 @@ func (s *Server) handleHosts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	generation, hosts := s.hosts.scoped(func(host string) bool { return s.authz.Allowed(token, host) })
+	resp := hostsResponse{Generation: generation, Hosts: hosts}
+	body, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, "encode", http.StatusInternalServerError)
+		return
+	}
+	etagResp := resp
+	etagResp.Generation = 0
+	etagBody, err := json.Marshal(etagResp)
+	if err != nil {
+		http.Error(w, "encode", http.StatusInternalServerError)
+		return
+	}
+	etag := etagOfString(string(etagBody))
+	w.Header().Set("ETag", etag)
+	if match := r.Header.Get("If-None-Match"); match != "" && etagMatch(match, etag) {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(body)
+}
+
+// handleGatedHosts serves the forward-auth-gated host list scoped to the edge's
+// allowed domains. The edge-proxy bypasses its response cache for these hosts so
+// a cached copy can't leak pre-auth content. ETag is over the scoped payload with
+// the generation zeroed, the same model as handleHosts/handleWAF. Reuses
+// hostsResponse — the {generation, hosts} shape is identical.
+func (s *Server) handleGatedHosts(w http.ResponseWriter, r *http.Request) {
+	token, ok := bearer(r)
+	if !ok || !s.authz.Known(token) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if s.gatedHosts == nil {
+		http.Error(w, "gated-hosts distribution disabled", http.StatusNotFound)
+		return
+	}
+	generation, hosts := s.gatedHosts.scoped(func(host string) bool { return s.authz.Allowed(token, host) })
 	resp := hostsResponse{Generation: generation, Hosts: hosts}
 	body, err := json.Marshal(resp)
 	if err != nil {


### PR DESCRIPTION
PR-6 of **Deployment Access** — the spec's single most important correctness item (SPEC §9).

## Problem
The out-of-cluster edge-proxy (`cmd/edge-proxy`) runs a response cache (`parapet/pkg/cache`) that sits **in front of** the in-cluster forward-auth gate. The cache key **ignores `Cookie`**, so a cached `200` for a forward-auth-gated host is served to **anonymous** users — the verifier is never consulted. This is the exact leak the deployment-access feature exists to prevent.

## Fix
Make the edge-proxy **bypass its response cache** (never serve-from, never store) for any host whose Ingress carries the `parapet.moonrhythm.io/forward-auth` annotation. The single hook is `parapet/pkg/cache` `Options.Cacheable` returning `false` — which short-circuits before both the storage read and the fill/store path. **No `parapet` (cache package) change is needed.**

## Design — CP-derived, mirrors `/v1/hosts` (no apiserver push)
A new gated-host distribution channel that clones the known-hosts channel end to end:

- **edgecp `GatedHostsStore`** + `GET /v1/gated-hosts` (per-edge bearer, scoped by `authz.Allowed`, ETag/304) — clone of `HostsStore`/`handleHosts`.
- **`IngressReloader`** collects hosts of Ingresses carrying a non-empty `forward-auth` annotation (`collectGatedHosts`) on the same watch that already feeds `/v1/hosts`. **CP-derived from k8s** ⇒ every CP replica converges identically; no apiserver→edgecp push, no new credential, no multi-replica skew, and the signal is the *same source of truth* (the annotation the deployer renders in PR-3) that actually enforces the gate.
- **edge `EdgeGatedHosts.IsGatedHost`** + `FetchGatedHosts` + refresh loop — clones of the hosts equivalents; fail-static (keeps last-good).
- **`cmd/edge-proxy`** composes `opts.Cacheable` so a gated host always bypasses, **independent of** whether cache-overrides (`eco`) are enabled. `r.Host` is already lowercased + port-stripped upstream (`host.StripPort`/`host.ToLower` before the cache), matching the CP's lowercased set.
- **events vector** gains `gatedHosts` so a toggle wakes edges in ~seconds; the jittered poll is the fallback floor.

On by default: `CP_GATED_HOSTS_ENABLED` (default `true`).

## Safety
The in-cluster forward-auth gate stays **authoritative**. A stale/empty gated set, an older CP (404), or the brief window before a newly-gated host propagates can only **serve a cached copy briefly** — it can never bypass authentication. The events poke + the deployer rendering the annotation atomically with the deploy keep that window small.

## Tests
6 new tests (store scoping/404/ETag, `IsGatedHost` empty/update, `collectGatedHosts` annotation filtering). `gofmt` clean; `go build ./...`, `go vet ./...` clean; `go test ./...` → 731 passed across 25 packages.

## Docs
`EDGE.md` updated: `GET /v1/gated-hosts` endpoint, the `gatedHosts` events-vector field, and `CP_GATED_HOSTS_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
