### PR TITLE
chore(controller): drop brotli compression, build pure-Go (no CGO)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ edgecp/                           # edge control-plane lib (cert store, authz, r
 cmd/edge-controlplane/            # edge control-plane binary (see EDGE.md)
 edge/                             # edge proxy lib: certstore, cp (CP client), waf, ratelimit, refresh, forward (cache is parapet/pkg/cache)
 cmd/edge-proxy/                   # out-of-cluster edge proxy binary (parapet framework; see EDGE.md)
-Dockerfile                        # controller image (multi-stage Go build, CGO + cbrotli)
+Dockerfile                        # controller image (multi-stage Go build, pure Go / no CGO, distroless/static)
 Dockerfile.edge-controlplane      # control-plane image (pure Go, distroless/static)
 Dockerfile.edge                   # edge proxy image (pure Go, distroless/static + baked GeoIP)
 # also at repo root: deploy/  WAF.md  RATELIMIT.md  SPEC.md  EDGE.md  conformance/
@@ -159,10 +159,9 @@ go test ./...
 # Build Docker image via buildctl
 make go-build-dev
 
-# Build binary directly
-go build -o parapet-ingress-controller \
+# Build binary directly (pure Go, no CGO)
+CGO_ENABLED=0 go build -o parapet-ingress-controller \
   -ldflags "-w -s -X main.version=$(git describe --tags)" \
