### PR TITLE
feat(edge): stamp X-Cache: BYPASS on responses the cache won't manage

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -690,12 +690,19 @@ cacheable object locally removes a full origin round trip. Enabled with
   fetch (no stampede): the first request fills while streaming to its own client
   and to disk; others wait (≤ a 2s timeout) then read the just-filled entry, or
   fall through to their own fetch if it turned out uncacheable.
-- **Observability.** Sets `X-Cache: HIT|MISS|STALE` (HIT = served from the edge
-  cache, MISS = fetched from parapet, STALE = served stale under RFC 5861).
+- **Observability.** Sets `X-Cache: HIT|MISS|STALE|BYPASS` (HIT = served from the
+  edge cache, MISS = fetched from parapet, STALE = served stale under RFC 5861,
+  BYPASS = the request was ineligible for caching — a non-cacheable method, a
+  protocol upgrade, a Range request, or a cache-override bypass rule — and was
+  proxied straight to the origin). parapet's cache emits HIT/MISS/STALE itself;
+  the edge's `CacheStatus` middleware (mounted just outside the cache) stamps
+  `X-Cache: BYPASS` on the ineligible responses the cache leaves untagged, so
+  every response under the cache carries an explicit status. A managed response,
+  or an `X-Cache` an origin set itself, is never overwritten; hijacked upgrades
+  (a 101) stay untagged.
   Cache outcomes are counted on the `:9187` metrics
   endpoint (`EDGE_METRICS_LISTEN`, set `""` to disable) as
-  `parapet_cache_total{result}` (`HIT|MISS|STALE|STALE_ERROR|BYPASS` — BYPASS is
-  the ineligible-request path that sends no `X-Cache` header) plus
+  `parapet_cache_total{result}` (`HIT|MISS|STALE|STALE_ERROR|BYPASS`) plus
   `parapet_cache_fill_duration_seconds` (origin-fill latency, observed only when
   parapet was contacted on the serving path). Deliberately **no `host` label** —
   the edge serves any Host the client sends, so a host label would be unbounded
@@ -709,9 +716,10 @@ cacheable object locally removes a full origin round trip. Enabled with
   bytes are invisible to `parapet_backend_network_read_bytes` (which only counts
   origin reads) and to pod-egress kernel counters (which only see traffic that
   reaches the pod). The `result` label carries `HIT`, `STALE`, or `MISS` for
-  the three cache outcomes that emit an `X-Cache` header; any unexpected value
-  is collapsed to `other` (defense in depth). Responses with no `X-Cache`
-  header (bypass, WebSocket upgrades, etc.) produce no series. The `host` label
+  the three cache outcomes that serve cached/filled bytes; any unexpected value
+  is collapsed to `other` (defense in depth). `BYPASS` responses (and those with
+  no `X-Cache` header, e.g. WebSocket upgrades) produce no series — their bytes
+  reach the origin and are already counted by origin-side counters. The `host` label
   is bounded by the same known-host oracle as `parapet_requests`: unknown hosts
   collapse to `"other"` so a Host-flood cannot grow series cardinality. This
   metric is only registered when the response cache is enabled

--- a/SPEC.md
+++ b/SPEC.md
@@ -217,7 +217,9 @@ invariants:
   only on explicit `Cache-Control`/`Expires` freshness; refuses
   `private`/`no-store`/`no-cache`/`Set-Cookie`/`Vary: *`; ignores **client**
   request `Cache-Control`, CDN-style), `GET`/`HEAD`, LRU-bounded, restart-
-  persistent, fail-static, `X-Cache: HIT|MISS`. This is an **edge-only** feature:
+  persistent, fail-static, `X-Cache: HIT|MISS|STALE|BYPASS` (BYPASS = stamped on
+  responses ineligible for caching — non-cacheable method, upgrade, Range, or
+  override bypass — that the cache proxies straight to the origin). This is an **edge-only** feature:
   the parapet controller does not cache, so there is no controller equivalent and
   no conformance obligation. A cache **hit** is served without contacting parapet,
   so parapet's authoritative WAF does not re-run on hits (only origin-opted-in

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -488,6 +488,11 @@ func main() {
 		// counts body bytes for every managed response (HITs, STALEs, MISSes)
 		// so billing can account for cache-HIT egress that never reaches the origin.
 		m.Use(edge.CacheEgress(edgeHosts.IsKnownHost))
+		// CacheStatus sits between CacheEgress and the cache: it stamps
+		// X-Cache: BYPASS on responses the cache declined to manage (non-cacheable
+		// method, upgrade, Range, or Cacheable=false), so every response under the
+		// cache carries an explicit X-Cache status. CacheEgress skips BYPASS bytes.
+		m.Use(edge.CacheStatus())
 		m.Use(respCache)
 	}
 	m.Use(forwarder)

