### PR TITLE
fix(plugin): forward-auth client must not follow redirects

### DIFF
--- a/plugin/auth.go
+++ b/plugin/auth.go
@@ -13,6 +13,14 @@ import (
 
 var authHTTPClient = &http.Client{
 	Timeout: 10 * time.Second,
+	// A forward-auth probe treats the auth server's response status as the
+	// verdict (2xx allows; anything else is relayed to the client). It must
+	// therefore NOT follow redirects: an auth server that denies by sending
+	// "302 -> login page" would otherwise be followed to the login page's 200,
+	// which reads as a 2xx "allow" and bypasses auth for every gated request.
+	CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
 	Transport: &http.Transport{
 		MaxIdleConnsPerHost:   10,
 		MaxConnsPerHost:       100,

--- a/plugin/auth_test.go
+++ b/plugin/auth_test.go
@@ -125,3 +125,46 @@ authRequestHeaders:
 		assert.False(t, called)
 	})
 }
+
+// TestForwardAuthDoesNotFollowRedirect guards against a fail-open: an auth
+// server that denies by redirecting to a login page (the access.deploys.app
+// gate) must have its 302 relayed, never followed. Following "302 -> login"
+// to the login page's 200 would read as an "allow" and let every gated
+// request through. authHTTPClient must not follow redirects.
+func TestForwardAuthDoesNotFollowRedirect(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/login" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("login page"))
+			return
+		}
+		http.Redirect(w, r, "/login", http.StatusFound)
+	}))
+	defer ts.Close()
+
+	config := fmt.Sprintf("\nurl: %s/verify\n", ts.URL)
+
+	ctx := Context{
+		Middlewares: &parapet.Middlewares{},
+		Ingress: &networking.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"parapet.moonrhythm.io/forward-auth": config,
+				},
+			},
+		},
+	}
+	ForwardAuth(ctx)
+
+	var called bool
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	ctx.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})).ServeHTTP(w, r)
+
+	assert.False(t, called, "upstream must not be reached when auth redirects to login")
+	assert.Equal(t, http.StatusFound, w.Code, "auth 302 must be relayed, not followed to a 200")
+}


### PR DESCRIPTION
## Problem — production login bypass

`requireGoogleLogin` deployments were **wide open**: every request reached the app without authenticating, across **all** gated deployments.

Root cause: the forward-auth client (`plugin/auth.go` `authHTTPClient`) had **no `CheckRedirect`**, so it used Go's default and **followed redirects**. The gate (`access.deploys.app/verify`) denies an unauthenticated request with `302 → /start → … → Google sign-in`, which ends at a `200`. `ForwardAuthenticator` treats `2xx` as **allow**, so the followed chain read as "authenticated" and let everyone through.

Reproduced exactly — a redirect-following probe of `/verify` with no session returned `FINAL=200 redirects=4` (terminating at the Google sign-in page).

## Fix

Set `CheckRedirect: http.ErrUseLastResponse` on `authHTTPClient` so the auth server's `302` is relayed to the browser as the redirect-to-login it is, instead of being chased to a `200`. Independent of HTTP/1.1 vs h2c.

## Test

`TestForwardAuthDoesNotFollowRedirect`: an auth server that `302`s to a `200` login page must not reach the upstream handler and must relay the `302`. Verified it **fails before** the fix (status `200`, allow) and **passes after**.

## Notes

- The access service itself is correct — `/verify` returns `302` over both HTTP/1.1 and h2c; the bug was entirely in the auth client's redirect handling here.
- Companion hardening upstream so this can't recur for any consumer: moonrhythm/parapet#249 (makes `ForwardAuthenticator` enforce no-follow even with a default/`nil` client). This controller PR fixes prod independently of that release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)