### PR TITLE
refactor(k8s): watch EndpointSlices instead of deprecated Endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ and the upstream hop.
 ## Key concepts
 
 ### Controller lifecycle
-`Controller.Watch()` starts four goroutines that continuously watch Ingress, Service, Secret, and EndpointSlice resources (plus a fifth, WAF ConfigMaps, when `WAF_ENABLED=true`, a sixth, rate-limit ConfigMaps, when `RATELIMIT_ENABLED=true`, and a seventh, Coraza ConfigMaps, when `CORAZA_ENABLED=true`). Changes are coalesced through a 300 ms `debounce.Debounce` before triggering a reload. On reload, a new `http.ServeMux` is built and swapped in atomically (`atomic.Pointer[routeState]`) — zero downtime. WAF, rate-limit, and Coraza ConfigMap changes are the exception: they recompile their rulesets/limit sets without rebuilding the mux (see the WAF, rate-limit, and Coraza concepts below).
+`Controller.Watch()` starts five goroutines that continuously watch Ingress, Service, Secret, EndpointSlice, and (legacy fallback) Endpoints resources (plus a sixth, WAF ConfigMaps, when `WAF_ENABLED=true`, a seventh, rate-limit ConfigMaps, when `RATELIMIT_ENABLED=true`, and an eighth, Coraza ConfigMaps, when `CORAZA_ENABLED=true`). Changes are coalesced through a 300 ms `debounce.Debounce` before triggering a reload. On reload, a new `http.ServeMux` is built and swapped in atomically (`atomic.Pointer[routeState]`) — zero downtime. WAF, rate-limit, and Coraza ConfigMap changes are the exception: they recompile their rulesets/limit sets without rebuilding the mux (see the WAF, rate-limit, and Coraza concepts below).
 
 ### Plugins
 A `Plugin` is `func(ctx plugin.Context)` where `Context` carries:
@@ -110,7 +110,7 @@ Routes are keyed as `host + path` strings (e.g. `"www.example.com/api/"`). PathT
 - `Exact` → registers `host/path` only (strips trailing slash)
 - `ImplementationSpecific` → registers as-is
 
