### PR TITLE
chore: update Go to 1.26.5

### DIFF
--- a/.github/workflows/edge-e2e.yaml
+++ b/.github/workflows/edge-e2e.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
       - name: Install test deps (openssl, curl, python3, nc)
         run: |
           sudo apt-get update

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        go: ['1.26.4']
+        go: ['1.26.5']
     name: Go ${{ matrix.go }}
     steps:
     - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ fails on unformatted files. See the umbrella [`Makefile`](Makefile) for the
 `make test` target.
 
 ### Docker image
-- Builder: `golang:1.26.4-trixie` (pure Go, `CGO_ENABLED=0`) — cross-compiles, so the image is multi-arch-capable (linux/amd64 + linux/arm64) without QEMU like the edge images
+- Builder: `golang:1.26.5-trixie` (pure Go, `CGO_ENABLED=0`) — cross-compiles, so the image is multi-arch-capable (linux/amd64 + linux/arm64) without QEMU like the edge images
 - Runtime: `gcr.io/distroless/static-debian12` (static binary; root variant so it can bind privileged :80/:443)
 - Build args: `VERSION` (injected as `main.version`), `GOAMD64` (v3 default, v1 for compatibility image; honored only for amd64)
 
@@ -196,7 +196,7 @@ All path-filtered to `**/*.go` + `go.mod`/`go.sum` (plus `Dockerfile*`):
 
 ```
 module github.com/moonrhythm/parapet-ingress-controller
-go 1.26.4
+go 1.26.5
 ```
 
 The module lives at the repo root, so `go install` targets are `…/parapet-ingress-controller/cmd/parapet-ingress-controller`. Key dependencies: `github.com/moonrhythm/parapet`, `k8s.io/client-go`, `go.opentelemetry.io`, `github.com/prometheus/client_golang`, `cloud.google.com/go/profiler`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # GOARCH=arm64). Build a multi-arch image with:
 #
 #     docker buildx build --platform linux/amd64,linux/arm64 -t parapet-ingress-controller .
-FROM --platform=$BUILDPLATFORM golang:1.26.4-trixie AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-trixie AS build
 
 ARG VERSION
 ARG GOAMD64

--- a/Dockerfile.edge
+++ b/Dockerfile.edge
@@ -15,7 +15,7 @@
 # GOARCH=arm64). Build a multi-arch image with:
 #
 #     docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile.edge -t parapet-edge .
-FROM --platform=$BUILDPLATFORM golang:1.26.4-trixie AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-trixie AS build
 
 ARG VERSION
 ARG GOAMD64

--- a/Dockerfile.edge-controlplane
+++ b/Dockerfile.edge-controlplane
@@ -10,7 +10,7 @@
 # $BUILDPLATFORM and Go cross-compiles to $TARGETARCH, so the arm64 image is
 # produced WITHOUT QEMU emulation (pure Go, CGO_ENABLED=0). GOAMD64 is honored
 # only for amd64 (Go ignores it when GOARCH=arm64).
-FROM --platform=$BUILDPLATFORM golang:1.26.4-trixie AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-trixie AS build
 
 ARG VERSION
 ARG GOAMD64

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moonrhythm/parapet-ingress-controller
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/profiler v0.6.0


### PR DESCRIPTION
Bumps Go 1.26.4 → 1.26.5 across the module, Docker builders, and CI.

- `go.mod` — `go` directive
- `Dockerfile`, `Dockerfile.edge`, `Dockerfile.edge-controlplane` — `golang:1.26.5-trixie` builder
- `.github/workflows/go-test.yaml`, `edge-e2e.yaml` — CI Go versions
- `CLAUDE.md` — doc references

`go build ./...` passes.