### PR TITLE
feat(transform): in-cluster CEL transform runtime

### DIFF
--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -54,6 +54,7 @@ func main() {
 	autoH2CTTL := config.DurationDefault("UPSTREAM_AUTO_H2C_TTL", 10*time.Minute)
 
 	rateLimitEnabled := config.Bool("RATELIMIT_ENABLED")
+	transformEnabled := config.Bool("TRANSFORM_ENABLED")
 
 	// Coraza (OWASP CRS / SecLang) firewall — an independent signature layer
 	// alongside the CEL WAF, same global+zone model. ClientIP/RootFS wired below.
@@ -164,6 +165,7 @@ func main() {
 		"waf_validated_proxy", config.String("WAF_VALIDATED_PROXY"),
 		"ratelimit_enabled", rateLimitEnabled,
 		"coraza_enabled", corazaConfig.Enabled,
+		"transform_enabled", transformEnabled,
 	)
 
 	if enableProfiler {
@@ -302,6 +304,20 @@ func main() {
 	ctrl.InitRateLimit()
 	ctrl.CorazaConfig = corazaConfig
 	ctrl.InitCoraza()
+	ctrl.TransformConfig = controller.TransformConfig{
+		Enabled: transformEnabled,
+		// The WAF's GeoIP resolvers double as the transform filter's
+		// request.country / request.asn resolvers (nil when the DB isn't loaded — a
+		// geo reference then simply never matches, mirroring ratelimit).
+		Country: wafConfig.Country,
+		ASN:     wafConfig.ASN,
+		// Bound a rule's CEL `filter` with the same operator knobs as the WAF: same
+		// engine, same tenant-authored trust surface (WAF_COST_LIMIT /
+		// WAF_DISABLE_MACROS feed all three CEL layers).
+		FilterCostLimit:     wafConfig.CostLimit,
+		FilterDisableMacros: wafConfig.DisableMacros,
+	}
+	ctrl.InitTransform()
 	ctrl.Use(plugin.InjectStateIngress)
 	ctrl.Use(plugin.AllowRemote)
 	if wafConfig.Enabled {
@@ -321,6 +337,19 @@ func main() {
 		ctrl.Use(plugin.RateLimitZone(ctrl.LookupRateLimitZone))
 	}
 	ctrl.Use(plugin.RateLimit)
+	if transformEnabled {
+		// SECURITY-CRITICAL SLOT (SPEC §4.4 / F1): transform mounts AFTER WAF +
+		// ratelimit (so security and throttle always see the ORIGINAL, un-rewritten
+		// request — a rewrite running first could evade a WAF rule or skip a
+		// rate-limit count) but BEFORE UpstreamProtocol/Host/Path, BasicAuth,
+		// ForwardAuth and StripPrefix. ForwardAuth deletes and re-stamps the
+		// X-Auth-* identity headers, so registering transform before it guarantees
+		// ForwardAuth always overwrites any transform-forged identity header — a
+		// set-only tenant must NOT be able to forge X-Auth-Email/X-Auth-User. The
+		// accepted tradeoff: a transform redirect short-circuits before the access
+		// gate, which is harmless for a soft re-route.
+		ctrl.Use(plugin.TransformZone(ctrl.LookupTransformZone))
+	}
 	ctrl.Use(plugin.BodyLimit)
 	ctrl.Use(plugin.UpstreamProtocol)
 	ctrl.Use(plugin.UpstreamHost)

--- a/cmd/parapet-ingress-controller/transform_order_test.go
+++ b/cmd/parapet-ingress-controller/transform_order_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTransformZoneRegistrationSlot is the security-critical F1 guard (SPEC
+// §4.4): the TransformZone plugin MUST be registered in ctrl.plugins AFTER WAF
+// and RateLimit (so security and throttle see the original, un-rewritten
+// request) and BEFORE UpstreamProtocol/Host/Path, BasicAuth, ForwardAuth and
+// StripPrefix (so ForwardAuth's delete + re-stamp of the X-Auth-* identity
+// headers always overwrites any transform-forged identity header).
+//
+// Registration order == request-processing order (first ctrl.Use = outermost),
+// so the order of the ctrl.Use(plugin.X) lines in main.go IS the onion. This
+// test pins that source order; moving the TransformZone registration out of its
+// slot fails here loudly.
+func TestTransformZoneRegistrationSlot(t *testing.T) {
+	t.Parallel()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	src, err := os.ReadFile(filepath.Join(filepath.Dir(thisFile), "main.go"))
+	require.NoError(t, err)
+	body := string(src)
+
+	idx := func(needle string) int {
+		i := strings.Index(body, needle)
+		require.GreaterOrEqualf(t, i, 0, "registration not found in main.go: %s", needle)
+		return i
+	}
+
+	waf := idx("ctrl.Use(plugin.WAFZone(")
+	rateLimit := idx("ctrl.Use(plugin.RateLimit)")
+	transform := idx("ctrl.Use(plugin.TransformZone(")
+	upstreamProto := idx("ctrl.Use(plugin.UpstreamProtocol)")
+	upstreamHost := idx("ctrl.Use(plugin.UpstreamHost)")
+	upstreamPath := idx("ctrl.Use(plugin.UpstreamPath)")
+	basicAuth := idx("ctrl.Use(plugin.BasicAuth)")
+	forwardAuth := idx("ctrl.Use(plugin.ForwardAuth)")
+	stripPrefix := idx("ctrl.Use(plugin.StripPrefix)")
+
+	// after WAF + ratelimit
+	require.Less(t, waf, transform, "transform must register AFTER WAFZone")
+	require.Less(t, rateLimit, transform, "transform must register AFTER RateLimit")
+
+	// before the upstream rewrites + auth + strip-prefix
+	require.Less(t, transform, upstreamProto, "transform must register BEFORE UpstreamProtocol")
+	require.Less(t, transform, upstreamHost, "transform must register BEFORE UpstreamHost")
+	require.Less(t, transform, upstreamPath, "transform must register BEFORE UpstreamPath")
+	require.Less(t, transform, basicAuth, "transform must register BEFORE BasicAuth")
+	require.Less(t, transform, forwardAuth,
+		"transform must register BEFORE ForwardAuth so X-Auth-* re-stamp overwrites any forged identity header (SPEC §4.4)")
+	require.Less(t, transform, stripPrefix, "transform must register BEFORE StripPrefix")
+}

--- a/controller.go
+++ b/controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/moonrhythm/parapet-ingress-controller/ratelimitrule"
 	"github.com/moonrhythm/parapet-ingress-controller/route"
 	"github.com/moonrhythm/parapet-ingress-controller/state"
+	"github.com/moonrhythm/parapet-ingress-controller/transformrule"
 )
 
 // IngressClass to load ingresses
@@ -100,6 +101,12 @@ type Controller struct {
 	// controller_coraza.go.
 	CorazaConfig CorazaConfig
 
+	// TransformConfig configures the ConfigMap-driven transform layer — a
+	// per-(project, location) zone of CEL-scoped request/response mutations. Set
+	// before Watch(); when disabled the feature does no work: no ConfigMap watch,
+	// no mount. See controller_transform.go.
+	TransformConfig TransformConfig
+
 	// globalWAF is the always-on baseline firewall; zones holds the tenant zone
 	// registry keyed by <namespace>/<name>, swapped atomically on WAF reload.
 	// WAF reloads are decoupled from the mux — they never rebuild routes.
@@ -117,6 +124,12 @@ type Controller struct {
 	// atomically on Coraza reload. Decoupled from the mux like the WAF registries.
 	globalCoraza *corazawaf.Instance
 	corazaZones  atomic.Pointer[map[string]*corazawaf.Instance]
+
+	// transformZones holds the per-(project, location) transform zone registry
+	// keyed by <namespace>/<name>, swapped atomically on transform reload. There
+	// is no global baseline (transforms are zone-only). Decoupled from the mux
+	// exactly like the WAF/ratelimit registries.
+	transformZones atomic.Pointer[map[string]*transformrule.Zone]
 
 	// WAF rule-input fingerprints from the last reload, used to skip recompiling
 	// CEL rulesets whose effective input (the sorted concatenated rule YAML) is
@@ -147,6 +160,13 @@ type Controller struct {
 	globalCorazaFingerprint string
 	corazaZoneFingerprints  map[string]string
 
+	// Transform reload state, mirroring the WAF/ratelimit fields above —
+	// transformReloadMu serializes overlapping debounce-fired passes, the
+	// fingerprints skip recompiling unchanged transform input. Accessed only under
+	// transformReloadMu.
+	transformReloadMu         sync.Mutex
+	transformZoneFingerprints map[string]string
+
 	// endpointReloadMu serializes host-route recomputes. Two watch goroutines now
 	// feed pod IPs — the EndpointSlice watch and the legacy-Endpoints fallback
 	// watch — and both compute a Service's host route by reading the slice +
@@ -158,14 +178,15 @@ type Controller struct {
 	endpointReloadMu sync.Mutex
 
 	// holds current k8s state
-	watchedIngresses        sync.Map
-	watchedServices         sync.Map
-	watchedSecrets          sync.Map
-	watchedEndpointSlices   sync.Map
-	watchedEndpoints        sync.Map // legacy fallback: only used for services with no EndpointSlice
-	watchedConfigMaps       sync.Map
-	watchedRLConfigMaps     sync.Map
-	watchedCorazaConfigMaps sync.Map
+	watchedIngresses           sync.Map
+	watchedServices            sync.Map
+	watchedSecrets             sync.Map
+	watchedEndpointSlices      sync.Map
+	watchedEndpoints           sync.Map // legacy fallback: only used for services with no EndpointSlice
+	watchedConfigMaps          sync.Map
+	watchedRLConfigMaps        sync.Map
+	watchedCorazaConfigMaps    sync.Map
+	watchedTransformConfigMaps sync.Map
 
 	certTable  cert.Table
 	routeTable route.Table
@@ -181,6 +202,7 @@ type Controller struct {
 	reloadWAFDebounce       *debounce.Debounce
 	reloadRateLimitDebounce *debounce.Debounce
 	reloadCorazaDebounce    *debounce.Debounce
+	reloadTransformDebounce *debounce.Debounce
 }
 
 // New creates new ingress controller
@@ -198,6 +220,7 @@ func New(watchNamespace string, proxy *proxy.Proxy) *Controller {
 	ctrl.reloadWAFDebounce = debounce.New(ctrl.reloadWAFDebounced, 300*time.Millisecond)
 	ctrl.reloadRateLimitDebounce = debounce.New(ctrl.reloadRateLimitDebounced, 300*time.Millisecond)
 	ctrl.reloadCorazaDebounce = debounce.New(ctrl.reloadCorazaDebounced, 300*time.Millisecond)
+	ctrl.reloadTransformDebounce = debounce.New(ctrl.reloadTransformDebounced, 300*time.Millisecond)
 	ctrl.proxy = proxy
 	ctrl.proxy.OnDialError = ctrl.routeTable.MarkBad
 	return ctrl
@@ -235,6 +258,9 @@ func (ctrl *Controller) Watch() {
 	}
 	if ctrl.CorazaConfig.Enabled {
 		go ctrl.watchCorazaConfigMaps(ctx)
+	}
+	if ctrl.TransformConfig.Enabled {
+		go ctrl.watchTransformConfigMaps(ctx)
 	}
 }
 
@@ -334,6 +360,19 @@ func (ctrl *Controller) preloadResources(ctx context.Context) {
 			return nil
 		})
 	}
+
+	if ctrl.TransformConfig.Enabled {
+		preloadList(ctx, "transform-configmaps", func() error {
+			configmaps, err := k8s.GetConfigMaps(ctx, ctrl.watchNamespace, transformLabelKey)
+			if err != nil {
+				return err
+			}
+			for i := range configmaps {
+				ctrl.watchedTransformConfigMaps.Store(configmaps[i].Namespace+"/"+configmaps[i].Name, &configmaps[i])
+			}
+			return nil
+		})
+	}
 }
 
 // preloadList runs fn, retrying with capped exponential backoff on error until it
@@ -373,6 +412,7 @@ func (ctrl *Controller) firstReload() {
 	ctrl.reloadWAFDebounced()       // no-op when WAF disabled
 	ctrl.reloadRateLimitDebounced() // no-op when rate limiting disabled
 	ctrl.reloadCorazaDebounced()    // no-op when Coraza disabled
+	ctrl.reloadTransformDebounced() // no-op when transform disabled
 
 	// Edge auto-trust: bounded wait for the edge-CA pool before reporting Ready, so the
 	// edge isn't routed here during the cold-start window. Runs AFTER preload (above), so

--- a/controller_transform.go
+++ b/controller_transform.go
@@ -1,0 +1,183 @@
+package controller
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/moonrhythm/parapet-ingress-controller/k8s"
+	"github.com/moonrhythm/parapet-ingress-controller/transformrule"
+)
+
+// transformLabelKey marks a ConfigMap as transform input. Unlike the WAF and
+// rate-limit labels there is no "global" baseline — transforms are a per-(project,
+// location) zone only — so the value is always "zone" (roleZone) and its id is the
+// ConfigMap name. It is a separate label key (and a separate watch) because a
+// Kubernetes label selector can't OR two keys; the store stays separate too.
+const transformLabelKey = "parapet.moonrhythm.io/transform"
+
+// TransformConfig configures the ConfigMap-driven transform layer. It is set on
+// the Controller before Watch(). When Enabled is false the feature does no work:
+// no ConfigMap watch, no mount, no per-request cost.
+type TransformConfig struct {
+	Enabled bool
+	// Country / ASN resolve the client's GeoIP country / ASN for a filter that
+	// references request.country / request.asn — the same resolvers the WAF and
+	// ratelimit use. nil makes those references simply never match (not an error),
+	// matching ratelimit's geo-without-DB behavior. Set from WAF_GEOIP_DB /
+	// WAF_ASN_DB in main.
+	Country func(*http.Request) string
+	ASN     func(*http.Request) int64
+	// FilterCostLimit / FilterDisableMacros bound a rule's CEL `filter` exactly
+	// like a WAF rule. Set from WAF_COST_LIMIT / WAF_DISABLE_MACROS in main so a
+	// transform filter — same CEL engine, same tenant-authored trust surface — is
+	// hardened by the same operator knobs. Zero values leave the parapet defaults.
+	FilterCostLimit     uint64
+	FilterDisableMacros bool
+}
+
+func (ctrl *Controller) transformOptions() transformrule.Options {
+	return transformrule.Options{
+		Country:             ctrl.TransformConfig.Country,
+		ASN:                 ctrl.TransformConfig.ASN,
+		FilterCostLimit:     ctrl.TransformConfig.FilterCostLimit,
+		FilterDisableMacros: ctrl.TransformConfig.FilterDisableMacros,
+	}
+}
+
+// InitTransform seeds the (empty) zone registry. Call after setting
+// TransformConfig, before Watch(). No-op when disabled — disabled means no
+// ConfigMap watch, no mount, no per-request work.
+func (ctrl *Controller) InitTransform() {
+	if !ctrl.TransformConfig.Enabled {
+		return
+	}
+	empty := map[string]*transformrule.Zone{}
+	ctrl.transformZones.Store(&empty)
+	ctrl.transformZoneFingerprints = map[string]string{}
+}
+
+// LookupTransformZone returns the compiled transform zone for a registry key
+// (<namespace>/<name>), or nil if no such zone is loaded. Looked up live on the
+// request path so zone edits and new zones propagate without a mux rebuild.
+func (ctrl *Controller) LookupTransformZone(key string) *transformrule.Zone {
+	m := ctrl.transformZones.Load()
+	if m == nil {
+		return nil
+	}
+	return (*m)[key]
+}
+
+func (ctrl *Controller) watchTransformConfigMaps(ctx context.Context) {
+	watchFn := func(ctx context.Context, namespace string) (watch.Interface, error) {
+		return k8s.WatchConfigMaps(ctx, namespace, transformLabelKey)
+	}
+	listFn := func(ctx context.Context, namespace string) ([]v1.ConfigMap, error) {
+		return k8s.GetConfigMaps(ctx, namespace, transformLabelKey)
+	}
+	// Named "transform-configmaps" so its watch/resync log lines are
+	// distinguishable from the WAF's and ratelimit's loops.
+	watchResource(ctx, ctrl.watchNamespace, "transform-configmaps", watchFn, listFn,
+		&ctrl.watchedTransformConfigMaps,
+		func(_ *v1.ConfigMap) { ctrl.reloadTransform() },
+		func(_ *v1.ConfigMap) { ctrl.reloadTransform() },
+		ctrl.reloadTransform,
+	)
+}
+
+func (ctrl *Controller) reloadTransform() {
+	ctrl.reloadTransformDebounce.Call()
+}
+
+// reloadTransformDebounced rebuilds the zone registry from the watched
+// ConfigMaps. Like the WAF/ratelimit reloads it never touches ctrl.mux — a
+// transform edit is a Parse + registry swap. Parse is all-or-nothing, so a bad
+// zone keeps its last-good compiled set; unchanged inputs (fingerprint match)
+// are skipped entirely (the compiled Zone is reused).
+func (ctrl *Controller) reloadTransformDebounced() {
+	if !ctrl.TransformConfig.Enabled {
+		return
+	}
+	// Serialize the whole pass: the debounce can fire two passes concurrently
+	// (same hazard as wafReloadMu/rlReloadMu), and the fingerprint map below is a
+	// read-modify-write that must be atomic across the pass.
+	ctrl.transformReloadMu.Lock()
+	defer ctrl.transformReloadMu.Unlock()
+
+	defer func() {
+		if err := recover(); err != nil {
+			slog.Error("reload transform failed", "error", err)
+		}
+	}()
+
+	zoneDocs := map[string][]string{}
+
+	ctrl.watchedTransformConfigMaps.Range(func(_, value any) bool {
+		cm := value.(*v1.ConfigMap)
+		// Only a "zone"-roled ConfigMap is transform input; anything else in this
+		// store (the fs backend ignores label selectors) falls through silently.
+		if cm.Labels[transformLabelKey] != roleZone {
+			return true
+		}
+		// Refuse a ConfigMap labeled for more than one feature (one ConfigMap per
+		// feature, by deployer policy): every reloader consumes all data values, so
+		// a multi-labeled ConfigMap would feed each side the other's documents,
+		// which the lenient YAML parsers cross-parse to empty/garbage sets silently.
+		if _, ok := cm.Labels[wafLabelKey]; ok {
+			slog.Warn("transform: ignoring configmap that also carries the waf label; use one configmap per feature",
+				"configmap", cm.Namespace+"/"+cm.Name)
+			return true
+		}
+		if _, ok := cm.Labels[rateLimitLabelKey]; ok {
+			slog.Warn("transform: ignoring configmap that also carries the ratelimit label; use one configmap per feature",
+				"configmap", cm.Namespace+"/"+cm.Name)
+			return true
+		}
+		key := cm.Namespace + "/" + cm.Name
+		zoneDocs[key] = append(zoneDocs[key], sortedDataValues(cm.Data)...)
+		return true
+	})
+
+	cur := ctrl.transformZones.Load()
+	newZones := make(map[string]*transformrule.Zone, len(zoneDocs))
+	newFingerprints := make(map[string]string, len(zoneDocs))
+	opts := ctrl.transformOptions()
+
+	for key, docs := range zoneDocs {
+		fp := fingerprintDocs(docs)
+
+		// Unchanged input: reuse the existing compiled Zone untouched.
+		if cur != nil {
+			if existing, ok := (*cur)[key]; ok && fp == ctrl.transformZoneFingerprints[key] {
+				newZones[key] = existing
+				newFingerprints[key] = fp
+				continue
+			}
+		}
+
+		zone, err := transformrule.Parse(opts, docs...)
+		if err != nil {
+			slog.Error("transform: invalid zone, keeping previous", "zone", key, "error", err)
+			// All-or-nothing: keep the last-good compiled Zone live (if any) and
+			// keep its prior fingerprint so the bad input is retried next reload. A
+			// zone with no previous good set is simply dropped (the plugin then
+			// passes traffic through unmodified — a safe no-op).
+			if cur != nil {
+				if existing, ok := (*cur)[key]; ok {
+					newZones[key] = existing
+					newFingerprints[key] = ctrl.transformZoneFingerprints[key]
+				}
+			}
+			continue
+		}
+		newZones[key] = zone
+		newFingerprints[key] = fp
+	}
+
+	ctrl.transformZones.Store(&newZones)
+	ctrl.transformZoneFingerprints = newFingerprints
+	slog.Info("reloaded transform", "zones", len(newZones))
+}

--- a/controller_transform_test.go
+++ b/controller_transform_test.go
@@ -1,0 +1,130 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/moonrhythm/parapet-ingress-controller/proxy"
+)
+
+func newTransformController() *Controller {
+	ctrl := New("", proxy.New())
+	ctrl.PodNamespace = "ctrl-ns"
+	ctrl.TransformConfig = TransformConfig{Enabled: true}
+	ctrl.InitTransform()
+	return ctrl
+}
+
+func transformCM(namespace, name, doc string) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels:    map[string]string{transformLabelKey: roleZone},
+		},
+		Data: map[string]string{"transforms.yaml": doc},
+	}
+}
+
+const transformOneRule = `
+transforms:
+- id: hsts
+  phase: response
+  ops:
+  - type: set-header
+    name: Strict-Transport-Security
+    value: max-age=63072000
+  priority: 0
+`
+
+func TestReloadTransform(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newTransformController()
+	ctrl.watchedTransformConfigMaps.Store("cust1/transform-42", transformCM("cust1", "transform-42", transformOneRule))
+	ctrl.reloadTransformDebounced()
+
+	zone := ctrl.LookupTransformZone("cust1/transform-42")
+	require.NotNil(t, zone, "zone resolves by <namespace>/<name>")
+	assert.Equal(t, []string{"hsts"}, zone.IDs())
+
+	assert.Nil(t, ctrl.LookupTransformZone("cust1/missing"), "unknown zone resolves to nil")
+}
+
+func TestReloadTransform_BadZoneKeepsLastGood(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newTransformController()
+	ctrl.watchedTransformConfigMaps.Store("cust1/transform-42", transformCM("cust1", "transform-42", transformOneRule))
+	ctrl.reloadTransformDebounced()
+	require.Equal(t, []string{"hsts"}, ctrl.LookupTransformZone("cust1/transform-42").IDs())
+
+	// push a set with an uncompilable CEL filter (api can't catch this; the
+	// controller rejects the whole set all-or-nothing).
+	ctrl.watchedTransformConfigMaps.Store("cust1/transform-42", transformCM("cust1", "transform-42", `
+transforms:
+- id: broken
+  phase: request
+  filter: "this is not && valid cel ("
+  ops:
+  - type: set-header
+    name: X-Test
+    value: "1"
+  priority: 0
+`))
+	ctrl.reloadTransformDebounced()
+
+	zone := ctrl.LookupTransformZone("cust1/transform-42")
+	require.NotNil(t, zone)
+	assert.Equal(t, []string{"hsts"}, zone.IDs(), "bad edit must not drop the live set")
+}
+
+func TestReloadTransform_UnchangedZoneReusesInstance(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newTransformController()
+	ctrl.watchedTransformConfigMaps.Store("cust1/transform-42", transformCM("cust1", "transform-42", transformOneRule))
+	ctrl.reloadTransformDebounced()
+
+	first := ctrl.LookupTransformZone("cust1/transform-42")
+	require.NotNil(t, first)
+
+	// identical input: the compiled Zone is reused (same pointer, no recompile).
+	ctrl.reloadTransformDebounced()
+	assert.Same(t, first, ctrl.LookupTransformZone("cust1/transform-42"),
+		"unchanged input reuses the compiled zone")
+}
+
+func TestReloadTransform_RemoveZone(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newTransformController()
+	ctrl.watchedTransformConfigMaps.Store("cust1/transform-42", transformCM("cust1", "transform-42", transformOneRule))
+	ctrl.reloadTransformDebounced()
+	require.NotNil(t, ctrl.LookupTransformZone("cust1/transform-42"))
+
+	// the deployer deletes the ConfigMap on transform.delete; the next reload
+	// drops the zone (the plugin then passes traffic through unmodified).
+	ctrl.watchedTransformConfigMaps.Delete("cust1/transform-42")
+	ctrl.reloadTransformDebounced()
+	assert.Nil(t, ctrl.LookupTransformZone("cust1/transform-42"), "deleted zone is gone after reload")
+}
+
+func TestReloadTransform_IgnoresMultiLabeledConfigMap(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newTransformController()
+	cm := transformCM("cust1", "transform-42", transformOneRule)
+	// a ConfigMap that also carries the waf label must be ignored (one ConfigMap
+	// per feature, by deployer policy).
+	cm.Labels[wafLabelKey] = roleZone
+	ctrl.watchedTransformConfigMaps.Store("cust1/transform-42", cm)
+	ctrl.reloadTransformDebounced()
+
+	assert.Nil(t, ctrl.LookupTransformZone("cust1/transform-42"),
+		"a multi-feature-labeled configmap is not consumed as transform input")
+}

--- a/plugin/transform.go
+++ b/plugin/transform.go
@@ -1,0 +1,39 @@
+package plugin
+
+import (
+	"net/http"
+
+	"github.com/moonrhythm/parapet"
+
+	"github.com/moonrhythm/parapet-ingress-controller/transformrule"
+)
+
+// TransformZone binds an ingress to a transform zone via the
+// parapet.moonrhythm.io/transform-zone annotation. The value is a zone
+// reference: a bare id resolves to a zone in the ingress's own namespace;
+// "ns/id" references a zone in another namespace — the same resolver the CEL
+// waf-zone uses. A transform zone is stateless, operator-authored config (like a
+// WAF zone, unlike a rate-limit zone's shared counters), so a cross-namespace
+// reference is harmless and honored.
+//
+// lookup resolves the registry key to the live zone on the request path, so zone
+// rule edits and newly-created zones take effect without a mux rebuild. A key
+// that resolves to no zone (deleted / not yet created / rejected first config)
+// simply passes the request through unmodified — a safe no-op, never a break.
+func TransformZone(lookup func(key string) *transformrule.Zone) Plugin {
+	return func(ctx Context) {
+		key, ok := ZoneKey(ctx.Ingress.Namespace, ctx.Ingress.Annotations[namespace+"/transform-zone"])
+		if !ok {
+			return
+		}
+		ctx.Use(parapet.MiddlewareFunc(func(h http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if z := lookup(key); z != nil {
+					z.ServeHandler(h).ServeHTTP(w, r)
+					return
+				}
+				h.ServeHTTP(w, r)
+			})
+		}))
+	}
+}

