### PR TITLE
feat(edge): export parapet_waf_matches + parapet_coraza_matches

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -432,9 +432,11 @@ Both layers record per-request rule-eval latency on `:9187` as
 `parapet_waf_eval_duration_seconds{outcome,scope}` (`outcome` =
 `pass|allow|block|error`, `scope` = `global|zone`), same metric as the
 controller; an empty ruleset (before the first snapshot lands) takes the
-no-rules fast path and records nothing. Edge rule *matches* are debug-logged
-but not yet a counter (the controller's `parapet_waf_matches` is
-controller-only).
+no-rules fast path and records nothing. Edge rule *matches* are also counted as
+`parapet_waf_matches{rule_id,action,scope}` — the same metric the controller
+records, so an edge's matches aggregate with the core's on one dashboard. Both
+series come from `metric/observe` (not the `metric` package), so the controller's
+init-materialized core-trust series never appear on the edge's `:9187`.
 
 ### parapet stays authoritative (the backstop)
 
@@ -641,10 +643,10 @@ What to know before enabling:
   `WAF_VALIDATED_PROXY`, the edge Coraza stamps **no claim** and the **core always
   re-runs its own Coraza** — parapet stays authoritative. The edge is purely an
   early-drop layer.
-- **Per-edge match logging** is debug-only; the edge stays off the `metric`
-  package, so there is no `parapet_coraza_matches` on the edge's `:9187` (only the
-  `observe`-based `parapet_coraza_eval_duration_seconds`). Per-rule match counters
-  are the core's job.
+- **Per-edge matches** are counted as `parapet_coraza_matches{rule_id,severity,
+  scope}` (alongside the debug log and `parapet_coraza_eval_duration_seconds`) —
+  the same metric the controller records, via `metric/observe` so the edge's
+  `:9187` stays free of the controller's core-trust series.
 - **Zone resolution is path-aware** (`route_zone_map`), like the edge WAF — the
   controller's own route keys on a real `http.ServeMux`.
 