-  -tags=cbrotli \
   ./cmd/parapet-ingress-controller
 ```
 
@@ -171,9 +170,9 @@ fails on unformatted files. See the umbrella [`Makefile`](Makefile) for the
 `make test` target.
 
 ### Docker image
-- Builder: `golang:1.26.4-trixie` with `libbrotli-dev` (CGO enabled, `-tags=cbrotli`)
-- Runtime: `debian:trixie-slim` with `libbrotli1` and `ca-certificates`
-- Build args: `VERSION` (injected as `main.version`), `GOAMD64` (v3 default, v1 for compatibility image)
+- Builder: `golang:1.26.4-trixie` (pure Go, `CGO_ENABLED=0`) — cross-compiles, so the image is multi-arch-capable (linux/amd64 + linux/arm64) without QEMU like the edge images
+- Runtime: `gcr.io/distroless/static-debian12` (static binary; root variant so it can bind privileged :80/:443)
+- Build args: `VERSION` (injected as `main.version`), `GOAMD64` (v3 default, v1 for compatibility image; honored only for amd64)
 
 ## CI / Release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,23 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.26.4-trixie AS build
+#
+# Ingress controller (Go). Pure Go (no CGO) — builds static and runs on
+# distroless/static. Build context is the repo root.
+#
+# Multi-arch (linux/amd64 + linux/arm64): the build stage is pinned to
+# $BUILDPLATFORM and Go cross-compiles to $TARGETARCH, so the arm64 image is
+# produced WITHOUT QEMU emulation (pure-Go, CGO_ENABLED=0, cross-compiles
+# natively on the runner). GOAMD64 is honored only for amd64 (Go ignores it when
+# GOARCH=arm64). Build a multi-arch image with:
+#
+#     docker buildx build --platform linux/amd64,linux/arm64 -t parapet-ingress-controller .
+FROM --platform=$BUILDPLATFORM golang:1.26.4-trixie AS build
 
 ARG VERSION
 ARG GOAMD64
+ARG TARGETOS
+ARG TARGETARCH
 
-RUN apt-get update && \
-	apt-get -y install libbrotli-dev
-
-ENV CGO_ENABLED=1
+ENV CGO_ENABLED=0
 ENV GOAMD64=$GOAMD64
 
 WORKDIR /workspace
@@ -15,10 +25,9 @@ ADD go.mod go.sum ./
 RUN go mod download
 
 ADD . .
-RUN go build \
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
 		-o parapet-ingress-controller \
 		-ldflags "-w -s -X main.version=$VERSION" \
-		-tags=cbrotli \
 		./cmd/parapet-ingress-controller
 
 # GeoIP databases for the WAF, both baked by default from IPLocate's free MMDBs
@@ -28,8 +37,10 @@ RUN go build \
 # WAF_ASN_DB=/geoip/ip-to-asn.mmdb). The ip-to-asn DB is large (~74 MB) — pass
 # --build-arg ASN_DB_URL= (empty) to skip it if you don't need request.asn.
 # Override either URL to bake a different .mmdb; an empty value bakes none (the
-# /geoip dir is still created so the COPY below always succeeds).
-FROM debian:trixie-slim AS geoip
+# /geoip dir is still created so the COPY below always succeeds). Pinned to
+# $BUILDPLATFORM: the MMDBs are arch-neutral data, so this stage runs on the
+# native runner arch (no QEMU needed to curl them for an arm64 target build).
+FROM --platform=$BUILDPLATFORM debian:trixie-slim AS geoip
 ARG GEOIP_DB_URL=https://github.com/iplocate/ip-address-databases/raw/main/ip-to-country/ip-to-country.mmdb
 ARG ASN_DB_URL=https://github.com/iplocate/ip-address-databases/raw/main/ip-to-asn/ip-to-asn.mmdb
 RUN mkdir -p /geoip && \
@@ -40,14 +51,12 @@ RUN mkdir -p /geoip && \
 	if [ -n "$ASN_DB_URL" ]; then curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 30 "$ASN_DB_URL" -o /geoip/ip-to-asn.mmdb; fi && \
 	ls -l /geoip
 
-FROM debian:trixie-slim
+# ---- runtime ----
+# distroless/static provides CA roots + tzdata; the default (root) variant — not
+# :nonroot — so the controller can bind the privileged :443 / :80 ports.
+FROM gcr.io/distroless/static-debian12
 
-RUN apt-get update && \
-	apt-get -y install libbrotli1 ca-certificates && \
-	rm -rf /var/lib/apt/lists/*
-
-WORKDIR /app
-
-COPY --from=build /workspace/parapet-ingress-controller ./
+COPY --from=build /workspace/parapet-ingress-controller /app/parapet-ingress-controller
 COPY --from=geoip /geoip/ /geoip/
+
 ENTRYPOINT ["/app/parapet-ingress-controller"]

--- a/EDGE.md
+++ b/EDGE.md
@@ -1047,8 +1047,10 @@ pin the build stage to `$BUILDPLATFORM` and cross-compile to `$TARGETARCH`, so t
 arm64 variant is produced **without QEMU emulation** — buildx compiles both arches
 natively on the runner (the edge's GeoIP-download stage is likewise pinned to
 `$BUILDPLATFORM`, since the MMDBs are arch-neutral data). The in-cluster
-controller image is a separate story: it links `libbrotli` via CGO, so an arm64
-variant there would need QEMU (or a cross-toolchain) and has not been enabled.
+controller image now follows the same pure-Go (`CGO_ENABLED=0`) model — it
+dropped its `libbrotli`/CGO dependency along with brotli response compression —
+so it cross-compiles to arm64 without QEMU as well (CI currently still publishes
+only the amd64 v3/v1 compatibility split).
 
 ## Implementation history
 

--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -317,7 +317,6 @@ func main() {
 	m.Use(state.Middleware(!disableLog))
 	m.Use(metric.Requests(ctrl.IsKnownHost))
 	m.Use(compress.Gzip())
-	m.Use(compress.BrWithQuality(4))
 	m.Use(compress.Zstd())
 	if wafConfig.Enabled {
 		// Global WAF runs just before routing: blocks are access-logged and


### PR DESCRIPTION
## What

Brotli (parapet's `cbrotli` middleware) was the controller's **sole CGO dependency**. This drops on-the-fly brotli response compression and the `cbrotli` build tag so the controller builds with `CGO_ENABLED=0`, bringing it in line with the edge + control-plane images (which are already pure-Go / distroless/static).

## Why

- **Pure-Go build** → static binary, no `libbrotli` toolchain, faster/simpler builds
- **distroless/static runtime** instead of `debian:trixie-slim` + `libbrotli1`
- **Multi-arch without QEMU** — build stage pinned to `$BUILDPLATFORM`, cross-compiles to `$TARGETARCH` (amd64+arm64), same model as `Dockerfile.edge`
- **Coherent stack**: the edge is pure-Go and can't emit brotli anyway, so after this no component emits br

## Changes

- `main.go`: remove `compress.BrWithQuality(4)`; keep `gzip` + `zstd`
- `Dockerfile`: `CGO_ENABLED=0`, drop `libbrotli-dev`/`libbrotli1` + `-tags=cbrotli`; runtime → `gcr.io/distroless/static-debian12`; `$BUILDPLATFORM`/`$TARGETARCH` cross-compile
- `CLAUDE.md` / `EDGE.md`: update stale CGO/cbrotli references

## Notes

- **Deflate was never wired up** — the controller only ever registered gzip/br/zstd, so nothing to remove there.
- **Without the cbrotli tag parapet's brotli is a no-op** (`br_noop.go`), not pure-Go brotli — so this genuinely removes brotli output rather than swapping implementations. Clients advertising `br` but not `zstd` fall back to gzip cleanly; `zstd` covers the modern high-ratio case, `gzip` is the universal floor.
- **Local dev was already brotli-free** (`go run` / `make run-local` never passed `-tags=cbrotli`), so this makes prod match dev.
- **CI unchanged**: `go-build`/`go-release` still publish amd64-only with the v3/v1 CPU-compat split (independent of the CGO change; the new Dockerfile is backward-compatible). The Dockerfile is now multi-arch-capable via `buildx --platform` — flipping CI to publish a multi-arch manifest is a follow-up (it'd change the tagging strategy).

## Verification

- `gofmt -l .` clean, `go vet ./...` clean
- `CGO_ENABLED=0 go build ./...` succeeds
- full suite: **740 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)