--- a/plugin/transform_test.go
+++ b/plugin/transform_test.go
@@ -1,0 +1,96 @@
+package plugin_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/moonrhythm/parapet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	networking "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/moonrhythm/parapet-ingress-controller/plugin"
+	"github.com/moonrhythm/parapet-ingress-controller/transformrule"
+)
+
+func TestTransformZone(t *testing.T) {
+	t.Parallel()
+
+	newZone := func(t *testing.T) *transformrule.Zone {
+		z, err := transformrule.Parse(transformrule.Options{}, `
+transforms:
+- id: hsts
+  phase: response
+  ops:
+  - type: set-header
+    name: Strict-Transport-Security
+    value: max-age=63072000
+  priority: 0
+`)
+		require.NoError(t, err)
+		return z
+	}
+
+	newCtx := func(ann map[string]string) Context {
+		return Context{
+			Middlewares: &parapet.Middlewares{},
+			Ingress: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "cust1", Name: "web", Annotations: ann},
+			},
+		}
+	}
+
+	serve := func(ctx Context) *httptest.ResponseRecorder {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+		ctx.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(w, r)
+		return w
+	}
+
+	t.Run("applies the resolved zone", func(t *testing.T) {
+		ctx := newCtx(map[string]string{"parapet.moonrhythm.io/transform-zone": "acme"})
+		var gotKey string
+		zone := newZone(t)
+		TransformZone(func(key string) *transformrule.Zone { gotKey = key; return zone })(ctx)
+
+		w := serve(ctx)
+		assert.Equal(t, "cust1/acme", gotKey, "bare id resolves in the ingress's namespace")
+		assert.Equal(t, "max-age=63072000", w.Header().Get("Strict-Transport-Security"))
+	})
+
+	t.Run("cross-namespace reference is honored (stateless config)", func(t *testing.T) {
+		ctx := newCtx(map[string]string{"parapet.moonrhythm.io/transform-zone": "team-x/acme"})
+		var gotKey string
+		zone := newZone(t)
+		TransformZone(func(key string) *transformrule.Zone { gotKey = key; return zone })(ctx)
+
+		w := serve(ctx)
+		assert.Equal(t, "team-x/acme", gotKey)
+		assert.Equal(t, "max-age=63072000", w.Header().Get("Strict-Transport-Security"))
+	})
+
+	t.Run("passes through when zone resolves to nil", func(t *testing.T) {
+		ctx := newCtx(map[string]string{"parapet.moonrhythm.io/transform-zone": "acme"})
+		var lookups int
+		TransformZone(func(string) *transformrule.Zone { lookups++; return nil })(ctx)
+
+		w := serve(ctx)
+		assert.Equal(t, http.StatusOK, w.Code, "missing zone is a safe no-op")
+		assert.Empty(t, w.Header().Get("Strict-Transport-Security"))
+		assert.Positive(t, lookups, "lookup is consulted live on the request path")
+	})
+
+	t.Run("no annotation injects no middleware", func(t *testing.T) {
+		ctx := newCtx(nil)
+		var lookupCalled bool
+		TransformZone(func(string) *transformrule.Zone { lookupCalled = true; return newZone(t) })(ctx)
+
+		w := serve(ctx)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.False(t, lookupCalled, "no annotation => no mount => lookup never called")
+	})
+}

