### PR TITLE
transform: global baseline (parapet.moonrhythm.io/transform: global)

### DIFF
--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -400,6 +400,17 @@ func main() {
 		// Per-zone limits run inside the per-ingress chain (plugin.RateLimitZone).
 		m.Use(ctrl.GlobalRateLimit())
 	}
+	if transformEnabled {
+		// Global transform runs after every global security layer (WAF, Coraza,
+		// rate limit) so security and throttle always see the original,
+		// un-rewritten request and blocked/limited traffic is never transformed —
+		// the same F1 reasoning that slots the per-ingress TransformZone plugin.
+		// It runs BEFORE forwardGeoHeaders below, so a transform-set
+		// X-Forwarded-Country/ASN is always overwritten by the authoritative GeoIP
+		// values, and before routing, so its response ops (e.g. a global
+		// X-Robots-Tag) also stamp unrouted-host (404) responses.
+		m.Use(ctrl.GlobalTransform())
+	}
 	// Forward the resolved GeoIP country/ASN to upstreams. Mounted only when a DB
 	// is loaded (resolver non-nil); runs just before routing so the headers reach
 	// the proxied request.

--- a/controller.go
+++ b/controller.go
@@ -101,10 +101,11 @@ type Controller struct {
 	// controller_coraza.go.
 	CorazaConfig CorazaConfig
 
-	// TransformConfig configures the ConfigMap-driven transform layer — a
-	// per-(project, location) zone of CEL-scoped request/response mutations. Set
-	// before Watch(); when disabled the feature does no work: no ConfigMap watch,
-	// no mount. See controller_transform.go.
+	// TransformConfig configures the ConfigMap-driven transform layer of
+	// CEL-scoped request/response mutations — a global baseline plus
+	// per-(project, location) zones, following the WAF's model. Set before
+	// Watch(); when disabled the feature does no work: no ConfigMap watch, no
+	// mount. See controller_transform.go.
 	TransformConfig TransformConfig
 
 	// globalWAF is the always-on baseline firewall; zones holds the tenant zone
@@ -125,11 +126,14 @@ type Controller struct {
 	globalCoraza *corazawaf.Instance
 	corazaZones  atomic.Pointer[map[string]*corazawaf.Instance]
 
-	// transformZones holds the per-(project, location) transform zone registry
-	// keyed by <namespace>/<name>, swapped atomically on transform reload. There
-	// is no global baseline (transforms are zone-only). Decoupled from the mux
-	// exactly like the WAF/ratelimit registries.
-	transformZones atomic.Pointer[map[string]*transformrule.Zone]
+	// globalTransform is the baseline transform set (nil = none loaded, a
+	// pass-through); transformZones holds the per-(project, location) transform
+	// zone registry keyed by <namespace>/<name>, swapped atomically on transform
+	// reload. Decoupled from the mux exactly like the WAF/ratelimit registries.
+	// Unlike globalWAF (a mutable instance fed by SetRules), a transformrule.Zone
+	// is immutable, so the global set is itself an atomic.Pointer swap.
+	globalTransform atomic.Pointer[transformrule.Zone]
+	transformZones  atomic.Pointer[map[string]*transformrule.Zone]
 
 	// WAF rule-input fingerprints from the last reload, used to skip recompiling
 	// CEL rulesets whose effective input (the sorted concatenated rule YAML) is
@@ -164,8 +168,9 @@ type Controller struct {
 	// transformReloadMu serializes overlapping debounce-fired passes, the
 	// fingerprints skip recompiling unchanged transform input. Accessed only under
 	// transformReloadMu.
-	transformReloadMu         sync.Mutex
-	transformZoneFingerprints map[string]string
+	transformReloadMu          sync.Mutex
+	globalTransformFingerprint string
+	transformZoneFingerprints  map[string]string
 
 	// endpointReloadMu serializes host-route recomputes. Two watch goroutines now
 	// feed pod IPs — the EndpointSlice watch and the legacy-Endpoints fallback

--- a/controller_transform.go
+++ b/controller_transform.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"sort"
 
+	"github.com/moonrhythm/parapet"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/watch"
 
@@ -12,11 +14,12 @@ import (
 	"github.com/moonrhythm/parapet-ingress-controller/transformrule"
 )
 
-// transformLabelKey marks a ConfigMap as transform input. Unlike the WAF and
-// rate-limit labels there is no "global" baseline — transforms are a per-(project,
-// location) zone only — so the value is always "zone" (roleZone) and its id is the
-// ConfigMap name. It is a separate label key (and a separate watch) because a
-// Kubernetes label selector can't OR two keys; the store stays separate too.
+// transformLabelKey marks a ConfigMap as transform input. Its value selects the
+// role, following the WAF/ratelimit model: "global" (baseline mutations applied
+// to all traffic, honored only in the controller's own namespace) or "zone" (a
+// per-(project, location) zone whose id is the ConfigMap name). It is a separate
+// label key (and a separate watch) because a Kubernetes label selector can't OR
+// two keys; the store stays separate too.
 const transformLabelKey = "parapet.moonrhythm.io/transform"
 
 // TransformConfig configures the ConfigMap-driven transform layer. It is set on
@@ -60,6 +63,26 @@ func (ctrl *Controller) InitTransform() {
 	ctrl.transformZoneFingerprints = map[string]string{}
 }
 
+// GlobalTransform returns the global transform middleware to mount in the
+// server chain, or nil when the feature is disabled. The compiled set is looked
+// up live per request (a transformrule.Zone is immutable, so reloads swap the
+// pointer), so global edits propagate without a mux rebuild; no set loaded
+// (nil) passes traffic through unmodified — a safe no-op.
+func (ctrl *Controller) GlobalTransform() parapet.Middleware {
+	if !ctrl.TransformConfig.Enabled {
+		return nil
+	}
+	return parapet.MiddlewareFunc(func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if z := ctrl.globalTransform.Load(); z != nil {
+				z.ServeHandler(h).ServeHTTP(w, r)
+				return
+			}
+			h.ServeHTTP(w, r)
+		})
+	})
+}
+
 // LookupTransformZone returns the compiled transform zone for a registry key
 // (<namespace>/<name>), or nil if no such zone is loaded. Looked up live on the
 // request path so zone edits and new zones propagate without a mux rebuild.