--- a/edge/coraza.go
+++ b/edge/coraza.go
@@ -53,15 +53,17 @@ func NewEdgeCoraza(rootFS fs.FS, requestBodyLimit int) *EdgeCoraza {
 		return ""
 	}
 	newInstance := func(scope string) *corazawaf.Instance {
+		// Per-rule match counter (parapet_coraza_matches), same metric as the
+		// controller — recorded through observe (not metric) so the controller's
+		// init-materialized core-trust series stay off the edge's /metrics.
+		corazaMatch := observe.CorazaMatch(scope)
 		return corazawaf.New(corazawaf.Options{
 			RootFS:           rootFS,
 			RequestBodyLimit: requestBodyLimit,
 			ClientIP:         clientIP,
 			Observe:          observe.CorazaEval(scope),
-			// Edge logs matches at debug only; it deliberately stays off the metric
-			// package (observe keeps the edge's /metrics free of the controller's
-			// core-trust series). Per-rule match counters are the core's job.
 			OnMatch: func(ev corazawaf.MatchEvent) {
+				corazaMatch(ev.RuleID, ev.Severity)
 				slog.Debug("edge coraza match", "scope", scope, "rule", ev.RuleID,
 					"disruptive", ev.Disruptive, "uri", ev.URI, "message", ev.Message)
 			},

--- a/edge/waf.go
+++ b/edge/waf.go
@@ -63,6 +63,10 @@ func NewEdgeWAF(country func(*http.Request) string, asn func(*http.Request) int6
 		// observe (not metric) keeps the controller's init-materialized
 		// core-trust series off the edge's /metrics.
 		w.Observe = observe.WAFEval(scope)
+		// Per-rule match counter (parapet_waf_matches), same metric as the
+		// controller — so an edge's matches aggregate with the core's. Fires only
+		// on a match, which the eval-outcome histogram can't attribute to a rule.
+		w.OnMatch = observe.WAFMatch(scope)
 		return w
 	}
 	w := &EdgeWAF{newZone: func() *waf.WAF { return newWAF("zone") }}

--- a/metric/observe/coraza.go
+++ b/metric/observe/coraza.go
@@ -1,6 +1,8 @@
 package observe
 
 import (
+	"strconv"
+	"sync"
 	"time"
 
 	"github.com/moonrhythm/parapet/pkg/prom"
@@ -9,6 +11,15 @@ import (
 
 var _corazaEval struct {
 	vec *prometheus.HistogramVec
+}
+
+// _corazaMatch registers lazily for the same reason as _wafMatch: the controller
+// records Coraza matches via metric.CorazaMatch (registered in metric's init), so
+// eager registration here would duplicate-register and panic. Only the edge wires
+// the hook.
+var _corazaMatch struct {
+	once sync.Once
+	vec  *prometheus.CounterVec
 }
 
 func init() {
@@ -36,5 +47,30 @@ func CorazaEval(scope string) func(d time.Duration, blocked bool) {
 			return
 		}
 		pass.Observe(d.Seconds())
+	}
+}
+
+// CorazaMatch returns the corazawaf.Options.OnMatch hook counting every rule that
+// fires as parapet_coraza_matches{rule_id,severity,scope} — the Coraza analogue
+// of WAFMatch and the same metric the controller's metric.CorazaMatch records.
+// scope is "global"/"zone"; all three labels are bounded (rule_id and severity
+// come from the operator's ruleset, scope is caller-fixed). It takes the rule id
+// and severity raw rather than a corazawaf.MatchEvent so observe stays decoupled
+// from corazawaf (mirroring CorazaEval's raw signature). Lazy registration, same
+// reasoning as WAFMatch; call only when Coraza is enabled.
+func CorazaMatch(scope string) func(ruleID int, severity string) {
+	_corazaMatch.once.Do(func() {
+		_corazaMatch.vec = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: prom.Namespace,
+			Name:      "coraza_matches",
+		}, []string{"rule_id", "severity", "scope"})
+		prom.Registry().MustRegister(_corazaMatch.vec)
+	})
+	return func(ruleID int, severity string) {
+		_corazaMatch.vec.With(prometheus.Labels{
+			"rule_id":  strconv.Itoa(ruleID),
+			"severity": severity,
+			"scope":    scope,
+		}).Inc()
 	}
 }

--- a/metric/observe/coraza_test.go
+++ b/metric/observe/coraza_test.go
@@ -1,0 +1,43 @@
+package observe
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func corazaMatchCount(t *testing.T, ruleID, severity, scope string) float64 {
+	t.Helper()
+	h, err := _corazaMatch.vec.GetMetricWith(prometheus.Labels{"rule_id": ruleID, "severity": severity, "scope": scope})
+	require.NoError(t, err)
+	var m dto.Metric
+	require.NoError(t, h.(prometheus.Metric).Write(&m))
+	return m.GetCounter().GetValue()
+}
+
+func TestCorazaMatch(t *testing.T) {
+	const scope = "coraza-match-test"
+	onMatch := CorazaMatch(scope)
+
+	onMatch(942100, "critical")
+	onMatch(942100, "critical")
+	onMatch(913100, "warning")
+
+	assert.EqualValues(t, 2, corazaMatchCount(t, "942100", "critical", scope))
+	assert.EqualValues(t, 1, corazaMatchCount(t, "913100", "warning", scope))
+}
+
+func TestCorazaMatchScopesAreDistinct(t *testing.T) {
+	global := CorazaMatch("coraza-match-scope-g")
+	zone := CorazaMatch("coraza-match-scope-z")
+
+	global(949110, "critical")
+	zone(949110, "critical")
+	zone(949110, "critical")
+
+	assert.EqualValues(t, 1, corazaMatchCount(t, "949110", "critical", "coraza-match-scope-g"))
+	assert.EqualValues(t, 2, corazaMatchCount(t, "949110", "critical", "coraza-match-scope-z"))
+}

--- a/metric/observe/observe.go
+++ b/metric/observe/observe.go
@@ -1,7 +1,8 @@
 // Package observe provides bounded, pre-resolved Prometheus observers for
-// parapet's per-request observability hooks (waf.WAF.Observe,
-// ratelimit.RateLimiter.Observe, cache.Options.OnResult), shared by the
-// controller and edge-proxy binaries.
+// parapet's per-request observability hooks (waf.WAF.Observe + OnMatch,
+// ratelimit.RateLimiter.Observe, cache.Options.OnResult, and the corazawaf
+// Observe + OnMatch analogues), shared by the controller and edge-proxy
+// binaries.
 //
 // It is deliberately a LEAF package, separate from metric: importing metric
 // materializes the controller's core-trust alerting series at init
@@ -18,4 +19,12 @@
 // the names collide, never wire parapet's prom.WAF()/prom.RateLimit()/
 // prom.Cache() in a binary that uses this package — the duplicate
 // MustRegister panics at startup.
+//
+// The match counters (WAFMatch -> parapet_waf_matches, CorazaMatch ->
+// parapet_coraza_matches) duplicate names the metric package registers in its
+// own init, so they register LAZILY on first call (see _wafMatch / _corazaMatch):
+// a binary that imports both — the controller — records matches through metric
+// and never calls these, so the lazy registration never fires there; only the
+// edge, which never imports metric, mints them here. Wiring one of these in a
+// binary that also imports metric would duplicate-register and panic.
 package observe

--- a/metric/observe/waf.go
+++ b/metric/observe/waf.go
@@ -1,6 +1,8 @@
 package observe
 
 import (
+	"sync"
+
 	"github.com/moonrhythm/parapet/pkg/prom"
 	"github.com/moonrhythm/parapet/pkg/waf"
 	"github.com/prometheus/client_golang/prometheus"
@@ -8,6 +10,17 @@ import (
 
 var _wafEval struct {
 	vec *prometheus.HistogramVec
+}
+
+// _wafMatch is registered LAZILY (first WAFMatch call), NOT in init(): the
+// controller imports this package for WAFEval but records matches through
+// metric.WAFMatch, whose init already registers parapet_waf_matches on the shared
+// registry — eager registration here would duplicate-register and panic at
+// startup. Only a binary that actually wires the OnMatch hook (the edge) mints
+// the series.
+var _wafMatch struct {
+	once sync.Once
+	vec  *prometheus.CounterVec
 }
 
 // wafEvalBuckets match parapet's prom.WAF tuning: dense below 1ms where the bulk
@@ -54,5 +67,33 @@ func WAFEval(scope string) waf.ObserveFunc {
 		if int(ev.Outcome) < len(handles) {
 			handles[ev.Outcome].Observe(ev.Duration.Seconds())
 		}
+	}
+}
+
+// WAFMatch returns a hook for waf.WAF.OnMatch counting every rule that fires as
+// parapet_waf_matches{rule_id,action,scope} — the SAME metric the controller's
+// metric.WAFMatch records, so an edge's matches aggregate with the core's on one
+// dashboard. scope is "global"/"zone"; all three labels are bounded (rule_id and
+// action come from the operator's ruleset, scope is caller-fixed — never request
+// input). See _wafMatch for why registration is lazy.
+//
+// Handles can't be pre-resolved the way WAFEval does — rule IDs aren't known
+// until a rule fires — so each event resolves through CounterVec.With (internally
+// locked+cached). Matches are rare relative to evals, so this lookup is off the
+// hot path. Call only when the WAF is actually enabled.
+func WAFMatch(scope string) func(waf.MatchEvent) {
+	_wafMatch.once.Do(func() {
+		_wafMatch.vec = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: prom.Namespace,
+			Name:      "waf_matches",
+		}, []string{"rule_id", "action", "scope"})
+		prom.Registry().MustRegister(_wafMatch.vec)
+	})
+	return func(ev waf.MatchEvent) {
+		_wafMatch.vec.With(prometheus.Labels{
+			"rule_id": ev.RuleID,
+			"action":  ev.Action.String(),
+			"scope":   scope,
+		}).Inc()
 	}
 }

--- a/metric/observe/waf_test.go
+++ b/metric/observe/waf_test.go
@@ -48,3 +48,36 @@ func TestWAFEvalScopesAreDistinct(t *testing.T) {
 	assert.EqualValues(t, 1, wafEvalSampleCount(t, "pass", "waf-eval-scope-g"))
 	assert.EqualValues(t, 2, wafEvalSampleCount(t, "pass", "waf-eval-scope-z"))
 }
+
+func wafMatchCount(t *testing.T, ruleID, action, scope string) float64 {
+	t.Helper()
+	h, err := _wafMatch.vec.GetMetricWith(prometheus.Labels{"rule_id": ruleID, "action": action, "scope": scope})
+	require.NoError(t, err)
+	var m dto.Metric
+	require.NoError(t, h.(prometheus.Metric).Write(&m))
+	return m.GetCounter().GetValue()
+}
+
+func TestWAFMatch(t *testing.T) {
+	const scope = "waf-match-test"
+	onMatch := WAFMatch(scope)
+
+	onMatch(waf.MatchEvent{RuleID: "1001", Action: waf.ActionBlock})
+	onMatch(waf.MatchEvent{RuleID: "1001", Action: waf.ActionBlock})
+	onMatch(waf.MatchEvent{RuleID: "1002", Action: waf.ActionLog})
+
+	assert.EqualValues(t, 2, wafMatchCount(t, "1001", waf.ActionBlock.String(), scope))
+	assert.EqualValues(t, 1, wafMatchCount(t, "1002", waf.ActionLog.String(), scope))
+}
+
+func TestWAFMatchScopesAreDistinct(t *testing.T) {
+	global := WAFMatch("waf-match-scope-g")
+	zone := WAFMatch("waf-match-scope-z")
+
+	global(waf.MatchEvent{RuleID: "2001", Action: waf.ActionBlock})
+	zone(waf.MatchEvent{RuleID: "2001", Action: waf.ActionBlock})
+	zone(waf.MatchEvent{RuleID: "2001", Action: waf.ActionBlock})
+
+	assert.EqualValues(t, 1, wafMatchCount(t, "2001", waf.ActionBlock.String(), "waf-match-scope-g"))
+	assert.EqualValues(t, 2, wafMatchCount(t, "2001", waf.ActionBlock.String(), "waf-match-scope-z"))
+}


### PR DESCRIPTION
## What

The edge proxy now collects **per-rule WAF match metrics**, matching what the controller already exports. Previously the edge recorded only eval-duration histograms (`parapet_waf_eval_duration_seconds` / `parapet_coraza_eval_duration_seconds`); rule *matches* were debug-logged but never counted.

- `observe.WAFMatch(scope)` → `parapet_waf_matches{rule_id,action,scope}`
- `observe.CorazaMatch(scope)` → `parapet_coraza_matches{rule_id,severity,scope}`

Both use the **same metric names + labels as the controller's** `metric.WAFMatch` / `metric.CorazaMatch`, so an edge fleet's matches aggregate with the core's on one dashboard.

## Wiring

- `edge/waf.go` — the edge CEL WAF now sets `w.OnMatch = observe.WAFMatch(scope)` (it previously had **no** match hook).
- `edge/coraza.go` — the edge Coraza `OnMatch` now calls the metric hook alongside its existing debug log.
- `observe.CorazaMatch` takes raw `(ruleID int, severity string)` rather than a `corazawaf.MatchEvent`, keeping `observe` decoupled from `corazawaf` (mirrors `CorazaEval`).

## The tricky bit: lazy registration

`metric.WAFMatch` / `metric.CorazaMatch` already register those exact metric names in `metric`'s `init()`. The controller imports **both** `metric` and `observe`, so eager registration in `observe` would `MustRegister`-panic at startup. The two new observers therefore register **lazily** (`sync.Once`, same pattern as the existing `CacheResult`):

- **Controller** imports `metric`, records matches via `metric.*`, never calls the new `observe.*` funcs → lazy path never fires → no collision.
- **Edge** never imports `metric` (verified via `go list -deps`) → only `observe` mints the series.

## Tests / verification

- New tests: `metric/observe/waf_test.go` (`TestWAFMatch`, `TestWAFMatchScopesAreDistinct`) and new `metric/observe/coraza_test.go` (per-rule counting + scope isolation).
- `gofmt -l .` clean, `go vet ./...` clean, `go build ./...` OK, `go test -race ./...` green.
- `EDGE.md` (WAF + Coraza sections) and the `observe` package doc updated to document the new counters and the lazy-registration invariant.