### PR TITLE
feat(edge): host-bound parapet_cache_total{host,result,edge_id}

### DIFF
--- a/CACHE.md
+++ b/CACHE.md
@@ -318,8 +318,8 @@ RFC 5861 surface.
 
 Every in-scope decision counts in
 **`parapet_cache_override_total{name,action,result}`** on the edge's `:9187`
-endpoint, alongside the existing `parapet_cache_total{result}` (HIT/MISS/…) and
-`parapet_cache_egress_bytes`:
+endpoint, alongside the existing `parapet_cache_total{host,result,edge_id}`
+(HIT/MISS/…, host bounded by the knownHost oracle) and `parapet_cache_egress_bytes`:
 
 - `action` = `cache` | `bypass`.
 - `result` = `applied` | `shadow` | `error` (a rule whose filter excludes the

--- a/EDGE.md
+++ b/EDGE.md
@@ -702,12 +702,15 @@ cacheable object locally removes a full origin round trip. Enabled with
   (a 101) stay untagged.
   Cache outcomes are counted on the `:9187` metrics
   endpoint (`EDGE_METRICS_LISTEN`, set `""` to disable) as
-  `parapet_cache_total{result}` (`HIT|MISS|STALE|STALE_ERROR|BYPASS`) plus
-  `parapet_cache_fill_duration_seconds` (origin-fill latency, observed only when
-  parapet was contacted on the serving path). Deliberately **no `host` label** —
-  the edge serves any Host the client sends, so a host label would be unbounded
-  series under a flood. Unless `DISABLE_LOG` is set, each access-log line also
-  carries the outcome as a `cacheStatus` field.
+  `parapet_cache_total{host,result,edge_id}` (`HIT|MISS|STALE|STALE_ERROR|BYPASS`)
+  plus `parapet_cache_fill_duration_seconds` (origin-fill latency, observed only
+  when parapet was contacted on the serving path). The `host` label is **bounded
+  by the knownHost oracle** — a Host the edge doesn't serve collapses to `other`,
+  the same serve-all bounding `parapet_requests` / `parapet_cache_egress_bytes`
+  use — so per-host cache attribution is possible without unbounded series under a
+  Host flood (`edge.CacheTotal`, the host-bounded replacement for the host-less
+  `metric/observe.CacheResult`). Unless `DISABLE_LOG` is set, each access-log line
+  also carries the outcome as a `cacheStatus` field.
 
   `parapet_cache_egress_bytes{host,result,edge_id}` counts the response-body
   bytes written to clients by the edge cache, partitioned by cache outcome. It

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/moonrhythm/parapet-ingress-controller/edge"
 	"github.com/moonrhythm/parapet-ingress-controller/geoip"
-	"github.com/moonrhythm/parapet-ingress-controller/metric/observe"
 	"github.com/moonrhythm/parapet-ingress-controller/trustcidr"
 )
 
