### PR TITLE
feat(routing): support ExternalName Services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,8 @@ Routes are keyed as `host + path` strings (e.g. `"www.example.com/api/"`). PathT
 
 Endpoint lookup is round-robin (`route.RRLB`). Bad addresses (dial errors) are marked and skipped temporarily.
 
+**ExternalName Services** (`spec.type: ExternalName`) are supported via a separate `route.Table` map (`addrToExternalName`, set by `reloadServiceDebounced` via `SetExternalNameRoutes` — full-replace, so it never races the incremental endpoint host-route path). They have no Endpoints, so `Table.Lookup` falls back to dialing `spec.externalName` (resolved by the dialer's `net.Resolver`) on the **service port** the ingress references (no `targetPort` indirection; no RRLB/bad-addr — single target). A pod-backed host route takes precedence over an ExternalName one (only transiently overlapping during a type change). See [`SPEC.md`](SPEC.md).
+
 ### TLS
 TLS secrets are loaded from `Secret.Data["tls.crt"]` / `["tls.key"]`. The `cert.Table` provides `GetCertificate` for SNI-based lookup (exact match, then a single-label wildcard climb), plugged directly into `tls.Config`. By default only secrets referenced by an Ingress's `spec.tls.secretName` are loaded; set `LOAD_ALL_CERTS=true` to index every TLS-typed secret in the watch namespace (lets a wildcard cert serve SNI without per-ingress wiring).
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -25,6 +25,17 @@ Endpoint selection is **round-robin**; an address that fails to dial is marked
 **bad for 2s** and skipped (reactive health — no active probing). Host is
 lowercased and port-stripped before matching.
 
+A Service of `type: ExternalName` is also supported: it has no Endpoints, so the
+backend is dialed at its `spec.externalName` (an external DNS name, resolved at
+connect time) on the **Service port the ingress references** (`targetPort` is a
+pod concept and does not apply to a DNS CNAME — the port the ingress addresses is
+used as-is). The referenced port must still be declared in the Service's
+`spec.ports` (as for any backend). No round-robin/bad-address tracking applies
+(a single target); `https`/`appProtocol` on the port work as usual, and the
+`upstream-host` annotation overrides the forwarded `Host` (the client `Host` is
+forwarded by default). A pod-backed route always wins over an ExternalName one
+for the same Service host (only briefly possible across a type change).
+
 **Retry is connection-only**: a dial failure — or a
 connection broken before any response — is retried up to 5× with backoff,
 marking the pod bad and round-robining to another. An upstream that *responds* —

--- a/controller.go
+++ b/controller.go
@@ -655,9 +655,30 @@ func (ctrl *Controller) reloadServiceDebounced() {
 	}()
 
 	addrToPort := make(map[string]string, endpointSizeHint)
+	externalNames := make(map[string]string)
 
 	ctrl.watchedServices.Range(func(_, value any) bool {
 		s := value.(*v1.Service)
+
+		// ExternalName services have no selector and thus no Endpoints object, so
+		// they never get a pod-IP host route. Map the service host to its external
+		// DNS name (dialed directly, resolved by the dialer) and map each declared
+		// service port to itself — the external host is contacted on the port the
+		// ingress references (targetPort is a pod concept and does not apply to a
+		// DNS CNAME).
+		if s.Spec.Type == v1.ServiceTypeExternalName {
+			extName := strings.TrimSuffix(strings.TrimSpace(s.Spec.ExternalName), ".")
+			if extName == "" {
+				slog.Error("externalName service has empty spec.externalName", "namespace", s.Namespace, "name", s.Name)
+				return true
+			}
+			externalNames[buildHost(s.Namespace, s.Name)] = extName
+			for _, p := range s.Spec.Ports {
+				addr := buildHostPort(s.Namespace, s.Name, int(p.Port))
+				addrToPort[addr] = strconv.Itoa(int(p.Port))
+			}
+			return true
+		}
 
 		// build route target port
 		for _, p := range s.Spec.Ports {
@@ -676,7 +697,8 @@ func (ctrl *Controller) reloadServiceDebounced() {
 	})
 
 	ctrl.routeTable.SetPortRoutes(addrToPort)
-	slog.Info("reloaded services", "ports", len(addrToPort))
+	ctrl.routeTable.SetExternalNameRoutes(externalNames)
+	slog.Info("reloaded services", "ports", len(addrToPort), "externalNames", len(externalNames))
 }
 
 // resolveTargetPort returns the concrete numeric pod port (as a string) a

--- a/controller_reload_test.go
+++ b/controller_reload_test.go
@@ -195,6 +195,85 @@ func endpointsNamedPort(namespace, name, ip, portName string, port int) *v1.Endp
 	}
 }
 