--- a/edge/cacheegress.go
+++ b/edge/cacheegress.go
@@ -23,8 +23,10 @@ package edge
 //   - result: bounded explicitly — only HIT, STALE, MISS from the X-Cache
 //     header pass through; any other value collapses to "other" (defense in
 //     depth; the header is set by our own cache.go, not by the client).
-//     Empty X-Cache (cache bypass, hijacked upgrade, etc.) records NOTHING,
-//     keeping series from accumulating for uncached traffic.
+//     Empty X-Cache (hijacked upgrade, etc.) and an explicit BYPASS (stamped by
+//     CacheStatus on uncacheable responses) record NOTHING — bypass bytes reach
+//     the origin and are already counted by origin-side counters — keeping series
+//     from accumulating for uncached traffic.
 //   - edge_id: single cardinality per process — the global edgeID var.
 
 import (
@@ -105,9 +107,14 @@ func cacheResultLabel(v string) string {
 		return ""
 	case "HIT", "STALE", "MISS":
 		return v
+	case "BYPASS":
+		// CacheStatus stamps BYPASS on responses the cache didn't manage. Those
+		// bytes reached the origin and are already counted by origin-side byte
+		// counters, so they are not cache egress — skip, same as an absent header.
+		return ""
 	default:
-		// Unexpected value (defense in depth — our cache.go is the only
-		// writer of X-Cache, but bound the label unconditionally).
+		// Unexpected value (defense in depth — our cache.go / CacheStatus are the
+		// only writers of X-Cache, but bound the label unconditionally).
 		return "other"
 	}
 }

--- a/edge/cacheegress_test.go
+++ b/edge/cacheegress_test.go
@@ -111,6 +111,19 @@ func TestCacheEgressNoHeaderRecordsNothing(t *testing.T) {
 	}
 }
 