-Endpoint lookup is round-robin (`route.RRLB`). Pod IPs come from the Service's EndpointSlices (`discovery.k8s.io/v1`) — a Service may own several slices, so they're unioned (ready addresses only, keyed back to the Service via the `kubernetes.io/service-name` label). Bad addresses (dial errors) are marked and skipped temporarily.
+Endpoint lookup is round-robin (`route.RRLB`). Pod IPs come from the Service's EndpointSlices (`discovery.k8s.io/v1`) — a Service may own several slices, so they're unioned (ready addresses only, keyed back to the Service via the `kubernetes.io/service-name` label). **EndpointSlices are authoritative**: a Service that owns at least one slice (even an empty one) is routed from its slices alone; only a Service with *no* slice falls back to its legacy `Endpoints` object (`aggregateServiceIPs` / `resolveTargetPort`, the no-mirror / `skip-mirror` case). Bad addresses (dial errors) are marked and skipped temporarily.
 
 **ExternalName Services** (`spec.type: ExternalName`) are supported via a separate `route.Table` map (`addrToExternalName`, set by `reloadServiceDebounced` via `SetExternalNameRoutes` — full-replace, so it never races the incremental endpoint host-route path). They have no EndpointSlices, so `Table.Lookup` falls back to dialing `spec.externalName` (resolved by the dialer's `net.Resolver`) on the **service port** the ingress references (no `targetPort` indirection; no RRLB/bad-addr — single target). A pod-backed host route takes precedence over an ExternalName one (only transiently overlapping during a type change). See [`SPEC.md`](SPEC.md).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # parapet-ingress-controller
 
-A Kubernetes ingress controller built in Go on the [parapet](https://github.com/moonrhythm/parapet) middleware framework. It watches Kubernetes Ingress, Service, Secret, ConfigMap, and Endpoints resources and hot-reloads an `http.ServeMux` router without restarting the process.
+A Kubernetes ingress controller built in Go on the [parapet](https://github.com/moonrhythm/parapet) middleware framework. It watches Kubernetes Ingress, Service, Secret, ConfigMap, and EndpointSlice resources and hot-reloads an `http.ServeMux` router without restarting the process.
 
 > The behavior contract — annotations, env vars, metrics, WAF model,
 > per-request order — is [`SPEC.md`](SPEC.md): change behavior in the code and
@@ -94,7 +94,7 @@ and the upstream hop.
 ## Key concepts
 
 ### Controller lifecycle
-`Controller.Watch()` starts four goroutines that continuously watch Ingress, Service, Secret, and Endpoints resources (plus a fifth, WAF ConfigMaps, when `WAF_ENABLED=true`, a sixth, rate-limit ConfigMaps, when `RATELIMIT_ENABLED=true`, and a seventh, Coraza ConfigMaps, when `CORAZA_ENABLED=true`). Changes are coalesced through a 300 ms `debounce.Debounce` before triggering a reload. On reload, a new `http.ServeMux` is built and swapped in atomically (`atomic.Pointer[routeState]`) — zero downtime. WAF, rate-limit, and Coraza ConfigMap changes are the exception: they recompile their rulesets/limit sets without rebuilding the mux (see the WAF, rate-limit, and Coraza concepts below).
+`Controller.Watch()` starts four goroutines that continuously watch Ingress, Service, Secret, and EndpointSlice resources (plus a fifth, WAF ConfigMaps, when `WAF_ENABLED=true`, a sixth, rate-limit ConfigMaps, when `RATELIMIT_ENABLED=true`, and a seventh, Coraza ConfigMaps, when `CORAZA_ENABLED=true`). Changes are coalesced through a 300 ms `debounce.Debounce` before triggering a reload. On reload, a new `http.ServeMux` is built and swapped in atomically (`atomic.Pointer[routeState]`) — zero downtime. WAF, rate-limit, and Coraza ConfigMap changes are the exception: they recompile their rulesets/limit sets without rebuilding the mux (see the WAF, rate-limit, and Coraza concepts below).
 
 ### Plugins
 A `Plugin` is `func(ctx plugin.Context)` where `Context` carries:
@@ -110,9 +110,9 @@ Routes are keyed as `host + path` strings (e.g. `"www.example.com/api/"`). PathT
 - `Exact` → registers `host/path` only (strips trailing slash)
 - `ImplementationSpecific` → registers as-is
 
-Endpoint lookup is round-robin (`route.RRLB`). Bad addresses (dial errors) are marked and skipped temporarily.
+Endpoint lookup is round-robin (`route.RRLB`). Pod IPs come from the Service's EndpointSlices (`discovery.k8s.io/v1`) — a Service may own several slices, so they're unioned (ready addresses only, keyed back to the Service via the `kubernetes.io/service-name` label). Bad addresses (dial errors) are marked and skipped temporarily.
 
-**ExternalName Services** (`spec.type: ExternalName`) are supported via a separate `route.Table` map (`addrToExternalName`, set by `reloadServiceDebounced` via `SetExternalNameRoutes` — full-replace, so it never races the incremental endpoint host-route path). They have no Endpoints, so `Table.Lookup` falls back to dialing `spec.externalName` (resolved by the dialer's `net.Resolver`) on the **service port** the ingress references (no `targetPort` indirection; no RRLB/bad-addr — single target). A pod-backed host route takes precedence over an ExternalName one (only transiently overlapping during a type change). See [`SPEC.md`](SPEC.md).
+**ExternalName Services** (`spec.type: ExternalName`) are supported via a separate `route.Table` map (`addrToExternalName`, set by `reloadServiceDebounced` via `SetExternalNameRoutes` — full-replace, so it never races the incremental endpoint host-route path). They have no EndpointSlices, so `Table.Lookup` falls back to dialing `spec.externalName` (resolved by the dialer's `net.Resolver`) on the **service port** the ingress references (no `targetPort` indirection; no RRLB/bad-addr — single target). A pod-backed host route takes precedence over an ExternalName one (only transiently overlapping during a type change). See [`SPEC.md`](SPEC.md).
 
 ### TLS
 TLS secrets are loaded from `Secret.Data["tls.crt"]` / `["tls.key"]`. The `cert.Table` provides `GetCertificate` for SNI-based lookup (exact match, then a single-label wildcard climb), plugged directly into `tls.Config`. By default only secrets referenced by an Ingress's `spec.tls.secretName` are loaded; set `LOAD_ALL_CERTS=true` to index every TLS-typed secret in the watch namespace (lets a wildcard cert serve SNI without per-ingress wiring).

--- a/SPEC.md
+++ b/SPEC.md
@@ -20,12 +20,13 @@ Routes are keyed `host + path`. PathType semantics:
 | `Exact` | `host/path` only (trailing slash stripped; root `/` falls back to prefix) |
 | `ImplementationSpecific` | as-is |
 
-Backends resolve to a Service `host:port`, then to pod IPs via Endpoints.
-Endpoint selection is **round-robin**; an address that fails to dial is marked
-**bad for 2s** and skipped (reactive health — no active probing). Host is
-lowercased and port-stripped before matching.
+Backends resolve to a Service `host:port`, then to pod IPs via EndpointSlices
+(`discovery.k8s.io/v1`; a Service's slices are unioned into one address set,
+ready addresses only). Endpoint selection is **round-robin**; an address that
+fails to dial is marked **bad for 2s** and skipped (reactive health — no active
+probing). Host is lowercased and port-stripped before matching.
 
-A Service of `type: ExternalName` is also supported: it has no Endpoints, so the
+A Service of `type: ExternalName` is also supported: it has no EndpointSlices, so the
 backend is dialed at its `spec.externalName` (an external DNS name, resolved at
 connect time) on the **Service port the ingress references** (`targetPort` is a
 pod concept and does not apply to a DNS CNAME — the port the ingress addresses is

--- a/SPEC.md
+++ b/SPEC.md
@@ -22,7 +22,9 @@ Routes are keyed `host + path`. PathType semantics:
 
 Backends resolve to a Service `host:port`, then to pod IPs via EndpointSlices
 (`discovery.k8s.io/v1`; a Service's slices are unioned into one address set,
-ready addresses only). Endpoint selection is **round-robin**; an address that
+ready addresses only). EndpointSlices are authoritative; a Service with **no**
+slice falls back to its legacy `Endpoints` object (the no-mirror / `skip-mirror`
+case). Endpoint selection is **round-robin**; an address that
 fails to dial is marked **bad for 2s** and skipped (reactive health — no active
 probing). Host is lowercased and port-stripped before matching.
 

--- a/controller.go
+++ b/controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moonrhythm/parapet/pkg/healthz"
 	"github.com/moonrhythm/parapet/pkg/waf"
 	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -150,7 +151,7 @@ type Controller struct {
 	watchedIngresses        sync.Map
 	watchedServices         sync.Map
 	watchedSecrets          sync.Map
-	watchedEndpoints        sync.Map
+	watchedEndpointSlices   sync.Map
 	watchedConfigMaps       sync.Map
 	watchedRLConfigMaps     sync.Map
 	watchedCorazaConfigMaps sync.Map
@@ -213,7 +214,7 @@ func (ctrl *Controller) Watch() {
 	go ctrl.watchIngresses(ctx)
 	go ctrl.watchServices(ctx)
 	go ctrl.watchSecrets(ctx)
-	go ctrl.watchEndpoints(ctx)
+	go ctrl.watchEndpointSlices(ctx)
 	if ctrl.WAFConfig.Enabled {
 		go ctrl.watchConfigMaps(ctx)
 	}
@@ -262,13 +263,13 @@ func (ctrl *Controller) preloadResources(ctx context.Context) {
 		}
 		return nil
 	})
-	preloadList(ctx, "endpoints", func() error {
-		endpoints, err := k8s.GetEndpoints(ctx, ctrl.watchNamespace)
+	preloadList(ctx, "endpointslices", func() error {
+		slices, err := k8s.GetEndpointSlices(ctx, ctrl.watchNamespace)
 		if err != nil {
 			return err
 		}
-		for i := range endpoints {
-			ctrl.watchedEndpoints.Store(endpoints[i].Namespace+"/"+endpoints[i].Name, &endpoints[i])
+		for i := range slices {
+			ctrl.watchedEndpointSlices.Store(slices[i].Namespace+"/"+slices[i].Name, &slices[i])
 		}
 		return nil
 	})
@@ -509,24 +510,26 @@ func (ctrl *Controller) watchSecrets(ctx context.Context) {
 	)
 }
 
-func (ctrl *Controller) watchEndpoints(ctx context.Context) {
-	// a single endpoint event only touches its own service's host, so both
-	// upsert and delete update just that one host in place instead of rebuilding
-	// the whole endpoint table. The full rebuild (reloadEndpointDebounced) is
-	// reserved for the initial sync / resync in firstReload, where the entire
-	// set is (re)listed.
-	watchResource(ctx, ctrl.watchNamespace, "endpoints", k8s.WatchEndpoints, k8s.GetEndpoints,
-		&ctrl.watchedEndpoints,
-		func(ep *v1.Endpoints) {
-			ctrl.reloadSingleEndpoint(ep)
-			// Endpoints carry the numeric port a *named* Service targetPort resolves
-			// to, so a service whose named port wasn't resolvable at service-reload
-			// time (endpoints not yet present) converges once its endpoints arrive.
-			// Debounced, so high endpoint churn coalesces into at most one cheap
-			// port-table rebuild per window.
+func (ctrl *Controller) watchEndpointSlices(ctx context.Context) {
+	// A single EndpointSlice event only touches its own Service's host, so both
+	// upsert and delete recompute just that one host in place (by re-aggregating
+	// the Service's slices from the store) instead of rebuilding the whole
+	// endpoint table. The full rebuild (reloadEndpointDebounced) is reserved for
+	// the initial sync / resync in firstReload, where the entire set is (re)listed.
+	watchResource(ctx, ctrl.watchNamespace, "endpointslices", k8s.WatchEndpointSlices, k8s.GetEndpointSlices,
+		&ctrl.watchedEndpointSlices,
+		func(es *discovery.EndpointSlice) {
+			ctrl.reloadEndpointSlice(es)
+			// EndpointSlices carry the numeric port a *named* Service targetPort
+			// resolves to, so a service whose named port wasn't resolvable at
+			// service-reload time (slices not yet present) converges once its slices
+			// arrive. Debounced, so high endpoint churn coalesces into at most one
+			// cheap port-table rebuild per window.
 			ctrl.reloadService()
 		},
-		ctrl.deleteSingleEndpoint,
+		// delete: the store has already dropped this slice, so re-aggregating the
+		// Service drops the host when its last slice is gone.
+		ctrl.reloadEndpointSlice,
 		// resync: rebuild the full host-route table from the reconciled store.
 		ctrl.reloadEndpointDebounced,
 	)
@@ -745,8 +748,8 @@ func (ctrl *Controller) reloadServiceDebounced() {
 // resolveTargetPort returns the concrete numeric pod port (as a string) a
 // ServicePort routes to. A numeric targetPort is used directly. A *named*
 // targetPort (intstr.String) carries no number in the Service object, so it is
-// resolved from the service's Endpoints — matching the EndpointPort whose Name
-// equals this ServicePort's Name (Kubernetes keys EndpointPort.Name to
+// resolved from the service's EndpointSlices — matching the EndpointPort whose
+// Name equals this ServicePort's Name (Kubernetes keys EndpointPort.Name to
 // ServicePort.Name). Returns ok=false when a named port can't be resolved yet,
 // so the caller skips it instead of producing a dead ":0" route.
 func (ctrl *Controller) resolveTargetPort(s *v1.Service, p v1.ServicePort) (string, bool) {
@@ -759,19 +762,26 @@ func (ctrl *Controller) resolveTargetPort(s *v1.Service, p v1.ServicePort) (stri
 		return strconv.Itoa(int(p.Port)), true
 	}
 
-	v, ok := ctrl.watchedEndpoints.Load(s.Namespace + "/" + s.Name)
-	if !ok {
-		return "", false
-	}
-	ep := v.(*v1.Endpoints)
-	for _, ss := range ep.Subsets {
-		for _, epp := range ss.Ports {
-			if epp.Name == p.Name && epp.Port > 0 {
-				return strconv.Itoa(int(epp.Port)), true
+	// Scan the service's EndpointSlices (a service may own several) for the
+	// matching named port. All slices of a service share the same port set, so
+	// the first match wins.
+	var resolved string
+	var found bool
+	ctrl.watchedEndpointSlices.Range(func(_, value any) bool {
+		es := value.(*discovery.EndpointSlice)
+		if es.Namespace != s.Namespace || sliceServiceName(es) != s.Name {
+			return true
+		}
+		for _, epp := range es.Ports {
+			if epp.Name != nil && *epp.Name == p.Name && epp.Port != nil && *epp.Port > 0 {
+				resolved = strconv.Itoa(int(*epp.Port))
+				found = true
+				return false
 			}
 		}
-	}
-	return "", false
+		return true
+	})
+	return resolved, found
 }
 
 func (ctrl *Controller) reloadSecret() {
@@ -842,9 +852,13 @@ func (ctrl *Controller) reloadSecretDebounced() {
 }
 
 // reloadEndpointDebounced rebuilds the entire host -> pod-IP table from the
-// whole watched-endpoints store. It is the initial-sync / resync path (called
-// from firstReload); steady-state endpoint events are applied incrementally
-// per host by reloadSingleEndpoint / deleteSingleEndpoint and never come here.
+// whole watched-endpointslices store. It is the initial-sync / resync path
+// (called from firstReload); steady-state endpoint events are applied
+// incrementally per host by reloadEndpointSlice and never come here.
+//
+// A Service may own several EndpointSlices, so this groups slices by their
+// owning Service (the kubernetes.io/service-name label) in a single pass and
+// unions the ready addresses of all of a Service's slices into one RRLB.
 func (ctrl *Controller) reloadEndpointDebounced() {
 	defer func() {
 		if err := recover(); err != nil {
@@ -853,30 +867,68 @@ func (ctrl *Controller) reloadEndpointDebounced() {
 	}()
 
 	routes := make(map[string]*route.RRLB, endpointSizeHint)
-	ctrl.watchedEndpoints.Range(func(_, value any) bool {
-		ep := value.(*v1.Endpoints)
-		if lb := endpointToRRLB(ep); lb != nil {
-			routes[buildHost(ep.Namespace, ep.Name)] = lb
+	ctrl.watchedEndpointSlices.Range(func(_, value any) bool {
+		es := value.(*discovery.EndpointSlice)
+		svc := sliceServiceName(es)
+		if svc == "" {
+			return true
 		}
+		host := buildHost(es.Namespace, svc)
+		lb := routes[host]
+		if lb == nil {
+			lb = &route.RRLB{}
+			routes[host] = lb
+		}
+		appendReadyIPs(lb, es)
 		return true
 	})
+
+	// Drop services whose slices yielded no ready address — an empty RRLB would
+	// 503 anyway, and leaving it out keeps Lookup's host-present check meaningful.
+	for host, lb := range routes {
+		if len(lb.IPs) == 0 {
+			delete(routes, host)
+		}
+	}
 
 	ctrl.routeTable.SetHostRoutes(routes)
 	slog.Info("reloaded endpoints", "hosts", len(routes))
 }
 
-func (ctrl *Controller) reloadSingleEndpoint(ep *v1.Endpoints) {
-	slog.Debug("reload single endpoint", "namespace", ep.Namespace, "name", ep.Name)
+// reloadEndpointSlice recomputes the host route for the Service owning es by
+// re-aggregating every slice the Service currently has in the store, then
+// swapping just that one host entry. It serves both upsert and delete events:
+// on delete the store has already dropped es, so an empty aggregate deletes the
+// host (SetHostRoute(nil)). The store is written only by the single endpoint
+// watch goroutine, which is also the only caller here, so the Range is consistent.
+func (ctrl *Controller) reloadEndpointSlice(es *discovery.EndpointSlice) {
+	svc := sliceServiceName(es)
+	if svc == "" {
+		slog.Warn("endpointslice without service-name label", "namespace", es.Namespace, "name", es.Name)
+		return
+	}
+	slog.Debug("reload endpointslice", "namespace", es.Namespace, "service", svc, "name", es.Name)
 
-	ctrl.routeTable.SetHostRoute(buildHost(ep.Namespace, ep.Name), endpointToRRLB(ep))
+	ctrl.routeTable.SetHostRoute(buildHost(es.Namespace, svc), ctrl.aggregateServiceIPs(es.Namespace, svc))
 }
 
-func (ctrl *Controller) deleteSingleEndpoint(ep *v1.Endpoints) {
-	slog.Debug("delete single endpoint", "namespace", ep.Namespace, "name", ep.Name)
-
-	// the host is gone, so drop just that one entry; passing nil makes
-	// SetHostRoute delete it, leaving the rest of the table untouched.
-	ctrl.routeTable.SetHostRoute(buildHost(ep.Namespace, ep.Name), nil)
+// aggregateServiceIPs unions the ready addresses of every watched EndpointSlice
+// owned by namespace/serviceName into one RRLB, or returns nil when none have a
+// ready address (so SetHostRoute deletes the host).
+func (ctrl *Controller) aggregateServiceIPs(namespace, serviceName string) *route.RRLB {
+	var b route.RRLB
+	ctrl.watchedEndpointSlices.Range(func(_, value any) bool {
+		es := value.(*discovery.EndpointSlice)
+		if es.Namespace != namespace || sliceServiceName(es) != serviceName {
+			return true
+		}
+		appendReadyIPs(&b, es)
+		return true
+	})
+	if len(b.IPs) == 0 {
+		return nil
+	}
+	return &b
 }
 
 func (ctrl *Controller) GetCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
@@ -1018,15 +1070,27 @@ func (ctrl *Controller) makeHandler(ing *networking.Ingress, svc *v1.Service, co
 	})
 }
 
-func endpointToRRLB(ep *v1.Endpoints) *route.RRLB {
-	var b route.RRLB
-	for _, ss := range ep.Subsets {
-		for _, addr := range ss.Addresses {
-			b.IPs = append(b.IPs, addr.IP)
+// sliceServiceName returns the name of the Service an EndpointSlice belongs to,
+// from the well-known kubernetes.io/service-name label, or "" if unset (e.g. a
+// hand-written slice not owned by a Service — skipped, as it maps to no host).
+func sliceServiceName(es *discovery.EndpointSlice) string {
+	return es.Labels[discovery.LabelServiceName]
+}
+
+// appendReadyIPs appends the ready addresses of an EndpointSlice to lb. Only
+// IPv4/IPv6 slices contribute pod IPs; FQDN slices carry hostnames the RRLB
+// can't treat as pod IPs (and never arise for the normal selector-backed
+// services this resolves). A nil Ready is treated as ready per the EndpointSlice
+// contract, matching the legacy Endpoints.Subsets[].Addresses behavior (which
+// only listed ready addresses).
+func appendReadyIPs(lb *route.RRLB, es *discovery.EndpointSlice) {
+	if es.AddressType == discovery.AddressTypeFQDN {
+		return
+	}
+	for _, e := range es.Endpoints {
+		if e.Conditions.Ready != nil && !*e.Conditions.Ready {
+			continue
 		}
+		lb.IPs = append(lb.IPs, e.Addresses...)
 	}
-	if len(b.IPs) == 0 {
-		return nil
-	}
-	return &b
 }

--- a/controller.go
+++ b/controller.go
@@ -147,11 +147,22 @@ type Controller struct {
 	globalCorazaFingerprint string
 	corazaZoneFingerprints  map[string]string
 
+	// endpointReloadMu serializes host-route recomputes. Two watch goroutines now
+	// feed pod IPs — the EndpointSlice watch and the legacy-Endpoints fallback
+	// watch — and both compute a Service's host route by reading the slice +
+	// endpoints stores and then SetHostRoute. Without serialization, one
+	// goroutine could read a now-stale "slice present" state and write its result
+	// after the other goroutine wrote the fresh "slice gone → fallback" result,
+	// clobbering it. Holding this across read+write makes the last writer also the
+	// latest reader, so the route always reflects the current store state.
+	endpointReloadMu sync.Mutex
+
 	// holds current k8s state
 	watchedIngresses        sync.Map
 	watchedServices         sync.Map
 	watchedSecrets          sync.Map
 	watchedEndpointSlices   sync.Map
+	watchedEndpoints        sync.Map // legacy fallback: only used for services with no EndpointSlice
 	watchedConfigMaps       sync.Map
 	watchedRLConfigMaps     sync.Map
 	watchedCorazaConfigMaps sync.Map
@@ -215,6 +226,7 @@ func (ctrl *Controller) Watch() {
 	go ctrl.watchServices(ctx)
 	go ctrl.watchSecrets(ctx)
 	go ctrl.watchEndpointSlices(ctx)
+	go ctrl.watchEndpoints(ctx)
 	if ctrl.WAFConfig.Enabled {
 		go ctrl.watchConfigMaps(ctx)
 	}
@@ -270,6 +282,16 @@ func (ctrl *Controller) preloadResources(ctx context.Context) {
 		}
 		for i := range slices {
 			ctrl.watchedEndpointSlices.Store(slices[i].Namespace+"/"+slices[i].Name, &slices[i])
+		}
+		return nil
+	})
+	preloadList(ctx, "endpoints", func() error {
+		endpoints, err := k8s.GetEndpoints(ctx, ctrl.watchNamespace)
+		if err != nil {
+			return err
+		}
+		for i := range endpoints {
+			ctrl.watchedEndpoints.Store(endpoints[i].Namespace+"/"+endpoints[i].Name, &endpoints[i])
 		}
 		return nil
 	})
@@ -535,6 +557,29 @@ func (ctrl *Controller) watchEndpointSlices(ctx context.Context) {
 	)
 }
 
+func (ctrl *Controller) watchEndpoints(ctx context.Context) {
+	// Legacy Endpoints watch — the fallback for a Service that has NO
+	// EndpointSlice (e.g. hand-managed Endpoints labeled
+	// endpointslice.kubernetes.io/skip-mirror=true, or a cluster without the
+	// EndpointSlice mirroring controller). aggregateServiceIPs / resolveTargetPort
+	// only consult this store when the Service has zero slices, so on any normal
+	// Service these events recompute a host route that immediately re-prefers the
+	// slices and changes nothing. Keyed by Service name (an Endpoints object is
+	// named after its Service), matching buildHost.
+	watchResource(ctx, ctrl.watchNamespace, "endpoints", k8s.WatchEndpoints, k8s.GetEndpoints,
+		&ctrl.watchedEndpoints,
+		func(ep *v1.Endpoints) {
+			ctrl.reloadEndpointsObject(ep)
+			ctrl.reloadService() // converge a named targetPort resolvable only from Endpoints
+		},
+		// delete: the store has already dropped this object, so re-aggregating the
+		// Service drops the host when it has neither a slice nor an Endpoints object.
+		ctrl.reloadEndpointsObject,
+		// resync: rebuild the full host-route table from the reconciled stores.
+		ctrl.reloadEndpointDebounced,
+	)
+}
+
 func (ctrl *Controller) reloadIngress() {
 	ctrl.reloadIngressDebounce.Call()
 }
@@ -750,8 +795,10 @@ func (ctrl *Controller) reloadServiceDebounced() {
 // targetPort (intstr.String) carries no number in the Service object, so it is
 // resolved from the service's EndpointSlices — matching the EndpointPort whose
 // Name equals this ServicePort's Name (Kubernetes keys EndpointPort.Name to
-// ServicePort.Name). Returns ok=false when a named port can't be resolved yet,
-// so the caller skips it instead of producing a dead ":0" route.
+// ServicePort.Name). A Service with no EndpointSlice falls back to its legacy
+// Endpoints object (the same authoritative-slice rule as aggregateServiceIPs).
+// Returns ok=false when a named port can't be resolved yet, so the caller skips
+// it instead of producing a dead ":0" route.
 func (ctrl *Controller) resolveTargetPort(s *v1.Service, p v1.ServicePort) (string, bool) {
 	if p.TargetPort.Type == intstr.Int {
 		if p.TargetPort.IntVal > 0 {
@@ -766,12 +813,13 @@ func (ctrl *Controller) resolveTargetPort(s *v1.Service, p v1.ServicePort) (stri
 	// matching named port. All slices of a service share the same port set, so
 	// the first match wins.
 	var resolved string
-	var found bool
+	var found, sliceExists bool
 	ctrl.watchedEndpointSlices.Range(func(_, value any) bool {
 		es := value.(*discovery.EndpointSlice)
 		if es.Namespace != s.Namespace || sliceServiceName(es) != s.Name {
 			return true
 		}
+		sliceExists = true
 		for _, epp := range es.Ports {
 			if epp.Name != nil && *epp.Name == p.Name && epp.Port != nil && *epp.Port > 0 {
 				resolved = strconv.Itoa(int(*epp.Port))
@@ -781,7 +829,26 @@ func (ctrl *Controller) resolveTargetPort(s *v1.Service, p v1.ServicePort) (stri
 		}
 		return true
 	})
-	return resolved, found
+	if found {
+		return resolved, true
+	}
+	if sliceExists {
+		// Slices are authoritative; do not fall back when they exist but lack the port.
+		return "", false
+	}
+
+	// No EndpointSlice for this Service — fall back to the legacy Endpoints object.
+	if v, ok := ctrl.watchedEndpoints.Load(s.Namespace + "/" + s.Name); ok {
+		ep := v.(*v1.Endpoints)
+		for _, ss := range ep.Subsets {
+			for _, epp := range ss.Ports {
+				if epp.Name == p.Name && epp.Port > 0 {
+					return strconv.Itoa(int(epp.Port)), true
+				}
+			}
+		}
+	}
+	return "", false
 }
 
 func (ctrl *Controller) reloadSecret() {
@@ -852,13 +919,16 @@ func (ctrl *Controller) reloadSecretDebounced() {
 }
 
 // reloadEndpointDebounced rebuilds the entire host -> pod-IP table from the
-// whole watched-endpointslices store. It is the initial-sync / resync path
-// (called from firstReload); steady-state endpoint events are applied
-// incrementally per host by reloadEndpointSlice and never come here.
+// whole watched-endpointslices store (with a legacy-Endpoints fallback). It is
+// the initial-sync / resync path (called from firstReload); steady-state endpoint
+// events are applied incrementally per host by reloadEndpointSlice /
+// reloadEndpointsObject and never come here.
 //
 // A Service may own several EndpointSlices, so this groups slices by their
 // owning Service (the kubernetes.io/service-name label) in a single pass and
-// unions the ready addresses of all of a Service's slices into one RRLB.
+// unions the ready addresses of all of a Service's slices into one RRLB. A
+// Service that has NO slice falls back to its legacy Endpoints object — slices
+// are authoritative, so a host already produced from slices is never overwritten.
 func (ctrl *Controller) reloadEndpointDebounced() {
 	defer func() {
 		if err := recover(); err != nil {
@@ -866,7 +936,13 @@ func (ctrl *Controller) reloadEndpointDebounced() {
 		}
 	}()
 
+	// Serialize with the incremental per-host updates (both watch goroutines):
+	// this full replace and a single-host SetHostRoute must not interleave.
+	ctrl.endpointReloadMu.Lock()
+	defer ctrl.endpointReloadMu.Unlock()
+
 	routes := make(map[string]*route.RRLB, endpointSizeHint)
+	sliceHosts := make(map[string]struct{}, endpointSizeHint)
 	ctrl.watchedEndpointSlices.Range(func(_, value any) bool {
 		es := value.(*discovery.EndpointSlice)
 		svc := sliceServiceName(es)
@@ -874,6 +950,7 @@ func (ctrl *Controller) reloadEndpointDebounced() {
 			return true
 		}
 		host := buildHost(es.Namespace, svc)
+		sliceHosts[host] = struct{}{} // slice-managed (even if it yields no ready IP)
 		lb := routes[host]
 		if lb == nil {
 			lb = &route.RRLB{}
@@ -883,8 +960,26 @@ func (ctrl *Controller) reloadEndpointDebounced() {
 		return true
 	})
 
-	// Drop services whose slices yielded no ready address — an empty RRLB would
-	// 503 anyway, and leaving it out keeps Lookup's host-present check meaningful.
+	// Fallback: services with no EndpointSlice are routed from their legacy
+	// Endpoints object. A host present in sliceHosts is skipped — slices win even
+	// when they currently resolve to zero ready addresses.
+	ctrl.watchedEndpoints.Range(func(_, value any) bool {
+		ep := value.(*v1.Endpoints)
+		host := buildHost(ep.Namespace, ep.Name)
+		if _, ok := sliceHosts[host]; ok {
+			return true
+		}
+		lb := routes[host]
+		if lb == nil {
+			lb = &route.RRLB{}
+			routes[host] = lb
+		}
+		appendEndpointsReadyIPs(lb, ep)
+		return true
+	})
+
+	// Drop services that yielded no ready address — an empty RRLB would 503
+	// anyway, and leaving it out keeps Lookup's host-present check meaningful.
 	for host, lb := range routes {
 		if len(lb.IPs) == 0 {
 			delete(routes, host)
@@ -909,22 +1004,50 @@ func (ctrl *Controller) reloadEndpointSlice(es *discovery.EndpointSlice) {
 	}
 	slog.Debug("reload endpointslice", "namespace", es.Namespace, "service", svc, "name", es.Name)
 
+	ctrl.endpointReloadMu.Lock()
+	defer ctrl.endpointReloadMu.Unlock()
 	ctrl.routeTable.SetHostRoute(buildHost(es.Namespace, svc), ctrl.aggregateServiceIPs(es.Namespace, svc))
 }
 
+// reloadEndpointsObject recomputes the host route for the Service named by a
+// legacy Endpoints object (its name is the Service name). It re-runs the same
+// slice-first aggregation, so the legacy addresses take effect only while the
+// Service has no EndpointSlice; the moment slices appear they win. Serves both
+// upsert and delete (delete leaves an empty aggregate that drops the host).
+func (ctrl *Controller) reloadEndpointsObject(ep *v1.Endpoints) {
+	slog.Debug("reload endpoints", "namespace", ep.Namespace, "name", ep.Name)
+
+	ctrl.endpointReloadMu.Lock()
+	defer ctrl.endpointReloadMu.Unlock()
+	ctrl.routeTable.SetHostRoute(buildHost(ep.Namespace, ep.Name), ctrl.aggregateServiceIPs(ep.Namespace, ep.Name))
+}
+
 // aggregateServiceIPs unions the ready addresses of every watched EndpointSlice
-// owned by namespace/serviceName into one RRLB, or returns nil when none have a
-// ready address (so SetHostRoute deletes the host).
+// owned by namespace/serviceName into one RRLB. EndpointSlices are authoritative:
+// if the Service owns at least one slice (even an empty one), its slices alone
+// decide the route. Only when the Service has NO slice does it fall back to the
+// legacy Endpoints object (keyed by Service name). Returns nil when neither
+// source yields a ready address (so SetHostRoute deletes the host).
 func (ctrl *Controller) aggregateServiceIPs(namespace, serviceName string) *route.RRLB {
 	var b route.RRLB
+	var sliceExists bool
 	ctrl.watchedEndpointSlices.Range(func(_, value any) bool {
 		es := value.(*discovery.EndpointSlice)
 		if es.Namespace != namespace || sliceServiceName(es) != serviceName {
 			return true
 		}
+		sliceExists = true
 		appendReadyIPs(&b, es)
 		return true
 	})
+
+	if !sliceExists {
+		// No EndpointSlice for this Service — fall back to its legacy Endpoints.
+		if v, ok := ctrl.watchedEndpoints.Load(namespace + "/" + serviceName); ok {
+			appendEndpointsReadyIPs(&b, v.(*v1.Endpoints))
+		}
+	}
+
 	if len(b.IPs) == 0 {
 		return nil
 	}
@@ -1092,5 +1215,16 @@ func appendReadyIPs(lb *route.RRLB, es *discovery.EndpointSlice) {
 			continue
 		}
 		lb.IPs = append(lb.IPs, e.Addresses...)
+	}
+}
+
+// appendEndpointsReadyIPs appends the ready addresses of a legacy Endpoints
+// object to lb. Subsets[].Addresses holds the ready set (NotReadyAddresses is
+// excluded), mirroring appendReadyIPs for the no-EndpointSlice fallback.
+func appendEndpointsReadyIPs(lb *route.RRLB, ep *v1.Endpoints) {
+	for _, ss := range ep.Subsets {
+		for _, addr := range ss.Addresses {
+			lb.IPs = append(lb.IPs, addr.IP)
+		}
 	}
 }

--- a/controller_endpoint_test.go
+++ b/controller_endpoint_test.go
@@ -4,30 +4,35 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func endpoints(namespace, name string, ips ...string) *v1.Endpoints {
-	ep := &v1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+// endpointSlice builds an IPv4 EndpointSlice for namespace/svcName (carrying the
+// kubernetes.io/service-name label the controller maps back to a host). All
+// addresses are ready. sliceName is the slice's own object name — a Service may
+// own several, so tests vary it to model multiple slices per Service.
+func endpointSlice(namespace, svcName, sliceName string, ips ...string) *discovery.EndpointSlice {
+	es := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      sliceName,
+			Labels:    map[string]string{discovery.LabelServiceName: svcName},
+		},
+		AddressType: discovery.AddressTypeIPv4,
 	}
-	if len(ips) > 0 {
-		addrs := make([]v1.EndpointAddress, 0, len(ips))
-		for _, ip := range ips {
-			addrs = append(addrs, v1.EndpointAddress{IP: ip})
-		}
-		ep.Subsets = []v1.EndpointSubset{{Addresses: addrs}}
+	for _, ip := range ips {
+		es.Endpoints = append(es.Endpoints, discovery.Endpoint{Addresses: []string{ip}})
 	}
-	return ep
+	return es
 }
 
-// TestReloadSingleEndpoint checks that the per-event endpoint path
-// (reloadSingleEndpoint upsert / deleteSingleEndpoint delete) leaves the route
+// TestReloadEndpointSlice checks that the per-event EndpointSlice path
+// (reloadEndpointSlice, driven off the watched-slices store) leaves the route
 // table in the same state a full reloadEndpointDebounced rebuild would, for the
-// four cases that matter on pod churn: add a host, change a host's IPs, delete a
-// host, and a no-op re-upsert.
-func TestReloadSingleEndpoint(t *testing.T) {
+// cases that matter on pod churn: add a host, change a host's IPs, two slices
+// unioning into one host, delete a slice, delete a host, and a no-op re-upsert.
+func TestReloadEndpointSlice(t *testing.T) {
 	t.Parallel()
 
 	// port routing so Lookup resolves host -> ip:port
@@ -38,60 +43,95 @@ func TestReloadSingleEndpoint(t *testing.T) {
 		})
 	}
 
-	// incremental controller, driven only through the watch-event entry points
+	// incremental controller, driven only through the watch-event entry points:
+	// store the slice (as watchResource does) then recompute its service.
 	var incr Controller
 	setPorts(&incr)
+	upsert := func(es *discovery.EndpointSlice) {
+		incr.watchedEndpointSlices.Store(es.Namespace+"/"+es.Name, es)
+		incr.reloadEndpointSlice(es)
+	}
+	del := func(es *discovery.EndpointSlice) {
+		incr.watchedEndpointSlices.Delete(es.Namespace + "/" + es.Name)
+		incr.reloadEndpointSlice(es)
+	}
 
-	// full-rebuild controller, kept in lock-step via the watched-endpoints store.
+	// full-rebuild controller, kept in lock-step via the watched-slices store.
 	// desired is the current intended set; rebuild relists it like initial sync.
 	var full Controller
 	setPorts(&full)
-	desired := map[string]*v1.Endpoints{}
+	desired := map[string]*discovery.EndpointSlice{}
 	rebuild := func() {
-		full.watchedEndpoints.Range(func(k, _ any) bool { full.watchedEndpoints.Delete(k); return true })
-		for _, ep := range desired {
-			full.watchedEndpoints.Store(ep.Namespace+"/"+ep.Name, ep)
+		full.watchedEndpointSlices.Range(func(k, _ any) bool { full.watchedEndpointSlices.Delete(k); return true })
+		for _, es := range desired {
+			full.watchedEndpointSlices.Store(es.Namespace+"/"+es.Name, es)
 		}
 		full.reloadEndpointDebounced()
 	}
 
+	// backendSet collects the distinct backends a host round-robins over. Only the
+	// SET of reachable pod IPs is well-defined: a host's IPs are unioned across
+	// several slices in nondeterministic (sync.Map.Range) order, and each Table
+	// keeps its own rotation counter, so a single Lookup is not comparable between
+	// the incremental and full-rebuild tables — the set is.
+	backendSet := func(c *Controller, host string) map[string]bool {
+		set := map[string]bool{}
+		for i := 0; i < 20; i++ {
+			set[c.routeTable.Lookup(host+":80")] = true
+		}
+		return set
+	}
 	assertSame := func(host string) {
 		t.Helper()
 		assert.Equal(t,
-			full.routeTable.Lookup(host+":80"),
-			incr.routeTable.Lookup(host+":80"),
+			backendSet(&full, host),
+			backendSet(&incr, host),
 			"incremental and full-rebuild disagree for %s", host)
 	}
 
-	// add host a
-	desired["default/a"] = endpoints("default", "a", "10.0.0.1")
-	incr.reloadSingleEndpoint(desired["default/a"])
+	// add host a (single slice)
+	desired["default/a-1"] = endpointSlice("default", "a", "a-1", "10.0.0.1")
+	upsert(desired["default/a-1"])
 	rebuild()
 	assert.Equal(t, "10.0.0.1:8080", incr.routeTable.Lookup("a.default.svc.cluster.local:80"))
 	assertSame("a.default.svc.cluster.local")
 
 	// add host b
-	desired["default/b"] = endpoints("default", "b", "10.0.1.1", "10.0.1.2")
-	incr.reloadSingleEndpoint(desired["default/b"])
+	desired["default/b-1"] = endpointSlice("default", "b", "b-1", "10.0.1.1", "10.0.1.2")
+	upsert(desired["default/b-1"])
 	rebuild()
 	assertSame("b.default.svc.cluster.local")
 
-	// change host a's IP
-	desired["default/a"] = endpoints("default", "a", "10.0.0.9")
-	incr.reloadSingleEndpoint(desired["default/a"])
+	// add a SECOND slice for host a — its IPs union with the first slice's
+	desired["default/a-2"] = endpointSlice("default", "a", "a-2", "10.0.0.2")
+	upsert(desired["default/a-2"])
+	rebuild()
+	// both slices' pod IPs are reachable through the one host route (round-robin)
+	assert.Equal(t, map[string]bool{"10.0.0.1:8080": true, "10.0.0.2:8080": true},
+		backendSet(&incr, "a.default.svc.cluster.local"))
+	assertSame("a.default.svc.cluster.local")
+
+	// change host a's first slice IP
+	desired["default/a-1"] = endpointSlice("default", "a", "a-1", "10.0.0.9")
+	upsert(desired["default/a-1"])
+	rebuild()
+	assertSame("a.default.svc.cluster.local")
+
+	// no-op re-upsert of host a's first slice (same IP)
+	upsert(desired["default/a-1"])
+	rebuild()
+	assertSame("a.default.svc.cluster.local")
+
+	// delete host a's SECOND slice — host a survives on its remaining slice
+	delete(desired, "default/a-2")
+	del(endpointSlice("default", "a", "a-2", "10.0.0.2"))
 	rebuild()
 	assert.Equal(t, "10.0.0.9:8080", incr.routeTable.Lookup("a.default.svc.cluster.local:80"))
 	assertSame("a.default.svc.cluster.local")
 
-	// no-op re-upsert of host a (same IP)
-	incr.reloadSingleEndpoint(desired["default/a"])
-	rebuild()
-	assert.Equal(t, "10.0.0.9:8080", incr.routeTable.Lookup("a.default.svc.cluster.local:80"))
-	assertSame("a.default.svc.cluster.local")
-
-	// delete host b
-	delete(desired, "default/b")
-	incr.deleteSingleEndpoint(endpoints("default", "b"))
+	// delete host b (its only slice) -> host route is gone
+	delete(desired, "default/b-1")
+	del(endpointSlice("default", "b", "b-1"))
 	rebuild()
 	assert.Empty(t, incr.routeTable.Lookup("b.default.svc.cluster.local:80"))
 	assertSame("b.default.svc.cluster.local")

--- a/controller_endpoint_test.go
+++ b/controller_endpoint_test.go
@@ -4,9 +4,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// legacyEndpoints builds a core/v1 Endpoints object (named after its Service)
+// with all addresses ready, for the no-EndpointSlice fallback tests.
+func legacyEndpoints(namespace, name string, ips ...string) *v1.Endpoints {
+	ep := &v1.Endpoints{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+	if len(ips) > 0 {
+		addrs := make([]v1.EndpointAddress, 0, len(ips))
+		for _, ip := range ips {
+			addrs = append(addrs, v1.EndpointAddress{IP: ip})
+		}
+		ep.Subsets = []v1.EndpointSubset{{Addresses: addrs}}
+	}
+	return ep
+}
 
 // endpointSlice builds an IPv4 EndpointSlice for namespace/svcName (carrying the
 // kubernetes.io/service-name label the controller maps back to a host). All
@@ -138,4 +153,83 @@ func TestReloadEndpointSlice(t *testing.T) {
 	// host a is untouched by b's deletion
 	assert.Equal(t, "10.0.0.9:8080", incr.routeTable.Lookup("a.default.svc.cluster.local:80"))
 	assertSame("a.default.svc.cluster.local")
+}
+
+// TestEndpointSliceFallbackToEndpoints checks the no-slice fallback: a Service
+// with only a legacy Endpoints object routes from it, an EndpointSlice takes
+// over the moment one appears (slices are authoritative — even an empty slice
+// suppresses the fallback), and removing the slice restores the fallback.
+func TestEndpointSliceFallbackToEndpoints(t *testing.T) {
+	t.Parallel()
+
+	const host = "c.default.svc.cluster.local"
+	newCtrl := func() *Controller {
+		var c Controller
+		c.routeTable.SetPortRoutes(map[string]string{host + ":80": "8080"})
+		return &c
+	}
+
+	t.Run("incremental: endpoints -> slice wins -> slice removed restores fallback", func(t *testing.T) {
+		c := newCtrl()
+
+		// only legacy Endpoints exist -> routed from them
+		ep := legacyEndpoints("default", "c", "10.0.0.50")
+		c.watchedEndpoints.Store("default/c", ep)
+		c.reloadEndpointsObject(ep)
+		assert.Equal(t, "10.0.0.50:8080", c.routeTable.Lookup(host+":80"))
+
+		// a slice appears -> it is authoritative, the legacy IP is dropped
+		sl := endpointSlice("default", "c", "c-1", "10.0.0.60")
+		c.watchedEndpointSlices.Store("default/c-1", sl)
+		c.reloadEndpointSlice(sl)
+		assert.Equal(t, "10.0.0.60:8080", c.routeTable.Lookup(host+":80"))
+
+		// an empty slice still suppresses the fallback (slices authoritative)
+		empty := endpointSlice("default", "c", "c-1")
+		c.watchedEndpointSlices.Store("default/c-1", empty)
+		c.reloadEndpointSlice(empty)
+		assert.Empty(t, c.routeTable.Lookup(host+":80"))
+
+		// slice removed -> fallback to legacy Endpoints restored
+		c.watchedEndpointSlices.Delete("default/c-1")
+		c.reloadEndpointSlice(empty)
+		assert.Equal(t, "10.0.0.50:8080", c.routeTable.Lookup(host+":80"))
+	})
+
+	t.Run("full rebuild: slice wins over endpoints for the same service", func(t *testing.T) {
+		c := newCtrl()
+		c.watchedEndpoints.Store("default/c", legacyEndpoints("default", "c", "10.0.0.50"))
+
+		// endpoints-only -> rebuild routes from them
+		c.reloadEndpointDebounced()
+		assert.Equal(t, "10.0.0.50:8080", c.routeTable.Lookup(host+":80"))
+
+		// add a slice -> rebuild prefers it
+		c.watchedEndpointSlices.Store("default/c-1", endpointSlice("default", "c", "c-1", "10.0.0.60"))
+		c.reloadEndpointDebounced()
+		assert.Equal(t, "10.0.0.60:8080", c.routeTable.Lookup(host+":80"))
+	})
+
+	t.Run("resolveTargetPort falls back to Endpoints named port", func(t *testing.T) {
+		c := newCtrl()
+		svc := namedPortService("default", "c", "http", 80)
+
+		// no slice, no endpoints -> unresolved
+		_, ok := c.resolveTargetPort(svc, svc.Spec.Ports[0])
+		assert.False(t, ok)
+
+		// legacy Endpoints carry the named port -> resolved from them
+		ep := legacyEndpoints("default", "c", "10.0.0.50")
+		ep.Subsets[0].Ports = []v1.EndpointPort{{Name: "http", Port: 8080}}
+		c.watchedEndpoints.Store("default/c", ep)
+		got, ok := c.resolveTargetPort(svc, svc.Spec.Ports[0])
+		assert.True(t, ok)
+		assert.Equal(t, "8080", got)
+
+		// once a slice exists with the port, it is authoritative
+		c.watchedEndpointSlices.Store("default/c-1", endpointSliceNamedPort("default", "c", "c-1", "10.0.0.60", "http", 9090))
+		got, ok = c.resolveTargetPort(svc, svc.Spec.Ports[0])
+		assert.True(t, ok)
+		assert.Equal(t, "9090", got)
+	})
 }

--- a/controller_reload_test.go
+++ b/controller_reload_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -152,12 +153,7 @@ func TestReloadIngress(t *testing.T) {
 func TestReloadServiceAndEndpoint(t *testing.T) {
 	ctrl := New("", proxy.New())
 	ctrl.watchedServices.Store("default/web", clusterIPService("default", "web", 80, 8080))
-	ctrl.watchedEndpoints.Store("default/web", &v1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "web"},
-		Subsets: []v1.EndpointSubset{
-			{Addresses: []v1.EndpointAddress{{IP: "10.0.0.1"}}},
-		},
-	})
+	ctrl.watchedEndpointSlices.Store("default/web-1", endpointSlice("default", "web", "web-1", "10.0.0.1"))
 
 	ctrl.reloadServiceDebounced()  // populates port routes (svc addr -> target port)
 	ctrl.reloadEndpointDebounced() // populates host routes (svc host -> pod IPs)
@@ -183,16 +179,10 @@ func namedPortService(namespace, name, portName string, port int) *v1.Service {
 	}
 }
 
-func endpointsNamedPort(namespace, name, ip, portName string, port int) *v1.Endpoints {
-	return &v1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
-		Subsets: []v1.EndpointSubset{
-			{
-				Addresses: []v1.EndpointAddress{{IP: ip}},
-				Ports:     []v1.EndpointPort{{Name: portName, Port: int32(port)}},
-			},
-		},
-	}
+func endpointSliceNamedPort(namespace, svcName, sliceName, ip, portName string, port int) *discovery.EndpointSlice {
+	es := endpointSlice(namespace, svcName, sliceName, ip)
+	es.Ports = []discovery.EndpointPort{{Name: ptr(portName), Port: ptr(int32(port))}}
+	return es
 }
 
 func externalNameService(namespace, name, externalName string, ports ...int) *v1.Service {
@@ -257,17 +247,14 @@ func TestReloadServiceExternalName(t *testing.T) {
 		ctrl := New("", proxy.New())
 		// Start as a ClusterIP service with one endpoint.
 		ctrl.watchedServices.Store("default/svc", clusterIPService("default", "svc", 80, 8080))
-		ctrl.watchedEndpoints.Store("default/svc", &v1.Endpoints{
-			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "svc"},
-			Subsets:    []v1.EndpointSubset{{Addresses: []v1.EndpointAddress{{IP: "10.0.0.1"}}}},
-		})
+		ctrl.watchedEndpointSlices.Store("default/svc-1", endpointSlice("default", "svc", "svc-1", "10.0.0.1"))
 		ctrl.reloadServiceDebounced()
 		ctrl.reloadEndpointDebounced()
 		assert.Equal(t, "10.0.0.1:8080", ctrl.routeTable.Lookup("svc.default.svc.cluster.local:80"))
 
-		// Flip to ExternalName; the endpoints controller removes the Endpoints object.
+		// Flip to ExternalName; the endpointslice controller removes the slices.
 		ctrl.watchedServices.Store("default/svc", externalNameService("default", "svc", "api.example.com", 80))
-		ctrl.watchedEndpoints.Delete("default/svc")
+		ctrl.watchedEndpointSlices.Delete("default/svc-1")
 		ctrl.reloadServiceDebounced()
 		ctrl.reloadEndpointDebounced()
 		assert.Equal(t, "api.example.com:80", ctrl.routeTable.Lookup("svc.default.svc.cluster.local:80"))
@@ -280,7 +267,7 @@ func TestReloadServiceNamedTargetPort(t *testing.T) {
 	// would route every request to ":0" → dial failure → 503).
 	ctrl := New("", proxy.New())
 	ctrl.watchedServices.Store("default/web", namedPortService("default", "web", "http", 80))
-	ctrl.watchedEndpoints.Store("default/web", endpointsNamedPort("default", "web", "10.0.0.1", "http", 8080))
+	ctrl.watchedEndpointSlices.Store("default/web-1", endpointSliceNamedPort("default", "web", "web-1", "10.0.0.1", "http", 8080))
 
 	ctrl.reloadServiceDebounced()
 	ctrl.reloadEndpointDebounced()
@@ -302,7 +289,7 @@ func TestReloadServiceNamedTargetPortConvergesWhenEndpointsArrive(t *testing.T) 
 	assert.Empty(t, ctrl.routeTable.Lookup("web.default.svc.cluster.local:80"),
 		"unresolved named port must not create a ':0' route")
 
-	ctrl.watchedEndpoints.Store("default/web", endpointsNamedPort("default", "web", "10.0.0.2", "http", 9090))
+	ctrl.watchedEndpointSlices.Store("default/web-1", endpointSliceNamedPort("default", "web", "web-1", "10.0.0.2", "http", 9090))
 	ctrl.reloadServiceDebounced()  // endpoint watch triggers this in production
 	ctrl.reloadEndpointDebounced() // host routes (pod IPs)
 
@@ -311,13 +298,11 @@ func TestReloadServiceNamedTargetPortConvergesWhenEndpointsArrive(t *testing.T) 
 		"named port converges once endpoints arrive")
 }
 
-func TestReloadEndpointEmptySubsetIsNotRouted(t *testing.T) {
+func TestReloadEndpointEmptySliceIsNotRouted(t *testing.T) {
 	ctrl := New("", proxy.New())
 	ctrl.watchedServices.Store("default/web", clusterIPService("default", "web", 80, 8080))
-	ctrl.watchedEndpoints.Store("default/web", &v1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "web"},
-		// no subsets -> no usable backend
-	})
+	// a slice with no endpoints -> no usable backend
+	ctrl.watchedEndpointSlices.Store("default/web-1", endpointSlice("default", "web", "web-1"))
 
 	ctrl.reloadServiceDebounced()
 	ctrl.reloadEndpointDebounced()

--- a/controller_test.go
+++ b/controller_test.go
@@ -16,9 +16,12 @@ import (
 	"github.com/moonrhythm/parapet"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+
+	"github.com/moonrhythm/parapet-ingress-controller/route"
 
 	"github.com/moonrhythm/parapet-ingress-controller/metric"
 	"github.com/moonrhythm/parapet-ingress-controller/proxy"
@@ -387,53 +390,63 @@ func TestGetBackendConfig(t *testing.T) {
 	})
 }
 
-func TestEndpointToRRLB(t *testing.T) {
+func TestAppendReadyIPs(t *testing.T) {
 	t.Parallel()
 
+	endpoint := func(ready *bool, ips ...string) discovery.Endpoint {
+		return discovery.Endpoint{Addresses: ips, Conditions: discovery.EndpointConditions{Ready: ready}}
+	}
+
 	t.Run("Empty", func(t *testing.T) {
-		ep := v1.Endpoints{}
-		lb := endpointToRRLB(&ep)
-		assert.Nil(t, lb)
+		var lb route.RRLB
+		appendReadyIPs(&lb, &discovery.EndpointSlice{AddressType: discovery.AddressTypeIPv4})
+		assert.Empty(t, lb.IPs)
 	})
 
-	t.Run("Single Subset", func(t *testing.T) {
-		ep := v1.Endpoints{
-			Subsets: []v1.EndpointSubset{
-				{
-					Addresses: []v1.EndpointAddress{
-						{IP: "192.168.0.1"},
-						{IP: "192.168.0.2"},
-						{IP: "192.168.0.3"},
-					},
-				},
+	t.Run("Ready and nil-ready addresses included", func(t *testing.T) {
+		var lb route.RRLB
+		appendReadyIPs(&lb, &discovery.EndpointSlice{
+			AddressType: discovery.AddressTypeIPv4,
+			Endpoints: []discovery.Endpoint{
+				endpoint(pointer.Bool(true), "192.168.0.1", "192.168.0.2"),
+				endpoint(nil, "192.168.0.3"), // nil Ready -> treated as ready
 			},
-		}
-		lb := endpointToRRLB(&ep)
-		if assert.NotNil(t, lb) {
-			assert.EqualValues(t, []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}, lb.IPs)
-		}
+		})
+		assert.EqualValues(t, []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}, lb.IPs)
 	})
 
-	t.Run("Multiple Subsets", func(t *testing.T) {
-		ep := v1.Endpoints{
-			Subsets: []v1.EndpointSubset{
-				{
-					Addresses: []v1.EndpointAddress{
-						{IP: "192.168.0.1"},
-						{IP: "192.168.0.2"},
-					},
-				},
-				{
-					Addresses: []v1.EndpointAddress{
-						{IP: "192.168.0.3"},
-					},
-				},
+	t.Run("Not-ready addresses excluded", func(t *testing.T) {
+		var lb route.RRLB
+		appendReadyIPs(&lb, &discovery.EndpointSlice{
+			AddressType: discovery.AddressTypeIPv4,
+			Endpoints: []discovery.Endpoint{
+				endpoint(pointer.Bool(true), "192.168.0.1"),
+				endpoint(pointer.Bool(false), "192.168.0.2"), // not ready -> skipped
 			},
-		}
-		lb := endpointToRRLB(&ep)
-		if assert.NotNil(t, lb) {
-			assert.EqualValues(t, []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}, lb.IPs)
-		}
+		})
+		assert.EqualValues(t, []string{"192.168.0.1"}, lb.IPs)
+	})
+
+	t.Run("FQDN slice skipped", func(t *testing.T) {
+		var lb route.RRLB
+		appendReadyIPs(&lb, &discovery.EndpointSlice{
+			AddressType: discovery.AddressTypeFQDN,
+			Endpoints:   []discovery.Endpoint{endpoint(pointer.Bool(true), "example.com")},
+		})
+		assert.Empty(t, lb.IPs)
+	})
+
+	t.Run("Multiple slices union into one RRLB", func(t *testing.T) {
+		var lb route.RRLB
+		appendReadyIPs(&lb, &discovery.EndpointSlice{
+			AddressType: discovery.AddressTypeIPv4,
+			Endpoints:   []discovery.Endpoint{endpoint(pointer.Bool(true), "192.168.0.1", "192.168.0.2")},
+		})
+		appendReadyIPs(&lb, &discovery.EndpointSlice{
+			AddressType: discovery.AddressTypeIPv4,
+			Endpoints:   []discovery.Endpoint{endpoint(pointer.Bool(true), "192.168.0.3")},
+		})
+		assert.EqualValues(t, []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}, lb.IPs)
 	})
 }
 

--- a/deploy/role-cluster.yaml
+++ b/deploy/role-cluster.yaml
@@ -17,13 +17,12 @@ rules:
   resources:
   - services
   - secrets
-  - endpoints
   - configmaps
   verbs:
   - list
   - watch
 - apiGroups:
-  - discovery.k8s.io/v1
+  - discovery.k8s.io
   resources:
   - endpointslices
   verbs:

--- a/deploy/role-cluster.yaml
+++ b/deploy/role-cluster.yaml
@@ -18,6 +18,8 @@ rules:
   - services
   - secrets
   - configmaps
+  # endpoints: legacy fallback for services that have no EndpointSlice
+  - endpoints
   verbs:
   - list
   - watch

--- a/deploy/role-namespaced.yaml
+++ b/deploy/role-namespaced.yaml
@@ -18,13 +18,12 @@ rules:
   resources:
   - services
   - secrets
-  - endpoints
   - configmaps
   verbs:
   - list
   - watch
 - apiGroups:
-  - discovery.k8s.io/v1
+  - discovery.k8s.io
   resources:
   - endpointslices
   verbs:

--- a/deploy/role-namespaced.yaml
+++ b/deploy/role-namespaced.yaml
@@ -19,6 +19,8 @@ rules:
   - services
   - secrets
   - configmaps
+  # endpoints: legacy fallback for services that have no EndpointSlice
+  - endpoints
   verbs:
   - list
   - watch

--- a/k8s/cluster.go
+++ b/k8s/cluster.go
@@ -71,6 +71,18 @@ func (c *clusterClient) WatchEndpointSlices(ctx context.Context, namespace strin
 	return c.client.DiscoveryV1().EndpointSlices(namespace).Watch(ctx, metav1.ListOptions{})
 }
 
+func (c *clusterClient) GetEndpoints(ctx context.Context, namespace string) ([]v1.Endpoints, error) {
+	list, err := c.client.CoreV1().Endpoints(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+func (c *clusterClient) WatchEndpoints(ctx context.Context, namespace string) (watch.Interface, error) {
+	return c.client.CoreV1().Endpoints(namespace).Watch(ctx, metav1.ListOptions{})
+}
+
 func (c *clusterClient) GetConfigMaps(ctx context.Context, namespace, labelSelector string) ([]v1.ConfigMap, error) {
 	list, err := c.client.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {

--- a/k8s/cluster.go
+++ b/k8s/cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -58,16 +59,16 @@ func (c *clusterClient) UpdateSecret(ctx context.Context, namespace string, secr
 	return c.client.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
 }
 
-func (c *clusterClient) GetEndpoints(ctx context.Context, namespace string) ([]v1.Endpoints, error) {
-	list, err := c.client.CoreV1().Endpoints(namespace).List(ctx, metav1.ListOptions{})
+func (c *clusterClient) GetEndpointSlices(ctx context.Context, namespace string) ([]discovery.EndpointSlice, error) {
+	list, err := c.client.DiscoveryV1().EndpointSlices(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 	return list.Items, nil
 }
 
-func (c *clusterClient) WatchEndpoints(ctx context.Context, namespace string) (watch.Interface, error) {
-	return c.client.CoreV1().Endpoints(namespace).Watch(ctx, metav1.ListOptions{})
+func (c *clusterClient) WatchEndpointSlices(ctx context.Context, namespace string) (watch.Interface, error) {
+	return c.client.DiscoveryV1().EndpointSlices(namespace).Watch(ctx, metav1.ListOptions{})
 }
 
 func (c *clusterClient) GetConfigMaps(ctx context.Context, namespace, labelSelector string) ([]v1.ConfigMap, error) {

--- a/k8s/fs.go
+++ b/k8s/fs.go
@@ -29,6 +29,7 @@ type fsClient struct {
 	ingresses      []networking.Ingress
 	services       []v1.Service
 	endpointSlices []discovery.EndpointSlice
+	endpoints      []v1.Endpoints
 	secrets        []v1.Secret
 	configmaps     []v1.ConfigMap
 }
@@ -48,6 +49,7 @@ func (c *fsClient) reset() {
 	c.ingresses = nil
 	c.services = nil
 	c.endpointSlices = nil
+	c.endpoints = nil
 	c.secrets = nil
 	c.configmaps = nil
 }
@@ -175,6 +177,17 @@ func (c *fsClient) addObject(raw []byte) {
 		c.endpointSlices = append(c.endpointSlices, es)
 	case runtime.TypeMeta{
 		APIVersion: "v1",
+		Kind:       "Endpoints",
+	}:
+		var ep v1.Endpoints
+		err := c.decode(raw, &ep)
+		if err != nil {
+			return
+		}
+		c.autofillMeta(&ep.ObjectMeta)
+		c.endpoints = append(c.endpoints, ep)
+	case runtime.TypeMeta{
+		APIVersion: "v1",
 		Kind:       "Secret",
 	}:
 		var s v1.Secret
@@ -275,6 +288,17 @@ func (c *fsClient) GetEndpointSlices(ctx context.Context, namespace string) ([]d
 }
 
 func (c *fsClient) WatchEndpointSlices(ctx context.Context, namespace string) (watch.Interface, error) {
+	ch := make(chan watch.Event)
+	return watch.NewProxyWatcher(ch), nil
+}
+
+func (c *fsClient) GetEndpoints(ctx context.Context, namespace string) ([]v1.Endpoints, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.endpoints, nil
+}
+
+func (c *fsClient) WatchEndpoints(ctx context.Context, namespace string) (watch.Interface, error) {
 	ch := make(chan watch.Event)
 	return watch.NewProxyWatcher(ch), nil
 }

--- a/k8s/fs.go
+++ b/k8s/fs.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	networking "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,13 +24,13 @@ import (
 )
 
 type fsClient struct {
-	mu         sync.RWMutex
-	dir        string
-	ingresses  []networking.Ingress
-	services   []v1.Service
-	endpoints  []v1.Endpoints
-	secrets    []v1.Secret
-	configmaps []v1.ConfigMap
+	mu             sync.RWMutex
+	dir            string
+	ingresses      []networking.Ingress
+	services       []v1.Service
+	endpointSlices []discovery.EndpointSlice
+	secrets        []v1.Secret
+	configmaps     []v1.ConfigMap
 }
 
 func newFSClient(dir string) (*fsClient, error) {
@@ -46,7 +47,7 @@ func newFSClient(dir string) (*fsClient, error) {
 func (c *fsClient) reset() {
 	c.ingresses = nil
 	c.services = nil
-	c.endpoints = nil
+	c.endpointSlices = nil
 	c.secrets = nil
 	c.configmaps = nil
 }
@@ -162,16 +163,16 @@ func (c *fsClient) addObject(raw []byte) {
 		c.autofillMeta(&svc.ObjectMeta)
 		c.services = append(c.services, svc)
 	case runtime.TypeMeta{
-		APIVersion: "v1",
-		Kind:       "Endpoints",
+		APIVersion: "discovery.k8s.io/v1",
+		Kind:       "EndpointSlice",
 	}:
-		var ep v1.Endpoints
-		err := c.decode(raw, &ep)
+		var es discovery.EndpointSlice
+		err := c.decode(raw, &es)
 		if err != nil {
 			return
 		}
-		c.autofillMeta(&ep.ObjectMeta)
-		c.endpoints = append(c.endpoints, ep)
+		c.autofillMeta(&es.ObjectMeta)
+		c.endpointSlices = append(c.endpointSlices, es)
 	case runtime.TypeMeta{
 		APIVersion: "v1",
 		Kind:       "Secret",
@@ -267,13 +268,13 @@ func (c *fsClient) UpdateSecret(ctx context.Context, namespace string, secret *v
 	return secret.DeepCopy(), nil
 }
 
-func (c *fsClient) GetEndpoints(ctx context.Context, namespace string) ([]v1.Endpoints, error) {
+func (c *fsClient) GetEndpointSlices(ctx context.Context, namespace string) ([]discovery.EndpointSlice, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.endpoints, nil
+	return c.endpointSlices, nil
 }
 
-func (c *fsClient) WatchEndpoints(ctx context.Context, namespace string) (watch.Interface, error) {
+func (c *fsClient) WatchEndpointSlices(ctx context.Context, namespace string) (watch.Interface, error) {
 	ch := make(chan watch.Event)
 	return watch.NewProxyWatcher(ch), nil
 }

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -57,8 +58,8 @@ var client interface {
 	WatchSecrets(ctx context.Context, namespace string) (watch.Interface, error)
 	GetSecret(ctx context.Context, namespace, name string) (*v1.Secret, error)
 	UpdateSecret(ctx context.Context, namespace string, secret *v1.Secret) (*v1.Secret, error)
-	GetEndpoints(ctx context.Context, namespace string) ([]v1.Endpoints, error)
-	WatchEndpoints(ctx context.Context, namespace string) (watch.Interface, error)
+	GetEndpointSlices(ctx context.Context, namespace string) ([]discovery.EndpointSlice, error)
+	WatchEndpointSlices(ctx context.Context, namespace string) (watch.Interface, error)
 	GetConfigMaps(ctx context.Context, namespace, labelSelector string) ([]v1.ConfigMap, error)
 	WatchConfigMaps(ctx context.Context, namespace, labelSelector string) (watch.Interface, error)
 }
@@ -105,14 +106,14 @@ func UpdateSecret(ctx context.Context, namespace string, secret *v1.Secret) (*v1
 	return client.UpdateSecret(ctx, namespace, secret)
 }
 
-// GetEndpoints lists all endpoints
-func GetEndpoints(ctx context.Context, namespace string) ([]v1.Endpoints, error) {
-	return client.GetEndpoints(ctx, namespace)
+// GetEndpointSlices lists all endpoint slices
+func GetEndpointSlices(ctx context.Context, namespace string) ([]discovery.EndpointSlice, error) {
+	return client.GetEndpointSlices(ctx, namespace)
 }
 
-// WatchEndpoints watches endpoints
-func WatchEndpoints(ctx context.Context, namespace string) (watch.Interface, error) {
-	return client.WatchEndpoints(ctx, namespace)
+// WatchEndpointSlices watches endpoint slices
+func WatchEndpointSlices(ctx context.Context, namespace string) (watch.Interface, error) {
+	return client.WatchEndpointSlices(ctx, namespace)
 }
 
 // GetConfigMaps lists config maps for given namespace, filtered by labelSelector

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -60,6 +60,8 @@ var client interface {
 	UpdateSecret(ctx context.Context, namespace string, secret *v1.Secret) (*v1.Secret, error)
 	GetEndpointSlices(ctx context.Context, namespace string) ([]discovery.EndpointSlice, error)
 	WatchEndpointSlices(ctx context.Context, namespace string) (watch.Interface, error)
+	GetEndpoints(ctx context.Context, namespace string) ([]v1.Endpoints, error)
+	WatchEndpoints(ctx context.Context, namespace string) (watch.Interface, error)
 	GetConfigMaps(ctx context.Context, namespace, labelSelector string) ([]v1.ConfigMap, error)
 	WatchConfigMaps(ctx context.Context, namespace, labelSelector string) (watch.Interface, error)
 }
@@ -114,6 +116,17 @@ func GetEndpointSlices(ctx context.Context, namespace string) ([]discovery.Endpo
 // WatchEndpointSlices watches endpoint slices
 func WatchEndpointSlices(ctx context.Context, namespace string) (watch.Interface, error) {
 	return client.WatchEndpointSlices(ctx, namespace)
+}
+
+// GetEndpoints lists all (legacy) endpoints. Only consulted as a fallback for a
+// Service that has no EndpointSlice; see Controller.aggregateServiceIPs.
+func GetEndpoints(ctx context.Context, namespace string) ([]v1.Endpoints, error) {
+	return client.GetEndpoints(ctx, namespace)
+}
+
+// WatchEndpoints watches (legacy) endpoints — the no-EndpointSlice fallback.
+func WatchEndpoints(ctx context.Context, namespace string) (watch.Interface, error) {
+	return client.WatchEndpoints(ctx, namespace)
 }
 
 // GetConfigMaps lists config maps for given namespace, filtered by labelSelector

--- a/route/table.go
+++ b/route/table.go
@@ -1,6 +1,7 @@
 package route
 
 import (
+	"net"
 	"strings"
 	"sync"
 )
@@ -47,14 +48,16 @@ func (t *Table) Lookup(addr string) string {
 			// not found any pod
 			return ""
 		}
-		return hostIP + ":" + targetPort
+		// JoinHostPort brackets IPv6 literals (EndpointSlices surface IPv6 pod IPs
+		// on dual-stack services); for IPv4/hostnames it is a plain host:port join.
+		return net.JoinHostPort(hostIP, targetPort)
 	}
 
 	if okExt {
 		// ExternalName service: dial the external DNS name directly — the dialer's
 		// net.Resolver resolves it at connect time. No RRLB/badAddr: there is a
 		// single target, and transient failures are handled by the retry path.
-		return externalName + ":" + targetPort
+		return net.JoinHostPort(externalName, targetPort)
 	}
 
 	// neither a pod route nor an externalName route for this host

--- a/route/table_test.go
+++ b/route/table_test.go
@@ -176,8 +176,8 @@ func TestTableIncrementalMatchesRebuild(t *testing.T) {
 	}
 
 	// incremental: seed with the first state, then apply each subsequent state
-	// as per-host upserts/deletes, mirroring reloadSingleEndpoint /
-	// deleteSingleEndpoint.
+	// as per-host upserts/deletes, mirroring the per-host SetHostRoute path
+	// reloadEndpointSlice drives.
 	var incr Table
 	incr.SetHostRoutes(toRoutes(states[0]))
 	for i := 1; i < len(states); i++ {


### PR DESCRIPTION
## What

Switch the controller's backend pod-IP resolution from the deprecated `core/v1` **Endpoints** API (discouraged/feature-frozen since Kubernetes v1.33) to **`discovery.k8s.io/v1` EndpointSlice** — with a **legacy-Endpoints fallback** for Services that have no slice.

## How

A Service owns *several* EndpointSlices, so the refactor groups slices by their owning Service (the `kubernetes.io/service-name` label) and unions the **ready** addresses of all of a Service's slices into one `route.RRLB`:

- **Incremental** (per watch event): recompute just the affected Service's host route by re-aggregating its slices from the store. Serves both upsert and delete (an empty aggregate deletes the host).
- **Full rebuild** (initial sync / resync): group-by-Service in a single pass.
- **Named `targetPort`**: scan the Service's slices for the matching `EndpointPort`.
- Readiness: include endpoints with `Conditions.Ready == nil || *Ready` (nil = ready per the EndpointSlice contract), matching the legacy `Endpoints.Subsets[].Addresses` "ready only" behavior. FQDN-type slices are skipped (RRLB dials pod IPs).

### Legacy-Endpoints fallback
A Service can legitimately have a `core/v1` Endpoints object and **zero** EndpointSlices — hand-managed Endpoints labeled `endpointslice.kubernetes.io/skip-mirror=true`, or a cluster without the EndpointSlice mirroring controller. The Endpoints watch is kept as a fallback:

- **EndpointSlices are authoritative.** If a Service owns ≥1 slice (*even an empty one*), its slices alone decide the route/port. Only a Service with **no** slice consults its Endpoints object (keyed by Service name).
- `aggregateServiceIPs` and `resolveTargetPort` implement the rule; the full rebuild fills in Endpoints-only services after the slice pass (a slice-managed host is never overwritten).
- A new `endpointReloadMu` serializes the host-route recompute: two watch goroutines (slice + endpoints) now write host routes, so compute+write is held under one lock — the last writer is the latest reader, preventing a stale "slice present" result from clobbering a fresh "slice gone → fallback" one (the [debounce-not-serialized] hazard).

### Other changes
- **k8s client**: add `GetEndpointSlices`/`WatchEndpointSlices` (`DiscoveryV1`); keep `GetEndpoints`/`WatchEndpoints` for the fallback. The `fs` dev/test backend decodes both `discovery.k8s.io/v1 EndpointSlice` and `v1 Endpoints`.
- **`route.Table.Lookup`**: join host+port with `net.JoinHostPort` so IPv6 pod IPs — now surfaced per-family by EndpointSlice on dual-stack clusters — are bracketed. IPv4 output is byte-identical.
- **Docs**: `SPEC.md` and `CLAUDE.md` updated to match.

## ⚠️ Operational note (RBAC)

The prior manifests carried a **malformed** apiGroup `discovery.k8s.io/v1` (RBAC groups have no version), so that rule never actually granted slice access — the controller worked only via the core `endpoints` grant. This PR fixes the group to `discovery.k8s.io` (and keeps the `endpoints` grant for the fallback).

**Operators upgrading must `kubectl apply` the updated `deploy/role-cluster.yaml` / `deploy/role-namespaced.yaml` before rolling the new image**, otherwise list/watch of `endpointslices` is forbidden and the route table stays empty.

## Behavior notes
- **Dual-stack**: legacy Endpoints published only the primary IP family; EndpointSlice exposes IPv4 + IPv6 as separate slices, both now unioned, so a dual-stack Service round-robins across both families (and is dialed correctly thanks to the `net.JoinHostPort` change). Single-stack IPv4 is unchanged.
- For a normal Service (both slices and a mirrored Endpoints object exist), each pod-churn produces both a slice event and an endpoints event; the endpoints recompute is a cheap no-op since slices win.

## Testing
- `go test -race ./...` green; `go vet` / `gofmt` clean.
- `TestReloadEndpointSlice` and `TestEndpointSliceFallbackToEndpoints` stress-passed 200×/`-race`. The slice test compares the reachable backend **set** (a host's IPs are unioned across slices in nondeterministic order and each table keeps its own round-robin counter, so a single `Lookup` is not comparable between tables).
- Coverage: add host, multi-slice union into one host, change a slice's IPs, delete one of several slices (host survives), delete last slice (host removed), named-port resolution, empty slice not routed, ClusterIP→ExternalName flip; **fallback**: endpoints-only routing → slice takes over → empty slice still suppresses fallback → slice removed restores fallback, full-rebuild precedence, and `resolveTargetPort` named-port fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)