### PR TITLE
ci(controller): publish multi-arch (amd64+arm64) controller images

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -37,11 +37,17 @@ jobs:
     - uses: docker/setup-buildx-action@v3
       with:
         version: latest
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
+    # Default tags: a multi-arch manifest (linux/amd64 GOAMD64=v3 + linux/arm64).
+    # The controller is pure Go (CGO_ENABLED=0), so buildx cross-compiles each
+    # arch natively on the runner — no QEMU/binfmt (see the $BUILDPLATFORM build
+    # stage in the Dockerfile). GOAMD64 applies to amd64 only; Go ignores it for
+    # arm64.
     - uses: docker/build-push-action@v6
       with:
         provenance: false
         context: .
+        platforms: linux/amd64,linux/arm64
         build-args: |
           VERSION=${{ github.sha }}
           GOAMD64=v3
@@ -49,10 +55,13 @@ jobs:
         tags: |
           us-docker.pkg.dev/moonrhythm-containers/gcr.io/parapet-ingress-controller:${{ github.sha }}
           asia-southeast3-docker.pkg.dev/moonrhythm-core/public/parapet-ingress-controller:${{ github.sha }}
+    # Compatibility image: amd64-only, GOAMD64=v1 for older CPUs. No arm64 variant
+    # (GOAMD64 microarch levels are an amd64 concept).
     - uses: docker/build-push-action@v6
       with:
         provenance: false
         context: .
+        platforms: linux/amd64
         build-args: |
           VERSION=${{ github.sha }}
           GOAMD64=v1

--- a/.github/workflows/go-release.yaml
+++ b/.github/workflows/go-release.yaml
@@ -27,11 +27,17 @@ jobs:
     - uses: docker/setup-buildx-action@v3
       with:
         version: latest
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
+    # Default tags: a multi-arch manifest (linux/amd64 GOAMD64=v3 + linux/arm64).
+    # The controller is pure Go (CGO_ENABLED=0), so buildx cross-compiles each
+    # arch natively on the runner — no QEMU/binfmt (see the $BUILDPLATFORM build
+    # stage in the Dockerfile). GOAMD64 applies to amd64 only; Go ignores it for
+    # arm64.
     - uses: docker/build-push-action@v6
       with:
         provenance: false
         context: .
+        platforms: linux/amd64,linux/arm64
         build-args: |
           VERSION=${{ github.ref_name }}
           GOAMD64=v3
@@ -41,10 +47,13 @@ jobs:
           us-docker.pkg.dev/moonrhythm-containers/gcr.io/parapet-ingress-controller:latest
           asia-southeast3-docker.pkg.dev/moonrhythm-core/public/parapet-ingress-controller:${{ github.ref_name }}
           asia-southeast3-docker.pkg.dev/moonrhythm-core/public/parapet-ingress-controller:latest
+    # Compatibility image: amd64-only, GOAMD64=v1 for older CPUs. No arm64 variant
+    # (GOAMD64 microarch levels are an amd64 concept).
     - uses: docker/build-push-action@v6
       with:
         provenance: false
         context: .
+        platforms: linux/amd64
         build-args: |
           VERSION=${{ github.ref_name }}
           GOAMD64=v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ fails on unformatted files. See the umbrella [`Makefile`](Makefile) for the
 
 All path-filtered to `**/*.go` + `go.mod`/`go.sum` (plus `Dockerfile*`):
 - **Push & PR touching Go files** → `go-test.yaml`: `go vet` + `go test -race`
-- **Push to `main`** → `go-build.yaml`: pushes two images tagged with `$GITHUB_SHA` (`:$sha` GOAMD64=v3, `:$sha-amd64v1` GOAMD64=v1). Docker build context is the repo root.
+- **Push to `main`** → `go-build.yaml`: pushes two images tagged with `$GITHUB_SHA` — `:$sha` is a **multi-arch manifest** (linux/amd64 GOAMD64=v3 + linux/arm64; pure-Go cross-compile, no QEMU), and `:$sha-amd64v1` is the amd64-only GOAMD64=v1 compatibility image (no arm64 — GOAMD64 levels are amd64-only). Docker build context is the repo root.
 - **Push a tag** → `go-release.yaml`: same plus `:latest` and `:{tag}`
 - Registries: `us-docker.pkg.dev/moonrhythm-containers/gcr.io/` and `asia-southeast3-docker.pkg.dev/moonrhythm-core/public/`
 

--- a/EDGE.md
+++ b/EDGE.md
@@ -1049,8 +1049,10 @@ natively on the runner (the edge's GeoIP-download stage is likewise pinned to
 `$BUILDPLATFORM`, since the MMDBs are arch-neutral data). The in-cluster
 controller image now follows the same pure-Go (`CGO_ENABLED=0`) model — it
 dropped its `libbrotli`/CGO dependency along with brotli response compression —
-so it cross-compiles to arm64 without QEMU as well (CI currently still publishes
-only the amd64 v3/v1 compatibility split).
+so it too is multi-arch: its default tags (`:<sha>`, `:latest`, `:<tag>`) are
+amd64 (GOAMD64=v3) + arm64 manifests, while the `-amd64v1` GOAMD64=v1
+compatibility image stays amd64-only (GOAMD64 microarch levels are an amd64
+concept).
 
 ## Implementation history
 


### PR DESCRIPTION
## What

Make CI publish **arm64** alongside amd64 for the controller image. Follow-up to #165 (which made the controller pure-Go / `CGO_ENABLED=0` and gave the Dockerfile a `$BUILDPLATFORM`-pinned, `$TARGETARCH` cross-compiling build stage). The Dockerfile already supported multi-arch; this just flips CI to use it.

## Changes

- **`go-build.yaml` / `go-release.yaml`**: the default tags (`:<sha>`, `:latest`, `:<tag>`) are now **multi-arch manifests** — `linux/amd64` (GOAMD64=v3) + `linux/arm64`. buildx cross-compiles each arch natively on the runner (**no QEMU/binfmt**, since the binary is pure Go), mirroring `edge-build.yaml`.
- The **`-amd64v1` compatibility image stays amd64-only**: GOAMD64 microarchitecture levels are an amd64 concept (Go ignores `GOAMD64` for arm64), so there's no meaningful arm64 v1 variant.
- **Docs**: updated the CLAUDE.md CI/Release section and the EDGE.md controller-image note.

## Tagging after this change

| tag | arches |
|-----|--------|
| `:<sha>` / `:latest` / `:<tag>` | linux/amd64 (v3) + linux/arm64 |
| `:<sha>-amd64v1` / `:latest-amd64v1` / `:<tag>-amd64v1` | linux/amd64 (v1) only |

arm64 nodes pulling the default tag now get a native image; amd64-on-old-CPU users keep the `-amd64v1` tag; everyone else is unaffected.

## Verification

- Both workflow YAMLs parse cleanly.
- No code/Dockerfile changes needed — the `$BUILDPLATFORM`/`$TARGETARCH` build stage landed in #165.
- This workflow edit is path-filtered in, so the push to `main` after merge will itself produce the first multi-arch images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)