### PR TITLE
Force Cache-Control: private on forward-auth-gated responses (deployment access PR-6)

### DIFF
--- a/CACHE.md
+++ b/CACHE.md
@@ -361,6 +361,18 @@ rule increments at **request** time. The `id` is bounded to `[A-Za-z0-9._-]`
 - **No request-Cache-Control honoring.** Like a CDN, the cache ignores a
   client's `no-cache`/`no-store` by design (a shared-cache DoS vector); overrides
   don't change that — they are operator policy, not client-driven.
+- **Forward-auth-gated ingresses are forced non-cacheable.** An ingress with the
+  `parapet.moonrhythm.io/forward-auth` annotation has every response stamped
+  `Cache-Control: private` by the in-cluster controller (`plugin.ForwardAuth`).
+  The edge cache is honor-origin and its key ignores `Cookie`, so without this a
+  cached `200` for a gated host would be served to anonymous users (the forward-
+  auth subrequest gates the request path, but a cache **hit** answers before the
+  request ever reaches the controller). `private` makes the shared edge cache
+  refuse to store/serve it, and it is honored even under an aggressive override
+  (a store-sensitivity refusal a force-cache rule cannot defeat — see
+  `parapet/pkg/cache` `policy.go`). This is the deployment-access edge-cache
+  bypass (SPEC §9): the override travels **with the response**, so there is no
+  separate gated-host list to distribute and no propagation window.
 - **No new CEL surface.** Request matching is the `filter` field, the WAF's
   expression surface through the one shared `waf.Predicate`; response narrowing
   is the non-CEL `status` list. There is no `response.*` CEL surface (the

--- a/plugin/auth.go
+++ b/plugin/auth.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/moonrhythm/parapet/pkg/authn"
+	"github.com/moonrhythm/parapet/pkg/headers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -58,6 +59,17 @@ func ForwardAuth(ctx Context) {
 	if err != nil {
 		return
 	}
+	// Make every response on a forward-auth-gated ingress non-cacheable at the
+	// out-of-cluster edge response cache. That cache is honor-origin and its key
+	// ignores Cookie, so a cached 200 for a gated host would be served to
+	// anonymous users (forward-auth gates the request path, not a cache hit that
+	// answers before the request ever reaches here). Cache-Control: private
+	// makes the edge (a shared cache) refuse to store or serve it — and the edge
+	// honors private even under an aggressive cache-override, so a force-cache
+	// rule can't defeat it. Installed BEFORE the authenticator so it is
+	// outermost: it overrides whatever Cache-Control the upstream sent and also
+	// covers the auth deny/redirect response.
+	ctx.Use(headers.SetResponse("Cache-Control", "private"))
 	ctx.Use(authn.ForwardAuthenticator{
 		URL:                 u,
 		Client:              authHTTPClient,

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -468,3 +468,58 @@ func TestStripPrefix(t *testing.T) {
 	})).ServeHTTP(w, r)
 	assert.True(t, called)
 }
+
+func TestForwardAuthCacheControl(t *testing.T) {
+	t.Parallel()
+
+	// Auth endpoint that allows every request (200).
+	authSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer authSrv.Close()
+
+	// An upstream that tries to make its response publicly cacheable — exactly
+	// the leak the override must defeat at the edge.
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Cache-Control", "public, max-age=600")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("gated ingress forces private and overrides the upstream", func(t *testing.T) {
+		ctx := Context{
+			Middlewares: &parapet.Middlewares{},
+			Ingress: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"parapet.moonrhythm.io/forward-auth": "url: " + authSrv.URL,
+					},
+				},
+			},
+		}
+		ForwardAuth(ctx)
+
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+		ctx.ServeHandler(upstream).ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		// private wins, the upstream's public/max-age is gone (clean override).
+		assert.Equal(t, "private", w.Header().Get("Cache-Control"))
+	})
+
+	t.Run("non-gated ingress leaves the upstream Cache-Control untouched", func(t *testing.T) {
+		ctx := Context{
+			Middlewares: &parapet.Middlewares{},
+			Ingress: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+			},
+		}
+		ForwardAuth(ctx)
+
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+		ctx.ServeHandler(upstream).ServeHTTP(w, r)
+
+		assert.Equal(t, "public, max-age=600", w.Header().Get("Cache-Control"))
+	})
+}


### PR DESCRIPTION
PR-6 of **Deployment Access** (SPEC §9) — the edge response-cache bypass for gated hosts, done as a **small controller change** instead of an edge-proxy gated-host distribution channel.

## Problem
The out-of-cluster edge response cache (`parapet/pkg/cache`) sits **in front of** the in-cluster forward-auth gate, and its cache key **ignores `Cookie`**. So a cached `200` for a forward-auth-gated host is served to **anonymous** users — a cache *hit* answers before the request ever reaches the controller's `ForwardAuthenticator`. (`cache.go` documents this exact cross-user-leak mode.)

## Fix
`plugin.ForwardAuth` now stamps `Cache-Control: private` on every response of a forward-auth-gated ingress, via `headers.SetResponse` (a write-time, interface-preserving override). The edge cache is honor-origin: `policy.go:77-82` refuses to store/serve a `private` response, and `policy.go:122-129` honors `private` **even under an aggressive cache-override** (a store-sensitivity refusal a force-cache rule can't defeat). Installed **before** the authenticator so it is outermost — it overrides whatever `Cache-Control` the app sent and also covers the auth deny/redirect.

## Why this over an edge gated-host channel
The header travels **with the response**, so there is:
- **no separate gated-host list** to distribute to the edge (no new endpoint/store/fetch loop/events),
- **no multi-replica skew** and **no propagation window** (the first response after a deployment is gated is already `private`),
- **nothing in the apiserver or edge-proxy to change** — and it can't drift from the gate, since it's keyed on the same `parapet.moonrhythm.io/forward-auth` annotation that enforces it.

It covers container and static deployments uniformly (both gated ingresses get the annotation in PR-3) and any manually forward-auth'd route.

## Tests
`TestForwardAuthCacheControl`: a gated ingress forces `private` and **overrides** an upstream `public, max-age=600`; a non-gated ingress leaves the upstream `Cache-Control` untouched. `gofmt` clean; `go build`/`vet` clean; `go test ./...` → **728 passed across 25 packages**.

## Docs
`CACHE.md` "Scope and non-goals" documents the forced-non-cacheable behavior for gated ingresses.

Supersedes #160 (the edge gated-host-store approach), which is closed in favor of this smaller, distribution-free design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