--- a/transformrule/transformrule.go
+++ b/transformrule/transformrule.go
@@ -1,0 +1,571 @@
+// Package transformrule parses the YAML transform documents carried in
+// transform ConfigMaps (one per (project, location) zone) and runs them as a
+// per-Ingress request/response mutation layer.
+//
+// It mirrors ratelimitrule's split shape: the YAML DTO (Document/Rule/Op) is the
+// wire contract written by the deployer, and Parse is the single source of truth
+// for compiling a zone — validating each rule, compiling its CEL Filter via the
+// parapet lib waf.NewPredicate (the SAME request.* surface WAF and ratelimit
+// use), and building an ordered op pipeline. Compilation is ALL-OR-NOTHING: one
+// bad rule rejects the whole Document, so the controller keeps the last-good
+// Zone live (no partial apply). A filter that errors at EVAL (not compile) skips
+// only that one rule at request time — the safe bias for a mutation layer.
+//
+// Two physical mutation seams (SPEC §4.1):
+//   - request phase: an http.Handler wrapper that mutates r (headers, URL path/
+//     query) before proxying, or short-circuits with an HTTP redirect.
+//   - response phase: a headers.ResponseInterceptor whose callback fires lazily
+//     at the upstream's first WriteHeader, editing response headers and
+//     overriding the status before they go on the wire.
+//
+// The one documented exception is the dual-seam `cors` op (SPEC §2.3): authored
+// in a response-phase rule but mounted as a standalone request-spanning
+// cors.CORS middleware, so its OPTIONS preflight short-circuit fires at request
+// time. Validation requires it to be the sole op in its rule.
+package transformrule
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/moonrhythm/parapet/pkg/cors"
+	"github.com/moonrhythm/parapet/pkg/headers"
+	"github.com/moonrhythm/parapet/pkg/waf"
+	"gopkg.in/yaml.v3"
+)
+
+// Document is the YAML shape of a transform ConfigMap data value. The root key
+// is `transforms`, matching the api TransformSet.Transforms field and the
+// deployer's wire marshal (SPEC §5.2).
+type Document struct {
+	Transforms []Rule `yaml:"transforms"`
+}
+
+// Rule is one phase + optional CEL scope + an ordered list of ops of that phase.
+// The snake_case yaml tags ARE the parapet wire contract; do not rename them.
+type Rule struct {
+	ID          string `yaml:"id"`
+	Description string `yaml:"description"`
+	Phase       string `yaml:"phase"`    // "request" | "response"
+	Filter      string `yaml:"filter"`   // CEL over request.*; "" = always; eval-error => skip
+	Ops         []Op   `yaml:"ops"`      // applied in array order; all belong to Phase
+	Mode        string `yaml:"mode"`     // "" = enforce | "shadow" (match+count, apply nothing)
+	Priority    int    `yaml:"priority"` // ascending within a phase; declaration order breaks ties
+}
+
+// Op is flat and omitempty-driven on the api side; each op reads only its own
+// subset of fields. The yaml keys are the frozen wire contract.
+type Op struct {
+	Type string `yaml:"type"`
+
+	// header ops (request or response per the rule's Phase)
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+
+	// redirect (request)
+	To string `yaml:"to"`
+
+	// rewrite-path (request)
+	Path    string `yaml:"path"`
+	Regex   string `yaml:"regex"`
+	Replace string `yaml:"replace"`
+
+	// rewrite-query (request)
+	Query       map[string]string `yaml:"query"`
+	RemoveQuery []string          `yaml:"remove_query"`
+
+	// redirect / set-status
+	Status int `yaml:"status"`
+
+	// cors (response, dual-seam, sole op)
+	AllowOrigins     []string `yaml:"allow_origins"`
+	AllowMethods     []string `yaml:"allow_methods"`
+	AllowHeaders     []string `yaml:"allow_headers"`
+	ExposeHeaders    []string `yaml:"expose_headers"`
+	AllowCredentials bool     `yaml:"allow_credentials"`
+	MaxAge           string   `yaml:"max_age"`
+}
+
+// op type ids (the frozen vocabulary, SPEC §2.3).
+const (
+	opSetHeader    = "set-header"
+	opRemoveHeader = "remove-header"
+	opRewritePath  = "rewrite-path"
+	opRewriteQuery = "rewrite-query"
+	opRedirect     = "redirect"
+	opSetStatus    = "set-status"
+	opCORS         = "cors"
+)
+
+const (
+	phaseRequest  = "request"
+	phaseResponse = "response"
+	modeShadow    = "shadow"
+)
+
+// Options configures filter compilation and the request snapshot resolvers,
+// mirroring the ratelimit Limiter's filter knobs so a transform filter is
+// bounded and resolved exactly like a WAF rule. Zero values leave the parapet
+// defaults; nil Country/ASN make a geo reference (request.country/asn) simply
+// never match rather than being rejected.
+type Options struct {
+	Country             func(*http.Request) string
+	ASN                 func(*http.Request) int64
+	FilterCostLimit     uint64
+	FilterDisableMacros bool
+}
+
+func (o Options) predicateOptions() []waf.PredicateOption {
+	var opts []waf.PredicateOption
+	if o.FilterCostLimit > 0 {
+		opts = append(opts, waf.WithPredicateCostLimit(o.FilterCostLimit))
+	}
+	if o.FilterDisableMacros {
+		opts = append(opts, waf.WithPredicateDisableMacros())
+	}
+	return opts
+}
+
+// reqOp mutates the request in place; a true return short-circuits the chain
+// (only `redirect` does this). origURI is the request URI captured BEFORE any
+// rule ran, so `redirect`'s $uri token always expands to the ORIGINAL URI even
+// when a higher-priority rewrite rule precedes it (SPEC open-q §12.5).
+type reqOp func(w http.ResponseWriter, r *http.Request, origURI string) (shortCircuit bool)
+
+// respOp is either a header mutation (mutate != nil) or a status override
+// (setStatus > 0). The interceptor applies header mutations in order, then
+// commits the last status override, so headers are never lost behind an
+// early WriteHeader regardless of op declaration order.
+type respOp struct {
+	setStatus int
+	mutate    func(http.Header)
+}
+
+type compiledReqRule struct {
+	id     string
+	prio   int
+	filter *waf.Predicate // nil => always applies
+	shadow bool
+	ops    []reqOp
+}
+
+type compiledRespRule struct {
+	id     string
+	prio   int
+	filter *waf.Predicate
+	shadow bool
+	ops    []respOp
+}
+
+type compiledCorsRule struct {
+	id     string
+	prio   int
+	filter *waf.Predicate
+	shadow bool
+	cors   cors.CORS
+}
+
+// Zone is a compiled, immutable transform set ready for the request path. It is
+// produced by Parse and swapped atomically in the controller registry; Serve
+// concurrently from many requests.
+type Zone struct {
+	reqRules  []compiledReqRule
+	respRules []compiledRespRule
+	corsRules []compiledCorsRule
+	country   func(*http.Request) string
+	asn       func(*http.Request) int64
+}
+
+// Parse parses and compiles one or more YAML transform documents (each
+// ConfigMap data value is one document) into a single Zone. Documents are
+// concatenated in the caller's order; rules are split by phase and each phase
+// is stable-sorted by Priority (declaration order breaks ties). Compilation is
+// all-or-nothing: any YAML, validation, regex, or CEL-compile error returns a
+// nil Zone and an error, so the controller keeps the previous good Zone live.
+func Parse(opts Options, docs ...string) (*Zone, error) {
+	var rules []Rule
+	for _, doc := range docs {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		var d Document
+		if err := yaml.Unmarshal([]byte(doc), &d); err != nil {
+			return nil, fmt.Errorf("transform: parse document: %w", err)
+		}
+		rules = append(rules, d.Transforms...)
+	}
+
+	z := &Zone{country: opts.Country, asn: opts.ASN}
+	predOpts := opts.predicateOptions()
+
+	for _, rule := range rules {
+		if err := z.compileRule(rule, predOpts); err != nil {
+			return nil, fmt.Errorf("transform: rule %q: %w", rule.ID, err)
+		}
+	}
+
+	// Stable sort within each phase: ascending Priority, declaration order breaks
+	// ties (the slices were built in declaration order above).
+	sort.SliceStable(z.reqRules, func(i, j int) bool { return z.reqRules[i].priority() < z.reqRules[j].priority() })
+	sort.SliceStable(z.respRules, func(i, j int) bool { return z.respRules[i].priority() < z.respRules[j].priority() })
+	sort.SliceStable(z.corsRules, func(i, j int) bool { return z.corsRules[i].priority() < z.corsRules[j].priority() })
+
+	return z, nil
+}
+
+// priority accessors kept on the compiled rules so the sort closures read the
+// stored priority without re-threading the source Rule (priorities are folded in
+// during compileRule).
+func (r compiledReqRule) priority() int  { return r.prio }
+func (r compiledRespRule) priority() int { return r.prio }
+func (r compiledCorsRule) priority() int { return r.prio }
+
+func (z *Zone) compileRule(rule Rule, predOpts []waf.PredicateOption) error {
+	var filter *waf.Predicate
+	if f := strings.TrimSpace(rule.Filter); f != "" {
+		p, err := waf.NewPredicate(f, predOpts...)
+		if err != nil {
+			return fmt.Errorf("filter: %w", err)
+		}
+		filter = p
+	}
+
+	switch rule.Mode {
+	case "", modeShadow:
+	default:
+		return fmt.Errorf("invalid mode %q", rule.Mode)
+	}
+	shadow := rule.Mode == modeShadow
+
+	if len(rule.Ops) == 0 {
+		return errors.New("rule has no ops")
+	}
+
+	switch rule.Phase {
+	case phaseRequest:
+		ops, err := compileReqOps(rule.Ops)
+		if err != nil {
+			return err
+		}
+		z.reqRules = append(z.reqRules, compiledReqRule{id: rule.ID, prio: rule.Priority, filter: filter, shadow: shadow, ops: ops})
+	case phaseResponse:
+		// cors is the dual-seam op: a response-phase rule whose sole op is `cors`
+		// is mounted as a standalone request-spanning cors.CORS middleware, NOT via
+		// the response interceptor (SPEC §2.3).
+		if isCORSRule(rule.Ops) {
+			c, err := compileCORS(rule.Ops[0])
+			if err != nil {
+				return err
+			}
+			z.corsRules = append(z.corsRules, compiledCorsRule{id: rule.ID, prio: rule.Priority, filter: filter, shadow: shadow, cors: c})
+			return nil
+		}
+		ops, err := compileRespOps(rule.Ops)
+		if err != nil {
+			return err
+		}
+		z.respRules = append(z.respRules, compiledRespRule{id: rule.ID, prio: rule.Priority, filter: filter, shadow: shadow, ops: ops})
+	default:
+		return fmt.Errorf("invalid phase %q", rule.Phase)
+	}
+	return nil
+}
+
+func isCORSRule(ops []Op) bool {
+	return len(ops) == 1 && ops[0].Type == opCORS
+}
+
+func compileReqOps(ops []Op) ([]reqOp, error) {
+	out := make([]reqOp, 0, len(ops))
+	for i, op := range ops {
+		switch op.Type {
+		case opSetHeader:
+			name, value := op.Name, op.Value
+			out = append(out, func(_ http.ResponseWriter, r *http.Request, _ string) bool {
+				r.Header.Set(name, value)
+				return false
+			})
+		case opRemoveHeader:
+			name := op.Name
+			out = append(out, func(_ http.ResponseWriter, r *http.Request, _ string) bool {
+				r.Header.Del(name)
+				return false
+			})
+		case opRewritePath:
+			rw, err := compileRewritePath(op)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, rw)
+		case opRewriteQuery:
+			rw, err := compileRewriteQuery(op)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, rw)
+		case opRedirect:
+			// redirect short-circuits the whole chain, so any later op would be
+			// dead code: it must be the sole op in its rule (SPEC §3.4).
+			if len(ops) != 1 {
+				return nil, errors.New("redirect must be the only op in its rule")
+			}
+			to := op.To
+			status := op.Status
+			if status == 0 {
+				status = http.StatusFound // 302 default
+			}
+			out = append(out, func(w http.ResponseWriter, r *http.Request, origURI string) bool {
+				target := strings.ReplaceAll(to, "$uri", origURI)
+				http.Redirect(w, r, target, status)
+				return true
+			})
+		default:
+			return nil, fmt.Errorf("op %d: %q is not a request-phase op", i, op.Type)
+		}
+	}
+	return out, nil
+}
+
+func compileRewritePath(op Op) (reqOp, error) {
+	// literal `path` XOR (`regex` + `replace`).
+	if op.Path != "" {
+		if op.Regex != "" || op.Replace != "" {
+			return nil, errors.New("rewrite-path: set exactly one of path or regex+replace")
+		}
+		path := op.Path
+		return func(_ http.ResponseWriter, r *http.Request, _ string) bool {
+			r.URL.Path = path
+			r.URL.RawPath = "" // recompute the escaped form from Path
+			return false
+		}, nil
+	}
+	if op.Regex == "" || op.Replace == "" {
+		return nil, errors.New("rewrite-path: requires path, or regex+replace")
+	}
+	re, err := regexp.Compile(op.Regex)
+	if err != nil {
+		return nil, fmt.Errorf("rewrite-path: regex: %w", err)
+	}
+	replace := op.Replace
+	return func(_ http.ResponseWriter, r *http.Request, _ string) bool {
+		r.URL.Path = re.ReplaceAllString(r.URL.Path, replace)
+		r.URL.RawPath = ""
+		return false
+	}, nil
+}
+
+func compileRewriteQuery(op Op) (reqOp, error) {
+	if len(op.Query) == 0 && len(op.RemoveQuery) == 0 {
+		return nil, errors.New("rewrite-query: requires query and/or remove_query")
+	}
+	setQuery := op.Query
+	removeQuery := op.RemoveQuery
+	return func(_ http.ResponseWriter, r *http.Request, _ string) bool {
+		q := r.URL.Query()
+		for k, v := range setQuery {
+			q.Set(k, v)
+		}
+		for _, k := range removeQuery {
+			q.Del(k)
+		}
+		r.URL.RawQuery = q.Encode()
+		return false
+	}, nil
+}
+
+func compileRespOps(ops []Op) ([]respOp, error) {
+	out := make([]respOp, 0, len(ops))
+	for i, op := range ops {
+		switch op.Type {
+		case opSetHeader:
+			name, value := op.Name, op.Value
+			out = append(out, respOp{mutate: func(h http.Header) { h.Set(name, value) }})
+		case opRemoveHeader:
+			name := op.Name
+			out = append(out, respOp{mutate: func(h http.Header) { h.Del(name) }})
+		case opSetStatus:
+			if op.Status < 100 || op.Status > 599 {
+				return nil, fmt.Errorf("set-status: status %d out of range", op.Status)
+			}
+			out = append(out, respOp{setStatus: op.Status})
+		case opCORS:
+			// cors must be the sole op in its rule and is routed to the standalone
+			// mount in compileRule; reaching here means it was mixed with other ops.
+			return nil, errors.New("cors must be the only op in its rule")
+		default:
+			return nil, fmt.Errorf("op %d: %q is not a response-phase op", i, op.Type)
+		}
+	}
+	return out, nil
+}
+
+func compileCORS(op Op) (cors.CORS, error) {
+	c := cors.CORS{
+		AllowMethods:     op.AllowMethods,
+		AllowHeaders:     op.AllowHeaders,
+		ExposeHeaders:    op.ExposeHeaders,
+		AllowCredentials: op.AllowCredentials,
+	}
+	if op.MaxAge != "" {
+		d, err := time.ParseDuration(op.MaxAge)
+		if err != nil {
+			return cors.CORS{}, fmt.Errorf("cors: max_age: %w", err)
+		}
+		c.MaxAge = d
+	}
+	if len(op.AllowOrigins) == 0 {
+		return cors.CORS{}, errors.New("cors: allow_origins is required")
+	}
+	// A single "*" origin means "any origin". Browsers forbid wildcard-with-
+	// credentials, which cors.CORS.ServeHandler would PANIC on — refuse it here so
+	// a bad set is rejected all-or-nothing instead of crashing the request path.
+	if len(op.AllowOrigins) == 1 && op.AllowOrigins[0] == "*" {
+		if op.AllowCredentials {
+			return cors.CORS{}, errors.New("cors: allow_credentials cannot be combined with a wildcard origin")
+		}
+		c.AllowAllOrigins = true
+	} else {
+		c.AllowOrigins = cors.AllowOrigins(op.AllowOrigins...)
+	}
+	return c, nil
+}
+
+// ServeHandler wraps next with the zone's request- and response-phase mutations
+// (plus the cors special-case mount). It is the parapet.Middleware seam the
+// per-Ingress TransformZone plugin mounts.
+func (z *Zone) ServeHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Capture the URI before any rule mutates the request, so `redirect`'s
+		// $uri expands to the original (SPEC open-q §12.5).
+		origURI := r.URL.RequestURI()
+
+		// The CEL request snapshot is built lazily and rebuilt whenever a request
+		// rule mutates the request, so each rule's predicate (and every response/
+		// cors predicate) sees the request as mutated by all prior request rules
+		// (SPEC §4.2 — request rules compose top-to-bottom).
+		var (
+			input      waf.Input
+			inputValid bool
+		)
+		evalInput := func() waf.Input {
+			if !inputValid {
+				var country string
+				var asn int64
+				if z.country != nil {
+					country = z.country(r)
+				}
+				if z.asn != nil {
+					asn = z.asn(r)
+				}
+				input = waf.NewInput(r, "", country, asn)
+				inputValid = true
+			}
+			return input
+		}
+		// matched reports whether a rule's filter fires. A nil filter always
+		// matches; a runtime EVAL error skips the rule (no mutation) — fail-closed
+		// for a mutation layer.
+		matched := func(filter *waf.Predicate) bool {
+			if filter == nil {
+				return true
+			}
+			ok, err := filter.Eval(r.Context(), evalInput())
+			if err != nil {
+				return false
+			}
+			return ok
+		}
+
+		// Request phase: apply ops in priority order; a redirect short-circuits.
+		for i := range z.reqRules {
+			rule := &z.reqRules[i]
+			if !matched(rule.filter) {
+				continue
+			}
+			if rule.shadow {
+				continue // count the match (Phase-2 metric); apply no mutation
+			}
+			for _, op := range rule.ops {
+				if op(w, r, origURI) {
+					return
+				}
+			}
+			inputValid = false // request mutated; later predicates see a fresh snapshot
+		}
+
+		// Response phase: collect matched ops for one interceptor.
+		var respOps []respOp
+		for i := range z.respRules {
+			rule := &z.respRules[i]
+			if !matched(rule.filter) {
+				continue
+			}
+			if rule.shadow {
+				continue
+			}
+			respOps = append(respOps, rule.ops...)
+		}
+
+		h := next
+		if len(respOps) > 0 {
+			h = headers.InterceptResponse(func(rw headers.ResponseHeaderWriter) {
+				status := 0
+				for _, op := range respOps {
+					if op.setStatus > 0 {
+						status = op.setStatus
+						continue
+					}
+					op.mutate(rw.Header())
+				}
+				if status > 0 {
+					rw.WriteHeader(status)
+				}
+			}).ServeHandler(h)
+		}
+
+		// cors special-case: each matched cors rule wraps the chain as a standalone
+		// request-spanning middleware (handles its own OPTIONS preflight). Wrapped
+		// in reverse so the lowest-priority rule ends up outermost.
+		for i := len(z.corsRules) - 1; i >= 0; i-- {
+			rule := &z.corsRules[i]
+			if !matched(rule.filter) {
+				continue
+			}
+			if rule.shadow {
+				continue
+			}
+			h = rule.cors.ServeHandler(h)
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}
+
+// IDs returns every compiled rule id (request, then response, then cors), in
+// evaluation order. Used for introspection and reload logging, mirroring
+// ratelimitrule.Limiter.IDs.
+func (z *Zone) IDs() []string {
+	out := make([]string, 0, len(z.reqRules)+len(z.respRules)+len(z.corsRules))
+	for i := range z.reqRules {
+		out = append(out, z.reqRules[i].id)
+	}
+	for i := range z.respRules {
+		out = append(out, z.respRules[i].id)
+	}
+	for i := range z.corsRules {
+		out = append(out, z.corsRules[i].id)
+	}
+	return out
+}
+
+// Empty reports whether the zone has no rules (a valid inert zone, e.g. from an
+// empty `transforms:` document). The plugin still mounts it as a cheap
+// pass-through.
+func (z *Zone) Empty() bool {
+	return len(z.reqRules) == 0 && len(z.respRules) == 0 && len(z.corsRules) == 0
+}

