### PR TITLE
feat(edge): add per-host connection ceiling for edge→core hop

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -922,11 +922,26 @@ The edge→parapet hop runs **HTTP/2 by default**, matching the multiplexing the
 core already accepts (`edge/forward.go`):
 
 ```
-EDGE_UPSTREAM_ADDR   parapet host:port (default parapet:80)
-EDGE_UPSTREAM_TLS    re-encrypt the hop with TLS (default false)
-EDGE_UPSTREAM_SNI    SNI/Host on the re-encrypt handshake (default: addr's host)
-EDGE_UPSTREAM_HTTP2  HTTP/2 on the hop (default true — opt-out)
+EDGE_UPSTREAM_ADDR                parapet host:port (default parapet:80)
+EDGE_UPSTREAM_TLS                 re-encrypt the hop with TLS (default false)
+EDGE_UPSTREAM_SNI                 SNI/Host on the re-encrypt handshake (default: addr's host)
+EDGE_UPSTREAM_HTTP2               HTTP/2 on the hop (default true — opt-out)
+EDGE_UPSTREAM_MAX_CONNS_PER_HOST  hard ceiling on total conns per core host (default 0 = unlimited)
+EDGE_UPSTREAM_MAX_IDLE_CONNS_PER_HOST  idle keep-alive pool per core host (default 0 ⇒ 32)
 ```