@@ -327,10 +326,12 @@ func main() {
 			}
 		}
 		if storage != nil {
-			// Cache outcomes: bounded prom counters (no host label — serve-all
-			// means r.Host is unbounded) + a cacheStatus access-log field
-			// (no-op under DISABLE_LOG — no logger record to set).
-			cacheMetrics := observe.CacheResult()
+			// Cache outcomes: the host-bounded parapet_cache_total{host,result,
+			// edge_id} counter (host collapsed to "other" off the knownHost oracle,
+			// the same serve-all bounding parapet_requests uses, so the per-project
+			// usage pipeline can attribute outcomes by host) + a cacheStatus
+			// access-log field (no-op under DISABLE_LOG — no logger record to set).
+			cacheMetrics := edge.CacheTotal(edgeHosts.IsKnownHost)
 			opts := cache.Options{
 				MaxFileSize: maxFile,
 				// Cache GET responses that arrive chunked with no Content-Length —

--- a/edge/cachetotal.go
+++ b/edge/cachetotal.go
@@ -1,0 +1,80 @@
+package edge
+
+// cachetotal.go — host-bounded parapet_cache_total counter for the edge.
+//
+// WHY THIS EXISTS
+//
+// parapet's prom.Cache (and the shared metric/observe.CacheResult helper) emit
+// parapet_cache_total WITHOUT a host label, because the serve-all edge accepts
+// any client Host and an unbounded host label would mint unbounded series. That
+// makes the counter a single global-per-edge total — fine for a fleet hit-ratio
+// alert, but it cannot attribute cache outcomes back to a project/host the way
+// the per-project usage pipeline needs.
+//
+// parapet_requests and parapet_cache_egress_bytes face the exact same serve-all
+// hazard and solve it the same way: the edge registers its own copy of the
+// family with a host label bounded by the knownHost oracle (unknown hosts
+// collapse to "other"). CacheTotal is that treatment for the cache-outcome
+// counter — it replaces observe.CacheResult on the edge, recording the same
+// parapet_cache_fill_duration_seconds histogram so nothing is lost.
+//
+// LABEL CARDINALITY INVARIANTS
+//
+//   - host: bounded by knownHost (same oracle as parapet_requests /
+//     parapet_cache_egress_bytes). Unknown hosts collapse to "other".
+//   - result: cache's closed five-value set (HIT/MISS/STALE/STALE_ERROR/BYPASS).
+//   - edge_id: single cardinality per process — the global edgeID var.
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/moonrhythm/parapet/pkg/cache"
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	cacheTotalOnce sync.Once
+	cacheTotalVec  *prometheus.CounterVec
+	cacheFillHist  prometheus.Histogram
+)
+
+func cacheTotalRegister() {
+	cacheTotalOnce.Do(func() {
+		cacheTotalVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: prom.Namespace,
+			Name:      "cache_total",
+			Help:      "Edge response-cache outcomes, by result (HIT/MISS/STALE/STALE_ERROR/BYPASS) and host. Hit ratio = HIT / all. Host is bounded by the knownHost oracle (\"other\" when not served), like parapet_requests.",
+		}, []string{"host", "result", "edge_id"})
+		cacheFillHist = prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: prom.Namespace,
+			Name:      "cache_fill_duration_seconds",
+			Help:      "Origin-fill latency, observed only when the origin was contacted on the serving path (a MISS fill or a stale-if-error revalidation).",
+			Buckets:   prometheus.DefBuckets,
+		})
+		prom.Registry().MustRegister(cacheTotalVec, cacheFillHist)
+	})
+}
+
+// CacheTotal returns a cache.ResultFunc for cache.Options.OnResult that records
+// the host-bounded parapet_cache_total{host,result,edge_id} counter and the
+// parapet_cache_fill_duration_seconds histogram. It is the edge's host-bounded
+// replacement for metric/observe.CacheResult (which is host-less); mount one or
+// the other, never both — they register the same metric family names.
+//
+// knownHost (may be nil — then the host passes through, as in tests) bounds the
+// host label: a host it reports false for collapses to the "other" sentinel.
+func CacheTotal(knownHost func(host string) bool) cache.ResultFunc {
+	cacheTotalRegister()
+	return func(r *http.Request, info cache.ResultInfo) {
+		cacheTotalVec.WithLabelValues(
+			hostLabel(r.Host, knownHost),
+			string(info.Result),
+			edgeID,
+		).Inc()
+		if info.FillDuration > 0 {
+			cacheFillHist.Observe(info.FillDuration.Seconds())
+		}
+	}
+}