--- a/transformrule/transformrule_test.go
+++ b/transformrule/transformrule_test.go
@@ -1,0 +1,363 @@
+package transformrule_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet-ingress-controller/transformrule"
+)
+
+// goldenDoc is the EXACT cross-repo wire contract the deployer marshals from the
+// api types with gopkg.in/yaml.v2 (SPEC §5.2). transformrule.Parse MUST consume
+// it byte-for-byte.
+const goldenDoc = `transforms:
+- id: 42-9f3a1c
+  description: force www
+  phase: request
+  filter: request.host == "acme.com"
+  ops:
+  - type: redirect
+    to: https://www.acme.com$uri
+    status: 308
+  priority: 10
+- id: 42-1a8d44
+  description: security headers
+  phase: response
+  ops:
+  - type: set-header
+    name: Strict-Transport-Security
+    value: max-age=63072000
+  - type: remove-header
+    name: Server
+  mode: shadow
+  priority: 0
+- id: 42-cors01
+  description: ""
+  phase: response
+  ops:
+  - type: cors
+    allow_origins:
+    - https://app.acme.com
+    allow_methods:
+    - GET
+    - POST
+    allow_credentials: true
+    max_age: 600s
+  priority: 0
+`
+
+func serve(t *testing.T, z *transformrule.Zone, r *http.Request, downstream http.HandlerFunc) *httptest.ResponseRecorder {
+	t.Helper()
+	if downstream == nil {
+		downstream = func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }
+	}
+	w := httptest.NewRecorder()
+	z.ServeHandler(downstream).ServeHTTP(w, r)
+	return w
+}
+
+func TestParse_Golden(t *testing.T) {
+	t.Parallel()
+
+	z, err := transformrule.Parse(transformrule.Options{}, goldenDoc)
+	require.NoError(t, err, "the golden wire doc must parse exactly")
+	require.NotNil(t, z)
+
+	// request rules first, then response-interceptor rules, then cors rules.
+	assert.Equal(t, []string{"42-9f3a1c", "42-1a8d44", "42-cors01"}, z.IDs())
+
+	t.Run("redirect with $uri (request phase, sole-op short-circuit)", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "http://acme.com/pricing?ref=x", nil)
+		var proxied bool
+		w := serve(t, z, r, func(w http.ResponseWriter, _ *http.Request) { proxied = true })
+
+		assert.False(t, proxied, "a matched redirect short-circuits before proxying")
+		assert.Equal(t, http.StatusPermanentRedirect, w.Code) // 308
+		assert.Equal(t, "https://www.acme.com/pricing?ref=x", w.Header().Get("Location"),
+			"$uri expands to the original RequestURI")
+	})
+
+	t.Run("redirect filter scopes the match", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "http://www.acme.com/pricing", nil)
+		var proxied bool
+		w := serve(t, z, r, func(w http.ResponseWriter, _ *http.Request) {
+			proxied = true
+			w.Header().Set("Server", "origin/1.0")
+			w.WriteHeader(http.StatusOK)
+		})
+		assert.True(t, proxied, "non-matching host proxies normally")
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("shadow rule counts but mutates nothing", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "http://www.acme.com/", nil)
+		w := serve(t, z, r, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Server", "origin/1.0")
+			w.WriteHeader(http.StatusOK)
+		})
+		assert.Empty(t, w.Header().Get("Strict-Transport-Security"), "shadow set-header applies nothing")
+		assert.Equal(t, "origin/1.0", w.Header().Get("Server"), "shadow remove-header removes nothing")
+	})
+
+	t.Run("cors preflight short-circuit (dual-seam standalone mount)", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodOptions, "http://www.acme.com/", nil)
+		r.Header.Set("Origin", "https://app.acme.com")
+		var proxied bool
+		w := serve(t, z, r, func(http.ResponseWriter, *http.Request) { proxied = true })
+
+		assert.False(t, proxied, "cors answers the OPTIONS preflight without proxying")
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "https://app.acme.com", w.Header().Get("Access-Control-Allow-Origin"))
+		assert.Contains(t, w.Header().Get("Access-Control-Allow-Methods"), "GET")
+		assert.Equal(t, "true", w.Header().Get("Access-Control-Allow-Credentials"))
+		assert.Equal(t, "600", w.Header().Get("Access-Control-Max-Age"), "max_age 600s => 600")
+	})
+
+	t.Run("cors injects ACAO on a real request", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "http://www.acme.com/data", nil)
+		r.Header.Set("Origin", "https://app.acme.com")
+		w := serve(t, z, r, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+		assert.Equal(t, "https://app.acme.com", w.Header().Get("Access-Control-Allow-Origin"))
+	})
+}
+
+func TestParse_ResponseEnforce(t *testing.T) {
+	t.Parallel()
+
+	// enforce (no shadow): set-header + remove-header + set-status via the
+	// ResponseInterceptor seam.
+	z, err := transformrule.Parse(transformrule.Options{}, `
+transforms:
+- id: r1
+  phase: response
+  ops:
+  - type: set-header
+    name: Strict-Transport-Security
+    value: max-age=63072000
+  - type: remove-header
+    name: Server
+  - type: set-status
+    status: 203
+  priority: 0
+`)
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodGet, "http://x.test/", nil)
+	w := serve(t, z, r, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Server", "origin/1.0")
+		w.WriteHeader(http.StatusOK) // upstream 200, overridden to 203
+		_, _ = w.Write([]byte("body"))
+	})
+
+	assert.Equal(t, "max-age=63072000", w.Header().Get("Strict-Transport-Security"))
+	assert.Empty(t, w.Header().Get("Server"), "remove-header drops it before commit")
+	assert.Equal(t, 203, w.Code, "set-status overrides the upstream status (wroteHeader guard)")
+}
+
+func TestParse_RewritePathAndQuery(t *testing.T) {
+	t.Parallel()
+
+	// two request rules compose top-to-bottom; rule 25's predicate sees the path
+	// already rewritten by rule 20 (SPEC §14.3).
+	z, err := transformrule.Parse(transformrule.Options{}, `
+transforms:
+- id: rw-path
+  phase: request
+  filter: request.path.startsWith("/api/v1/")
+  ops:
+  - type: rewrite-path
+    regex: ^/api/v1/(.*)$
+    replace: /api/v2/$1
+  priority: 20
+- id: rw-query
+  phase: request
+  filter: request.path.startsWith("/api/")
+  ops:
+  - type: rewrite-query
+    remove_query:
+    - debug
+  priority: 25
+`)
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodGet, "http://x.test/api/v1/users?debug=1&page=2", nil)
+	var gotPath, gotQuery string
+	serve(t, z, r, func(_ http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+	})
+
+	assert.Equal(t, "/api/v2/users", gotPath, "regex rewrite-path applied")
+	assert.Equal(t, "page=2", gotQuery, "rewrite-query saw the mutated path and dropped debug")
+}
+
+func TestParse_RewritePathLiteral(t *testing.T) {
+	t.Parallel()
+
+	z, err := transformrule.Parse(transformrule.Options{}, `
+transforms:
+- id: lit
+  phase: request
+  ops:
+  - type: rewrite-path
+    path: /healthz
+  priority: 0
+`)
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodGet, "http://x.test/anything", nil)
+	var gotPath string
+	serve(t, z, r, func(_ http.ResponseWriter, r *http.Request) { gotPath = r.URL.Path })
+	assert.Equal(t, "/healthz", gotPath)
+}
+
+func TestParse_PriorityOrder(t *testing.T) {
+	t.Parallel()
+
+	// two response rules set the same header; ascending priority means the
+	// higher-priority rule runs LAST and wins.
+	z, err := transformrule.Parse(transformrule.Options{}, `
+transforms:
+- id: late
+  phase: response
+  ops:
+  - type: set-header
+    name: X-Order
+    value: high-prio
+  priority: 20
+- id: early
+  phase: response
+  ops:
+  - type: set-header
+    name: X-Order
+    value: low-prio
+  priority: 10
+`)
+	require.NoError(t, err)
+	// IDs() reflects the sorted order: priority 10 (early) before priority 20 (late).
+	assert.Equal(t, []string{"early", "late"}, z.IDs())
+
+	r := httptest.NewRequest(http.MethodGet, "http://x.test/", nil)
+	w := serve(t, z, r, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	assert.Equal(t, "high-prio", w.Header().Get("X-Order"), "higher priority runs last and wins")
+}
+
+func TestParse_BadFilterRejectsWholeDocument(t *testing.T) {
+	t.Parallel()
+
+	// A filter that fails to COMPILE rejects the WHOLE set all-or-nothing — the
+	// good rule alongside it never takes effect (the controller keeps last-good).
+	z, err := transformrule.Parse(transformrule.Options{}, `
+transforms:
+- id: good
+  phase: response
+  ops:
+  - type: set-header
+    name: X-Good
+    value: "1"
+  priority: 0
+- id: bad
+  phase: request
+  filter: "request.host == "
+  ops:
+  - type: set-header
+    name: X-Bad
+    value: "1"
+  priority: 0
+`)
+	require.Error(t, err, "an uncompilable filter rejects the whole document")
+	assert.Nil(t, z)
+}
+
+func TestParse_EvalErrorSkipsOneRule(t *testing.T) {
+	t.Parallel()
+
+	// rule A's filter COMPILES but ERRORS at eval (int() of a non-numeric host);
+	// it must be skipped (no mutation) while rule B still applies. A runtime eval
+	// error never rejects the whole set — only a compile error does.
+	z, err := transformrule.Parse(transformrule.Options{}, `
+transforms:
+- id: a-eval-error
+  phase: request
+  filter: int(request.host) > 0
+  ops:
+  - type: set-header
+    name: X-A
+    value: "1"
+  priority: 10
+- id: b-applies
+  phase: request
+  ops:
+  - type: set-header
+    name: X-B
+    value: "1"
+  priority: 20
+`)
+	require.NoError(t, err, "both filters compile; the error is at eval time")
+
+	r := httptest.NewRequest(http.MethodGet, "http://acme.com/", nil)
+	var gotA, gotB string
+	serve(t, z, r, func(_ http.ResponseWriter, r *http.Request) {
+		gotA = r.Header.Get("X-A")
+		gotB = r.Header.Get("X-B")
+	})
+	assert.Empty(t, gotA, "the eval-error rule is skipped (no mutation)")
+	assert.Equal(t, "1", gotB, "other rules still apply")
+}
+
+func TestParse_EmptyDocIsInert(t *testing.T) {
+	t.Parallel()
+
+	z, err := transformrule.Parse(transformrule.Options{}, "transforms:\n")
+	require.NoError(t, err)
+	require.NotNil(t, z)
+	assert.True(t, z.Empty())
+
+	r := httptest.NewRequest(http.MethodGet, "http://x.test/", nil)
+	var proxied bool
+	serve(t, z, r, func(http.ResponseWriter, *http.Request) { proxied = true })
+	assert.True(t, proxied, "an empty zone is a pass-through")
+}
+
+func TestParse_CORSWildcardWithCredentialsRejected(t *testing.T) {
+	t.Parallel()
+
+	// Browsers forbid wildcard-with-credentials; cors.CORS.ServeHandler would
+	// PANIC. Parse must reject it all-or-nothing instead of crashing the request
+	// path.
+	_, err := transformrule.Parse(transformrule.Options{}, `
+transforms:
+- id: bad-cors
+  phase: response
+  ops:
+  - type: cors
+    allow_origins:
+    - "*"
+    allow_credentials: true
+  priority: 0
+`)
+	require.Error(t, err)
+}
+
+func TestParse_RedirectMustBeSoleOp(t *testing.T) {
+	t.Parallel()
+
+	_, err := transformrule.Parse(transformrule.Options{}, `
+transforms:
+- id: bad
+  phase: request
+  ops:
+  - type: redirect
+    to: https://x.test/
+    status: 302
+  - type: set-header
+    name: X-Extra
+    value: "1"
+  priority: 0
+`)
+	require.Error(t, err, "redirect must be the only op in its rule")
+}


### PR DESCRIPTION
## feat(transform): in-cluster CEL transform runtime

Implements the in-cluster runtime for the deploys.app Edge Transform feature — declarative, CEL-scoped request/response transforms (no user code/WASM).

- `transformrule/`: `Document` parse (yaml `transforms:`), per-rule filter compiled via `waf.NewPredicate`, ordered op pipeline. Request ops mutate inline (set/remove-header, rewrite-path, rewrite-query, redirect short-circuit with `$uri`); response ops via the `headers` ResponseInterceptor (set/remove-header, set-status); `cors` via `cors.CORS`. All-or-nothing compile keeps the last-good zone; a runtime eval error skips one rule; shadow mode; ascending priority.
- `plugin/transform.go`: `TransformZone` plugin (annotation `parapet.moonrhythm.io/transform-zone`), pass-through on a missing zone.
- `controller_transform.go`: zone store + watch/reload; `TransformConfig`; gated by `TRANSFORM_ENABLED`.
- **Security-critical ordering:** the plugin registers AFTER WAF + RateLimit (security/throttle see the original request) but BEFORE ForwardAuth — so ForwardAuth's delete + re-stamp of `X-Auth-*` always overwrites any transform-forged identity header (a `transform.set`-only tenant cannot impersonate an authenticated user). Pinned by `TestTransformZoneRegistrationSlot`.

No parapet-lib change. `go build/vet` clean, 831 tests pass. Deploy before the apiserver starts emitting transform commands.