+
+- **Connection ceiling.** `EDGE_UPSTREAM_MAX_CONNS_PER_HOST` mirrors the
+  controller's `TR_MAX_CONNS_PER_HOST`: a hard cap on the total (active + idle)
+  connections each edge replica opens to a core host, bounding fan-out and FD/memory
+  use under load. It applies to the HTTP/1.1 transports and the re-encrypt
+  ForceAttemptHTTP2 transport (net/http enforces it at the dial layer for both the h2
+  and HTTP/1.1-fallback conns it manages). The **default plaintext h2c path
+  multiplexes** every request over a handful of connections (`golang.org/x/net/http2`
+  has no per-host conn limit), so there the ceiling bounds only the HTTP/1.1
+  Upgrade/WebSocket fallback — the multiplexed stream traffic is low-connection by
+  construction. `EDGE_UPSTREAM_MAX_IDLE_CONNS_PER_HOST` tunes the idle keep-alive pool
+  (parapet's default is 32); raise it to keep more warm connections for bursty
+  traffic. Both are **per edge replica**.
 
 - **Plaintext hop (`EDGE_UPSTREAM_TLS=false`)** → **h2c** prior-knowledge, via
   parapet's `upstream.H2CTransport`. The core's `:80` server runs with `H2C=true`

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Out-of-cluster TLS-terminating proxy. See [EDGE.md](EDGE.md).
 | `EDGE_UPSTREAM_ADDR` | `parapet:80` | Where to forward (the in-cluster parapet) |
 | `EDGE_UPSTREAM_TLS` | `false` | Re-encrypt the upstream hop with TLS |
 | `EDGE_UPSTREAM_SNI` | `""` | SNI/Host for the upstream TLS hop |
+| `EDGE_UPSTREAM_MAX_CONNS_PER_HOST` | `0` | Hard ceiling on total conns per core host (`0` = unlimited); like the controller's `TR_MAX_CONNS_PER_HOST` |
+| `EDGE_UPSTREAM_MAX_IDLE_CONNS_PER_HOST` | `0` | Idle keep-alive pool per core host (`0` ⇒ parapet default 32) |
 | `EDGE_DATAPLANE_MTLS` | `false` | Present a CP-issued client cert on the upstream hop (requires `EDGE_UPSTREAM_TLS=true` + `EDGE_ID`) |
 | `EDGE_WAF_ENABLED` | `false` | Run the global+zone WAF at the edge |
 | `EDGE_RATELIMIT_ENABLED` | `false` | Enforce the CP-distributed rate limits at the edge (requires `CP_RATELIMIT_ENABLED`) |

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -76,6 +76,16 @@ func main() {
 	// Set EDGE_UPSTREAM_HTTP2=false to force HTTP/1.1 — e.g. a core that predates H2C
 	// on :80, or an L4 in front of :443 that can't ALPN.
 	upstreamHTTP2 := envOr("EDGE_UPSTREAM_HTTP2", "true") == "true"
+	// Per-host connection ceiling to the core (mirrors the controller's
+	// TR_MAX_CONNS_PER_HOST / TR_MAX_IDLE_CONNS_PER_HOST). MAX_CONNS_PER_HOST=0
+	// (default) leaves connections unbounded; MAX_IDLE_CONNS_PER_HOST=0 falls back
+	// to parapet's default idle pool (32). See edge.ForwarderTuning for which paths
+	// the hard ceiling applies to (HTTP/1.1 + re-encrypt h2; the multiplexed h2c
+	// stream path is inherently low-connection and not connection-capped).
+	upstreamTuning := edge.ForwarderTuning{
+		MaxConnsPerHost:     int(envInt64("EDGE_UPSTREAM_MAX_CONNS_PER_HOST", 0)),
+		MaxIdleConnsPerHost: int(envInt64("EDGE_UPSTREAM_MAX_IDLE_CONNS_PER_HOST", 0)),
+	}
 	dataplaneMTLS := envOr("EDGE_DATAPLANE_MTLS", "false") == "true"
 	if dataplaneMTLS && !upstreamTLS {
 		slog.Error("EDGE_DATAPLANE_MTLS=true requires EDGE_UPSTREAM_TLS=true (a client cert can only ride TLS)")
@@ -395,7 +405,7 @@ func main() {
 		// fires a (non-blocking) reactive re-mint. nil when mTLS is off.
 		onCertReject = func() { remintCoord.Trigger("reactive") }
 	}
-	forwarder := edge.NewForwarder(upstreamAddr, upstreamTLS, upstreamHTTP2, upstreamSNI, getClientCert, onCertReject)
+	forwarder := edge.NewForwarder(upstreamAddr, upstreamTLS, upstreamHTTP2, upstreamSNI, upstreamTuning, getClientCert, onCertReject)
 
 	if metricsListen != "" {
 		go func() {

--- a/edge/forward.go
+++ b/edge/forward.go
@@ -34,6 +34,34 @@ type Forwarder struct {
 	rp *httputil.ReverseProxy
 }
 
+// defaultMaxIdleConnsPerHost mirrors parapet's upstream.defaultMaxIdleConns (32):
+// the idle keep-alive pool kept per core host when ForwarderTuning leaves it at 0.
+const defaultMaxIdleConnsPerHost = 32
+
+// ForwarderTuning bounds the edge→core connection pool per upstream host. The
+// zero value preserves the historical behavior: no connection ceiling
+// (MaxConnsPerHost == 0 ⇒ unlimited) and parapet's default idle pool (32).
+//
+// MaxConnsPerHost is a hard ceiling on the total (active + idle) connections to
+// each core host, applied to the HTTP/1.1 transports and the re-encrypt
+// ForceAttemptHTTP2 transport (net/http enforces it at the dial layer for both
+// the h2 and HTTP/1.1-fallback conns it manages). The DEFAULT plaintext h2c path
+// multiplexes every request over a small number of connections via
+// golang.org/x/net/http2.Transport, which has no per-host connection limit — so
+// the ceiling there bounds only the HTTP/1.1 Upgrade/WebSocket fallback, not the
+// multiplexed stream traffic (which needs few connections by construction).
+type ForwarderTuning struct {
+	MaxConnsPerHost     int // 0 = unlimited (no hard ceiling)
+	MaxIdleConnsPerHost int // 0 = parapet default (32)
+}
+
+func (t ForwarderTuning) idle() int {
+	if t.MaxIdleConnsPerHost > 0 {
+		return t.MaxIdleConnsPerHost
+	}
+	return defaultMaxIdleConnsPerHost
+}
+
 // NewForwarder builds a forwarder to addr (host:port).
 //
 // useTLS selects re-encrypt (TLS) vs plaintext; sni is the SNI/Host presented when
@@ -61,7 +89,10 @@ type Forwarder struct {
 // CORE rejects the edge's data-plane client cert in the re-encrypt TLS handshake — the
 // reactive force-re-mint floor. It is the coordinator's reactive Trigger; nil when
 // data-plane mTLS is off.
-func NewForwarder(addr string, useTLS, enableHTTP2 bool, sni string, getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error), onCertReject func()) *Forwarder {
+//
+// tuning bounds the per-host connection pool to the core (see ForwarderTuning);
+// the zero value keeps the historical unbounded/idle-32 behavior.
+func NewForwarder(addr string, useTLS, enableHTTP2 bool, sni string, tuning ForwarderTuning, getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error), onCertReject func()) *Forwarder {
 	var tr http.RoundTripper
 	switch {
 	case useTLS:
@@ -74,20 +105,28 @@ func NewForwarder(addr string, useTLS, enableHTTP2 bool, sni string, getClientCe
 		}
 		// HTTPSTransport sets r.URL.Scheme = "https" and dials r.URL.Host with TLS,
 		// HTTP/1.1 only (net/http won't auto-enable h2 with a custom TLS config).
-		h1 := &upstream.HTTPSTransport{TLSClientConfig: tlsConfig}
+		h1 := &upstream.HTTPSTransport{
+			TLSClientConfig: tlsConfig,
+			MaxConn:         tuning.MaxConnsPerHost,
+			MaxIdleConns:    tuning.idle(),
+		}
 		if enableHTTP2 {
-			tr = newH2TLSTransport(tlsConfig, h1)
+			tr = newH2TLSTransport(tlsConfig, tuning, h1)
 		} else {
 			tr = h1
 		}
 	case enableHTTP2:
 		// Plaintext h2c (prior-knowledge) to the core's H2C=true :80 listener.
 		// H2CTransport sets r.URL.Scheme = "http" and downgrades Upgrade/WebSocket
-		// requests to HTTP/1.1.
-		tr = &upstream.H2CTransport{}
+		// requests to HTTP/1.1. The multiplexed h2 path has no per-host conn cap;
+		// the ceiling applies to the HTTP/1.1 Upgrade fallback we wire up here.
+		tr = &upstream.H2CTransport{HTTPTransport: h2cFallbackTransport(tuning)}
 	default:
 		// HTTPTransport sets r.URL.Scheme = "http" and speaks HTTP/1.1.
-		tr = &upstream.HTTPTransport{}
+		tr = &upstream.HTTPTransport{
+			MaxConn:      tuning.MaxConnsPerHost,
+			MaxIdleConns: tuning.idle(),
+		}
 	}
 
 	scheme := "http"
@@ -172,7 +211,7 @@ type h2TLSTransport struct {
 	h1 http.RoundTripper // HTTP/1.1-over-TLS, for Upgrade requests
 }
 
-func newH2TLSTransport(tlsConfig *tls.Config, h1 http.RoundTripper) *h2TLSTransport {
+func newH2TLSTransport(tlsConfig *tls.Config, tuning ForwarderTuning, h1 http.RoundTripper) *h2TLSTransport {
 	return &h2TLSTransport{
 		// ForceAttemptHTTP2 makes net/http wire up the bundled http2 transport even
 		// though we supply a custom TLSClientConfig + DialContext (which otherwise trips
@@ -180,18 +219,38 @@ func newH2TLSTransport(tlsConfig *tls.Config, h1 http.RoundTripper) *h2TLSTransp
 		// ALPN then negotiates h2, falling back to HTTP/1.1 if the core only offers it.
 		// Fields mirror upstream.HTTPSTransport's defaults so only the protocol changes;
 		// DisableCompression keeps the proxy hop byte-transparent (no auto-gzip).
+		// MaxConnsPerHost caps total conns to the core (net/http enforces it for the h2
+		// and HTTP/1.1-fallback conns it manages); 0 leaves it unbounded.
 		h2: &http.Transport{
 			Proxy:                 http.ProxyFromEnvironment,
 			DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
 			TLSClientConfig:       tlsConfig,
 			ForceAttemptHTTP2:     true,
-			MaxIdleConnsPerHost:   32,
+			MaxConnsPerHost:       tuning.MaxConnsPerHost,
+			MaxIdleConnsPerHost:   tuning.idle(),
 			IdleConnTimeout:       10 * time.Minute,
 			TLSHandshakeTimeout:   5 * time.Second,
 			ResponseHeaderTimeout: time.Minute,
 			DisableCompression:    true,
 		},
 		h1: h1,
+	}
+}
+
+// h2cFallbackTransport builds the HTTP/1.1 transport that upstream.H2CTransport
+// uses for Upgrade/WebSocket requests (the multiplexed h2c path can't carry
+// them). It mirrors parapet's own default h2c fallback but threads the connection
+// ceiling through, so EDGE_UPSTREAM_MAX_CONNS_PER_HOST also bounds the plaintext
+// Upgrade path. A 0 ceiling leaves it unbounded, matching parapet's default.
+func h2cFallbackTransport(tuning ForwarderTuning) *http.Transport {
+	return &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
+		MaxConnsPerHost:       tuning.MaxConnsPerHost,
+		MaxIdleConnsPerHost:   tuning.idle(),
+		IdleConnTimeout:       10 * time.Minute,
+		ResponseHeaderTimeout: time.Minute,
+		DisableCompression:    true,
 	}
 }
 

--- a/edge/forward_http2_test.go
+++ b/edge/forward_http2_test.go
@@ -48,10 +48,10 @@ func TestForwarder_Plaintext_H2COptOut(t *testing.T) {
 	defer srv.Close()
 	addr := addrOf(t, srv.URL)
 
-	if got := forwardThrough(t, NewForwarder(addr, false, true, "", nil, nil)); got != "proto=2" {
+	if got := forwardThrough(t, NewForwarder(addr, false, true, "", ForwarderTuning{}, nil, nil)); got != "proto=2" {
 		t.Errorf("h2c default: want proto=2, got %q", got)
 	}
-	if got := forwardThrough(t, NewForwarder(addr, false, false, "", nil, nil)); got != "proto=1" {
+	if got := forwardThrough(t, NewForwarder(addr, false, false, "", ForwarderTuning{}, nil, nil)); got != "proto=1" {
 		t.Errorf("opt-out: want proto=1 (HTTP/1.1), got %q", got)
 	}
 }
@@ -66,10 +66,10 @@ func TestForwarder_TLS_H2OptOut(t *testing.T) {
 	defer srv.Close()
 	addr := addrOf(t, srv.URL)
 
-	if got := forwardThrough(t, NewForwarder(addr, true, true, "", nil, nil)); got != "proto=2" {
+	if got := forwardThrough(t, NewForwarder(addr, true, true, "", ForwarderTuning{}, nil, nil)); got != "proto=2" {
 		t.Errorf("h2 default: want proto=2, got %q", got)
 	}
-	if got := forwardThrough(t, NewForwarder(addr, true, false, "", nil, nil)); got != "proto=1" {
+	if got := forwardThrough(t, NewForwarder(addr, true, false, "", ForwarderTuning{}, nil, nil)); got != "proto=1" {
 		t.Errorf("opt-out: want proto=1 (HTTP/1.1 over TLS), got %q", got)
 	}
 }
@@ -83,7 +83,7 @@ func TestForwarder_TLS_H2FallsBackToHTTP1(t *testing.T) {
 	defer srv.Close()
 	addr := addrOf(t, srv.URL)
 
-	if got := forwardThrough(t, NewForwarder(addr, true, true, "", nil, nil)); got != "proto=1" {
+	if got := forwardThrough(t, NewForwarder(addr, true, true, "", ForwarderTuning{}, nil, nil)); got != "proto=1" {
 		t.Errorf("h2 requested, http/1.1-only core: want graceful proto=1, got %q", got)
 	}
 }

--- a/edge/forward_tuning_test.go
+++ b/edge/forward_tuning_test.go
@@ -1,0 +1,82 @@
+package edge
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/moonrhythm/parapet/pkg/upstream"
+)
+
+// ForwarderTuning must thread the per-host connection ceiling into whichever
+// transport NewForwarder selects, so EDGE_UPSTREAM_MAX_CONNS_PER_HOST is a real
+// hard cap on each path (and a 0 idle pool falls back to parapet's default 32).
+func TestForwarderTuning_AppliesToEveryTransport(t *testing.T) {
+	const (
+		maxConns = 7
+		maxIdle  = 3
+	)
+	tuning := ForwarderTuning{MaxConnsPerHost: maxConns, MaxIdleConnsPerHost: maxIdle}
+
+	t.Run("plaintext HTTP/1.1", func(t *testing.T) {
+		f := NewForwarder("core:80", false, false, "", tuning, nil, nil)
+		tr := f.rp.Transport.(*upstream.HTTPTransport)
+		if tr.MaxConn != maxConns {
+			t.Fatalf("MaxConn = %d, want %d", tr.MaxConn, maxConns)
+		}
+		if tr.MaxIdleConns != maxIdle {
+			t.Fatalf("MaxIdleConns = %d, want %d", tr.MaxIdleConns, maxIdle)
+		}
+	})
+
+	t.Run("plaintext h2c Upgrade fallback", func(t *testing.T) {
+		f := NewForwarder("core:80", false, true, "", tuning, nil, nil)
+		tr := f.rp.Transport.(*upstream.H2CTransport)
+		if tr.HTTPTransport == nil {
+			t.Fatal("H2CTransport.HTTPTransport (Upgrade fallback) not wired")
+		}
+		if got := tr.HTTPTransport.MaxConnsPerHost; got != maxConns {
+			t.Fatalf("fallback MaxConnsPerHost = %d, want %d", got, maxConns)
+		}
+		if got := tr.HTTPTransport.MaxIdleConnsPerHost; got != maxIdle {
+			t.Fatalf("fallback MaxIdleConnsPerHost = %d, want %d", got, maxIdle)
+		}
+	})
+
+	t.Run("re-encrypt h2", func(t *testing.T) {
+		f := NewForwarder("core:443", true, true, "", tuning, nil, nil)
+		h2 := f.rp.Transport.(*h2TLSTransport).h2.(*http.Transport)
+		if h2.MaxConnsPerHost != maxConns {
+			t.Fatalf("h2 MaxConnsPerHost = %d, want %d", h2.MaxConnsPerHost, maxConns)
+		}
+		if h2.MaxIdleConnsPerHost != maxIdle {
+			t.Fatalf("h2 MaxIdleConnsPerHost = %d, want %d", h2.MaxIdleConnsPerHost, maxIdle)
+		}
+	})
+
+	t.Run("re-encrypt HTTP/1.1", func(t *testing.T) {
+		f := NewForwarder("core:443", true, false, "", tuning, nil, nil)
+		tr := f.rp.Transport.(*upstream.HTTPSTransport)
+		if tr.MaxConn != maxConns {
+			t.Fatalf("MaxConn = %d, want %d", tr.MaxConn, maxConns)
+		}
+		if tr.MaxIdleConns != maxIdle {
+			t.Fatalf("MaxIdleConns = %d, want %d", tr.MaxIdleConns, maxIdle)
+		}
+	})
+}
+
+// The zero value keeps the historical behavior: no connection ceiling, idle pool
+// defaulting to parapet's 32.
+func TestForwarderTuning_ZeroValueDefaults(t *testing.T) {
+	if got := (ForwarderTuning{}).idle(); got != defaultMaxIdleConnsPerHost {
+		t.Fatalf("zero idle() = %d, want %d", got, defaultMaxIdleConnsPerHost)
+	}
+	f := NewForwarder("core:80", false, false, "", ForwarderTuning{}, nil, nil)
+	tr := f.rp.Transport.(*upstream.HTTPTransport)
+	if tr.MaxConn != 0 {
+		t.Fatalf("MaxConn = %d, want 0 (unlimited)", tr.MaxConn)
+	}
+	if tr.MaxIdleConns != defaultMaxIdleConnsPerHost {
+		t.Fatalf("MaxIdleConns = %d, want %d", tr.MaxIdleConns, defaultMaxIdleConnsPerHost)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a configurable **hard connection ceiling** for the edge → core hop, mirroring the controller's existing `TR_MAX_CONNS_PER_HOST`. Previously the edge forwarder hard-coded its upstream pool (idle 32, **no `MaxConnsPerHost`**) with no env knob, so each edge replica could open unbounded connections to a core host under load.

## What changed

New `ForwarderTuning{MaxConnsPerHost, MaxIdleConnsPerHost}` threaded through **all four** transport paths in `NewForwarder`:
- plaintext HTTP/1.1 (`upstream.HTTPTransport`)
- plaintext h2c — its HTTP/1.1 Upgrade/WebSocket fallback (new `h2cFallbackTransport`)
- re-encrypt h2 (`h2TLSTransport`'s `ForceAttemptHTTP2` transport)
- re-encrypt HTTP/1.1 (`upstream.HTTPSTransport`)

Driven by two new env vars (both default to the prior behavior — **purely additive**):

| Env var | Default | Effect |
|---|---|---|
| `EDGE_UPSTREAM_MAX_CONNS_PER_HOST` | `0` (unlimited) | Hard cap on total active+idle conns per core host |
| `EDGE_UPSTREAM_MAX_IDLE_CONNS_PER_HOST` | `0` ⇒ `32` | Idle keep-alive pool per core host |

## Caveat (documented)

The **default** path is plaintext h2c, which multiplexes over `golang.org/x/net/http2.Transport` — which has **no per-host connection limit**. So on the default path the ceiling bounds only the HTTP/1.1 Upgrade fallback, not the multiplexed stream traffic (low-connection by construction). The ceiling bites hardest on the HTTP/1.1 and re-encrypt-h2 paths, where net/http enforces `MaxConnsPerHost` at the dial layer. This is called out in the `ForwarderTuning` doc comment, `EDGE.md`, and `README.md`.

## Tests

`edge/forward_tuning_test.go` asserts the ceiling reaches every transport path, plus the zero-value default (unlimited conns, idle ⇒ 32).

`gofmt -l .` clean · `go vet ./...` clean · `go test ./edge/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)