+func externalNameService(namespace, name, externalName string, ports ...int) *v1.Service {
+	sp := make([]v1.ServicePort, 0, len(ports))
+	for _, p := range ports {
+		sp = append(sp, v1.ServicePort{Port: int32(p)})
+	}
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: v1.ServiceSpec{
+			Type:         v1.ServiceTypeExternalName,
+			ExternalName: externalName,
+			Ports:        sp,
+		},
+	}
+}
+
+func TestReloadServiceExternalName(t *testing.T) {
+	t.Run("resolves to the external DNS name on the service port (no Endpoints)", func(t *testing.T) {
+		ctrl := New("", proxy.New())
+		ctrl.watchedServices.Store("default/ext",
+			externalNameService("default", "ext", "api.example.com", 443))
+
+		ctrl.reloadServiceDebounced()
+		// An ExternalName service has no Endpoints object, yet it still resolves.
+		assert.Equal(t, "api.example.com:443",
+			ctrl.routeTable.Lookup("ext.default.svc.cluster.local:443"))
+	})
+
+	t.Run("each declared port dials the external host on that port", func(t *testing.T) {
+		ctrl := New("", proxy.New())
+		ctrl.watchedServices.Store("default/ext",
+			externalNameService("default", "ext", "api.example.com", 80, 443))
+
+		ctrl.reloadServiceDebounced()
+		assert.Equal(t, "api.example.com:80",
+			ctrl.routeTable.Lookup("ext.default.svc.cluster.local:80"))
+		assert.Equal(t, "api.example.com:443",
+			ctrl.routeTable.Lookup("ext.default.svc.cluster.local:443"))
+	})
+
+	t.Run("a trailing dot in spec.externalName is trimmed", func(t *testing.T) {
+		ctrl := New("", proxy.New())
+		ctrl.watchedServices.Store("default/ext",
+			externalNameService("default", "ext", "api.example.com.", 443))
+
+		ctrl.reloadServiceDebounced()
+		assert.Equal(t, "api.example.com:443",
+			ctrl.routeTable.Lookup("ext.default.svc.cluster.local:443"))
+	})
+
+	t.Run("empty spec.externalName produces no route and does not panic", func(t *testing.T) {
+		ctrl := New("", proxy.New())
+		ctrl.watchedServices.Store("default/ext",
+			externalNameService("default", "ext", "", 443))
+
+		assert.NotPanics(t, func() { ctrl.reloadServiceDebounced() })
+		assert.Empty(t, ctrl.routeTable.Lookup("ext.default.svc.cluster.local:443"))
+	})
+
+	t.Run("flipping ClusterIP->ExternalName drops the stale pod route", func(t *testing.T) {
+		ctrl := New("", proxy.New())
+		// Start as a ClusterIP service with one endpoint.
+		ctrl.watchedServices.Store("default/svc", clusterIPService("default", "svc", 80, 8080))
+		ctrl.watchedEndpoints.Store("default/svc", &v1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "svc"},
+			Subsets:    []v1.EndpointSubset{{Addresses: []v1.EndpointAddress{{IP: "10.0.0.1"}}}},
+		})
+		ctrl.reloadServiceDebounced()
+		ctrl.reloadEndpointDebounced()
+		assert.Equal(t, "10.0.0.1:8080", ctrl.routeTable.Lookup("svc.default.svc.cluster.local:80"))
+
+		// Flip to ExternalName; the endpoints controller removes the Endpoints object.
+		ctrl.watchedServices.Store("default/svc", externalNameService("default", "svc", "api.example.com", 80))
+		ctrl.watchedEndpoints.Delete("default/svc")
+		ctrl.reloadServiceDebounced()
+		ctrl.reloadEndpointDebounced()
+		assert.Equal(t, "api.example.com:80", ctrl.routeTable.Lookup("svc.default.svc.cluster.local:80"))
+	})
+}
+
 func TestReloadServiceNamedTargetPort(t *testing.T) {
 	// A named targetPort ("http") carries no number in the Service; it must be
 	// resolved from the matching EndpointPort, not read as IntVal (which is 0 and

--- a/route/table.go
+++ b/route/table.go
@@ -6,11 +6,12 @@ import (
 )
 
 type Table struct {
-	mu               sync.RWMutex
-	onceStartBgJob   sync.Once
-	addrToTargetHost map[string]*RRLB
-	addrToTargetPort map[string]string
-	badAddr          badAddrTable
+	mu                 sync.RWMutex
+	onceStartBgJob     sync.Once
+	addrToTargetHost   map[string]*RRLB
+	addrToTargetPort   map[string]string
+	addrToExternalName map[string]string
+	badAddr            badAddrTable
 }
 
 func (t *Table) runBackgroundJob() {
@@ -30,20 +31,34 @@ func (t *Table) Lookup(addr string) string {
 
 	t.mu.RLock()
 	targetHost, okHost := t.addrToTargetHost[host]
+	externalName, okExt := t.addrToExternalName[host]
 	targetPort, okPort := t.addrToTargetPort[addr]
 	t.mu.RUnlock()
 
-	if !okHost || !okPort {
-		// host or port not found in table
+	if !okPort {
+		// port not found in table
 		return ""
 	}
 
-	hostIP := targetHost.Get(&t.badAddr)
-	if hostIP == "" {
-		// not found any pod
-		return ""
+	if okHost {
+		// pod-backed service: round-robin a healthy pod IP.
+		hostIP := targetHost.Get(&t.badAddr)
+		if hostIP == "" {
+			// not found any pod
+			return ""
+		}
+		return hostIP + ":" + targetPort
 	}
-	return hostIP + ":" + targetPort
+
+	if okExt {
+		// ExternalName service: dial the external DNS name directly — the dialer's
+		// net.Resolver resolves it at connect time. No RRLB/badAddr: there is a
+		// single target, and transient failures are handled by the retry path.
+		return externalName + ":" + targetPort
+	}
+
+	// neither a pod route nor an externalName route for this host
+	return ""
 }
 
 // SetHostRoutes sets route from host to RRLB (IPs)
@@ -78,6 +93,19 @@ func (t *Table) SetHostRoute(host string, lb *RRLB) {
 func (t *Table) SetPortRoutes(routes map[string]string) {
 	t.mu.Lock()
 	t.addrToTargetPort = routes
+	t.mu.Unlock()
+}
+
+// SetExternalNameRoutes sets route from a service's host
+// (service.namespace.svc.cluster.local) to its spec.externalName — an external
+// DNS name dialed directly instead of a pod IP. It is a full replace, mirroring
+// SetPortRoutes, and is owned solely by the service reload, so it never races the
+// incremental endpoint host-route path (SetHostRoute). A host present here but not
+// in addrToTargetHost (an ExternalName service has no Endpoints) resolves via the
+// externalName branch in Lookup.
+func (t *Table) SetExternalNameRoutes(routes map[string]string) {
+	t.mu.Lock()
+	t.addrToExternalName = routes
 	t.mu.Unlock()
 }
 

--- a/route/table_test.go
+++ b/route/table_test.go
@@ -73,6 +73,47 @@ func TestTable(t *testing.T) {
 	})
 }
 
+func TestTableExternalName(t *testing.T) {
+	t.Parallel()
+
+	tb := Table{}
+	tb.SetExternalNameRoutes(map[string]string{
+		"ext.default.svc.cluster.local": "api.example.com",
+	})
+	tb.SetPortRoutes(map[string]string{
+		"ext.default.svc.cluster.local:443": "443",
+		"ext.default.svc.cluster.local:80":  "80",
+	})
+
+	t.Run("resolves to the external DNS name and port", func(t *testing.T) {
+		assert.Equal(t, "api.example.com:443",
+			tb.Lookup("ext.default.svc.cluster.local:443"))
+		assert.Equal(t, "api.example.com:80",
+			tb.Lookup("ext.default.svc.cluster.local:80"))
+	})
+
+	t.Run("missing port misses even with an externalName host", func(t *testing.T) {
+		assert.Empty(t, tb.Lookup("ext.default.svc.cluster.local:8443"))
+	})
+
+	t.Run("unknown host misses", func(t *testing.T) {
+		assert.Empty(t, tb.Lookup("other.default.svc.cluster.local:443"))
+	})
+
+	t.Run("a pod host route takes precedence over externalName", func(t *testing.T) {
+		// Both maps can briefly hold the same host during a Service type change;
+		// the real pod endpoints win, and once they are gone Lookup falls back to
+		// the externalName.
+		tb.SetHostRoutes(map[string]*RRLB{
+			"ext.default.svc.cluster.local": {IPs: []string{"10.0.0.9"}},
+		})
+		assert.Equal(t, "10.0.0.9:443", tb.Lookup("ext.default.svc.cluster.local:443"))
+
+		tb.SetHostRoutes(map[string]*RRLB{})
+		assert.Equal(t, "api.example.com:443", tb.Lookup("ext.default.svc.cluster.local:443"))
+	})
+}
+
 // hostIPs reads back the IP set the table currently holds for each host so two
 // tables built different ways can be compared for equality.
 func hostIPs(t *Table) map[string][]string {


### PR DESCRIPTION
## What

Support backend Services of `type: ExternalName`. Previously, pointing an Ingress at one returned **503 Service Unavailable** — the controller resolves backends from Endpoints → pod IPs only, and an ExternalName Service (no selector) has no Endpoints object, so `route.Table.Lookup` returned `""`.

## How

A new `route.Table` map `addrToExternalName` (svc host → `spec.externalName`), set by `reloadServiceDebounced` via `SetExternalNameRoutes` (full-replace, mirroring `SetPortRoutes`).

Keeping it **separate** from the endpoint host-route map (`addrToTargetHost`) is deliberate: that map has two writers — the incremental `SetHostRoute` (per endpoint event) and the full `SetHostRoutes` (resync) — so folding ExternalName routes into it would clobber/race. The dedicated map is owned solely by the service reload, so deletions and `type` changes reconcile automatically on the next reload.

`Table.Lookup` now:
1. prefers a pod-backed route (`addrToTargetHost`, round-robin) — so normal Services are unchanged, and a pod route wins on the brief overlap during a type change;
2. otherwise falls back to dialing `spec.externalName` (resolved by the dialer's `net.Resolver` at connect time) on the **service port the ingress references**.

### Semantics

- Dials the **service port** the ingress references; `targetPort` is ignored (a pod concept, meaningless for a DNS CNAME) — matches nginx-ingress.
- The referenced port must still be declared in `spec.ports` (same as any backend).
- Single target → no RRLB / bad-address tracking; transient failures ride the existing retry path.
- `https` / `appProtocol` on the port work (TLS `InsecureSkipVerify`, SNI from the host); `upstream-host` overrides the forwarded `Host` (client `Host` forwarded by default).
- Empty `spec.externalName` is logged and skipped (no route); a trailing dot is trimmed.
- **No proxy change needed** — the handler sets `r.URL.Host`; the proxy dials it.

## Tests

- `route/table_test.go::TestTableExternalName` — resolution, missing port, unknown host, pod-route precedence + fallback.
- `controller_reload_test.go::TestReloadServiceExternalName` — single/multi-port, trailing-dot trim, empty externalName, and a ClusterIP→ExternalName flip dropping the stale pod route.
- `gofmt`/`go vet` clean; full suite green.

## Docs

SPEC.md Routing section + CLAUDE.md Routing concept updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)