### PR TITLE
feat(edge): multi-arch (amd64+arm64) edge proxy + control-plane images

### DIFF
--- a/.github/workflows/edge-build.yaml
+++ b/.github/workflows/edge-build.yaml
@@ -7,6 +7,9 @@ name: edge-build
 #   edge-<sha>          — the Go edge proxy    (Dockerfile.edge)
 # See EDGE.md. Triggered when the Go module or the edge manifests change.
 # Auth/registries mirror go-build.
+# Both images are multi-arch manifests (linux/amd64 + linux/arm64). They are pure
+# Go (CGO_ENABLED=0), so buildx cross-compiles each arch natively on the runner —
+# no QEMU/binfmt needed (see the $BUILDPLATFORM build stages in the Dockerfiles).
 on:
   push:
     branches:
@@ -48,12 +51,13 @@ jobs:
       - uses: docker/setup-buildx-action@v3
         with:
           version: latest
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
       - uses: docker/build-push-action@v6
         with:
           provenance: false
           context: .
           file: Dockerfile.edge-controlplane
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             VERSION=${{ github.sha }}
@@ -85,12 +89,13 @@ jobs:
       - uses: docker/setup-buildx-action@v3
         with:
           version: latest
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
       - uses: docker/build-push-action@v6
         with:
           provenance: false
           context: .
           file: Dockerfile.edge
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             VERSION=${{ github.sha }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ Dockerfile.edge                   # edge proxy image (pure Go, distroless/static
 # also at repo root: deploy/  WAF.md  RATELIMIT.md  SPEC.md  EDGE.md  conformance/
 # .github/workflows/: go-test / go-build / go-release .yaml (path-filtered to **/*.go + go.mod/go.sum);
 #   edge-build / edge-e2e .yaml build + smoke-test the edge + control-plane images
+#   (edge-build images are multi-arch: linux/amd64 + linux/arm64, cross-compiled, no QEMU)
 ```
 
 ### Edge proxy (`cmd/edge-proxy` + `edge/`)

--- a/Dockerfile.edge
+++ b/Dockerfile.edge
@@ -7,10 +7,20 @@
 # distroless/static. Build context is the repo root:
 #
 #     docker build -f Dockerfile.edge -t parapet-edge .
-FROM golang:1.26.4-trixie AS build
+#
+# Multi-arch (linux/amd64 + linux/arm64): the build stage is pinned to
+# $BUILDPLATFORM and Go cross-compiles to $TARGETARCH, so the arm64 image is
+# produced WITHOUT QEMU emulation (pure-Go, CGO_ENABLED=0, cross-compiles
+# natively on the runner). GOAMD64 is honored only for amd64 (Go ignores it when
+# GOARCH=arm64). Build a multi-arch image with:
+#
+#     docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile.edge -t parapet-edge .
+FROM --platform=$BUILDPLATFORM golang:1.26.4-trixie AS build
 
 ARG VERSION
 ARG GOAMD64
+ARG TARGETOS
+ARG TARGETARCH
 
 ENV CGO_ENABLED=0
 ENV GOAMD64=$GOAMD64
@@ -20,7 +30,7 @@ ADD go.mod go.sum ./
 RUN go mod download
 
 ADD . .
-RUN go build \
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
 		-o edge-proxy \
 		-ldflags "-w -s -X main.version=$VERSION" \
 		./cmd/edge-proxy
@@ -31,7 +41,9 @@ RUN go build \
 # iplocate.io) so WAF_GEOIP_DB / WAF_ASN_DB default paths exist, mirroring the
 # controller image. The ip-to-asn DB is large (~74 MB) — pass --build-arg
 # ASN_DB_URL= (empty) to skip it; an empty URL bakes none (the dir still exists).
-FROM debian:trixie-slim AS geoip
+# Pinned to $BUILDPLATFORM: the MMDBs are arch-neutral data, so this stage runs on
+# the native runner arch (no QEMU needed to curl them for an arm64 target build).
+FROM --platform=$BUILDPLATFORM debian:trixie-slim AS geoip
 ARG GEOIP_DB_URL=https://github.com/iplocate/ip-address-databases/raw/main/ip-to-country/ip-to-country.mmdb
 ARG ASN_DB_URL=https://github.com/iplocate/ip-address-databases/raw/main/ip-to-asn/ip-to-asn.mmdb
 RUN mkdir -p /geoip && \

--- a/Dockerfile.edge-controlplane
+++ b/Dockerfile.edge-controlplane
@@ -5,10 +5,17 @@
 # over HTTPS REST. See EDGE.md. Build context is the repo root:
 #
 #     docker build -f Dockerfile.edge-controlplane -t parapet-edge-controlplane .
-FROM golang:1.26.4-trixie AS build
+#
+# Multi-arch (linux/amd64 + linux/arm64): the build stage is pinned to
+# $BUILDPLATFORM and Go cross-compiles to $TARGETARCH, so the arm64 image is
+# produced WITHOUT QEMU emulation (pure Go, CGO_ENABLED=0). GOAMD64 is honored
+# only for amd64 (Go ignores it when GOARCH=arm64).
+FROM --platform=$BUILDPLATFORM golang:1.26.4-trixie AS build
 
 ARG VERSION
 ARG GOAMD64
+ARG TARGETOS
+ARG TARGETARCH
 
 ENV CGO_ENABLED=0
 ENV GOAMD64=$GOAMD64
@@ -18,7 +25,7 @@ ADD go.mod go.sum ./
 RUN go mod download
 
 ADD . .
-RUN go build \
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
 		-o edge-controlplane \
 		-ldflags "-w -s -X main.version=$VERSION" \
 		./cmd/edge-controlplane

--- a/EDGE.md
+++ b/EDGE.md
@@ -1040,6 +1040,16 @@ and `:edge-<sha>`); `edge-e2e.yaml` runs the cluster-free smoke test
 (`deploy/edge/e2e/run.sh`). Image tag prefixes are component-keyed (not
 language-keyed), so `:edge-<sha>` carried over the Rust→Go migration unchanged.
 
+Both images are **multi-arch manifests** (`linux/amd64` + `linux/arm64`): one tag
+serves either CPU and the registry resolves the right variant per `docker pull` /
+node arch. Because both binaries are pure Go (`CGO_ENABLED=0`), the Dockerfiles
+pin the build stage to `$BUILDPLATFORM` and cross-compile to `$TARGETARCH`, so the
+arm64 variant is produced **without QEMU emulation** — buildx compiles both arches
+natively on the runner (the edge's GeoIP-download stage is likewise pinned to
+`$BUILDPLATFORM`, since the MMDBs are arch-neutral data). The in-cluster
+controller image is a separate story: it links `libbrotli` via CGO, so an arm64
+variant there would need QEMU (or a cross-toolchain) and has not been enabled.
+
 ## Implementation history
 
 The edge was originally **Rust/Pingora**; it was rewritten in **Go** on the


### PR DESCRIPTION
## What

Make the **edge proxy** and **edge control-plane** Docker images multi-arch (`linux/amd64` + `linux/arm64`). One tag serves either CPU; the registry resolves the right variant per `docker pull` / node arch.

## How

Both binaries are pure Go (`CGO_ENABLED=0`), so there is no need for QEMU emulation — buildx cross-compiles each architecture natively on the runner:

- `Dockerfile.edge` / `Dockerfile.edge-controlplane`: build stage pinned to `--platform=$BUILDPLATFORM`, build via `GOOS=$TARGETOS GOARCH=$TARGETARCH go build`. `GOAMD64` is honored only for amd64 (Go ignores it when `GOARCH=arm64`).
- `Dockerfile.edge`'s GeoIP-download stage is **also** pinned to `$BUILDPLATFORM` — required, not just an optimization: with no QEMU registered an arm64-target `apt`/`curl` couldn't run, and the MMDBs are arch-neutral data anyway. The distroless runtime stage is COPY-only, so it needs no emulation.
- `edge-build.yaml`: `platforms: linux/amd64,linux/arm64` on the buildx setup and both `build-push-action` steps. No `setup-qemu-action` added. `provenance: false` (already set) keeps the pushed manifest a clean OCI image index.

## Scope

The in-cluster **controller image is intentionally left amd64-only**: it links `libbrotli` via CGO, so its arm64 variant would need QEMU (or a cross-toolchain) — a separate follow-up.

## Verification

- `GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build ./cmd/edge-proxy` and `./cmd/edge-controlplane` both produce static `ARM aarch64` binaries.
- The Dockerfile wraps exactly that command via the standard `$BUILDPLATFORM`/`$TARGETARCH` pattern.
- A full multi-platform buildx build runs in CI (`docker/setup-buildx-action@v3`); it could not be run on the local machine (no buildx component installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)