+func TestCacheEgressBypassRecordsNothing(t *testing.T) {
+	// CacheStatus stamps X-Cache: BYPASS on uncacheable responses; those bytes
+	// reached the origin and are not cache egress, so CacheEgress must skip them.
+	CacheEgress(knownCacheHost) //nolint:errcheck
+
+	countBefore := testutil.CollectAndCount(cacheEgressVec)
+	serveCacheEgress(t, "known.example.com", "BYPASS", []byte("bypass body"))
+	countAfter := testutil.CollectAndCount(cacheEgressVec)
+	if countAfter > countBefore {
+		t.Errorf("BYPASS: series count went from %d to %d, want no new series", countBefore, countAfter)
+	}
+}
+
 func TestCacheEgressBytesAccumulate(t *testing.T) {
 	mw := CacheEgress(knownCacheHost)
 	_ = mw
@@ -134,7 +147,7 @@ func TestCacheResultLabel(t *testing.T) {
 		{"HIT", "HIT"},
 		{"STALE", "STALE"},
 		{"MISS", "MISS"},
-		{"BYPASS", "other"},
+		{"BYPASS", ""}, // stamped by CacheStatus; bytes reach origin, not cache egress
 		{"STALE_ERROR", "other"},
 		{"revalidated", "other"},
 	}

--- a/edge/cachestatus.go
+++ b/edge/cachestatus.go
@@ -1,0 +1,100 @@
+package edge
+
+// cachestatus.go — stamp `X-Cache: BYPASS` on responses the cache won't manage.
+//
+// parapet/pkg/cache sets X-Cache to HIT / MISS / STALE for every response it
+// manages, and ALWAYS sets it on the shared header map before it calls
+// WriteHeader on the underlying writer (writeStored, the teeWriter fill path,
+// and serveLeader all Set("X-Cache", …) then WriteHeader). A *bypass* — a
+// non-cacheable method, a protocol upgrade, a Range request, or Options.Cacheable
+// returning false — is proxied straight to the origin with no X-Cache header at
+// all.
+//
+// So, observed from immediately OUTSIDE the cache, "no X-Cache present when the
+// header block is about to flush" is exactly a bypass. CacheStatus wraps the
+// writer and, on the first real (non-1xx) WriteHeader/Write, stamps
+// `X-Cache: BYPASS` iff no X-Cache is already set. A managed response is never
+// touched, and an X-Cache an origin set itself is preserved. Hijacked upgrades
+// never reach WriteHeader, so a 101 stays untagged — consistent with CacheEgress.
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+
+	"github.com/moonrhythm/parapet"
+)
+
+// CacheStatus returns middleware that stamps `X-Cache: BYPASS` on responses the
+// response cache declined to manage. Mount it immediately OUTSIDE (before) the
+// cache so its writer wraps the cache's output and its WriteHeader fires after
+// the cache has set any X-Cache of its own.
+func CacheStatus() parapet.Middleware {
+	return parapet.MiddlewareFunc(func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(&cacheStatusRW{ResponseWriter: w}, r)
+		})
+	})
+}
+
+// cacheStatusRW wraps ResponseWriter and stamps X-Cache: BYPASS on the first
+// non-1xx response head when no X-Cache is present. It preserves the optional
+// interfaces the chain relies on: Flush (SSE/chunked), Hijack (WebSocket/upgrade),
+// Push (HTTP/2), Unwrap.
+type cacheStatusRW struct {
+	http.ResponseWriter
+	wroteHeader bool
+}
+
+// tagBypass runs once, immediately before the header block is flushed: if the
+// cache (or origin) set no X-Cache, this response bypassed the cache.
+func (w *cacheStatusRW) tagBypass() {
+	if w.wroteHeader {
+		return
+	}
+	w.wroteHeader = true
+	if w.Header().Get("X-Cache") == "" {
+		w.Header().Set("X-Cache", "BYPASS")
+	}
+}
+
+func (w *cacheStatusRW) WriteHeader(code int) {
+	// 1xx interim responses (100 Continue, 103 Early Hints) are not the final
+	// status and X-Cache belongs on the final head — pass them through untouched.
+	if code >= 100 && code < 200 {
+		w.ResponseWriter.WriteHeader(code)
+		return
+	}
+	w.tagBypass()
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *cacheStatusRW) Write(p []byte) (int, error) {
+	w.tagBypass()
+	return w.ResponseWriter.Write(p)
+}
+
+func (w *cacheStatusRW) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+// Flush implements http.Flusher.
+func (w *cacheStatusRW) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack implements http.Hijacker.
+func (w *cacheStatusRW) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, http.ErrNotSupported
+}
+
+// Push implements http.Pusher.
+func (w *cacheStatusRW) Push(target string, opts *http.PushOptions) error {
+	if p, ok := w.ResponseWriter.(http.Pusher); ok {
+		return p.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}

--- a/edge/cachestatus_test.go
+++ b/edge/cachestatus_test.go
@@ -1,0 +1,185 @@
+package edge
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/moonrhythm/parapet/pkg/cache"
+	"github.com/stretchr/testify/assert"
+)
+
+// serveCacheStatus drives one request through the CacheStatus middleware with the
+// given inner handler, returning the recorded response.
+func serveCacheStatus(inner http.HandlerFunc) *httptest.ResponseRecorder {
+	h := CacheStatus().ServeHandler(inner)
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "http://x.example.com/", nil)
+	h.ServeHTTP(rec, r)
+	return rec
+}
+
+func TestCacheStatusStampsBypass(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no X-Cache from inner -> BYPASS", func(t *testing.T) {
+		rec := serveCacheStatus(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("origin"))
+		})
+		assert.Equal(t, "BYPASS", rec.Header().Get("X-Cache"))
+		assert.Equal(t, "origin", rec.Body.String())
+	})
+
+	t.Run("write-only (implicit 200) -> BYPASS", func(t *testing.T) {
+		rec := serveCacheStatus(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("body"))
+		})
+		assert.Equal(t, "BYPASS", rec.Header().Get("X-Cache"))
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("error status with no X-Cache -> BYPASS", func(t *testing.T) {
+		rec := serveCacheStatus(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "nope", http.StatusBadGateway)
+		})
+		assert.Equal(t, "BYPASS", rec.Header().Get("X-Cache"))
+		assert.Equal(t, http.StatusBadGateway, rec.Code)
+	})
+}
+
+func TestCacheStatusPreservesManagedStatus(t *testing.T) {
+	t.Parallel()
+
+	// A cache-managed response sets X-Cache before WriteHeader; CacheStatus must
+	// never overwrite it.
+	for _, tag := range []string{"HIT", "MISS", "STALE"} {
+		t.Run(tag+" preserved", func(t *testing.T) {
+			rec := serveCacheStatus(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-Cache", tag)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("x"))
+			})
+			assert.Equal(t, tag, rec.Header().Get("X-Cache"))
+		})
+	}
+
+	t.Run("origin-set X-Cache preserved on bypass", func(t *testing.T) {
+		rec := serveCacheStatus(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Cache", "HIT") // e.g. an origin with its own cache
+			_, _ = w.Write([]byte("x"))
+		})
+		assert.Equal(t, "HIT", rec.Header().Get("X-Cache"))
+	})
+}
+
+// TestCacheStatusWithRealCache wires CacheStatus around the actual
+// parapet/pkg/cache to prove the integration: a real bypass yields BYPASS, while
+// a real cache-managed MISS keeps its own X-Cache tag.
+func TestCacheStatusWithRealCache(t *testing.T) {
+	t.Parallel()
+
+	origin := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		_, _ = w.Write([]byte("ok"))
+	})
+	c := cache.New(cache.NewMemory(1<<20), cache.Options{
+		// /private is declared non-cacheable -> the cache bypasses it.
+		Cacheable: func(r *http.Request) bool { return !strings.HasPrefix(r.URL.Path, "/private") },
+		// Match the edge default so the chunked (no Content-Length) origin body is
+		// storable and the second GET is a real HIT.
+		CacheChunked: true,
+	})
+	h := CacheStatus().ServeHandler(c.ServeHandler(origin))
+
+	do := func(method, path string) string {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(method, "http://x.example.com"+path, nil))
+		return rec.Header().Get("X-Cache")
+	}
+
+	// Cacheable GET: the cache contacts the origin and tags MISS — CacheStatus must
+	// not overwrite it.
+	assert.Equal(t, "MISS", do(http.MethodGet, "/public"))
+	// Same URL again: served from store, HIT — also preserved.
+	assert.Equal(t, "HIT", do(http.MethodGet, "/public"))
+	// Cacheable=false -> real bypass -> stamped BYPASS.
+	assert.Equal(t, "BYPASS", do(http.MethodGet, "/private/x"))
+	// Non-cacheable method -> real bypass -> stamped BYPASS.
+	assert.Equal(t, "BYPASS", do(http.MethodPost, "/public"))
+}
+
+// recordingWriter captures each WriteHeader code and the X-Cache header value
+// present at that moment — httptest.ResponseRecorder can't model a 1xx interim
+// followed by a final status (it freezes on the first WriteHeader).
+type recordingWriter struct {
+	header   http.Header
+	codes    []int
+	xcacheAt []string
+}
+
+func (w *recordingWriter) Header() http.Header { return w.header }
+func (w *recordingWriter) WriteHeader(code int) {
+	w.codes = append(w.codes, code)
+	w.xcacheAt = append(w.xcacheAt, w.header.Get("X-Cache"))
+}
+func (w *recordingWriter) Write(b []byte) (int, error) { return len(b), nil }
+
+func TestCacheStatus1xxNotTagged(t *testing.T) {
+	t.Parallel()
+
+	// A 1xx interim head must pass through untagged; the BYPASS tag belongs on the
+	// final status. Verify the 103 is forwarded carrying no X-Cache, and the final
+	// 200 is forwarded carrying BYPASS.
+	rw := &recordingWriter{header: http.Header{}}
+	h := CacheStatus().ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusEarlyHints) // 103 interim
+		w.WriteHeader(http.StatusOK)         // final
+		_, _ = w.Write([]byte("body"))
+	}))
+	h.ServeHTTP(rw, httptest.NewRequest(http.MethodGet, "http://x/", nil))
+
+	assert.Equal(t, []int{http.StatusEarlyHints, http.StatusOK}, rw.codes, "both heads must be forwarded")
+	assert.Equal(t, "", rw.xcacheAt[0], "the 103 interim must carry no X-Cache")
+	assert.Equal(t, "BYPASS", rw.xcacheAt[1], "the final head must carry BYPASS")
+	assert.Equal(t, "BYPASS", rw.header.Get("X-Cache"))
+}
+
+// hijackRecorder is an httptest.ResponseRecorder that also reports a Hijacker, so
+// the interface-preservation test can assert CacheStatus forwards Hijack.
+type hijackRecorder struct {
+	*httptest.ResponseRecorder
+	hijacked bool
+}
+
+func (h *hijackRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h.hijacked = true
+	return nil, nil, nil
+}
+
+func (h *hijackRecorder) Flush() {}
+
+func TestCacheStatusPreservesInterfaces(t *testing.T) {
+	t.Parallel()
+
+	hr := &hijackRecorder{ResponseRecorder: httptest.NewRecorder()}
+	var gotFlusher, gotHijacker bool
+	h := CacheStatus().ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, gotFlusher = w.(http.Flusher)
+		hj, ok := w.(http.Hijacker)
+		gotHijacker = ok
+		if ok {
+			// a hijacked upgrade never calls WriteHeader -> stays untagged
+			_, _, _ = hj.Hijack()
+		}
+	}))
+	h.ServeHTTP(hr, httptest.NewRequest(http.MethodGet, "http://x/", nil))
+
+	assert.True(t, gotFlusher, "Flusher must be exposed through the wrapper")
+	assert.True(t, gotHijacker, "Hijacker must be exposed through the wrapper")
+	assert.True(t, hr.hijacked, "Hijack must reach the underlying writer")
+	assert.Empty(t, hr.Header().Get("X-Cache"), "a hijacked upgrade must not be tagged")
+}


