### PR TITLE
feat(edge): accept human-readable size suffixes for edge cache caps

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -669,7 +669,8 @@ cacheable object locally removes a full origin round trip. Enabled with
   **streamed** to a temp file, so it survives restarts and isn't bounded by RSS,
   which matters given the edge's memory-pressure history) and **`memory`** (bodies
   in RAM, lost on restart). Total size is bounded by an **LRU** keyed on body
-  bytes (`EDGE_CACHE_MAX_SIZE`); per-object size by `EDGE_CACHE_MAX_FILE_SIZE`. A
+  bytes (`EDGE_CACHE_MAX_SIZE`); per-object size by `EDGE_CACHE_MAX_FILE_SIZE`.
+  Both accept a unit suffix (`2gib`, `512mb`, …) as well as a bare byte count. A
   `Content-Length` over the cap is simply not cached (the client still gets the
   full response). A GET is cached **only with a `Content-Length`** and committed
   only once written bytes == `Content-Length` — so a truncated response (client
@@ -753,8 +754,11 @@ authorization-sensitive responses publicly cacheable.
 EDGE_CACHE_ENABLED       on/off (default false)
 EDGE_CACHE_BACKEND       disk | memory (default disk)
 EDGE_CACHE_DIR           cache root, disk backend only (default /var/cache/parapet-edge)
-EDGE_CACHE_MAX_SIZE      total bytes cap, LRU-evicted (default 1073741824 = 1 GiB)
-EDGE_CACHE_MAX_FILE_SIZE per-object bytes cap (default 8388608 = 8 MiB)
+EDGE_CACHE_MAX_SIZE      total size cap, LRU-evicted (default 1 GiB). Accepts a
+                         unit suffix: a bare number is bytes, or use kb/mb/gb/tb
+                         (decimal, 1000ⁿ) or kib/mib/gib/tib (binary, 1024ⁿ),
+                         e.g. "2gib", "512mb", "1.5gb" (case-insensitive)
+EDGE_CACHE_MAX_FILE_SIZE per-object size cap (default 8 MiB; same unit suffixes)
 EDGE_CACHE_CHUNKED       cache GET responses with no Content-Length (chunked /
                          on-the-fly-compressed bodies — gzip/br/zstd) by buffering
                          to derive a length (default true; the cap is enforced

--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ Out-of-cluster TLS-terminating proxy. See [EDGE.md](EDGE.md).
 | `EDGE_CACHE_ENABLED` | `false` | Enable the HTTP response cache |
 | `EDGE_CACHE_BACKEND` | `disk` | `disk` or `memory` |
 | `EDGE_CACHE_DIR` | `/var/cache/parapet-edge` | Cache root (disk backend only) |
-| `EDGE_CACHE_MAX_SIZE` | `1073741824` (1 GiB) | Total bytes cap, LRU-evicted |
-| `EDGE_CACHE_MAX_FILE_SIZE` | `8388608` (8 MiB) | Per-object bytes cap |
+| `EDGE_CACHE_MAX_SIZE` | `1GiB` | Total size cap, LRU-evicted. Accepts a unit suffix — bare number = bytes, or `kb`/`mb`/`gb`/`tb` (decimal) / `kib`/`mib`/`gib`/`tib` (binary), e.g. `2gib`, `512mb` |
+| `EDGE_CACHE_MAX_FILE_SIZE` | `8MiB` | Per-object size cap (same unit suffixes) |
 | `EDGE_CACHE_CHUNKED` | `true` | Cache GET responses with no `Content-Length` (chunked / on-the-fly-compressed bodies — gzip/br/zstd) by buffering to derive a length; the cap is still enforced mid-stream, SSE is never buffered, and a truncated upstream is never committed. `false` caches only `Content-Length`'d responses |
 | `EDGE_CACHE_PURGE_ENABLED` | `true` | Poll for + apply cache purges (needs `CP_PURGE_ENABLED`) |
 | `EDGE_CACHE_PURGE_POLL_INTERVAL` | `10` (s) | Poll `GET /v1/purges` cadence |

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -12,6 +12,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -296,8 +297,8 @@ func main() {
 	var purgeTable *edge.PurgeTable
 	var purgeStorage cache.Storage // the live backend, for the reaper's Range sweep
 	if cacheEnabled {
-		maxSize := envInt64("EDGE_CACHE_MAX_SIZE", 1<<30)
-		maxFile := envInt64("EDGE_CACHE_MAX_FILE_SIZE", 8<<20)
+		maxSize := envBytes("EDGE_CACHE_MAX_SIZE", 1<<30)
+		maxFile := envBytes("EDGE_CACHE_MAX_FILE_SIZE", 8<<20)
 		var storage cache.Storage
 		var purgeStatePath string // disk backend persists purge state alongside the cache
 		switch envOr("EDGE_CACHE_BACKEND", "disk") {
@@ -663,6 +664,79 @@ func envFloat(key string, def float64) float64 {
 		}
 	}
 	return def
+}
+
+// envBytes reads a byte-size env var that may carry a human-readable unit suffix
+// (e.g. "2gib", "512mb", "1.5 GiB"). A bare number is bytes, so existing numeric
+// values keep working. On a parse error it logs and falls back to def, matching
+// envInt64's lenient posture.
+func envBytes(key string, def int64) int64 {
+	v, ok := os.LookupEnv(key)
+	if !ok {
+		return def
+	}
+	n, err := parseBytes(v)
+	if err != nil {
+		slog.Warn("edge: invalid byte size; using default", "key", key, "value", v, "default", def, "error", err)
+		return def
+	}
+	return n
+}
+
+// parseBytes parses a size like "10", "10b", "2kb", "2kib", "512mb", "1gib",
+// "1.5gb". Units are case-insensitive; decimal (kb/mb/gb/tb = 1000ⁿ) and binary
+// (kib/mib/gib/tib = 1024ⁿ) suffixes are both accepted, and a missing unit means
+// bytes. The result is rounded to the nearest byte and must be ≥ 1.
+func parseBytes(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty size")
+	}
+	// Split into the leading numeric literal and the trailing unit.
+	i := 0
+	for i < len(s) && (s[i] >= '0' && s[i] <= '9' || s[i] == '.' || s[i] == '+' || s[i] == '-') {
+		i++
+	}
+	num, err := strconv.ParseFloat(s[:i], 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid size %q: %w", s, err)
+	}
+	mult, ok := byteUnit(strings.ToLower(strings.TrimSpace(s[i:])))
+	if !ok {
+		return 0, fmt.Errorf("unknown size unit in %q", s)
+	}
+	v := num * mult
+	if v < 1 {
+		return 0, fmt.Errorf("size %q must be >= 1 byte", s)
+	}
+	return int64(v + 0.5), nil
+}
+
+// byteUnit maps a (lowercased) size suffix to its byte multiplier. "" / "b" are
+// bytes; k/m/g/t are decimal (1000ⁿ), ki/mi/gi/ti (with optional trailing "b")
+// are binary (1024ⁿ).
+func byteUnit(u string) (float64, bool) {
+	switch u {
+	case "", "b":
+		return 1, true
+	case "k", "kb":
+		return 1e3, true
+	case "ki", "kib":
+		return 1 << 10, true
+	case "m", "mb":
+		return 1e6, true
+	case "mi", "mib":
+		return 1 << 20, true
+	case "g", "gb":
+		return 1e9, true
+	case "gi", "gib":
+		return 1 << 30, true
+	case "t", "tb":
+		return 1e12, true
+	case "ti", "tib":
+		return 1 << 40, true
+	}
+	return 0, false
 }
 
 // splitDomains parses the comma-separated EDGE_DOMAINS list, trimming entries

--- a/cmd/edge-proxy/main_test.go
+++ b/cmd/edge-proxy/main_test.go
@@ -1,0 +1,51 @@
+package main
+
+import "testing"
+
+func TestParseBytes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int64
+	}{
+		// bare number = bytes (backward compatible with the old envInt64 values)
+		{"1", 1},
+		{"1073741824", 1 << 30},
+		{"1024b", 1024},
+		// decimal units (1000ⁿ)
+		{"2kb", 2000},
+		{"512mb", 512_000_000},
+		{"1gb", 1_000_000_000},
+		{"3tb", 3_000_000_000_000},
+		// binary units (1024ⁿ)
+		{"2kib", 2 << 10},
+		{"8mib", 8 << 20},
+		{"1gib", 1 << 30},
+		{"2gib", 2 << 30},
+		{"1tib", 1 << 40},
+		// case-insensitive + surrounding/inner whitespace
+		{"1GiB", 1 << 30},
+		{"  4 GB  ", 4_000_000_000},
+		{"512MiB", 512 << 20},
+		// fractional
+		{"1.5gib", 1<<30 + 1<<29},
+		{"0.5gb", 500_000_000},
+	}
+	for _, c := range cases {
+		got, err := parseBytes(c.in)
+		if err != nil {
+			t.Errorf("parseBytes(%q) unexpected error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("parseBytes(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseBytes_Errors(t *testing.T) {
+	for _, in := range []string{"", "  ", "abc", "10xb", "gib", "1pb", "0", "-5mb", "0.4b"} {
+		if got, err := parseBytes(in); err == nil {
+			t.Errorf("parseBytes(%q) = %d, want error", in, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`EDGE_CACHE_MAX_SIZE` and `EDGE_CACHE_MAX_FILE_SIZE` previously accepted **raw byte counts only** (e.g. `2147483648`). This adds a byte-size parser so operators can write `2gib`, `512mb`, `1.5gb`, etc.

## What changed

- New `parseBytes` / `byteUnit` helpers in `cmd/edge-proxy/main.go`:
  - **Bare number = bytes** → fully backward compatible with existing numeric configs.
  - **Decimal** suffixes `kb`/`mb`/`gb`/`tb` (1000ⁿ) and **binary** suffixes `kib`/`mib`/`gib`/`tib` (1024ⁿ).
  - Case-insensitive, tolerant of surrounding/inner whitespace (`"  4 GB  "`), fractional values (`1.5gib`), rounded to the nearest byte, must be ≥ 1.
- New `envBytes` wrapper mirrors `envInt64`'s lenient posture — on a bad value it logs a warning and falls back to the default rather than failing startup.
- Applied to **both** cache caps (`EDGE_CACHE_MAX_SIZE`, `EDGE_CACHE_MAX_FILE_SIZE`).

## Examples

```
EDGE_CACHE_MAX_SIZE=2gib        # 2 * 1024³
EDGE_CACHE_MAX_SIZE=512mb       # 512 * 1000²
EDGE_CACHE_MAX_FILE_SIZE=16mib
EDGE_CACHE_MAX_SIZE=2147483648  # still works (bytes)
```

## Tests

`cmd/edge-proxy/main_test.go` covers units (decimal + binary), whitespace, case-insensitivity, fractional values, backward-compat bare bytes, and the error cases (empty, junk, unknown unit, non-positive, sub-byte fraction).

`gofmt -l` clean · `go vet ./cmd/edge-proxy/...` clean · `go test ./cmd/edge-proxy/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)