--- a/edge/cachetotal_test.go
+++ b/edge/cachetotal_test.go
@@ -1,0 +1,93 @@
+package edge
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/moonrhythm/parapet/pkg/cache"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// cacheTotalCount reads the current counter value for the given host+result.
+// CacheTotal() registers the vec, so call it first.
+func cacheTotalCount(host, result string) float64 {
+	return testutil.ToFloat64(cacheTotalVec.WithLabelValues(host, result, edgeID))
+}
+
+// recordCacheResult drives one cache outcome through the CacheTotal ResultFunc.
+func recordCacheResult(host string, result cache.Result, fill time.Duration) {
+	fn := CacheTotal(knownCacheHost)
+	r := httptest.NewRequest(http.MethodGet, "http://"+host+"/", nil)
+	r.Host = host
+	fn(r, cache.ResultInfo{Result: result, FillDuration: fill})
+}
+
+func TestCacheTotalCountsEveryResult(t *testing.T) {
+	CacheTotal(knownCacheHost) // ensure registered
+
+	// All five closed-set results increment their own (host, result) series — in
+	// particular BYPASS, which cache egress bytes deliberately drops.
+	for _, res := range []cache.Result{
+		cache.ResultHit, cache.ResultMiss, cache.ResultStale,
+		cache.ResultStaleError, cache.ResultBypass,
+	} {
+		before := cacheTotalCount("known.example.com", string(res))
+		recordCacheResult("known.example.com", res, 0)
+		after := cacheTotalCount("known.example.com", string(res))
+		if got := after - before; got != 1 {
+			t.Errorf("result %s: got %.0f, want 1", res, got)
+		}
+	}
+}
+
+func TestCacheTotalUnknownHostCollapsesToOther(t *testing.T) {
+	CacheTotal(knownCacheHost)
+
+	before := cacheTotalCount("other", "HIT")
+	recordCacheResult("evil.example.net", cache.ResultHit, 0) // unknown host → "other"
+	after := cacheTotalCount("other", "HIT")
+	if got := after - before; got != 1 {
+		t.Errorf("unknown host: got %.0f under \"other\", want 1", got)
+	}
+}
+
+func TestCacheTotalAccumulates(t *testing.T) {
+	CacheTotal(knownCacheHost)
+
+	before := cacheTotalCount("known.example.com", "HIT")
+	for i := 0; i < 5; i++ {
+		recordCacheResult("known.example.com", cache.ResultHit, 0)
+	}
+	after := cacheTotalCount("known.example.com", "HIT")
+	if got := after - before; got != 5 {
+		t.Errorf("accumulate: got %.0f, want 5", got)
+	}
+}
+
+func TestCacheTotalFillDurationObserved(t *testing.T) {
+	CacheTotal(knownCacheHost)
+
+	// A MISS with a non-zero fill duration records into the histogram (and must
+	// not panic); a hit with zero fill does not. We assert the histogram's total
+	// sample count rises by exactly one across a fill + a no-fill outcome.
+	before := histogramSampleCount(t)
+	recordCacheResult("known.example.com", cache.ResultMiss, 5*time.Millisecond)
+	recordCacheResult("known.example.com", cache.ResultHit, 0) // zero fill → not observed
+	after := histogramSampleCount(t)
+	if got := after - before; got != 1 {
+		t.Errorf("fill histogram samples: got +%d, want +1", got)
+	}
+}
+
+// histogramSampleCount returns the cache-fill histogram's total observation count.
+func histogramSampleCount(t *testing.T) uint64 {
+	t.Helper()
+	m := &dto.Metric{}
+	if err := cacheFillHist.Write(m); err != nil {
+		t.Fatalf("write histogram: %v", err)
+	}
+	return m.GetHistogram().GetSampleCount()
+}


### PR DESCRIPTION
## What

Adds `edge.CacheTotal(knownHost)` — a host-bounded `parapet_cache_total{host,result,edge_id}` counter (plus the preserved `parapet_cache_fill_duration_seconds` histogram) — and swaps the edge-proxy `OnResult` wiring from the host-less `metric/observe.CacheResult()` to it.

## Why

The edge wired `observe.CacheResult()`, which deliberately **drops the `host` label** (serve-all → `r.Host` is unbounded), so `parapet_cache_total` was a single global-per-edge total with no way to attribute cache outcomes to a project/host.

`parapet_requests` (`edge/requests.go`) and `parapet_cache_egress_bytes` (`edge/cacheegress.go`) face the identical serve-all hazard and already solve it: register the edge's own copy of the family with a `host` label **bounded by the `knownHost` oracle** (`other` when not served). `CacheTotal` is that exact treatment for the cache-outcome counter — so a per-project usage pipeline can attribute hit/miss/stale/bypass by host without unbounded series under a Host flood.

## Notes

- Closed result set unchanged: `HIT|MISS|STALE|STALE_ERROR|BYPASS`.
- `observe.CacheResult()` is left in place (still a valid host-less helper) but is no longer used by the edge; `edge.CacheTotal` replaces it at the single call site. Both register the same family names, so exactly one is mounted.
- Histogram preserved (host-less, identical to before).
- Docs updated (EDGE.md, CACHE.md); `gofmt`/`go vet` clean; new `edge/cachetotal_test.go` covers per-result counts (incl. BYPASS), unknown-host collapse, and the fill histogram.

This is the data source for a new project-level cache hit/miss/stale/bypass chart (consumed by deploys.app collector → apiserver → console). The chart's bandwidth view already works off `parapet_cache_egress_bytes`; this PR unblocks the requests view. **Edge deploy required** for the requests data to flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_011d4bVuGLnCbcJD9ZvastPH