### PR DESCRIPTION
## What

The edge response cache (`parapet/pkg/cache`) sets `X-Cache: HIT|MISS|STALE` for every response it manages, but a **bypass** — a non-cacheable method, a protocol upgrade, a Range request, or a cache-override `Cacheable=false` rule — is proxied straight to the origin with **no `X-Cache` header at all**. Clients (and dashboards) then can't distinguish "this resource was bypassed" from "the cache isn't configured".

This adds an explicit **`X-Cache: BYPASS`** on those responses.

## How

A new `edge.CacheStatus()` middleware is mounted immediately **outside** the cache (between `CacheEgress` and `respCache`). It wraps the ResponseWriter and, on the first non-1xx `WriteHeader`/`Write`, stamps `X-Cache: BYPASS` **iff no `X-Cache` is already present**.

The key insight: parapet's cache *always* sets its `X-Cache` tag on the shared header map **before** it calls `WriteHeader` on the underlying writer (verified in `writeStored`, the `teeWriter` fill path, and `serveLeader`). So, observed from just outside the cache, "no `X-Cache` at flush time" is *exactly* a bypass — no `OnResult` hook or shared flag is needed.

Properties:
- A managed response (`HIT`/`MISS`/`STALE`), or an `X-Cache` an origin set itself, is **never overwritten**.
- **1xx** interim heads (`100 Continue`, `103 Early Hints`) pass through untagged — the tag lands on the final status.
- **Hijacked upgrades** (a `101`) never reach `WriteHeader`, so they stay untagged.
- The wrapper preserves `Flusher`/`Hijacker`/`Pusher`/`Unwrap`.

`CacheEgress` now **skips `BYPASS`** bytes: they reached the origin and are already counted by origin-side byte counters, so they're not cache egress (keeps `parapet_cache_egress_bytes` meaning intact — no new series for bypass traffic).

## Testing
- `go test -race ./...` green; `go vet` / `gofmt` clean.
- Unit: bypass → BYPASS (explicit `WriteHeader`, write-only implicit 200, and error status); managed `HIT`/`MISS`/`STALE` preserved; origin-set `X-Cache` preserved; 1xx interim forwarded untagged with the tag on the final head; `Flusher`/`Hijacker` preserved and a hijacked upgrade left untagged.
- **Integration against the real `parapet/pkg/cache`**: a cacheable GET → `MISS` then `HIT` (both preserved), `Cacheable=false` → `BYPASS`, `POST` → `BYPASS`.
- `cacheResultLabel("BYPASS")` now maps to skip; added `TestCacheEgressBypassRecordsNothing`.

## Docs
`EDGE.md` and `SPEC.md` updated: `X-Cache: HIT|MISS|STALE|BYPASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)