### PR TITLE
transform: inline set via the parapet.moonrhythm.io/transform annotation

### DIFF
--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -349,6 +349,11 @@ func main() {
 		// accepted tradeoff: a transform redirect short-circuits before the access
 		// gate, which is harmless for a soft re-route.
 		ctrl.Use(plugin.TransformZone(ctrl.LookupTransformZone))
+		// Inline transform (the ingress's own set, carried in the annotation)
+		// runs after the zone so shared zone config applies first and the
+		// ingress's inline rules see — and can override — its effects, mirroring
+		// global→zone. Same security-critical slot as TransformZone above.
+		ctrl.Use(plugin.Transform(ctrl.TransformConfig.Options()))
 	}
 	ctrl.Use(plugin.BodyLimit)
 	ctrl.Use(plugin.UpstreamProtocol)

--- a/cmd/parapet-ingress-controller/transform_order_test.go
+++ b/cmd/parapet-ingress-controller/transform_order_test.go
@@ -39,6 +39,7 @@ func TestTransformZoneRegistrationSlot(t *testing.T) {
 	waf := idx("ctrl.Use(plugin.WAFZone(")
 	rateLimit := idx("ctrl.Use(plugin.RateLimit)")
 	transform := idx("ctrl.Use(plugin.TransformZone(")
+	transformInline := idx("ctrl.Use(plugin.Transform(")
 	upstreamProto := idx("ctrl.Use(plugin.UpstreamProtocol)")
 	upstreamHost := idx("ctrl.Use(plugin.UpstreamHost)")
 	upstreamPath := idx("ctrl.Use(plugin.UpstreamPath)")
@@ -50,12 +51,18 @@ func TestTransformZoneRegistrationSlot(t *testing.T) {
 	require.Less(t, waf, transform, "transform must register AFTER WAFZone")
 	require.Less(t, rateLimit, transform, "transform must register AFTER RateLimit")
 
+	// the inline set runs after the zone (shared config first, the ingress's own
+	// rules see and can override its effects) and shares the whole F1 slot.
+	require.Less(t, transform, transformInline, "inline transform must register AFTER TransformZone")
+
 	// before the upstream rewrites + auth + strip-prefix
-	require.Less(t, transform, upstreamProto, "transform must register BEFORE UpstreamProtocol")
-	require.Less(t, transform, upstreamHost, "transform must register BEFORE UpstreamHost")
-	require.Less(t, transform, upstreamPath, "transform must register BEFORE UpstreamPath")
-	require.Less(t, transform, basicAuth, "transform must register BEFORE BasicAuth")
-	require.Less(t, transform, forwardAuth,
-		"transform must register BEFORE ForwardAuth so X-Auth-* re-stamp overwrites any forged identity header (SPEC §4.4)")
-	require.Less(t, transform, stripPrefix, "transform must register BEFORE StripPrefix")
+	for name, pos := range map[string]int{"zone": transform, "inline": transformInline} {
+		require.Less(t, pos, upstreamProto, "%s transform must register BEFORE UpstreamProtocol", name)
+		require.Less(t, pos, upstreamHost, "%s transform must register BEFORE UpstreamHost", name)
+		require.Less(t, pos, upstreamPath, "%s transform must register BEFORE UpstreamPath", name)
+		require.Less(t, pos, basicAuth, "%s transform must register BEFORE BasicAuth", name)
+		require.Less(t, pos, forwardAuth,
+			"%s transform must register BEFORE ForwardAuth so X-Auth-* re-stamp overwrites any forged identity header (SPEC §4.4)", name)
+		require.Less(t, pos, stripPrefix, "%s transform must register BEFORE StripPrefix", name)
+	}
 }

--- a/controller_transform.go
+++ b/controller_transform.go
@@ -42,13 +42,20 @@ type TransformConfig struct {
 	FilterDisableMacros bool
 }
 
-func (ctrl *Controller) transformOptions() transformrule.Options {
+// Options returns the compile options shared by every transform surface
+// (global, zone, and the inline-annotation plugin), so all three are bounded
+// and geo-resolved identically.
+func (c TransformConfig) Options() transformrule.Options {
 	return transformrule.Options{
-		Country:             ctrl.TransformConfig.Country,
-		ASN:                 ctrl.TransformConfig.ASN,
-		FilterCostLimit:     ctrl.TransformConfig.FilterCostLimit,
-		FilterDisableMacros: ctrl.TransformConfig.FilterDisableMacros,
+		Country:             c.Country,
+		ASN:                 c.ASN,
+		FilterCostLimit:     c.FilterCostLimit,
+		FilterDisableMacros: c.FilterDisableMacros,
 	}
+}
+
+func (ctrl *Controller) transformOptions() transformrule.Options {
+	return ctrl.TransformConfig.Options()
 }
 
 // InitTransform seeds the (empty) zone registry. Call after setting

--- a/plugin/transform.go
+++ b/plugin/transform.go
@@ -1,12 +1,47 @@
 package plugin
 
 import (
+	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/moonrhythm/parapet"
 
 	"github.com/moonrhythm/parapet-ingress-controller/transformrule"
 )
+
+// Transform mounts an inline transform set carried directly in the
+// parapet.moonrhythm.io/transform annotation — the same YAML document a
+// transform ConfigMap holds (`transforms:` root key). It complements the
+// zone reference (transform-zone): a zone is shared, ConfigMap-managed config;
+// the inline set is the ingress's own, hot-reloaded the way every other inline
+// annotation is — plugins re-run on each mux reload, so an annotation edit
+// recompiles naturally and there is no registry to look up per request.
+//
+// The compile options (CEL cost limit / macro policy, GeoIP resolvers) are the
+// same ones the global and zone sets use, so an inline `filter` is bounded
+// identically. A set that fails to parse is logged and mounted as nothing —
+// traffic passes through unmodified (the same log-and-skip failure mode as a
+// bad `redirect` annotation; unlike a ConfigMap edit there is no previous
+// compiled set to keep). An empty/valid-but-ruleless set mounts nothing.
+func Transform(opts transformrule.Options) Plugin {
+	return func(ctx Context) {
+		doc := ctx.Ingress.Annotations[namespace+"/transform"]
+		if strings.TrimSpace(doc) == "" {
+			return
+		}
+		z, err := transformrule.Parse(opts, doc)
+		if err != nil {
+			slog.Error("plugin/transform: invalid inline transform set; passing traffic through unmodified",
+				"ingress", ctx.ingressID(), "error", err)
+			return
+		}
+		if z.Empty() {
+			return
+		}
+		ctx.Use(parapet.MiddlewareFunc(z.ServeHandler))
+	}
+}
 
 // TransformZone binds an ingress to a transform zone via the
 // parapet.moonrhythm.io/transform-zone annotation. The value is a zone

--- a/plugin/transform_test.go
+++ b/plugin/transform_test.go
@@ -15,6 +15,105 @@ import (
 	"github.com/moonrhythm/parapet-ingress-controller/transformrule"
 )
 
+func TestTransform_Inline(t *testing.T) {
+	t.Parallel()
+
+	newCtx := func(ann map[string]string) Context {
+		return Context{
+			Middlewares: &parapet.Middlewares{},
+			Ingress: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "cust1", Name: "web", Annotations: ann},
+			},
+		}
+	}
+
+	serve := func(ctx Context, target string) (*httptest.ResponseRecorder, *http.Request) {
+		var upstream *http.Request
+		r := httptest.NewRequest(http.MethodGet, target, nil)
+		w := httptest.NewRecorder()
+		ctx.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			upstream = r
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(w, r)
+		return w, upstream
+	}
+
+	t.Run("mounts the inline set", func(t *testing.T) {
+		ctx := newCtx(map[string]string{"parapet.moonrhythm.io/transform": `
+transforms:
+- id: robots
+  phase: response
+  ops:
+  - type: set-header
+    name: X-Robots-Tag
+    value: noindex
+- id: upstream-marker
+  phase: request
+  ops:
+  - type: set-header
+    name: X-Inline
+    value: "1"
+`})
+		Transform(transformrule.Options{})(ctx)
+
+		w, upstream := serve(ctx, "/")
+		assert.Equal(t, "noindex", w.Header().Get("X-Robots-Tag"), "response op applies")
+		require.NotNil(t, upstream)
+		assert.Equal(t, "1", upstream.Header.Get("X-Inline"), "request op applies")
+	})
+
+	t.Run("filter scopes the rule", func(t *testing.T) {
+		ctx := newCtx(map[string]string{"parapet.moonrhythm.io/transform": `
+transforms:
+- id: robots
+  phase: response
+  filter: request.path.startsWith("/private")
+  ops:
+  - type: set-header
+    name: X-Robots-Tag
+    value: noindex
+`})
+		Transform(transformrule.Options{})(ctx)
+
+		w, _ := serve(ctx, "/private/x")
+		assert.Equal(t, "noindex", w.Header().Get("X-Robots-Tag"))
+
+		w, _ = serve(ctx, "/public")
+		assert.Empty(t, w.Header().Get("X-Robots-Tag"))
+	})
+
+	t.Run("invalid set is a safe no-op", func(t *testing.T) {
+		ctx := newCtx(map[string]string{"parapet.moonrhythm.io/transform": `
+transforms:
+- id: broken
+  phase: request
+  filter: "this is not && valid cel ("
+  ops:
+  - type: set-header
+    name: X-Test
+    value: "1"
+`})
+		Transform(transformrule.Options{})(ctx)
+
+		w, upstream := serve(ctx, "/")
+		assert.Equal(t, http.StatusOK, w.Code, "bad inline set passes traffic through unmodified")
+		require.NotNil(t, upstream)
+		assert.Empty(t, upstream.Header.Get("X-Test"))
+	})
+
+	t.Run("no annotation injects no middleware", func(t *testing.T) {
+		ctx := newCtx(nil)
+		Transform(transformrule.Options{})(ctx)
+		assert.Empty(t, *ctx.Middlewares, "no annotation => no mount")
+	})
+
+	t.Run("empty ruleset injects no middleware", func(t *testing.T) {
+		ctx := newCtx(map[string]string{"parapet.moonrhythm.io/transform": "transforms: []\n"})
+		Transform(transformrule.Options{})(ctx)
+		assert.Empty(t, *ctx.Middlewares, "ruleless set => no mount")
+	})
+}
+
 func TestTransformZone(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Adds the third transform surface: an ingress can now carry its own transform set inline in an annotation, without creating a ConfigMap zone and binding to it:

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    parapet.moonrhythm.io/transform: |
      transforms:
      - id: robots
        phase: response
        filter: request.path.startsWith("/private")
        ops:
        - type: set-header
          name: X-Robots-Tag
          value: noindex
```

The value is the exact YAML document a transform ConfigMap data value holds (`transforms:` root key) — same DTO, same `transformrule.Parse`, no new engine surface.

## How

- **`plugin.Transform(opts)`** parses the annotation at reload time and mounts the compiled `Zone.ServeHandler` directly. Plugins re-run on every mux reload, so an annotation edit hot-reloads the way every other inline annotation (`redirect`, `basic-auth`, …) does — no registry, no per-request lookup.
- **Shared compile bounds**: the new `TransformConfig.Options()` feeds the same CEL cost limit / macro policy / GeoIP resolvers to global, zone, and inline sets, so an inline `filter` is hardened identically (`WAF_COST_LIMIT` / `WAF_DISABLE_MACROS` cover all three).
- **Slot**: registered immediately after `TransformZone`, inside the same security-critical F1 slot (after WAF/Coraza/ratelimit — security sees the original request; before ForwardAuth — X-Auth-* re-stamp overwrites anything inline rules set). Precedence is global → zone → inline: shared config first, the ingress's own rules can override its effects. `transform_order_test.go` now pins both registrations.
- **Failure mode**: an invalid inline set is logged and mounted as nothing — traffic passes through unmodified. Unlike a ConfigMap edit there is no previous compiled set to keep (plugins rebuild from scratch per reload); this matches the established bad-annotation behavior.

## Tests

`plugin/transform_test.go`: inline mount applies request+response ops end-to-end, CEL filter scoping, invalid set is a pass-through no-op, missing/empty annotation mounts nothing. Order test extended. `gofmt` clean, `go vet` clean, full suite passes (841 tests).

## Notes

- Gated by `TRANSFORM_ENABLED`, like the zone plugin — disabled means no mount, no per-request cost.
- Core-only, like zones (the edge runs no transforms yet).
- The external transform SPEC should gain the inline-annotation surface alongside the `global` role from #176.