@@ -92,11 +115,11 @@ func (ctrl *Controller) reloadTransform() {
 	ctrl.reloadTransformDebounce.Call()
 }
 
-// reloadTransformDebounced rebuilds the zone registry from the watched
-// ConfigMaps. Like the WAF/ratelimit reloads it never touches ctrl.mux — a
-// transform edit is a Parse + registry swap. Parse is all-or-nothing, so a bad
-// zone keeps its last-good compiled set; unchanged inputs (fingerprint match)
-// are skipped entirely (the compiled Zone is reused).
+// reloadTransformDebounced rebuilds the global set and the zone registry from
+// the watched ConfigMaps. Like the WAF/ratelimit reloads it never touches
+// ctrl.mux — a transform edit is a Parse + pointer/registry swap. Parse is
+// all-or-nothing, so a bad set keeps its last-good compiled one; unchanged
+// inputs (fingerprint match) are skipped entirely (the compiled Zone is reused).
 func (ctrl *Controller) reloadTransformDebounced() {
 	if !ctrl.TransformConfig.Enabled {
 		return
@@ -113,13 +136,16 @@ func (ctrl *Controller) reloadTransformDebounced() {
 		}
 	}()
 
+	var globalCMs []*v1.ConfigMap
 	zoneDocs := map[string][]string{}
 
 	ctrl.watchedTransformConfigMaps.Range(func(_, value any) bool {
 		cm := value.(*v1.ConfigMap)
-		// Only a "zone"-roled ConfigMap is transform input; anything else in this
-		// store (the fs backend ignores label selectors) falls through silently.
-		if cm.Labels[transformLabelKey] != roleZone {
+		role := cm.Labels[transformLabelKey]
+		// Only a "global"- or "zone"-roled ConfigMap is transform input; anything
+		// else in this store (the fs backend ignores label selectors) falls through
+		// silently.
+		if role != roleGlobal && role != roleZone {
 			return true
 		}
 		// Refuse a ConfigMap labeled for more than one feature (one ConfigMap per
@@ -136,15 +162,53 @@ func (ctrl *Controller) reloadTransformDebounced() {
 				"configmap", cm.Namespace+"/"+cm.Name)
 			return true
 		}
+		if role == roleGlobal {
+			// Global transforms are platform-owned: only honored from the
+			// controller's own namespace so a tenant can't mutate all traffic.
+			if cm.Namespace != ctrl.PodNamespace {
+				slog.Warn("transform: ignoring global set outside controller namespace",
+					"configmap", cm.Namespace+"/"+cm.Name, "pod_namespace", ctrl.PodNamespace)
+				return true
+			}
+			globalCMs = append(globalCMs, cm)
+			return true
+		}
 		key := cm.Namespace + "/" + cm.Name
 		zoneDocs[key] = append(zoneDocs[key], sortedDataValues(cm.Data)...)
 		return true
 	})
 
+	opts := ctrl.transformOptions()
+
+	// Concatenate global ConfigMaps in a deterministic name order (they all live
+	// in PodNamespace; the sync.Map.Range above visits them in random order) so
+	// equal-priority rule precedence and the fingerprint are stable across
+	// reloads — same reasoning as the WAF's global concatenation.
+	sort.Slice(globalCMs, func(i, j int) bool { return globalCMs[i].Name < globalCMs[j].Name })
+	var globalDocs []string
+	for _, cm := range globalCMs {
+		globalDocs = append(globalDocs, sortedDataValues(cm.Data)...)
+	}
+	globalFP := fingerprintDocs(globalDocs)
+	if globalFP != ctrl.globalTransformFingerprint {
+		if len(globalDocs) == 0 {
+			// No global ConfigMap: drop to nil so the mounted middleware is a pure
+			// pass-through (cheaper than an empty compiled Zone).
+			ctrl.globalTransform.Store(nil)
+			ctrl.globalTransformFingerprint = globalFP
+		} else if zone, err := transformrule.Parse(opts, globalDocs...); err != nil {
+			// All-or-nothing: keep the last-good global set live and keep its prior
+			// fingerprint so the bad input is retried next reload.
+			slog.Error("transform: invalid global set, keeping previous", "error", err)
+		} else {
+			ctrl.globalTransform.Store(zone)
+			ctrl.globalTransformFingerprint = globalFP
+		}
+	}
+
 	cur := ctrl.transformZones.Load()
 	newZones := make(map[string]*transformrule.Zone, len(zoneDocs))
 	newFingerprints := make(map[string]string, len(zoneDocs))
-	opts := ctrl.transformOptions()
 
 	for key, docs := range zoneDocs {
 		fp := fingerprintDocs(docs)
@@ -179,5 +243,9 @@ func (ctrl *Controller) reloadTransformDebounced() {
 
 	ctrl.transformZones.Store(&newZones)
 	ctrl.transformZoneFingerprints = newFingerprints
-	slog.Info("reloaded transform", "zones", len(newZones))
+	globalRules := 0
+	if z := ctrl.globalTransform.Load(); z != nil {
+		globalRules = len(z.IDs())
+	}
+	slog.Info("reloaded transform", "global_rules", globalRules, "zones", len(newZones))
 }

--- a/controller_transform_test.go
+++ b/controller_transform_test.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -112,6 +114,105 @@ func TestReloadTransform_RemoveZone(t *testing.T) {
 	ctrl.watchedTransformConfigMaps.Delete("cust1/transform-42")
 	ctrl.reloadTransformDebounced()
 	assert.Nil(t, ctrl.LookupTransformZone("cust1/transform-42"), "deleted zone is gone after reload")
+}
+
+func globalTransformCM(namespace, name, doc string) *v1.ConfigMap {
+	cm := transformCM(namespace, name, doc)
+	cm.Labels[transformLabelKey] = roleGlobal
+	return cm
+}
+
+const transformGlobalRule = `
+transforms:
+- id: robots
+  phase: response
+  ops:
+  - type: set-header
+    name: X-Robots-Tag
+    value: noindex, nofollow
+  priority: 0
+`
+
+func TestReloadTransform_Global(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newTransformController()
+	ctrl.watchedTransformConfigMaps.Store("ctrl-ns/transform-global", globalTransformCM("ctrl-ns", "transform-global", transformGlobalRule))
+	ctrl.reloadTransformDebounced()
+
+	// the global set serves through the mounted middleware end-to-end.
+	h := ctrl.GlobalTransform().ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, "noindex, nofollow", w.Header().Get("X-Robots-Tag"),
+		"global response op applies to all traffic")
+
+	// deleting the global ConfigMap drops the set back to a pass-through.
+	ctrl.watchedTransformConfigMaps.Delete("ctrl-ns/transform-global")
+	ctrl.reloadTransformDebounced()
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Empty(t, w.Header().Get("X-Robots-Tag"), "deleted global set is gone after reload")
+}
+
+func TestReloadTransform_GlobalOutsidePodNamespaceIgnored(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newTransformController()
+	ctrl.watchedTransformConfigMaps.Store("cust1/transform-global", globalTransformCM("cust1", "transform-global", transformGlobalRule))
+	ctrl.reloadTransformDebounced()
+
+	assert.Nil(t, ctrl.globalTransform.Load(),
+		"a tenant-namespace global set must not mutate all traffic")
+}
+
+func TestReloadTransform_BadGlobalKeepsLastGood(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newTransformController()
+	ctrl.watchedTransformConfigMaps.Store("ctrl-ns/transform-global", globalTransformCM("ctrl-ns", "transform-global", transformGlobalRule))
+	ctrl.reloadTransformDebounced()
+	require.NotNil(t, ctrl.globalTransform.Load())
+
+	ctrl.watchedTransformConfigMaps.Store("ctrl-ns/transform-global", globalTransformCM("ctrl-ns", "transform-global", `
+transforms:
+- id: broken
+  phase: response
+  filter: "this is not && valid cel ("
+  ops:
+  - type: set-header
+    name: X-Test
+    value: "1"
+  priority: 0
+`))
+	ctrl.reloadTransformDebounced()
+
+	z := ctrl.globalTransform.Load()
+	require.NotNil(t, z)
+	assert.Equal(t, []string{"robots"}, z.IDs(), "bad edit must not drop the live global set")
+
+	// a fixed edit applies (the rejected input didn't advance the fingerprint).
+	ctrl.watchedTransformConfigMaps.Store("ctrl-ns/transform-global", globalTransformCM("ctrl-ns", "transform-global", `
+transforms:
+- id: robots-v2
+  phase: response
+  ops:
+  - type: set-header
+    name: X-Robots-Tag
+    value: none
+  priority: 0
+`))
+	ctrl.reloadTransformDebounced()
+	assert.Equal(t, []string{"robots-v2"}, ctrl.globalTransform.Load().IDs())
+}
+
+func TestGlobalTransform_DisabledReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	ctrl := New("", proxy.New())
+	assert.Nil(t, ctrl.GlobalTransform(), "disabled transform mounts nothing")
 }
 
 func TestReloadTransform_IgnoresMultiLabeledConfigMap(t *testing.T) {


### PR DESCRIPTION
## What

The transform layer was zone-only by design; this adds the missing **global** role, following the WAF's global+zone model, so an operator can mutate all traffic — e.g. globally stamp `X-Robots-Tag: noindex, nofollow` to block crawler bots:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: transform-global
  namespace: <controller-namespace>
  labels:
    parapet.moonrhythm.io/transform: global
data:
  transforms.yaml: |
    transforms:
    - id: block-crawlers
      phase: response
      ops:
      - type: set-header
        name: X-Robots-Tag
        value: noindex, nofollow
```

## How

- **Role guard**: `transform: global` ConfigMaps are honored only from `POD_NAMESPACE` (platform-owned, same tenant-injection guard as the WAF/ratelimit/Coraza globals). Multiple global ConfigMaps concatenate in deterministic name order.
- **Storage**: a `transformrule.Zone` is immutable (unlike `globalWAF`'s `SetRules`), so the global set is an `atomic.Pointer[transformrule.Zone]` swap; nil (no global ConfigMap) is a pure pass-through. Reload mirrors the zone path: fingerprint skip, all-or-nothing `Parse` keeping last-good, rejected input doesn't advance the fingerprint so a fixed edit applies, delete drops to nil.
- **Mount position** (`main.go` server chain): after global WAF/Coraza/ratelimit — security and throttle always see the original, un-rewritten request, and blocked/limited responses are never transformed (the same F1 reasoning as the per-ingress `TransformZone` slot) — and before `forwardGeoHeaders` (a transform-set `X-Forwarded-Country/ASN` is always overwritten) and routing (global response ops also stamp unrouted-host 404s).

## Semantics worth noting

- Global response ops run **outer** to zone ops, so on a same-header conflict the global value wins — consistent with the repo's "global is authoritative" posture.
- Core-only for now: the edge doesn't run transforms yet, so pure edge-cache hits carry whatever header was stamped when the response was fetched from core.

## Tests

New coverage in `controller_transform_test.go`: global load + end-to-end response-header serve through the mounted middleware, tenant-namespace global ignored, bad global keeps last-good then a *different* fixed edit applies (proves the fingerprint isn't wedged), deleted global drops to pass-through, disabled returns nil. `gofmt` clean, `go vet` clean, full suite passes (835 tests).