### PR TITLE
feat: WebSocket over HTTP/2 on the edge→core hop (RFC 8441 extended CONNECT)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,10 @@ FROM gcr.io/distroless/static-debian12
 COPY --from=build /workspace/parapet-ingress-controller /app/parapet-ingress-controller
 COPY --from=geoip /geoip/ /geoip/
 
+# RFC 8441 extended CONNECT (WebSocket over HTTP/2) acceptance is gated by this
+# real GODEBUG env var, read by the h2 server at startup. A user-supplied GODEBUG
+# in the pod spec REPLACES this value entirely — main.go warns at startup when
+# http2xconnect=1 is missing. See WEBSOCKET.md.
+ENV GODEBUG=http2xconnect=1
+
 ENTRYPOINT ["/app/parapet-ingress-controller"]

--- a/EDGE.md
+++ b/EDGE.md
@@ -945,7 +945,7 @@ EDGE_UPSTREAM_SNI                 SNI/Host on the re-encrypt handshake (default:
 EDGE_UPSTREAM_HTTP2               HTTP/2 on the hop (default true — opt-out)
 EDGE_UPSTREAM_MAX_CONNS_PER_HOST  hard ceiling on total conns per core host (default 0 = unlimited)
 EDGE_UPSTREAM_MAX_IDLE_CONNS_PER_HOST  idle keep-alive pool per core host (default 0 ⇒ 32)
-EDGE_UPSTREAM_WS_H2               tunnel WebSocket over the h2/h2c hop via RFC 8441 (default false; see WEBSOCKET.md)
+EDGE_UPSTREAM_WS_H2               tunnel WebSocket over the h2/h2c hop via RFC 8441 (default true — opt-out; see WEBSOCKET.md)
 ```
 
 - **Connection ceiling.** `EDGE_UPSTREAM_MAX_CONNS_PER_HOST` mirrors the
@@ -978,9 +978,9 @@ has no HTTP/2 upgrade path and an h2 connection rejects the
 `Connection`/`Upgrade` request headers: `H2CTransport` downgrades them itself, and
 the re-encrypt path routes them to a dedicated HTTP/1.1-over-TLS transport. That
 costs **one edge→core TCP connection per WebSocket client** — the tuple space to a
-single core VIP exhausts around 28k–64k concurrent sockets. Opt-in
-`EDGE_UPSTREAM_WS_H2=true` instead tunnels each WebSocket as an **RFC 8441
-extended CONNECT stream** on dedicated h2/h2c tunnel transports (never the RPC
+single core VIP exhausts around 28k–64k concurrent sockets. By default
+(`EDGE_UPSTREAM_WS_H2`, opt-out) the edge instead tunnels each WebSocket as an
+**RFC 8441 extended CONNECT stream** on dedicated h2/h2c tunnel transports (never the RPC
 transports — long-lived streams would pin their stream budget; h2-only ALPN on
 the re-encrypt hop; PING keepalive so a silently-dropped connection can't hold
 its sessions hostage). The core must run with `GODEBUG=http2xconnect=1` (baked

--- a/EDGE.md
+++ b/EDGE.md
@@ -945,6 +945,7 @@ EDGE_UPSTREAM_SNI                 SNI/Host on the re-encrypt handshake (default:
 EDGE_UPSTREAM_HTTP2               HTTP/2 on the hop (default true — opt-out)
 EDGE_UPSTREAM_MAX_CONNS_PER_HOST  hard ceiling on total conns per core host (default 0 = unlimited)
 EDGE_UPSTREAM_MAX_IDLE_CONNS_PER_HOST  idle keep-alive pool per core host (default 0 ⇒ 32)
+EDGE_UPSTREAM_WS_H2               tunnel WebSocket over the h2/h2c hop via RFC 8441 (default false; see WEBSOCKET.md)
 ```
 
 - **Connection ceiling.** `EDGE_UPSTREAM_MAX_CONNS_PER_HOST` mirrors the
@@ -972,10 +973,23 @@ EDGE_UPSTREAM_MAX_IDLE_CONNS_PER_HOST  idle keep-alive pool per core host (defau
   (`EDGE_DATAPLANE_MTLS`) rides h2 or HTTP/1.1 identically — the client cert is
   presented in the TLS handshake either way.
 
-**WebSocket / `Upgrade` requests always ride HTTP/1.1.** `httputil.ReverseProxy`
-has no HTTP/2 upgrade path (no RFC 8441) and an h2 connection rejects the
+**WebSocket / `Upgrade` requests ride HTTP/1.1 by default.** `httputil.ReverseProxy`
+has no HTTP/2 upgrade path and an h2 connection rejects the
 `Connection`/`Upgrade` request headers: `H2CTransport` downgrades them itself, and
-the re-encrypt path routes them to a dedicated HTTP/1.1-over-TLS transport.
+the re-encrypt path routes them to a dedicated HTTP/1.1-over-TLS transport. That
+costs **one edge→core TCP connection per WebSocket client** — the tuple space to a
+single core VIP exhausts around 28k–64k concurrent sockets. Opt-in
+`EDGE_UPSTREAM_WS_H2=true` instead tunnels each WebSocket as an **RFC 8441
+extended CONNECT stream** on dedicated h2/h2c tunnel transports (never the RPC
+transports — long-lived streams would pin their stream budget; h2-only ALPN on
+the re-encrypt hop; PING keepalive so a silently-dropped connection can't hold
+its sessions hostage). The core must run with `GODEBUG=http2xconnect=1` (baked
+into the controller Dockerfile) to advertise acceptance; against a core that
+doesn't, the attempt fails **pre-flight with zero wire cost** and the edge falls
+back to the HTTP/1.1 path per request — rollout is order-free. Fallbacks count in
+`parapet_edge_ws_upstream{protocol="http1",result="fallback"}` (a persistent
+non-zero rate is the "core lost its GODEBUG" alarm). Full design in
+[WEBSOCKET.md](WEBSOCKET.md).
 
 **Opt-out (`EDGE_UPSTREAM_HTTP2=false`)** forces HTTP/1.1 on both hops. Use it for
 a core that predates `H2C=true` on `:80`, or a dumb L4 in front of `:443` that

--- a/SPEC.md
+++ b/SPEC.md
@@ -93,7 +93,10 @@ handshake has) — and then follows the same order; every step sees it exactly
 as it sees an h1 WebSocket handshake. A `:protocol` other than `websocket` is
 refused with 501. On acceptance the proxy performs the h1 upgrade toward the
 pod itself (synthesizing `Sec-WebSocket-Key`, validating the pod's `Accept`)
-and splices the pod connection to the h2 stream. See
+and splices the pod connection to the h2 stream — unless the pod is
+h2c-capable and advertises extended CONNECT itself, in which case the tunnel
+is stream-to-stream over h2c (`UPSTREAM_WS_H2C`, default on; a pod that
+doesn't advertise falls back to the h1 upgrade). See
 [WEBSOCKET.md](WEBSOCKET.md).
 
 ### Request header normalization
@@ -296,6 +299,7 @@ invariants:
 | `WAF_VALIDATED_PROXY` | `""` | Skip the core's global+zone WAF for requests whose peer already ran the same rules (the edge proxy). Comma list of `edge-mtls` (peer client cert chains to the live edge CA; requires `EDGE_TRUST_CP_ENDPOINT`) and/or CIDRs/named groups (immediate TCP peer). Also requires the per-request `X-Parapet-Waf` claim the edge stamps after evaluating. `true` is refused; a bad spec is fatal at startup. Skips counted in `parapet_waf_skips{scope}`. See [EDGE.md](EDGE.md#skipping-the-core-re-run-waf_validated_proxy-opt-in) |
 | `UPSTREAM_AUTO_H2C` | `false` | Speculatively try h2c on plain-`http` upstreams, fall back to HTTP/1.1 when unsupported. The verdict (h2c or HTTP/1.1-only) is cached per-Service with a TTL and re-probed on expiry; concurrent probes for a cold/expired upstream are single-flighted so they can't stampede failed connections. WebSocket/Upgrade always uses HTTP/1.1; `https` and explicit `appProtocol: h2c` upstreams are unaffected |
 | `UPSTREAM_AUTO_H2C_TTL` | `10m` | How long a cached auto-h2c verdict is trusted before the upstream is re-probed (only when `UPSTREAM_AUTO_H2C` is on) |
+| `UPSTREAM_WS_H2C` | `true` | Kill switch for core→pod WebSocket-over-h2c: a tunneled WebSocket to an h2c-capable pod (explicit `appProtocol: h2c`, or a fresh auto-h2c positive verdict) is attempted as an RFC 8441 extended CONNECT stream instead of an h1 upgrade dial; a pod that doesn't advertise the capability falls back to h1 (negative verdict cached 10m per Service). See [WEBSOCKET.md](WEBSOCKET.md) |
 | `GODEBUG` | Dockerfile sets `http2xconnect=1` | Must contain `http2xconnect=1` for the core to **accept WebSocket-over-HTTP/2** (RFC 8441 extended CONNECT; see [WEBSOCKET.md](WEBSOCKET.md)). Read by `net/http` at process init — a `GODEBUG` set in a pod spec **replaces** the Dockerfile value, silently disabling acceptance (edges fall back to HTTP/1.1 per request); a startup warning is logged when the token is absent |
 
 ## Metrics
@@ -320,6 +324,7 @@ Prometheus, served on `:9187`.
 | `parapet_ratelimit_total{name,result}` | `result` = `allowed\|limited`; `name` = `host` / `host-country` for the env-configured limiters, `<ns>/<name>:<s\|m\|h>` for annotation limiters, `global:<id>` / `zone:<ns>/<name>:<id>` for ConfigMap-driven limits — the `zone:` prefix keeps zone names disjoint from annotation names |
 | `parapet_ws_tunnels{result}` | WebSocket-over-h2 extended-CONNECT handshakes at the core; `result` = `tunneled\|refused\|upstream_error\|bad_protocol`, no `_total` suffix (see [WEBSOCKET.md](WEBSOCKET.md)) |
 | `parapet_ws_tunnel_active` | live spliced WebSocket-over-h2 sessions at the core |
+| `parapet_ws_upstream_h2c{result}` | core→pod extended-CONNECT attempt outcomes; `result` = `ok\|not_supported\|error` — `not_supported` = the pod doesn't advertise the capability (fell back to h1), no `_total` suffix |
 | `parapet_edge_ws_upstream{protocol,result}` | edge-side WebSocket upstream outcomes; `protocol` = `h2\|http1`, `result` = `ok\|fallback\|error` — `fallback` = the core didn't accept extended CONNECT (edge-only metric, reaches Prometheus via the CP's merged registry) |
 | `parapet_connections{state}` | per-state connection gauge |
 | `go_*` runtime, `process_*` (client_golang), Cloud Profiler/Trace | |

--- a/SPEC.md
+++ b/SPEC.md
@@ -84,6 +84,18 @@ carries the edge's `X-Parapet-Waf` claim (stamped after the edge's WAF
 evaluated it), the **global WAF** and **zone WAF** steps are skipped for that
 request — counted as `parapet_waf_skips{scope}`; every other step is unchanged.
 
+An HTTP/2 **extended-CONNECT WebSocket handshake** (RFC 8441, accepted only
+when the process runs with `GODEBUG=http2xconnect=1`) is normalized **before
+step 1** into the equivalent HTTP/1.1 upgrade shape — method `GET`,
+`Connection: Upgrade` + `Upgrade: websocket`, the live tunnel stream detached
+from `r.Body` (so WAF/Coraza body inspection sees the same empty body an h1
+handshake has) — and then follows the same order; every step sees it exactly
+as it sees an h1 WebSocket handshake. A `:protocol` other than `websocket` is
+refused with 501. On acceptance the proxy performs the h1 upgrade toward the
+pod itself (synthesizing `Sec-WebSocket-Key`, validating the pod's `Accept`)
+and splices the pod connection to the h2 stream. See
+[WEBSOCKET.md](WEBSOCKET.md).
+
 ### Request header normalization
 
 Before the WAF reads the request and before forwarding upstream, an HTTP/2
@@ -284,6 +296,7 @@ invariants:
 | `WAF_VALIDATED_PROXY` | `""` | Skip the core's global+zone WAF for requests whose peer already ran the same rules (the edge proxy). Comma list of `edge-mtls` (peer client cert chains to the live edge CA; requires `EDGE_TRUST_CP_ENDPOINT`) and/or CIDRs/named groups (immediate TCP peer). Also requires the per-request `X-Parapet-Waf` claim the edge stamps after evaluating. `true` is refused; a bad spec is fatal at startup. Skips counted in `parapet_waf_skips{scope}`. See [EDGE.md](EDGE.md#skipping-the-core-re-run-waf_validated_proxy-opt-in) |
 | `UPSTREAM_AUTO_H2C` | `false` | Speculatively try h2c on plain-`http` upstreams, fall back to HTTP/1.1 when unsupported. The verdict (h2c or HTTP/1.1-only) is cached per-Service with a TTL and re-probed on expiry; concurrent probes for a cold/expired upstream are single-flighted so they can't stampede failed connections. WebSocket/Upgrade always uses HTTP/1.1; `https` and explicit `appProtocol: h2c` upstreams are unaffected |
 | `UPSTREAM_AUTO_H2C_TTL` | `10m` | How long a cached auto-h2c verdict is trusted before the upstream is re-probed (only when `UPSTREAM_AUTO_H2C` is on) |
+| `GODEBUG` | Dockerfile sets `http2xconnect=1` | Must contain `http2xconnect=1` for the core to **accept WebSocket-over-HTTP/2** (RFC 8441 extended CONNECT; see [WEBSOCKET.md](WEBSOCKET.md)). Read by `net/http` at process init — a `GODEBUG` set in a pod spec **replaces** the Dockerfile value, silently disabling acceptance (edges fall back to HTTP/1.1 per request); a startup warning is logged when the token is absent |
 
 ## Metrics
 
@@ -305,6 +318,9 @@ Prometheus, served on `:9187`.
 | `parapet_coraza_matches{rule_id,severity,scope}` | Coraza (OWASP CRS / SecLang) rule matches; `scope` = `global\|zone`, no `_total` suffix |
 | `parapet_coraza_eval_duration_seconds{outcome,scope}` | histogram of per-request Coraza request-phase eval latency; `outcome` = `pass\|block` |
 | `parapet_ratelimit_total{name,result}` | `result` = `allowed\|limited`; `name` = `host` / `host-country` for the env-configured limiters, `<ns>/<name>:<s\|m\|h>` for annotation limiters, `global:<id>` / `zone:<ns>/<name>:<id>` for ConfigMap-driven limits — the `zone:` prefix keeps zone names disjoint from annotation names |
+| `parapet_ws_tunnels{result}` | WebSocket-over-h2 extended-CONNECT handshakes at the core; `result` = `tunneled\|refused\|upstream_error\|bad_protocol`, no `_total` suffix (see [WEBSOCKET.md](WEBSOCKET.md)) |
+| `parapet_ws_tunnel_active` | live spliced WebSocket-over-h2 sessions at the core |
+| `parapet_edge_ws_upstream{protocol,result}` | edge-side WebSocket upstream outcomes; `protocol` = `h2\|http1`, `result` = `ok\|fallback\|error` — `fallback` = the core didn't accept extended CONNECT (edge-only metric, reaches Prometheus via the CP's merged registry) |
 | `parapet_connections{state}` | per-state connection gauge |
 | `go_*` runtime, `process_*` (client_golang), Cloud Profiler/Trace | |
 

--- a/WEBSOCKET.md
+++ b/WEBSOCKET.md
@@ -1,8 +1,9 @@
 # WebSocket over HTTP/2 on the internal hops (RFC 8441 extended CONNECT)
 
-Status: **phases 1–2 implemented** (core acceptance + edge tunnel; SPEC.md /
-EDGE.md carry the contract rows). Phase 3 (core→pod extended CONNECT) remains
-design-only.
+Status: **all three phases implemented** (core acceptance, edge tunnel —
+default on, `EDGE_UPSTREAM_WS_H2` opt-out — and core→pod extended CONNECT —
+default on, `UPSTREAM_WS_H2C` kill switch). SPEC.md / EDGE.md carry the
+contract rows.
 
 ## Problem
 
@@ -80,13 +81,14 @@ fallback so version skew is order-free:
    `EDGE_UPSTREAM_WS_H2`): translate the client's h1 upgrade into extended
    CONNECT on a dedicated multiplexed transport; fall back to the current h1
    path when the core doesn't advertise.
-3. **Core→pod extended CONNECT** (opt-in, later): when a pod's h2c connection
-   advertises the setting, tunnel over h2c instead of dialing an h1 upgrade.
+3. **Core→pod extended CONNECT** (`UPSTREAM_WS_H2C`, default true): when a
+   pod's h2c connection advertises the setting, tunnel over h2c instead of
+   dialing an h1 upgrade.
 
 Phase 1 ships first; phase 2 is the payoff (the edge falls back cleanly against
 an old core, so rollout order doesn't matter). Phase 3 is a nicety — the
 core→pod hop dials many distinct pod IPs, each with its own source-port space,
-so it has no exhaustion problem; see "Scope".
+so it has no exhaustion problem; see its section below.
 
 ## Core: accepting extended CONNECT
 
@@ -166,10 +168,11 @@ in an upstream header.
 
 ### Config
 
-`EDGE_UPSTREAM_WS_H2` (bool, **default false** at introduction; intended to
-flip to default-true once baked). Only meaningful when the upstream hop is
-multiplexed (`EDGE_UPSTREAM_HTTP2=true`, the default); with h2 disabled the
-flag is a no-op and WS rides h1 as today.
+`EDGE_UPSTREAM_WS_H2` (bool, **default true** — opt-out; safe at any version
+skew because the attempt against a non-advertising core fails pre-flight with
+zero wire cost and falls back per request). Only meaningful when the upstream
+hop is multiplexed (`EDGE_UPSTREAM_HTTP2=true`, the default); with h2 disabled
+the flag is a no-op and WS rides h1 as today.
 
 ### Behavior (`edge/forward.go` + new tunnel code)
 
@@ -236,28 +239,49 @@ unchanged; the multiplexed tunnel path needs few connections by construction
 
 Rollout is order-free; core first is natural (edges fall back until upgraded).
 
-## Phase 3: core→pod extended CONNECT (opt-in, later)
+## Phase 3: core→pod extended CONNECT (implemented; `UPSTREAM_WS_H2C` default true)
 
-When the pod itself speaks WS-over-h2c, the core can skip the h1 dial and
-tunnel stream-to-stream. Detection is exact and layered on what already exists:
+When the pod itself speaks WS-over-h2c, the core skips the h1 dial and tunnels
+stream-to-stream (`proxy/wsh2c.go`, attempted by `serveWSTunnel` before the h1
+path). Detection is exact and layered on what already exists:
 
-1. **Is the Service h2c at all?** Answered today by explicit
-   `appProtocol: h2c` or the `UPSTREAM_AUTO_H2C` per-Service TTL cache.
-   WS requests continue **not** to establish this verdict (regular traffic
-   does), preserving the current auto-h2c contract.
+1. **Is the Service h2c at all?** Explicit `appProtocol: h2c` (scheme `h2c`)
+   is always eligible; plain `http` is eligible only with a **fresh positive**
+   `UPSTREAM_AUTO_H2C` verdict (read-only accessor — WS requests still never
+   establish or refresh that verdict, preserving the auto-h2c contract);
+   `https` never (h1-over-TLS as before).
 2. **Does the h2c peer advertise `ENABLE_CONNECT_PROTOCOL`?** Attempt the
-   extended CONNECT; the not-supported error is local, instant on a live
-   connection, and sends nothing — fall back to the h1 upgrade dial and cache
-   the negative per-Service (same `<ns>/<name>:<port>` key + TTL pattern as
-   `proxy/autoh2c.go`).
+   extended CONNECT on a **dedicated** prior-knowledge h2c transport (dialing
+   through the shared dialer so bad-addr marking works; PING keepalive; never
+   the RPC h2c transport, whose stream budget long-lived tunnels must not
+   pin). The not-supported error is pre-flight — nothing written, the parked
+   client stream untouched — so the request falls back to the h1 upgrade dial
+   and the negative verdict is cached per-Service (`upstreamKey`, or the pod
+   `host:port` when auto-h2c is off; 10m TTL, expired entries pruned on read;
+   only negatives are cached).
+
+Failure semantics mirror phase 1: a **dial** failure cannot have consumed the
+request body, so it panics into `retryMiddleware` exactly like the h1 path
+(the dial error is captured at the `DialTLSContext` seam because x/net wraps
+RoundTrip errors); any other post-dial failure is a 502 with **no fallback and
+no retry** (the stream may be partially consumed — a replay could duplicate
+frames). Attempt outcomes count in `parapet_ws_upstream_h2c{result}`
+(`ok|not_supported|error`); the tunnel-vs-refusal distinction stays in
+`parapet_ws_tunnels`.
+
+Scope note: this path serves **tunneled** (h2-inbound / edge-tunneled)
+WebSockets. A legacy h1-inbound WebSocket at the core still rides the
+ReverseProxy hijack path to the pod over h1, unchanged — with the edge
+tunneling by default, edge-fronted traffic gets the stream-to-stream path
+end-to-end.
 
 Expectation-setting: almost no upstream advertises this by default — a Go pod
 needs the same `GODEBUG=http2xconnect=1`, Node needs
 `http2.createServer({settings: {enableConnectProtocol: true}})`, and gRPC
-servers don't do WebSocket. Negatives are free, positives are per-app opt-ins.
-This phase reuses the phase-1 splice code and the autoh2c cache pattern; it is
-deliberately last because the core→pod hop has no port-exhaustion problem
-(distinct pod IPs each carry their own tuple space).
+servers don't do WebSocket. Negatives are free and cached; positives are
+per-app opt-ins. The core→pod hop has no port-exhaustion problem (distinct pod
+IPs each carry their own tuple space), so this phase is about per-pod
+connection reduction and native-h2 apps.
 
 ## Failure semantics & blast radius
 
@@ -334,7 +358,8 @@ Dockerfile                  # ENV GODEBUG=http2xconnect=1
 edge/wstunnel.go            # edge: translate + dedicated tunnel transports (phase 2)
 metric/ws.go                # core counters/gauge
 metric/observe/ws.go        # edge counter (leaf package — edge binaries stay off metric)
-proxy/autoh2c.go            # phase 3: extended-CONNECT verdict cache alongside h2c cache
+proxy/wsh2c.go              # phase 3: pod-side extended CONNECT (dedicated h2c transport,
+                            #   eligibility + negative-verdict cache, dial-error retry seam)
 ```
 
 ## SPEC.md rows to add at implementation time
@@ -350,10 +375,11 @@ proxy/autoh2c.go            # phase 3: extended-CONNECT verdict cache alongside 
 
 ## Open questions
 
-1. When does `EDGE_UPSTREAM_WS_H2` default flip to true — after one release of
-   bake, or gated on a fleet-wide `parapet_edge_ws_upstream{result="fallback"}`
-   ≈ 0 observation?
-2. Do we expose `HTTP_SERVER_MAX_CONCURRENT_STREAMS` in phase 1 or defer until
-   someone needs to tune session-per-connection blast radius?
-3. Phase 3: worth doing at all until a real upstream advertises support? (The
-   detection is cheap, but so is not building it.)
+1. ~~When does `EDGE_UPSTREAM_WS_H2` default flip to true?~~ Resolved: default
+   true from the start — the pre-flight fallback makes it safe at any skew.
+2. Do we expose `HTTP_SERVER_MAX_CONCURRENT_STREAMS`, or defer until someone
+   needs to tune session-per-connection blast radius (~250/conn at Go's
+   default)?
+3. ~~Phase 3: worth doing at all?~~ Built (default on, `UPSTREAM_WS_H2C` kill
+   switch): detection is free-negative and cached, and edge-fronted traffic
+   now rides stream-to-stream end-to-end when the pod opts in.

--- a/WEBSOCKET.md
+++ b/WEBSOCKET.md
@@ -1,0 +1,359 @@
+# WebSocket over HTTP/2 on the internal hops (RFC 8441 extended CONNECT)
+
+Status: **phases 1–2 implemented** (core acceptance + edge tunnel; SPEC.md /
+EDGE.md carry the contract rows). Phase 3 (core→pod extended CONNECT) remains
+design-only.
+
+## Problem
+
+Every WebSocket client today costs one dedicated TCP connection on the
+edge→core hop. `edge/forward.go` deliberately routes Upgrade requests onto an
+HTTP/1.1 transport (`h2TLSTransport.RoundTrip` on the re-encrypt path,
+`upstream.H2CTransport`'s own downgrade on the plaintext path) because
+`httputil.ReverseProxy` has no HTTP/2 upgrade path and an h2 connection rejects
+the `Connection`/`Upgrade` request headers.
+
+That per-socket connection is the scaling wall: one edge IP talking to one core
+VIP:443 exhausts the ephemeral source-port space at roughly 28k–64k concurrent
+tuples — long before file descriptors or memory matter. `EDGE_UPSTREAM_MAX_CONNS_PER_HOST`
+bounds the damage but doesn't lift the ceiling; regular request/response
+traffic already multiplexes over a handful of h2/h2c connections and is
+unaffected.
+
+RFC 8441 ("Bootstrapping WebSockets with HTTP/2") is the standard fix: a
+WebSocket session rides a single h2 **stream** via the extended CONNECT method
+(`:method: CONNECT` + `:protocol: websocket`), so tens of thousands of sockets
+multiplex over a few TCP connections. This document specifies extended CONNECT
+on the **internal hops only** — client→edge and (by default) core→pod stay
+plain HTTP/1.1 WebSocket.
+
+```
+client ──(h1 WS: GET + Upgrade)──▶ edge ──(h2/h2c extended CONNECT)──▶ core ──(h1 WS)──▶ pod
+                                                                        └─(phase 3, opt-in: h2c extended CONNECT when the pod advertises it)
+```
+
+## Protocol background (verified against Go 1.26.5 / x/net v0.56.0)
+
+Facts the design leans on, checked in the shipped toolchain and module — not
+from documentation:
+
+- **Support is advertised in-band.** A server that accepts extended CONNECT
+  sends `SETTINGS_ENABLE_CONNECT_PROTOCOL = 1` in its first SETTINGS frame
+  (RFC 8441 §3). There is no probing heuristic; capability detection is exact.
+- **Go's server side is gated, client side is not.** In `x/net/http2` (and the
+  identical `net/http` h2 bundle), `disableExtendedConnectProtocol` guards only
+  the server paths (advertising the setting; rejecting `:protocol`). The gate
+  default is off because browsers immediately use WS-over-h2 against any server
+  that advertises it, breaking apps whose websocket libraries only speak the h1
+  handshake (golang/go#71128). The **client** transport is ungated: it sends
+  extended CONNECT whenever the request is `CONNECT` + `Header[":protocol"]`
+  and the peer advertised support.
+- **A failed attempt is free.** `clientStream.writeRequest` blocks until the
+  peer's first SETTINGS frame and returns `errExtendedConnectNotSupported`
+  **before writing any request bytes**. Nothing goes on the wire, so falling
+  back to HTTP/1.1 is always safe — there is no replay hazard (contrast with
+  auto-h2c's "only bodyless requests probe" rule; a WS handshake is a bodyless
+  GET anyway). The error is unexported; callers match its message
+  (`"net/http: extended connect not supported by peer"`). A missed match
+  degrades gracefully to "always fall back".
+- **The gate is the real `GODEBUG` env var, not `//go:debug`.** Both the bundle
+  and `x/net/http2` read `os.Getenv("GODEBUG")` directly in package `init()`.
+  The `//go:debug` directive only affects `internal/godebug` consumers, so it
+  does **not** enable this. The core must run with the environment variable
+  `GODEBUG=http2xconnect=1` set at process start.
+- **Handshake mapping (RFC 8441 §4–5):** the h2 handshake carries `:authority`,
+  `:path`, `:scheme` and the regular `Sec-WebSocket-Version` /
+  `Sec-WebSocket-Protocol` / `Sec-WebSocket-Extensions` headers, but **omits
+  `Sec-WebSocket-Key` / `Sec-WebSocket-Accept`** (stream setup replaces the
+  key/accept proof). Acceptance is a 2xx response on the stream; the stream
+  body is then the raw WebSocket framing, full duplex.
+
+## Design overview
+
+Three phases, independently shippable, each with an unconditional HTTP/1.1
+fallback so version skew is order-free:
+
+1. **Core accepts extended CONNECT** (server side): advertise the setting,
+   normalize the request so the existing chain is oblivious, tunnel to the pod
+   over the h1 upgrade it already speaks.
+2. **Edge tunnels WS over the upstream hop** (client side, opt-in
+   `EDGE_UPSTREAM_WS_H2`): translate the client's h1 upgrade into extended
+   CONNECT on a dedicated multiplexed transport; fall back to the current h1
+   path when the core doesn't advertise.
+3. **Core→pod extended CONNECT** (opt-in, later): when a pod's h2c connection
+   advertises the setting, tunnel over h2c instead of dialing an h1 upgrade.
+
+Phase 1 ships first; phase 2 is the payoff (the edge falls back cleanly against
+an old core, so rollout order doesn't matter). Phase 3 is a nicety — the
+core→pod hop dials many distinct pod IPs, each with its own source-port space,
+so it has no exhaustion problem; see "Scope".
+
+## Core: accepting extended CONNECT
+
+### Enabling
+
+- The controller image sets `ENV GODEBUG=http2xconnect=1` in `Dockerfile`.
+- **Footgun:** `GODEBUG` is a comma-list and a user-supplied `GODEBUG` in a pod
+  spec **replaces** the Dockerfile value entirely, silently disabling the
+  feature. `main.go` therefore verifies at startup that
+  `os.Getenv("GODEBUG")` contains `http2xconnect=1` and logs a prominent
+  warning when it doesn't (not fatal — the core is still correct, it just
+  can't accept WS-over-h2, and edges fall back to h1).
+- Both core listeners get it for free: `:443` (ALPN h2) and `:80` (`H2C: true`)
+  share the same bundled/x-net server code. There is no per-server opt-out in
+  Go today; when the env var is set, **every** h2 client of the core may send
+  extended CONNECT — which is exactly why normalization (below) must sit in
+  front of everything, not inside the proxy.
+
+### Normalization middleware (first in the `m` chain)
+
+A new middleware, mounted in `cmd/parapet-ingress-controller/main.go` **before
+host normalization** (i.e. before everything in SPEC.md's per-request order),
+rewrites an extended CONNECT into the h1-upgrade shape the rest of the chain
+already understands:
+
+- Match: `r.Method == "CONNECT"` and `r.Header.Get(":protocol") != ""` (Go's
+  h2 server surfaces the pseudo-header there; an h1 client cannot produce it —
+  colon-prefixed field names are invalid HTTP/1.1 tokens and net/http rejects
+  them, so the match is inherently h2-only and not client-spoofable over h1).
+- `:protocol` values other than `websocket` → **501 Not Implemented**. We
+  bridge WebSocket only.
+- Rewrite in place: `Method = "GET"`, set `Connection: Upgrade` and
+  `Upgrade: websocket`, delete `:protocol` and `Accept-Encoding` (the spliced
+  200 must never be compress-wrapped), **detach the live stream** — park
+  `r.Body` in an immutable context value and set `r.Body = http.NoBody` — so
+  WAF/Coraza body inspection sees the same empty body an h1 handshake has
+  (both do a blocking body read otherwise), and `retry.go` keeps treating the
+  handshake as retryable-before-send. (A context value, not the per-request
+  `state` map: normalization runs before `state.Middleware`, and the pooled
+  map must not hold a live stream.) `Sec-WebSocket-Version/Protocol/
+  Extensions` ride through untouched.
+- Everything downstream — host normalization, logging, metrics, **global/zone
+  CEL WAF** (`request.method` rules see `GET`, matching what an h1 WS handshake
+  already looks like), Coraza, rate limits, routing, plugins — behaves
+  identically for an h1 and an h2 WebSocket handshake. No rule breakage, no
+  SPEC.md order change; SPEC.md gains one sentence stating the equivalence.
+
+### Tunnel response path (in `proxy/`)
+
+The proxy cannot use `httputil.ReverseProxy`'s upgrade path for a normalized
+request: that path hijacks the downstream connection, and an h2 stream's
+`ResponseWriter` has no `Hijacker`. Instead, for requests flagged `wsTunnel`:
+
+1. Resolve and dial the pod exactly like today: `route.Table.Lookup`, the
+   shared dialer, bad-addr marking. A **dial error before the handshake** is
+   retryable exactly like today's dial errors (bodyless GET, nothing sent) and
+   follows the existing retry/bad-addr semantics.
+2. Send the h1 upgrade handshake to the pod. The pod requires a
+   `Sec-WebSocket-Key` (the h2 side has none): the core **generates a random
+   key**, validates the pod's `Sec-WebSocket-Accept` against it (cheap
+   correctness check; mismatch → 502), and **strips `Sec-WebSocket-Accept`**
+   from the response — it is meaningless on the h2 side and the edge
+   synthesizes its own toward the client.
+3. Pod answers `101` → respond **200** on the h2 stream (copying
+   `Sec-WebSocket-Protocol`/`Extensions` back), flush, then splice bytes both
+   ways between the pod connection and the stream (`r.Body` for reads, the
+   `ResponseWriter` for writes — h2 handlers are natively full duplex; reuse
+   `proxy/buffer.go`'s pool).
+4. Pod answers anything else (401 from the app, 404, …) → forward status,
+   headers, and body as a normal response on the stream. The edge translates a
+   non-200 back into a non-101 for the client.
+
+`:protocol` never reaches the pod (deleted at normalization) and never appears
+in an upstream header.
+
+## Edge: tunneling client WS over the upstream hop
+
+### Config
+
+`EDGE_UPSTREAM_WS_H2` (bool, **default false** at introduction; intended to
+flip to default-true once baked). Only meaningful when the upstream hop is
+multiplexed (`EDGE_UPSTREAM_HTTP2=true`, the default); with h2 disabled the
+flag is a no-op and WS rides h1 as today.
+
+### Behavior (`edge/forward.go` + new tunnel code)
+
+On a client request with `Upgrade: websocket` (other `Upgrade` values keep the
+h1 path unconditionally):
+
+1. Complete the client-side h1 handshake ourselves: validate
+   `Sec-WebSocket-Key` presence, then **translate** — `Method = "CONNECT"`,
+   `Header[":protocol"] = "websocket"`, drop `Connection`, `Upgrade`, and
+   `Sec-WebSocket-Key`, keep `Sec-WebSocket-Version/Protocol/Extensions`,
+   preserve `:authority`/path (the core routes on Host + path as usual).
+   Stripping `Connection`/`Upgrade` also means the existing transports'
+   downgrade checks (`h2TLSTransport.RoundTrip`, `H2CTransport`) never trigger.
+2. RoundTrip on the **dedicated tunnel transport** (below) with a pipe as the
+   request body (client→core frames) and read core→client frames from the
+   response body.
+3. Core answers **200** → write the `101 Switching Protocols` handshake to the
+   client (computing `Sec-WebSocket-Accept` from the client's original key,
+   echoing negotiated subprotocol/extensions), hijack the client connection,
+   splice.
+4. Core answers non-200 → translate to a plain h1 response (the handshake was
+   refused by WAF/auth/the app; status and body pass through).
+5. RoundTrip fails with the **not-supported error** (old core, or `GODEBUG`
+   lost from the core's environment) → **fall back to the existing h1 upgrade
+   path** for this request. Log once (rate-limited), count it (metrics below).
+   No negative cache is required for correctness — the check is pre-flight and
+   free on a live connection — but the implementation may remember the verdict
+   briefly to avoid re-attempt latency when no tunnel connection exists yet.
+
+### Dedicated tunnel transports (not the RPC transports)
+
+WS tunnels get their **own** transports, separate from the request/response
+transports in `NewForwarder`, for three reasons:
+
+- **Stream-slot starvation.** Long-lived tunnel streams would otherwise pin the
+  stream budget (`SETTINGS_MAX_CONCURRENT_STREAMS`) of the connections regular
+  traffic multiplexes on.
+- **Deterministic protocol.** On the re-encrypt hop the RPC transport is
+  `ForceAttemptHTTP2` `http.Transport`, which may ALPN-negotiate HTTP/1.1 — an
+  extended CONNECT serialized onto an h1 connection is garbage. The tunnel
+  transport is an `x/net http2.Transport` offering **ALPN `h2` only**
+  (handshake fails cleanly against an h1-only peer → h1 fallback), sharing the
+  same `tls.Config` (SNI, data-plane mTLS client cert) as the RPC transport.
+  On the plaintext hop it is a prior-knowledge h2c `http2.Transport`, matching
+  what `upstream.H2CTransport` wraps.
+- **Liveness.** A NAT/middlebox silently dropping one TCP connection kills
+  every stream on it with no FIN. The tunnel transports set `ReadIdleTimeout`
+  (h2 PING keepalive, ~30s) + `PingTimeout` so a dead connection is detected
+  and its sessions closed promptly instead of hanging.
+
+`EDGE_UPSTREAM_MAX_CONNS_PER_HOST` keeps bounding only the h1 fallback path,
+unchanged; the multiplexed tunnel path needs few connections by construction
+(the transport opens additional connections as stream limits fill —
+`StrictMaxConcurrentStreams` stays false).
+
+### Version-skew matrix
+
+| Edge | Core | Result |
+|---|---|---|
+| old | any | h1 per-socket connections (today's behavior) |
+| new, flag off | any | today's behavior |
+| new, flag on | old / `GODEBUG` missing | pre-flight local error → h1 fallback; zero wire cost |
+| new, flag on | new + `GODEBUG` set | WS multiplexed over h2/h2c streams |
+
+Rollout is order-free; core first is natural (edges fall back until upgraded).
+
+## Phase 3: core→pod extended CONNECT (opt-in, later)
+
+When the pod itself speaks WS-over-h2c, the core can skip the h1 dial and
+tunnel stream-to-stream. Detection is exact and layered on what already exists:
+
+1. **Is the Service h2c at all?** Answered today by explicit
+   `appProtocol: h2c` or the `UPSTREAM_AUTO_H2C` per-Service TTL cache.
+   WS requests continue **not** to establish this verdict (regular traffic
+   does), preserving the current auto-h2c contract.
+2. **Does the h2c peer advertise `ENABLE_CONNECT_PROTOCOL`?** Attempt the
+   extended CONNECT; the not-supported error is local, instant on a live
+   connection, and sends nothing — fall back to the h1 upgrade dial and cache
+   the negative per-Service (same `<ns>/<name>:<port>` key + TTL pattern as
+   `proxy/autoh2c.go`).
+
+Expectation-setting: almost no upstream advertises this by default — a Go pod
+needs the same `GODEBUG=http2xconnect=1`, Node needs
+`http2.createServer({settings: {enableConnectProtocol: true}})`, and gRPC
+servers don't do WebSocket. Negatives are free, positives are per-app opt-ins.
+This phase reuses the phase-1 splice code and the autoh2c cache pattern; it is
+deliberately last because the core→pod hop has no port-exhaustion problem
+(distinct pod IPs each carry their own tuple space).
+
+## Failure semantics & blast radius
+
+- **Before acceptance** (dial error, refused handshake): unchanged semantics —
+  dial errors retry per `retry.go`, HTTP refusals pass through.
+- **After acceptance**: a WebSocket session is stateful; no layer retries or
+  resumes it. Mid-stream failure closes both sides, the client reconnects
+  (standard WS client behavior).
+- **Blast radius**: one edge→core TCP connection now carries up to
+  `MAX_CONCURRENT_STREAMS` sessions (Go server default ~250); a connection
+  reset kills all of them at once, where today it kills one. This is the
+  accepted trade against port exhaustion (which kills *new* connections for
+  everyone). The PING keepalive bounds how long a dead connection can hold
+  sessions hostage. If finer control is needed, the core's
+  `net/http.Server.HTTP2.MaxConcurrentStreams` is the sizing knob (a possible
+  `HTTP_SERVER_MAX_CONCURRENT_STREAMS` env var — decide at implementation).
+
+## Metrics
+
+Following existing naming (`parapet_waf_matches`, `parapet_ratelimit_total`):
+
+- Core (`metric/ws.go`):
+  - `parapet_ws_tunnels{result}` counter — `result ∈ tunneled | refused |
+    upstream_error | bad_protocol` (extended-CONNECT handshakes and their
+    outcome).
+  - `parapet_ws_tunnel_active` gauge — live spliced sessions.
+- Edge (via `metric/observe` leaf, like the edge rate limiter):
+  - `parapet_edge_ws_upstream{protocol, result}` counter — `protocol ∈ h2 |
+    http1`, `result ∈ ok | fallback | error`; `fallback` counts not-supported
+    downgrades (the "core lost its GODEBUG" alarm).
+
+## Security considerations
+
+- `:protocol` is deleted at normalization and cannot arrive over h1 (invalid
+  h1 field name, rejected by net/http) — it never reaches WAF rules, the
+  claim-header logic, or the upstream.
+- WAF/Coraza/rate-limit posture is **identical** to an h1 WebSocket handshake
+  today: request-phase inspection of the handshake, no frame inspection
+  (already true — neither WAF sees post-upgrade bytes on the h1 path either).
+  The `X-Parapet-Waf` claim flow is untouched (the edge stamps after its WAF
+  ran; the handshake is a normal request to the WAF).
+- Stream exhaustion replaces connection exhaustion as the DoS surface on the
+  core listener; `MAX_CONCURRENT_STREAMS` (per conn) and existing host/country
+  concurrency limits (which see the normalized handshake) bound it.
+- The core advertising `ENABLE_CONNECT_PROTOCOL` publicly means any direct h2
+  client may attempt WS-over-h2 — handled identically by the same
+  normalization path, so this is a feature (direct clients gain WS-over-h2),
+  not a hazard.
+
+## Scope and non-goals
+
+- **No WS-over-h2 on the edge's public listener.** The edge does not set the
+  `GODEBUG`; browsers keep opening h1 WebSocket connections to the edge. The
+  client→edge side has no tuple-exhaustion problem (many client IPs), and Go
+  offers no per-server opt-in — flipping it process-wide on the edge is all
+  risk, no need. Revisit if/when Go exposes structured opt-in
+  (`HTTP2Config` has no field for it as of Go 1.26).
+- **No QUIC / HTTP/3** — separate concern, separate document if ever.
+- **No WS frame inspection** — the tunnel is byte-transparent after the
+  handshake, exactly like today's h1 splice.
+- **Edge response cache**: WebSocket is untouched by `parapet/pkg/cache`
+  (upgrades were never cacheable); no interaction.
+
+## Where the code will live
+
+```
+wsh2/                       # shared, pure, edge-importable (like corazawaf/):
+                            #   IsExtendedConnect/Normalize (+ stream detach via ctx),
+                            #   Sec-WebSocket-Key/Accept synth+check, splice loop
+proxy/wstunnel.go           # core: tunnel path for ctx-flagged requests (phase 1)
+cmd/parapet-ingress-controller/wsnormalize.go  # normalize middleware (mounted first in main.go's m chain)
+cmd/parapet-ingress-controller/main.go   # middleware mount + GODEBUG startup check
+Dockerfile                  # ENV GODEBUG=http2xconnect=1
+edge/wstunnel.go            # edge: translate + dedicated tunnel transports (phase 2)
+metric/ws.go                # core counters/gauge
+metric/observe/ws.go        # edge counter (leaf package — edge binaries stay off metric)
+proxy/autoh2c.go            # phase 3: extended-CONNECT verdict cache alongside h2c cache
+```
+
+## SPEC.md rows to add at implementation time
+
+- Per-request order: one sentence — an h2 extended-CONNECT WebSocket handshake
+  is normalized to the equivalent h1 upgrade before step 1 and follows the
+  same order.
+- Env table: `EDGE_UPSTREAM_WS_H2` (edge, default false), the core's
+  `GODEBUG=http2xconnect=1` requirement, and (if added)
+  `HTTP_SERVER_MAX_CONCURRENT_STREAMS`.
+- Metrics table: `parapet_ws_tunnels`, `parapet_ws_tunnel_active`,
+  `parapet_edge_ws_upstream`.
+
+## Open questions
+
+1. When does `EDGE_UPSTREAM_WS_H2` default flip to true — after one release of
+   bake, or gated on a fleet-wide `parapet_edge_ws_upstream{result="fallback"}`
+   ≈ 0 observation?
+2. Do we expose `HTTP_SERVER_MAX_CONCURRENT_STREAMS` in phase 1 or defer until
+   someone needs to tune session-per-connection blast radius?
+3. Phase 3: worth doing at all until a real upstream advertises support? (The
+   detection is cheap, but so is not building it.)

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -78,9 +78,12 @@ func main() {
 	upstreamHTTP2 := envOr("EDGE_UPSTREAM_HTTP2", "true") == "true"
 	// Tunnel client WebSocket upgrades over a single multiplexed h2/h2c stream to
 	// the core (RFC 8441 extended CONNECT) instead of one dedicated HTTP/1.1
-	// connection each. Only meaningful when the upstream hop is h2; with h2 off it
-	// is a no-op (WS rides h1 as today) — warn if it was set explicitly.
-	upstreamWSH2 := envOr("EDGE_UPSTREAM_WS_H2", "false") == "true"
+	// connection each. Default on (opt-out): against a core that doesn't advertise
+	// the capability the attempt fails pre-flight with zero wire cost and the
+	// request falls back to HTTP/1.1, so the flag being on is safe at any skew.
+	// Only meaningful when the upstream hop is h2; with h2 off it is a no-op (WS
+	// rides h1 as today) — warn if it was set explicitly.
+	upstreamWSH2 := envOr("EDGE_UPSTREAM_WS_H2", "true") == "true"
 	if upstreamWSH2 && !upstreamHTTP2 {
 		slog.Warn("EDGE_UPSTREAM_WS_H2 is ignored when EDGE_UPSTREAM_HTTP2=false; WebSocket rides HTTP/1.1")
 		upstreamWSH2 = false

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -76,6 +76,15 @@ func main() {
 	// Set EDGE_UPSTREAM_HTTP2=false to force HTTP/1.1 — e.g. a core that predates H2C
 	// on :80, or an L4 in front of :443 that can't ALPN.
 	upstreamHTTP2 := envOr("EDGE_UPSTREAM_HTTP2", "true") == "true"
+	// Tunnel client WebSocket upgrades over a single multiplexed h2/h2c stream to
+	// the core (RFC 8441 extended CONNECT) instead of one dedicated HTTP/1.1
+	// connection each. Only meaningful when the upstream hop is h2; with h2 off it
+	// is a no-op (WS rides h1 as today) — warn if it was set explicitly.
+	upstreamWSH2 := envOr("EDGE_UPSTREAM_WS_H2", "false") == "true"
+	if upstreamWSH2 && !upstreamHTTP2 {
+		slog.Warn("EDGE_UPSTREAM_WS_H2 is ignored when EDGE_UPSTREAM_HTTP2=false; WebSocket rides HTTP/1.1")
+		upstreamWSH2 = false
+	}
 	// Per-host connection ceiling to the core (mirrors the controller's
 	// TR_MAX_CONNS_PER_HOST / TR_MAX_IDLE_CONNS_PER_HOST). MAX_CONNS_PER_HOST=0
 	// (default) leaves connections unbounded; MAX_IDLE_CONNS_PER_HOST=0 falls back
@@ -407,7 +416,7 @@ func main() {
 		// fires a (non-blocking) reactive re-mint. nil when mTLS is off.
 		onCertReject = func() { remintCoord.Trigger("reactive") }
 	}
-	forwarder := edge.NewForwarder(upstreamAddr, upstreamTLS, upstreamHTTP2, upstreamSNI, upstreamTuning, getClientCert, onCertReject)
+	forwarder := edge.NewForwarder(upstreamAddr, upstreamTLS, upstreamHTTP2, upstreamSNI, upstreamTuning, getClientCert, onCertReject, upstreamWSH2)
 
 	if metricsListen != "" {
 		go func() {

--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -52,6 +52,10 @@ func main() {
 	loadAllCerts := config.Bool("LOAD_ALL_CERTS")
 	autoH2C := config.Bool("UPSTREAM_AUTO_H2C")
 	autoH2CTTL := config.DurationDefault("UPSTREAM_AUTO_H2C_TTL", 10*time.Minute)
+	// UPSTREAM_WS_H2C (default true, kill switch): tunnel WebSocket to h2c pods via
+	// RFC 8441 extended CONNECT instead of the h1 upgrade dial; falls back to h1 when
+	// the pod does not advertise it.
+	wsUpstreamH2C := config.BoolDefault("UPSTREAM_WS_H2C", true)
 
 	rateLimitEnabled := config.Bool("RATELIMIT_ENABLED")
 	transformEnabled := config.Bool("TRANSFORM_ENABLED")
@@ -292,6 +296,9 @@ func main() {
 	proxy.ConfigTransport(configTransport)
 	if autoH2C {
 		proxy.EnableAutoH2C(autoH2CTTL)
+	}
+	if wsUpstreamH2C {
+		proxy.EnableWSUpstreamH2C()
 	}
 
 	ctrl := controller.New(watchNamespace, proxy)

--- a/cmd/parapet-ingress-controller/main.go
+++ b/cmd/parapet-ingress-controller/main.go
@@ -168,6 +168,18 @@ func main() {
 		"transform_enabled", transformEnabled,
 	)
 
+	// WS-over-HTTP/2 acceptance (RFC 8441 extended CONNECT) is gated by the real
+	// GODEBUG env var, read by the h2 server in package init(). A user-supplied
+	// GODEBUG in the pod spec REPLACES the Dockerfile's ENV entirely, silently
+	// disabling the feature — so verify it at startup and warn prominently (not
+	// fatal: the core is still correct, it just can't accept WS-over-h2 and edges
+	// fall back to HTTP/1.1).
+	if !strings.Contains(os.Getenv("GODEBUG"), "http2xconnect=1") {
+		slog.Warn("WS-over-HTTP/2 acceptance DISABLED: GODEBUG does not contain http2xconnect=1 " +
+			"(a user-supplied GODEBUG replaces the image default); the core will not advertise " +
+			"SETTINGS_ENABLE_CONNECT_PROTOCOL and edges fall back to HTTP/1.1 WebSocket")
+	}
+
 	if enableProfiler {
 		if profilerName == "" {
 			profilerName = "parapet-ingress-controller"
@@ -367,6 +379,11 @@ func main() {
 	// reads ctrl.WaitTrustReady, so it must be installed before Watch runs.
 
 	m := parapet.Middlewares{}
+	// WS-over-HTTP/2 normalization runs first, before everything in SPEC.md's
+	// per-request order, so an h2 extended-CONNECT WebSocket handshake is rewritten
+	// into the h1-upgrade shape the whole chain already understands. Unconditional:
+	// a non-handshake request pays only two header checks.
+	m.Use(wsNormalize())
 	m.Use(ctrl.Healthz())
 	m.Use(host.StripPort())
 	m.Use(host.ToLower())

--- a/cmd/parapet-ingress-controller/wsnormalize.go
+++ b/cmd/parapet-ingress-controller/wsnormalize.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/moonrhythm/parapet"
+
+	"github.com/moonrhythm/parapet-ingress-controller/metric"
+	"github.com/moonrhythm/parapet-ingress-controller/wsh2"
+)
+
+// wsNormalize rewrites an RFC 8441 extended-CONNECT WebSocket handshake into the
+// HTTP/1.1 upgrade shape the rest of the chain understands, so WAF/Coraza/rate
+// limits/routing/plugins behave identically for an h1 and an h2 WebSocket
+// handshake. It is mounted first, before everything in SPEC.md's per-request
+// order, and is unconditional: a non-extended-CONNECT request pays only the two
+// header checks in IsExtendedConnect. Whether the h2 server actually accepts
+// extended CONNECT is gated by GODEBUG=http2xconnect=1; without it this is dead
+// code that never fires.
+func wsNormalize() parapet.Middleware {
+	return parapet.MiddlewareFunc(func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !wsh2.IsExtendedConnect(r) {
+				h.ServeHTTP(w, r)
+				return
+			}
+			if r.Header.Get(":protocol") != "websocket" {
+				// We bridge WebSocket only.
+				metric.WSTunnel("bad_protocol")
+				http.Error(w, "Not Implemented", http.StatusNotImplemented)
+				return
+			}
+			h.ServeHTTP(w, wsh2.Normalize(r))
+		})
+	})
+}

--- a/edge/forward.go
+++ b/edge/forward.go
@@ -32,6 +32,7 @@ import (
 // forwardGeoHeaders.
 type Forwarder struct {
 	rp *httputil.ReverseProxy
+	ws *wsTunnel // non-nil when EDGE_UPSTREAM_WS_H2 is on AND the upstream hop is h2
 }
 
 // defaultMaxIdleConnsPerHost mirrors parapet's upstream.defaultMaxIdleConns (32):
@@ -92,7 +93,13 @@ func (t ForwarderTuning) idle() int {
 //
 // tuning bounds the per-host connection pool to the core (see ForwarderTuning);
 // the zero value keeps the historical unbounded/idle-32 behavior.
-func NewForwarder(addr string, useTLS, enableHTTP2 bool, sni string, tuning ForwarderTuning, getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error), onCertReject func()) *Forwarder {
+//
+// wsH2 (EDGE_UPSTREAM_WS_H2, default off) tunnels client WebSocket upgrades over a
+// single multiplexed h2/h2c stream to the core (RFC 8441 extended CONNECT) instead
+// of a dedicated HTTP/1.1 connection each; it needs enableHTTP2 (a plain-h1 hop has
+// no stream to multiplex on) and falls back to the h1 upgrade path against a core
+// that doesn't advertise the capability.
+func NewForwarder(addr string, useTLS, enableHTTP2 bool, sni string, tuning ForwarderTuning, getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error), onCertReject func(), wsH2 bool) *Forwarder {
 	var tr http.RoundTripper
 	switch {
 	case useTLS:
@@ -158,7 +165,12 @@ func NewForwarder(addr string, useTLS, enableHTTP2 bool, sni string, tuning Forw
 			http.Error(w, "Bad Gateway", http.StatusBadGateway)
 		},
 	}
-	return &Forwarder{rp: rp}
+
+	f := &Forwarder{rp: rp}
+	if wsH2 && enableHTTP2 {
+		f.ws = newWSTunnel(addr, scheme, useTLS, sni, getClientCert)
+	}
+	return f
 }
 
 // isClientCertRejected reports whether err is the CORE rejecting the edge's client cert
@@ -267,6 +279,13 @@ func (t *h2TLSTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 // is ignored (the request is forwarded upstream).
 func (f *Forwarder) ServeHandler(_ http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if f.ws != nil && isWebSocketUpgrade(r) {
+			// serve returns false only before any byte reaches the client, so the
+			// fallback re-serves the original request on the h1 upgrade path.
+			if f.ws.serve(w, r) {
+				return
+			}
+		}
 		r.RemoteAddr = "" // stop ReverseProxy re-appending X-Forwarded-For
 		f.rp.ServeHTTP(w, r)
 	})

--- a/edge/forward_http2_test.go
+++ b/edge/forward_http2_test.go
@@ -48,10 +48,10 @@ func TestForwarder_Plaintext_H2COptOut(t *testing.T) {
 	defer srv.Close()
 	addr := addrOf(t, srv.URL)
 
-	if got := forwardThrough(t, NewForwarder(addr, false, true, "", ForwarderTuning{}, nil, nil)); got != "proto=2" {
+	if got := forwardThrough(t, NewForwarder(addr, false, true, "", ForwarderTuning{}, nil, nil, false)); got != "proto=2" {
 		t.Errorf("h2c default: want proto=2, got %q", got)
 	}
-	if got := forwardThrough(t, NewForwarder(addr, false, false, "", ForwarderTuning{}, nil, nil)); got != "proto=1" {
+	if got := forwardThrough(t, NewForwarder(addr, false, false, "", ForwarderTuning{}, nil, nil, false)); got != "proto=1" {
 		t.Errorf("opt-out: want proto=1 (HTTP/1.1), got %q", got)
 	}
 }
@@ -66,10 +66,10 @@ func TestForwarder_TLS_H2OptOut(t *testing.T) {
 	defer srv.Close()
 	addr := addrOf(t, srv.URL)
 
-	if got := forwardThrough(t, NewForwarder(addr, true, true, "", ForwarderTuning{}, nil, nil)); got != "proto=2" {
+	if got := forwardThrough(t, NewForwarder(addr, true, true, "", ForwarderTuning{}, nil, nil, false)); got != "proto=2" {
 		t.Errorf("h2 default: want proto=2, got %q", got)
 	}
-	if got := forwardThrough(t, NewForwarder(addr, true, false, "", ForwarderTuning{}, nil, nil)); got != "proto=1" {
+	if got := forwardThrough(t, NewForwarder(addr, true, false, "", ForwarderTuning{}, nil, nil, false)); got != "proto=1" {
 		t.Errorf("opt-out: want proto=1 (HTTP/1.1 over TLS), got %q", got)
 	}
 }
@@ -83,7 +83,7 @@ func TestForwarder_TLS_H2FallsBackToHTTP1(t *testing.T) {
 	defer srv.Close()
 	addr := addrOf(t, srv.URL)
 
-	if got := forwardThrough(t, NewForwarder(addr, true, true, "", ForwarderTuning{}, nil, nil)); got != "proto=1" {
+	if got := forwardThrough(t, NewForwarder(addr, true, true, "", ForwarderTuning{}, nil, nil, false)); got != "proto=1" {
 		t.Errorf("h2 requested, http/1.1-only core: want graceful proto=1, got %q", got)
 	}
 }

--- a/edge/forward_tuning_test.go
+++ b/edge/forward_tuning_test.go
@@ -18,7 +18,7 @@ func TestForwarderTuning_AppliesToEveryTransport(t *testing.T) {
 	tuning := ForwarderTuning{MaxConnsPerHost: maxConns, MaxIdleConnsPerHost: maxIdle}
 
 	t.Run("plaintext HTTP/1.1", func(t *testing.T) {
-		f := NewForwarder("core:80", false, false, "", tuning, nil, nil)
+		f := NewForwarder("core:80", false, false, "", tuning, nil, nil, false)
 		tr := f.rp.Transport.(*upstream.HTTPTransport)
 		if tr.MaxConn != maxConns {
 			t.Fatalf("MaxConn = %d, want %d", tr.MaxConn, maxConns)
@@ -29,7 +29,7 @@ func TestForwarderTuning_AppliesToEveryTransport(t *testing.T) {
 	})
 
 	t.Run("plaintext h2c Upgrade fallback", func(t *testing.T) {
-		f := NewForwarder("core:80", false, true, "", tuning, nil, nil)
+		f := NewForwarder("core:80", false, true, "", tuning, nil, nil, false)
 		tr := f.rp.Transport.(*upstream.H2CTransport)
 		if tr.HTTPTransport == nil {
 			t.Fatal("H2CTransport.HTTPTransport (Upgrade fallback) not wired")
@@ -43,7 +43,7 @@ func TestForwarderTuning_AppliesToEveryTransport(t *testing.T) {
 	})
 
 	t.Run("re-encrypt h2", func(t *testing.T) {
-		f := NewForwarder("core:443", true, true, "", tuning, nil, nil)
+		f := NewForwarder("core:443", true, true, "", tuning, nil, nil, false)
 		h2 := f.rp.Transport.(*h2TLSTransport).h2.(*http.Transport)
 		if h2.MaxConnsPerHost != maxConns {
 			t.Fatalf("h2 MaxConnsPerHost = %d, want %d", h2.MaxConnsPerHost, maxConns)
@@ -54,7 +54,7 @@ func TestForwarderTuning_AppliesToEveryTransport(t *testing.T) {
 	})
 
 	t.Run("re-encrypt HTTP/1.1", func(t *testing.T) {
-		f := NewForwarder("core:443", true, false, "", tuning, nil, nil)
+		f := NewForwarder("core:443", true, false, "", tuning, nil, nil, false)
 		tr := f.rp.Transport.(*upstream.HTTPSTransport)
 		if tr.MaxConn != maxConns {
 			t.Fatalf("MaxConn = %d, want %d", tr.MaxConn, maxConns)
@@ -71,7 +71,7 @@ func TestForwarderTuning_ZeroValueDefaults(t *testing.T) {
 	if got := (ForwarderTuning{}).idle(); got != defaultMaxIdleConnsPerHost {
 		t.Fatalf("zero idle() = %d, want %d", got, defaultMaxIdleConnsPerHost)
 	}
-	f := NewForwarder("core:80", false, false, "", ForwarderTuning{}, nil, nil)
+	f := NewForwarder("core:80", false, false, "", ForwarderTuning{}, nil, nil, false)
 	tr := f.rp.Transport.(*upstream.HTTPTransport)
 	if tr.MaxConn != 0 {
 		t.Fatalf("MaxConn = %d, want 0 (unlimited)", tr.MaxConn)

--- a/edge/wstunnel.go
+++ b/edge/wstunnel.go
@@ -1,0 +1,305 @@
+package edge
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/net/http2"
+
+	"github.com/moonrhythm/parapet-ingress-controller/metric/observe"
+	"github.com/moonrhythm/parapet-ingress-controller/wsh2"
+)
+
+// wsHandshakeTimeout bounds the extended-CONNECT handshake — the h2/h2c dial,
+// the request write, and the core's response-header read. x/net's http2.Transport
+// has no ResponseHeaderTimeout, so this is enforced by a timer that cancels the
+// request context and is disarmed the instant RoundTrip returns; the context then
+// lives for the whole (long-lived) WebSocket session. It matches the RPC
+// transports' one-minute ResponseHeaderTimeout.
+const wsHandshakeTimeout = time.Minute
+
+// errExtendedConnectNotSupported is the message x/net's http2 client returns
+// pre-flight (before writing any request bytes) when the peer's first SETTINGS
+// did not advertise ENABLE_CONNECT_PROTOCOL. The error type is unexported, so it
+// is matched by substring; a missed match degrades to the generic pre-commit
+// failure path, which also falls back to HTTP/1.1.
+const errExtendedConnectNotSupported = "extended connect not supported by peer"
+
+// wsTunnel translates a client's HTTP/1.1 WebSocket upgrade into an RFC 8441
+// extended CONNECT over a dedicated multiplexed transport to the core, so tens of
+// thousands of sockets ride a few TCP connections instead of one each. It is nil
+// on a Forwarder unless EDGE_UPSTREAM_WS_H2 is set AND the upstream hop is h2.
+type wsTunnel struct {
+	tr     http.RoundTripper // dedicated: ALPN h2-only (TLS) or prior-knowledge h2c
+	scheme string            // "https" (re-encrypt) or "http" (plaintext h2c)
+	addr   string            // core host:port
+}
+
+var wsFallbackWarn sync.Once
+
+// newWSTunnel builds the dedicated tunnel transport from the same inputs
+// NewForwarder gets. It is NEVER the RPC transport: sharing would pin the regular
+// traffic's stream budget with long-lived tunnel streams, and the re-encrypt RPC
+// transport may ALPN-negotiate HTTP/1.1 (onto which an extended CONNECT would
+// serialize as garbage). The TLS transport therefore offers ALPN h2 ONLY — an
+// h1-only core fails the handshake cleanly, routing to the h1 fallback.
+func newWSTunnel(addr, scheme string, useTLS bool, sni string, getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error)) *wsTunnel {
+	var tr *http2.Transport
+	if useTLS {
+		// Same SNI / data-plane mTLS client cert as the RPC transport, but ALPN h2
+		// only and InsecureSkipVerify (cluster-internal hop, matching the RPC posture).
+		cfg := &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: true, //nolint:gosec // cluster-internal hop, matches the RPC transport
+			NextProtos:         []string{"h2"},
+		}
+		if sni != "" {
+			cfg.ServerName = sni
+		}
+		if getClientCert != nil {
+			cfg.GetClientCertificate = getClientCert
+		}
+		tr = &http2.Transport{
+			TLSClientConfig:    cfg,
+			ReadIdleTimeout:    30 * time.Second,
+			PingTimeout:        15 * time.Second,
+			DisableCompression: true,
+		}
+	} else {
+		// Prior-knowledge h2c, matching upstream.H2CTransport's own transport shape.
+		tr = &http2.Transport{
+			AllowHTTP: true,
+			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+				return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, addr)
+			},
+			ReadIdleTimeout:    30 * time.Second,
+			PingTimeout:        15 * time.Second,
+			DisableCompression: true,
+		}
+	}
+	return &wsTunnel{tr: tr, scheme: scheme, addr: addr}
+}
+
+// serve attempts the WS-over-h2 tunnel for a client WebSocket upgrade. It returns
+// true when it owns the outcome (tunnel established, core refusal relayed, a
+// committed session torn down, or a malformed handshake rejected) and false when
+// the caller must fall back to the HTTP/1.1 ReverseProxy path with the ORIGINAL,
+// untouched request. The distinction is strict: false is only ever returned
+// BEFORE any byte is written to the client, so a fallback never double-serves.
+func (t *wsTunnel) serve(w http.ResponseWriter, r *http.Request) (handled bool) {
+	// Minimal server-side handshake validation. httputil.ReverseProxy would forward
+	// a keyless / non-GET upgrade upstream; reject it here so a malformed handshake
+	// never opens a tunnel (and we always have the client key to synthesize 101).
+	clientKey := r.Header.Get("Sec-WebSocket-Key")
+	if r.Method != http.MethodGet || clientKey == "" {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return true
+	}
+
+	// The client conn must be hijackable to splice raw frames. Upgrade requests only
+	// arrive on the edge's h1 public listener, so this holds; the check is
+	// non-committing (it does not hijack) so a miss falls back cleanly.
+	if !canHijack(w) {
+		return false
+	}
+
+	// One context for the whole session; a timer bounds only the handshake and is
+	// disarmed once RoundTrip returns (fact: x/net has no ResponseHeaderTimeout).
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	pr, pw := io.Pipe()
+	creq := t.translate(ctx, r, pr)
+
+	timer := time.AfterFunc(wsHandshakeTimeout, cancel)
+	resp, err := t.tr.RoundTrip(creq)
+	timer.Stop()
+	if err != nil {
+		// Pre-flight / pre-commit failure — nothing was written to the client, so
+		// fall back to HTTP/1.1. The not-supported error is the "core lost its
+		// GODEBUG" alarm; a clean ALPN/dial/TLS rejection from an old core lands here
+		// too and must NOT 502 the client.
+		pw.Close()
+		if strings.Contains(err.Error(), errExtendedConnectNotSupported) {
+			wsFallbackWarn.Do(func() {
+				slog.Warn("edge: core does not advertise WS-over-h2 (extended CONNECT); falling back to HTTP/1.1 — verify GODEBUG=http2xconnect=1 on the core", "error", err)
+			})
+		} else {
+			slog.Warn("edge: ws tunnel handshake failed; falling back to HTTP/1.1", "addr", t.addr, "error", err)
+		}
+		observe.WSUpstream("http1", "fallback")
+		return false
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// The core refused the handshake (WAF block / auth / app 4xx). Nothing is
+		// hijacked yet, so relay it as a normal h1 response on the client conn.
+		copyHeader(w.Header(), resp.Header)
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+		resp.Body.Close()
+		pw.Close()
+		observe.WSUpstream("h2", "ok")
+		return true
+	}
+
+	// Accepted. Commit to the client: hijack, write the synthesized 101, then splice.
+	conn, brw, err := http.NewResponseController(w).Hijack()
+	if err != nil {
+		// canHijack said yes, so this is not expected. The core stream is already
+		// committed and we cannot fall back — 502 via the still-usable ResponseWriter.
+		resp.Body.Close()
+		pw.Close()
+		slog.Warn("edge: ws tunnel hijack failed after core accepted", "addr", t.addr, "error", err)
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		observe.WSUpstream("h2", "error")
+		return true
+	}
+	defer conn.Close()
+
+	if err := writeClientHandshake(conn, clientKey, resp.Header); err != nil {
+		resp.Body.Close()
+		pw.Close()
+		observe.WSUpstream("h2", "error")
+		return true
+	}
+	observe.WSUpstream("h2", "ok")
+
+	// Splice both directions. The client→core side reads from brw.Reader (not conn)
+	// so any bytes the client pipelined before our 101 — already buffered by the
+	// hijack — are drained upstream first. Closing an endpoint on one side unblocks
+	// the other, so both copies return and serve completes when the session ends.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = wsh2.Copy(pw, brw.Reader, nil)
+		pw.Close()
+		cancel()
+	}()
+
+	_, _ = io.Copy(conn, resp.Body)
+	resp.Body.Close()
+	conn.Close()
+	<-done
+	return true
+}
+
+// translate builds the extended-CONNECT clone of r on ctx, leaving r untouched so
+// the caller can still fall back with the original. body is the client→core pipe.
+// Per RFC 8441 the h2 handshake carries no Sec-WebSocket-Key/Accept, and
+// Connection/Upgrade/Transfer-Encoding are illegal on h2 (x/net's client rejects
+// them); Sec-WebSocket-Version/Protocol/Extensions ride through. Scheme + host
+// mirror the Forwarder's Director; Host (→ :authority) and path route on the core.
+func (t *wsTunnel) translate(ctx context.Context, r *http.Request, body io.ReadCloser) *http.Request {
+	c := r.Clone(ctx)
+	c.Method = http.MethodConnect
+	c.Body = body
+	c.ContentLength = -1
+	c.Header.Del("Connection")
+	c.Header.Del("Upgrade")
+	c.Header.Del("Transfer-Encoding")
+	c.Header.Del("Sec-WebSocket-Key")
+	c.Header.Set(":protocol", "websocket")
+	c.URL.Scheme = t.scheme
+	c.URL.Host = t.addr
+	return c
+}
+
+// writeClientHandshake writes the synthesized client-facing 101 Switching
+// Protocols to the hijacked conn: Sec-WebSocket-Accept is computed from the
+// client's original key (the h2 side carried none), and the negotiated
+// subprotocol/extensions are echoed from the core's 200.
+func writeClientHandshake(conn net.Conn, clientKey string, coreHeader http.Header) error {
+	var b bytes.Buffer
+	b.WriteString("HTTP/1.1 101 Switching Protocols\r\n")
+	b.WriteString("Upgrade: websocket\r\n")
+	b.WriteString("Connection: Upgrade\r\n")
+	fmt.Fprintf(&b, "Sec-WebSocket-Accept: %s\r\n", wsh2.AcceptKey(clientKey))
+	for _, h := range []string{"Sec-WebSocket-Protocol", "Sec-WebSocket-Extensions"} {
+		for _, v := range coreHeader.Values(h) {
+			fmt.Fprintf(&b, "%s: %s\r\n", h, v)
+		}
+	}
+	b.WriteString("\r\n")
+
+	_ = conn.SetWriteDeadline(time.Now().Add(wsHandshakeTimeout))
+	if _, err := conn.Write(b.Bytes()); err != nil {
+		slog.Warn("edge: ws tunnel write 101 failed", "error", err)
+		return err
+	}
+	_ = conn.SetWriteDeadline(time.Time{})
+	return nil
+}
+
+// isWebSocketUpgrade reports whether r is a WebSocket upgrade handshake. Other
+// Upgrade values (e.g. h2c prior-knowledge, unknown protocols) always take the
+// existing HTTP/1.1 path.
+func isWebSocketUpgrade(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket")
+}
+
+// canHijack reports whether w's underlying ResponseWriter supports hijacking,
+// walking the Unwrap chain exactly as http.ResponseController does — WITHOUT
+// hijacking. This lets serve decide to fall back before committing.
+func canHijack(w http.ResponseWriter) bool {
+	for {
+		if _, ok := w.(http.Hijacker); ok {
+			return true
+		}
+		u, ok := w.(interface{ Unwrap() http.ResponseWriter })
+		if !ok {
+			return false
+		}
+		w = u.Unwrap()
+	}
+}
+
+// hopHeaders are the connection-scoped header fields httputil.ReverseProxy
+// strips when relaying a response — they describe this hop, not the payload,
+// and must never survive onto a different connection.
+var hopHeaders = []string{
+	"Connection",
+	"Proxy-Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te",
+	"Trailer",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+func isHopHeader(k string) bool {
+	ck := http.CanonicalHeaderKey(k)
+	for _, h := range hopHeaders {
+		if ck == h {
+			return true
+		}
+	}
+	return false
+}
+
+// copyHeader copies header values from src to dst, dropping hop-by-hop
+// headers. resp.Body is already transfer-decoded, so a copied
+// Transfer-Encoding would lie about the framing on the client connection
+// (Go's h1 server trusts a handler-set TE, corrupting the response); the rest
+// describe the now-closed core hop, not the client's.
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		if isHopHeader(k) {
+			continue
+		}
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}

--- a/edge/wstunnel_integration_test.go
+++ b/edge/wstunnel_integration_test.go
@@ -1,0 +1,315 @@
+package edge
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+
+	"github.com/moonrhythm/parapet-ingress-controller/wsh2"
+)
+
+// TestMain re-execs the edge test binary with GODEBUG=http2xconnect=1 when it's
+// missing, so the in-process h2c "core" advertises SETTINGS_ENABLE_CONNECT_PROTOCOL
+// (read in package init). Copied from proxy/wstunnel_test.go; keeps plain
+// `go test ./...` green everywhere with no CI changes.
+func TestMain(m *testing.M) {
+	const token = "http2xconnect=1"
+	if !strings.Contains(os.Getenv("GODEBUG"), token) {
+		godebug := token
+		if cur := os.Getenv("GODEBUG"); cur != "" {
+			godebug = cur + "," + token
+		}
+		cmd := exec.Command(os.Args[0], os.Args[1:]...)
+		cmd.Env = append(withoutGODEBUG(os.Environ()), "GODEBUG="+godebug)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			if ee, ok := err.(*exec.ExitError); ok {
+				os.Exit(ee.ExitCode())
+			}
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func withoutGODEBUG(env []string) []string {
+	out := env[:0:0]
+	for _, e := range env {
+		if strings.HasPrefix(e, "GODEBUG=") {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// startFakePod accepts one h1 WebSocket upgrade and echoes client frames back —
+// the pod at the far end of the core hop.
+func startFakePod(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		br := bufio.NewReader(conn)
+		req, err := http.ReadRequest(br)
+		if err != nil {
+			return
+		}
+		key := req.Header.Get("Sec-WebSocket-Key")
+		fmt.Fprintf(conn, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\nSec-WebSocket-Protocol: chat\r\n\r\n", wsh2.AcceptKey(key))
+		_, _ = io.Copy(conn, br) // echo
+	}()
+	return ln.Addr().String()
+}
+
+// startH2CCore serves handler as prior-knowledge h2c; GODEBUG=http2xconnect=1
+// (set by TestMain) makes it advertise extended CONNECT — a stand-in for the core's
+// :80 H2C listener.
+func startH2CCore(t *testing.T, handler http.Handler) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	h2s := &http2.Server{}
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go h2s.ServeConn(c, &http2.ServeConnOpts{Handler: handler})
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// coreWSHandler reproduces the REAL phase-1 core behavior with the shared wsh2
+// package: normalize the extended CONNECT (the two-line wsNormalize middleware),
+// then tunnel to the pod over the h1 upgrade (proxy.serveWSTunnel's logic). It is
+// hand-rolled rather than importing the proxy package on purpose: proxy pulls in
+// the metric package, and the edge test binary already wires observe's lazily
+// registered waf_matches/coraza_matches — linking metric would duplicate-register
+// and panic (the invariant import_boundary_test.go guards). wsh2 IS the phase-1
+// shared code, so this exercises the genuine translation/splice.
+func coreWSHandler(t *testing.T, podAddr string, saw chan<- string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case saw <- r.Method + " :protocol=" + r.Header.Get(":protocol"):
+		default:
+		}
+		if !wsh2.IsExtendedConnect(r) || r.Header.Get(":protocol") != "websocket" {
+			http.Error(w, "not a ws handshake", http.StatusBadRequest)
+			return
+		}
+		r = wsh2.Normalize(r)
+		stream, ok := wsh2.TunnelStream(r.Context())
+		require.True(t, ok)
+		coreTunnelToPod(t, w, r, podAddr, stream)
+	})
+}
+
+func coreTunnelToPod(t *testing.T, w http.ResponseWriter, r *http.Request, podAddr string, stream io.ReadCloser) {
+	conn, err := net.Dial("tcp", podAddr)
+	if err != nil {
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		return
+	}
+	defer conn.Close()
+
+	key := wsh2.GenerateKey()
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "GET %s HTTP/1.1\r\nHost: %s\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: %s\r\n", r.URL.RequestURI(), r.Host, key)
+	for _, h := range []string{"Sec-WebSocket-Protocol", "Sec-WebSocket-Extensions"} {
+		for _, v := range r.Header.Values(h) {
+			fmt.Fprintf(&b, "%s: %s\r\n", h, v)
+		}
+	}
+	b.WriteString("\r\n")
+	if _, err := conn.Write(b.Bytes()); err != nil {
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		return
+	}
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, r)
+	if err != nil {
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		return
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		copyHeader(w.Header(), resp.Header)
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+		resp.Body.Close()
+		return
+	}
+	require.True(t, wsh2.CheckAccept(resp.Header.Get("Sec-WebSocket-Accept"), key))
+
+	for _, h := range []string{"Sec-WebSocket-Protocol", "Sec-WebSocket-Extensions"} {
+		for _, v := range resp.Header.Values(h) {
+			w.Header().Add(h, v)
+		}
+	}
+	w.WriteHeader(http.StatusOK)
+	rc := http.NewResponseController(w)
+	_ = rc.Flush()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = wsh2.Copy(conn, stream, nil)
+		conn.Close()
+	}()
+	_ = wsh2.Copy(w, br, func() { _ = rc.Flush() })
+	stream.Close()
+	conn.Close()
+	<-done
+}
+
+// dialWSClient performs a raw HTTP/1.1 WebSocket handshake against the edge and
+// returns the connection + buffered reader positioned at the frame stream, plus the
+// 101 response. The repo has no WebSocket client dep, so the handshake is hand-rolled.
+func dialWSClient(t *testing.T, edgeAddr, path string) (net.Conn, *bufio.Reader, *http.Response, string) {
+	t.Helper()
+	c, err := net.Dial("tcp", edgeAddr)
+	require.NoError(t, err)
+	_ = c.SetDeadline(time.Now().Add(10 * time.Second))
+
+	key := wsh2.GenerateKey()
+	fmt.Fprintf(c, "GET %s HTTP/1.1\r\nHost: example.com\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: %s\r\n\r\n", path, key)
+
+	br := bufio.NewReader(c)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	return c, br, resp, key
+}
+
+func edgeAddrOf(t *testing.T, srv *httptest.Server) string {
+	t.Helper()
+	return strings.TrimPrefix(srv.URL, "http://")
+}
+
+// TestWSTunnel_EndToEnd_H2C drives the full loop: a real h1 WebSocket client → the
+// edge Forwarder (WS-h2 on, plaintext h2c) → an in-process h2c core (extended
+// CONNECT) → a fake pod echo server. It asserts a well-formed 101 with the correct
+// Accept, bidirectional echo, and that the edge→core hop actually used extended
+// CONNECT.
+func TestWSTunnel_EndToEnd_H2C(t *testing.T) {
+	podAddr := startFakePod(t)
+	saw := make(chan string, 1)
+	coreAddr := startH2CCore(t, coreWSHandler(t, podAddr, saw))
+
+	f := NewForwarder(coreAddr, false, true, "", ForwarderTuning{}, nil, nil, true)
+	require.NotNil(t, f.ws, "WS tunnel must be enabled")
+	edge := httptest.NewServer(f.ServeHandler(nil))
+	defer edge.Close()
+
+	conn, br, resp, key := dialWSClient(t, edgeAddrOf(t, edge), "/chat")
+	defer conn.Close()
+
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+	assert.Equal(t, wsh2.AcceptKey(key), resp.Header.Get("Sec-WebSocket-Accept"), "edge synthesizes Accept from the client key")
+	assert.Equal(t, "chat", resp.Header.Get("Sec-WebSocket-Protocol"), "negotiated subprotocol echoed to the client")
+
+	// the core hop really used RFC 8441 extended CONNECT
+	assert.Equal(t, "CONNECT :protocol=websocket", <-saw)
+
+	// client -> pod -> client echo
+	_, err := conn.Write([]byte("hello ws"))
+	require.NoError(t, err)
+	got := make([]byte, len("hello ws"))
+	_, err = io.ReadFull(br, got)
+	require.NoError(t, err)
+	assert.Equal(t, "hello ws", string(got))
+}
+
+// TestWSTunnel_EndToEnd_Refused verifies a core refusal (403 on the handshake) is
+// relayed to the client as a well-formed h1 403, not a hang, with its body intact
+// and without the core-hop's Connection/Transfer-Encoding headers leaking
+// through: resp.Body has already been transfer-decoded by the time copyHeader
+// runs, so a copied Transfer-Encoding would lie about the framing, and
+// Connection is hop-by-hop.
+func TestWSTunnel_EndToEnd_Refused(t *testing.T) {
+	coreAddr := startH2CCore(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The core (WAF/auth) refuses the extended-CONNECT handshake outright,
+		// echoing hop-by-hop headers the way a naive relay of its own upstream
+		// hop might.
+		w.Header().Set("Connection", "close")
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(http.StatusForbidden)
+		_ = http.NewResponseController(w).Flush() // commit headers without a Content-Length
+		_, _ = io.WriteString(w, "blocked")
+	}))
+
+	f := NewForwarder(coreAddr, false, true, "", ForwarderTuning{}, nil, nil, true)
+	edge := httptest.NewServer(f.ServeHandler(nil))
+	defer edge.Close()
+
+	conn, _, resp, _ := dialWSClient(t, edgeAddrOf(t, edge), "/chat")
+	defer conn.Close()
+
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Transfer-Encoding"), "Transfer-Encoding must not leak to the client")
+	assert.Empty(t, resp.Header.Get("Connection"), "Connection must not leak to the client")
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "blocked", string(body))
+}
+
+// TestWSTunnel_EndToEnd_Fallback points the edge at an HTTP/1.1-only core: the h2c
+// tunnel preface fails, so the request must still succeed via the h1 ReverseProxy
+// upgrade path. (An old core / GODEBUG-less core is the same clean-failure class.)
+func TestWSTunnel_EndToEnd_Fallback(t *testing.T) {
+	// h1-only core that echoes a WebSocket upgrade directly.
+	core := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, brw, err := http.NewResponseController(w).Hijack()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		key := r.Header.Get("Sec-WebSocket-Key")
+		fmt.Fprintf(conn, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\n\r\n", wsh2.AcceptKey(key))
+		_, _ = io.Copy(conn, brw)
+	}))
+	defer core.Close()
+	coreAddr := edgeAddrOf(t, core)
+
+	f := NewForwarder(coreAddr, false, true, "", ForwarderTuning{}, nil, nil, true)
+	edge := httptest.NewServer(f.ServeHandler(nil))
+	defer edge.Close()
+
+	conn, br, resp, key := dialWSClient(t, edgeAddrOf(t, edge), "/chat")
+	defer conn.Close()
+
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode, "fell back to h1 upgrade")
+	assert.Equal(t, wsh2.AcceptKey(key), resp.Header.Get("Sec-WebSocket-Accept"))
+
+	_, err := conn.Write([]byte("via-h1"))
+	require.NoError(t, err)
+	got := make([]byte, len("via-h1"))
+	_, err = io.ReadFull(br, got)
+	require.NoError(t, err)
+	assert.Equal(t, "via-h1", string(got))
+}

--- a/edge/wstunnel_test.go
+++ b/edge/wstunnel_test.go
@@ -1,0 +1,160 @@
+package edge
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newWSHandshake builds a minimal client-side HTTP/1.1 WebSocket upgrade request.
+func newWSHandshake(path string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "http://core.example"+path, nil)
+	r.Header.Set("Connection", "Upgrade")
+	r.Header.Set("Upgrade", "websocket")
+	r.Header.Set("Sec-WebSocket-Version", "13")
+	r.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	return r
+}
+
+// stubRT is an http.RoundTripper the tests inject into wsTunnel — the real
+// not-supported error is unexported and needs a non-advertising h2 server, so the
+// stub keeps the translation/fallback checks a unit test.
+type stubRT struct {
+	called bool
+	resp   *http.Response
+	err    error
+}
+
+func (s *stubRT) RoundTrip(r *http.Request) (*http.Response, error) {
+	s.called = true
+	if r.Body != nil {
+		// Drain nothing but close so the pipe writer side unblocks on teardown.
+		go func() { _, _ = io.Copy(io.Discard, r.Body) }()
+	}
+	return s.resp, s.err
+}
+
+// hijackRecorder (defined in cachestatus_test.go) is a hijackable
+// ResponseRecorder so canHijack passes; Hijack is only reached on the 200 path,
+// which these unit tests do not exercise.
+
+func TestWSTunnel_TranslateCloneShape(t *testing.T) {
+	tun := &wsTunnel{scheme: "https", addr: "core:443"}
+	r := newWSHandshake("/chat?x=1")
+	r.Header.Set("Sec-WebSocket-Protocol", "chat")
+	r.Header.Set("Sec-WebSocket-Extensions", "permessage-deflate")
+
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	c := tun.translate(context.Background(), r, pr)
+
+	// clone is the extended-CONNECT shape (RFC 8441 §4–5)
+	assert.Equal(t, http.MethodConnect, c.Method)
+	assert.Equal(t, "websocket", c.Header.Get(":protocol"))
+	assert.Equal(t, "https", c.URL.Scheme)
+	assert.Equal(t, "core:443", c.URL.Host)
+	assert.Equal(t, "/chat", c.URL.Path)
+	assert.Equal(t, "x=1", c.URL.RawQuery)
+	assert.Empty(t, c.Header.Get("Connection"), "Connection dropped (illegal on h2)")
+	assert.Empty(t, c.Header.Get("Upgrade"), "Upgrade dropped (illegal on h2)")
+	assert.Empty(t, c.Header.Get("Sec-WebSocket-Key"), "key does not exist on h2")
+	assert.Equal(t, "chat", c.Header.Get("Sec-WebSocket-Protocol"), "subprotocol rides through")
+	assert.Equal(t, "permessage-deflate", c.Header.Get("Sec-WebSocket-Extensions"), "extensions ride through")
+	assert.Equal(t, "13", c.Header.Get("Sec-WebSocket-Version"), "version rides through")
+
+	// original is untouched so the caller can still fall back with it
+	assert.Equal(t, http.MethodGet, r.Method)
+	assert.Equal(t, "Upgrade", r.Header.Get("Connection"))
+	assert.Equal(t, "websocket", r.Header.Get("Upgrade"))
+	assert.NotEmpty(t, r.Header.Get("Sec-WebSocket-Key"))
+	assert.Empty(t, r.Header.Get(":protocol"))
+}
+
+func TestWSTunnel_NotSupportedFallsBack(t *testing.T) {
+	rt := &stubRT{err: errors.New("net/http: extended connect not supported by peer")}
+	tun := &wsTunnel{tr: rt, scheme: "http", addr: "core:80"}
+
+	r := newWSHandshake("/chat")
+	w := &hijackRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+	handled := tun.serve(w, r)
+	assert.False(t, handled, "not-supported must fall back to the h1 path")
+	assert.True(t, rt.called, "the tunnel was attempted")
+	assert.Equal(t, 200, w.Code, "no response written to the client on fallback")
+
+	// original request preserved for the fallback
+	assert.Equal(t, http.MethodGet, r.Method)
+	assert.Equal(t, "websocket", r.Header.Get("Upgrade"))
+	assert.NotEmpty(t, r.Header.Get("Sec-WebSocket-Key"))
+}
+
+// A generic (non not-supported) pre-commit RoundTrip error also falls back —
+// a clean ALPN/dial failure from an old core must not 502 the client.
+func TestWSTunnel_GenericErrorFallsBack(t *testing.T) {
+	rt := &stubRT{err: errors.New("dial tcp: connection refused")}
+	tun := &wsTunnel{tr: rt, scheme: "http", addr: "core:80"}
+
+	r := newWSHandshake("/chat")
+	w := &hijackRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+	assert.False(t, tun.serve(w, r))
+	assert.True(t, rt.called)
+}
+
+func TestWSTunnel_BadHandshake(t *testing.T) {
+	tun := &wsTunnel{tr: &stubRT{}, scheme: "http", addr: "core:80"}
+
+	t.Run("missing key", func(t *testing.T) {
+		r := newWSHandshake("/chat")
+		r.Header.Del("Sec-WebSocket-Key")
+		w := httptest.NewRecorder()
+		require.True(t, tun.serve(w, r))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("non-GET", func(t *testing.T) {
+		r := newWSHandshake("/chat")
+		r.Method = http.MethodPost
+		w := httptest.NewRecorder()
+		require.True(t, tun.serve(w, r))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+// A non-hijackable ResponseWriter (never the edge's h1 listener) falls back
+// without committing anything to the client.
+func TestWSTunnel_NonHijackableFallsBack(t *testing.T) {
+	rt := &stubRT{}
+	tun := &wsTunnel{tr: rt, scheme: "http", addr: "core:80"}
+	r := newWSHandshake("/chat")
+	w := httptest.NewRecorder() // ResponseRecorder is not an http.Hijacker
+
+	assert.False(t, tun.serve(w, r))
+	assert.False(t, rt.called, "must not attempt the tunnel when it cannot hijack")
+}
+
+func TestIsWebSocketUpgrade(t *testing.T) {
+	cases := []struct {
+		upgrade string
+		want    bool
+	}{
+		{"websocket", true},
+		{"WebSocket", true},
+		{"WEBSOCKET", true},
+		{"h2c", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		r := httptest.NewRequest(http.MethodGet, "http://x/", nil)
+		if c.upgrade != "" {
+			r.Header.Set("Upgrade", c.upgrade)
+		}
+		assert.Equalf(t, c.want, isWebSocketUpgrade(r), "upgrade=%q", c.upgrade)
+	}
+}

--- a/metric/observe/ws.go
+++ b/metric/observe/ws.go
@@ -1,0 +1,40 @@
+package observe
+
+import (
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// _wsUpstream counts edge→core WebSocket handshake outcomes. Unlike the WAF /
+// Coraza match counters this is a NEW metric name — the metric package never
+// registers it — so it registers eagerly at init like the ratelimit/cache
+// observers, with no collision hazard.
+var _wsUpstream *prometheus.CounterVec
+
+func init() {
+	_wsUpstream = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "edge_ws_upstream",
+	}, []string{"protocol", "result"})
+	prom.Registry().MustRegister(_wsUpstream)
+}
+
+// WSUpstream records one edge→core WebSocket tunnel outcome as
+// parapet_edge_ws_upstream{protocol,result}:
+//   - ("h2","ok")            extended CONNECT to the core succeeded (the core
+//     answered 200 and the session spliced, or relayed a
+//     non-200 refusal — the h2 hop itself worked).
+//   - ("http1","fallback")   the tunnel was NOT used; the request fell back to the
+//     HTTP/1.1 upgrade path (core doesn't advertise extended
+//     CONNECT — GODEBUG=http2xconnect=1 missing / old core —
+//     or a pre-commit transport failure). The "core lost its
+//     GODEBUG" alarm.
+//   - ("h2","error")         the tunnel attempt failed AFTER bytes were committed to
+//     the client (101 written / hijacked), so it could not
+//     fall back and the client session is broken.
+//
+// Both label values are fixed operator-set strings, never request input, so the
+// series stays bounded.
+func WSUpstream(protocol, result string) {
+	_wsUpstream.WithLabelValues(protocol, result).Inc()
+}

--- a/metric/ws.go
+++ b/metric/ws.go
@@ -8,9 +8,11 @@ import (
 var _ws wsMetric
 
 type wsMetric struct {
-	vec    *prometheus.CounterVec
-	cache  *cache[string, prometheus.Counter]
-	active prometheus.Gauge
+	vec      *prometheus.CounterVec
+	cache    *cache[string, prometheus.Counter]
+	active   prometheus.Gauge
+	h2c      *prometheus.CounterVec
+	h2cCache *cache[string, prometheus.Counter]
 }
 
 func init() {
@@ -28,6 +30,15 @@ func init() {
 		Name:      "ws_tunnel_active",
 	})
 	prom.Registry().MustRegister(_ws.active)
+
+	_ws.h2c = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "ws_upstream_h2c",
+	}, []string{"result"})
+	// result is one of a fixed set (ok|not_supported|error), so the series is
+	// bounded and the cache never grows past it.
+	_ws.h2cCache = newCache[string, prometheus.Counter](3)
+	prom.Registry().MustRegister(_ws.h2c)
 }
 
 // WSTunnel counts an extended-CONNECT WebSocket handshake by its outcome. result
@@ -41,3 +52,11 @@ func WSTunnel(result string) {
 // WSTunnelActiveInc / WSTunnelActiveDec bracket a live spliced session.
 func WSTunnelActiveInc() { _ws.active.Inc() }
 func WSTunnelActiveDec() { _ws.active.Dec() }
+
+// WSUpstreamH2C counts a core→pod extended-CONNECT attempt by its outcome. result
+// is one of ok|not_supported|error.
+func WSUpstreamH2C(result string) {
+	_ws.h2cCache.getOrCreate(result, func() prometheus.Counter {
+		return _ws.h2c.With(prometheus.Labels{"result": result})
+	}).Inc()
+}

--- a/metric/ws.go
+++ b/metric/ws.go
@@ -1,0 +1,43 @@
+package metric
+
+import (
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var _ws wsMetric
+
+type wsMetric struct {
+	vec    *prometheus.CounterVec
+	cache  *cache[string, prometheus.Counter]
+	active prometheus.Gauge
+}
+
+func init() {
+	_ws.vec = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: prom.Namespace,
+		Name:      "ws_tunnels",
+	}, []string{"result"})
+	// result is one of a fixed set (tunneled|refused|upstream_error|bad_protocol),
+	// so the series is bounded and the cache never grows past it.
+	_ws.cache = newCache[string, prometheus.Counter](4)
+	prom.Registry().MustRegister(_ws.vec)
+
+	_ws.active = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: prom.Namespace,
+		Name:      "ws_tunnel_active",
+	})
+	prom.Registry().MustRegister(_ws.active)
+}
+
+// WSTunnel counts an extended-CONNECT WebSocket handshake by its outcome. result
+// is one of tunneled|refused|upstream_error|bad_protocol.
+func WSTunnel(result string) {
+	_ws.cache.getOrCreate(result, func() prometheus.Counter {
+		return _ws.vec.With(prometheus.Labels{"result": result})
+	}).Inc()
+}
+
+// WSTunnelActiveInc / WSTunnelActiveDec bracket a live spliced session.
+func WSTunnelActiveInc() { _ws.active.Inc() }
+func WSTunnelActiveDec() { _ws.active.Dec() }

--- a/proxy/autoh2c.go
+++ b/proxy/autoh2c.go
@@ -140,6 +140,15 @@ func (t *autoH2CTransport) lookup(key string) (h2cEntry, bool) {
 	return e, true
 }
 
+// freshPositive reports whether key holds a fresh cached h2c-positive verdict.
+// Read-only: it never probes, stores, or refreshes the entry, so a WS request
+// consulting it can never establish or extend the auto-h2c verdict (that contract
+// stays owned by regular traffic).
+func (t *autoH2CTransport) freshPositive(key string) bool {
+	e, ok := t.lookup(key)
+	return ok && e.h2c
+}
+
 // store records a probe outcome with a fresh TTL.
 func (t *autoH2CTransport) store(key string, supportsH2C bool) {
 	t.entries.Store(key, h2cEntry{h2c: supportsH2C, deadline: t.now().Add(t.ttl)})

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
+	"sync"
 	"time"
 
 	"github.com/moonrhythm/parapet-ingress-controller/wafclaim"
@@ -21,6 +22,13 @@ type Proxy struct {
 	h2cTransport  *h2cTransport
 	gw            *gateway
 	autoH2C       *autoH2CTransport
+
+	// WS-over-h2c (phase 3): a dedicated pod-side extended-CONNECT transport plus a
+	// per-Service negative-verdict cache. wsH2C is an interface so tests can inject a
+	// stub RoundTripper. wsH2CNeg maps an upstream key to a negative-verdict expiry.
+	wsUpstreamH2C bool
+	wsH2C         http.RoundTripper
+	wsH2CNeg      sync.Map // upstream key (string) -> time.Time (negative-verdict expiry)
 }
 
 func New() *Proxy {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -9,11 +9,13 @@ import (
 	"time"
 
 	"github.com/moonrhythm/parapet-ingress-controller/wafclaim"
+	"github.com/moonrhythm/parapet-ingress-controller/wsh2"
 )
 
 type Proxy struct {
 	OnDialError func(addr string)
 
+	dialer        *dialer
 	reverseProxy  httputil.ReverseProxy
 	httpTransport *http.Transport
 	h2cTransport  *h2cTransport
@@ -26,6 +28,7 @@ func New() *Proxy {
 
 	var p Proxy
 	d.onError = p.onDialError
+	p.dialer = d
 	p.httpTransport = newHTTPTransport(d.DialContext)
 	p.h2cTransport = newH2CTransport(d.DialContext, p.httpTransport)
 	p.gw = &gateway{
@@ -74,6 +77,16 @@ func (p *Proxy) onDialError(addr string) {
 }
 
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// A normalized extended-CONNECT WebSocket handshake (wsh2.Normalize parked its
+	// stream in the context) cannot ride httputil.ReverseProxy: that path hijacks
+	// the downstream connection, and an h2 stream's ResponseWriter has no Hijacker.
+	// Tunnel it to the pod over the h1 upgrade it already speaks instead. The
+	// Upgrade check keeps this off any other CONNECT that somehow carries a stream.
+	if stream, ok := wsh2.TunnelStream(r.Context()); ok && r.Header.Get("Upgrade") == "websocket" {
+		p.serveWSTunnel(w, r, stream)
+		return
+	}
+
 	p.reverseProxy.ServeHTTP(w, r)
 }
 

--- a/proxy/wsh2c.go
+++ b/proxy/wsh2c.go
@@ -1,0 +1,213 @@
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/net/http2"
+
+	"github.com/moonrhythm/parapet-ingress-controller/metric"
+	"github.com/moonrhythm/parapet-ingress-controller/wafclaim"
+	"github.com/moonrhythm/parapet-ingress-controller/wsh2"
+)
+
+// wsH2CNegTTL bounds a cached "pod does not advertise extended CONNECT" verdict.
+// It matches the auto-h2c default so a Service that gains support is re-attempted
+// on the same cadence; no separate env knob.
+const wsH2CNegTTL = 10 * time.Minute
+
+// errExtendedConnectNotSupported is the message x/net's http2 client returns
+// pre-flight (before writing any request bytes, before touching req.Body) when the
+// peer's first SETTINGS did not advertise ENABLE_CONNECT_PROTOCOL. The error type
+// is unexported, so it is matched by substring; a missed match degrades to the
+// generic error path (which does not fall back), so the match is the safety hinge
+// that keeps the parked stream replayable.
+const errExtendedConnectNotSupported = "extended connect not supported by peer"
+
+// EnableWSUpstreamH2C turns on core→pod WebSocket-over-h2c (RFC 8441 extended
+// CONNECT). It builds a dedicated prior-knowledge h2c transport — never the RPC
+// h2c transport, whose stream budget long-lived tunnels must not pin. Call before
+// serving traffic.
+func (p *Proxy) EnableWSUpstreamH2C() {
+	p.wsUpstreamH2C = true
+	p.wsH2C = &http2.Transport{
+		AllowHTTP:          true,
+		DisableCompression: true,
+		ReadIdleTimeout:    30 * time.Second,
+		PingTimeout:        15 * time.Second,
+		// Dial through p.dialer so bad-addr marking still fires; capture the dial
+		// error in the per-request holder (x/net wraps the RoundTrip error, so the
+		// holder is the reliable seam for classifying it as retryable).
+		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			conn, err := p.dialer.DialContext(ctx, network, addr)
+			if err != nil {
+				if h, ok := ctx.Value(wsDialErrKey{}).(*wsDialErr); ok {
+					h.err = err
+				}
+				return nil, err
+			}
+			return conn, nil
+		},
+	}
+}
+
+// wsDialErr holds the dial error captured at the DialTLSContext seam for one
+// extended-CONNECT attempt.
+type wsDialErr struct{ err error }
+
+type wsDialErrKey struct{}
+
+// wsH2CEligible reports whether an extended-CONNECT attempt to the pod should be
+// made for r. It never mutates the auto-h2c verdict.
+func (p *Proxy) wsH2CEligible(r *http.Request, key string) bool {
+	switch r.URL.Scheme {
+	case "h2c":
+		// explicit appProtocol: h2c — the pod speaks h2c, attempt extended CONNECT.
+	case "http":
+		// plain http: only when auto-h2c already holds a fresh positive verdict for
+		// this Service (established by regular traffic — a WS request must not probe).
+		if p.autoH2C == nil || !p.autoH2C.freshPositive(key) {
+			return false
+		}
+	default: // https and anything else stay on the h1-over-TLS path
+		return false
+	}
+	// A fresh negative (peer did not advertise) skips straight to the h1 path.
+	return !p.wsH2CNegativeFresh(key)
+}
+
+// wsH2CNegativeFresh reports whether key has an unexpired negative verdict.
+// Expired entries are deleted on read: with auto-h2c off the fallback key is the
+// dialed pod host:port, so pod churn would otherwise grow the map without bound.
+func (p *Proxy) wsH2CNegativeFresh(key string) bool {
+	v, ok := p.wsH2CNeg.Load(key)
+	if !ok {
+		return false
+	}
+	if !time.Now().Before(v.(time.Time)) {
+		p.wsH2CNeg.Delete(key)
+		return false
+	}
+	return true
+}
+
+// storeWSH2CNegative records a fresh negative verdict for key.
+func (p *Proxy) storeWSH2CNegative(key string) {
+	p.wsH2CNeg.Store(key, time.Now().Add(wsH2CNegTTL))
+}
+
+// tryWSTunnelH2C attempts an RFC 8441 extended CONNECT to the pod over h2c. It
+// returns true when it owns the outcome (tunnel spliced, refusal relayed, or a
+// non-retryable error 502'd), or panics with a retryable dial error for
+// retryMiddleware. It returns false ONLY on a not-supported peer — the pre-flight
+// failure leaves the parked stream untouched (fact: RFC 8441 not-supported fails
+// before any bytes or any req.Body read), so serveWSTunnel falls through to the h1
+// path with a pristine stream.
+func (p *Proxy) tryWSTunnelH2C(w http.ResponseWriter, r *http.Request, stream io.ReadCloser, key string) (handled bool) {
+	addr := r.URL.Host
+
+	// One context for the whole session; a timer bounds only the handshake and is
+	// disarmed once RoundTrip returns (x/net has no ResponseHeaderTimeout). The
+	// holder rides this context so DialTLSContext can hand back the dial error.
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+	holder := &wsDialErr{}
+	ctx = context.WithValue(ctx, wsDialErrKey{}, holder)
+
+	creq := buildWSConnect(ctx, r, stream, addr)
+
+	timer := time.AfterFunc(wsHandshakeTimeout, cancel)
+	resp, err := p.wsH2C.RoundTrip(creq)
+	timer.Stop()
+	if err != nil {
+		if strings.Contains(err.Error(), errExtendedConnectNotSupported) {
+			// Peer does not advertise extended CONNECT: cache the negative and let the
+			// caller fall back to the h1 upgrade dial. Nothing was written to the client
+			// or read from stream.
+			p.storeWSH2CNegative(key)
+			metric.WSUpstreamH2C("not_supported")
+			return false
+		}
+		// A dial failure cannot have consumed the request body: preserve phase-1 retry
+		// semantics (panic → retryMiddleware). The holder captures it at the dial seam;
+		// isDialError is the fallback when a shared/reused dial obscured the holder.
+		if holder.err != nil {
+			panic(holder.err)
+		}
+		if isDialError(err) {
+			panic(err)
+		}
+		// Conn died mid-handshake or the stream was reset: the body may have been
+		// partially consumed, so a replay could duplicate frames — no fallback, no
+		// retry.
+		slog.Warn("proxy: ws h2c tunnel handshake failed", "addr", addr, "error", err)
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		metric.WSUpstreamH2C("error")
+		metric.WSTunnel("upstream_error")
+		return true
+	}
+
+	if resp.StatusCode/100 != 2 {
+		// The pod refused the handshake (app auth / 404 / ...). The extended CONNECT
+		// mechanism itself worked, so count it ok here and relay the refusal like the
+		// h1 non-101 path; the refusal detail lives in ws_tunnels{result=refused}.
+		copyHeader(w.Header(), resp.Header)
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+		resp.Body.Close()
+		stream.Close()
+		metric.WSUpstreamH2C("ok")
+		metric.WSTunnel("refused")
+		return true
+	}
+
+	// Accepted. Respond 200 on the (h2 or h1) downstream stream, copying the
+	// negotiated subprotocol/extensions minus the pod-hop hop-by-hop headers.
+	copyWSResponseHeader(w.Header(), resp.Header)
+	w.WriteHeader(http.StatusOK)
+
+	rc := http.NewResponseController(w)
+	flush := func() { _ = rc.Flush() }
+	flush() // commit the 200 before any frames
+
+	metric.WSUpstreamH2C("ok")
+	metric.WSTunnel("tunneled")
+	metric.WSTunnelActiveInc()
+	defer metric.WSTunnelActiveDec()
+
+	// Single-direction copy pod→client (resp.Body → w). The client→pod direction is
+	// x/net streaming creq.Body (= stream) upward as DATA frames, so it needs no copy
+	// here; closing both endpoints when this returns ends the session.
+	_ = wsh2.Copy(w, resp.Body, flush)
+	resp.Body.Close()
+	stream.Close()
+	return true
+}
+
+// buildWSConnect clones the normalized h1-upgrade request into the RFC 8441
+// extended-CONNECT shape for the pod, leaving r (and its parked stream) untouched
+// so serveWSTunnel can still fall back on a not-supported peer. Connection/Upgrade
+// are illegal on h2 (x/net rejects them) and the WAF claim is never the pod's
+// business; Sec-WebSocket-Version/Protocol/Extensions ride through. The h2 side
+// carries no Sec-WebSocket-Key (RFC 8441 has no key/accept proof). body is the
+// parked client→pod stream.
+func buildWSConnect(ctx context.Context, r *http.Request, body io.ReadCloser, addr string) *http.Request {
+	c := r.Clone(ctx)
+	c.Method = http.MethodConnect
+	c.Body = body
+	c.ContentLength = -1
+	c.Header.Del("Connection")
+	c.Header.Del("Upgrade")
+	c.Header.Del("Transfer-Encoding")
+	c.Header.Del(wafclaim.Header)
+	c.Header.Set(":protocol", "websocket")
+	c.URL.Scheme = "http"
+	c.URL.Host = addr
+	return c
+}

--- a/proxy/wsh2c_test.go
+++ b/proxy/wsh2c_test.go
@@ -1,0 +1,299 @@
+package proxy
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/moonrhythm/parapet/pkg/compress"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet-ingress-controller/wsh2"
+)
+
+// wsH2CTunnelHandler mimics wsNormalize + the route handler, pointing the proxy at
+// podAddr with the given upstream scheme (h2c = explicit appProtocol, http = auto).
+func wsH2CTunnelHandler(p *Proxy, podAddr, scheme string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if wsh2.IsExtendedConnect(r) && r.Header.Get(":protocol") == "websocket" {
+			r = wsh2.Normalize(r)
+		}
+		r.URL.Scheme = scheme
+		r.URL.Host = podAddr
+		p.ServeHTTP(w, r)
+	})
+}
+
+// podReq captures the fields of the pod-side request the assertions care about,
+// copied out of the handler so the test goroutine never races the body read.
+type podReq struct {
+	method   string
+	protocol string
+	key      string
+	version  string
+}
+
+// startWSH2CEchoPod serves an h2c extended-CONNECT WebSocket that echoes DATA
+// frames. GODEBUG=http2xconnect=1 (set by TestMain) makes it advertise the
+// setting, so the core's client attempt succeeds.
+func startWSH2CEchoPod(t *testing.T, seen chan<- podReq) string {
+	return startH2CServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen <- podReq{
+			method:   r.Method,
+			protocol: r.Header.Get(":protocol"),
+			key:      r.Header.Get("Sec-WebSocket-Key"),
+			version:  r.Header.Get("Sec-WebSocket-Version"),
+		}
+		w.Header().Set("Sec-WebSocket-Protocol", "chat")
+		w.WriteHeader(http.StatusOK)
+		rc := http.NewResponseController(w)
+		_ = rc.Flush()
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Body.Read(buf)
+			if n > 0 {
+				_, _ = w.Write(buf[:n])
+				_ = rc.Flush()
+			}
+			if err != nil {
+				return
+			}
+		}
+	}))
+}
+
+// startFakePodN is startFakePod that accepts up to n sequential h1 connections, so
+// a test can drive several fallback handshakes at the same pod address (the
+// negative cache keys on that address).
+func startFakePodN(t *testing.T, n int, fn func(conn net.Conn, req *http.Request, br *bufio.Reader)) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for i := 0; i < n; i++ {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+				br := bufio.NewReader(conn)
+				req, err := http.ReadRequest(br)
+				if err != nil {
+					return
+				}
+				_ = conn.SetReadDeadline(time.Time{})
+				fn(conn, req, br)
+			}()
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// ws101 answers an h1 WebSocket upgrade with a valid 101 computed from the core's
+// generated key, then closes (the empty client stream ends the session at once).
+func ws101(conn net.Conn, req *http.Request, _ *bufio.Reader) {
+	key := req.Header.Get("Sec-WebSocket-Key")
+	fmt.Fprintf(conn, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\n\r\n", wsh2.AcceptKey(key))
+}
+
+// TestWSTunnelH2C_ExtendedConnect drives an extended CONNECT through the core to a
+// pod that itself speaks WS-over-h2c: the pod-side hop must be extended CONNECT
+// (CONNECT + :protocol, no Sec-WebSocket-Key), and bytes must flow both ways.
+func TestWSTunnelH2C_ExtendedConnect(t *testing.T) {
+	seen := make(chan podReq, 1)
+	podAddr := startWSH2CEchoPod(t, seen)
+
+	p := New()
+	p.EnableWSUpstreamH2C()
+	h := compress.Gzip().ServeHandler(wsH2CTunnelHandler(p, podAddr, "h2c"))
+	serverAddr := startH2CServer(t, h)
+
+	pr, pw := io.Pipe()
+	tr := h2cClient(t)
+	resp, err := tr.RoundTrip(extendedConnect(t, serverAddr, "/chat", pr))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "chat", resp.Header.Get("Sec-WebSocket-Protocol"))
+
+	// the pod-side hop really was extended CONNECT
+	got := <-seen
+	assert.Equal(t, http.MethodConnect, got.method)
+	assert.Equal(t, "websocket", got.protocol)
+	assert.Empty(t, got.key, "RFC 8441 has no Sec-WebSocket-Key on the h2 hop")
+	assert.Equal(t, "13", got.version)
+
+	// client -> pod -> client round trip
+	_, err = pw.Write([]byte("ping"))
+	require.NoError(t, err)
+	buf := make([]byte, 4)
+	_, err = io.ReadFull(resp.Body, buf)
+	require.NoError(t, err)
+	assert.Equal(t, "ping", string(buf))
+	pw.Close()
+}
+
+// TestWSTunnelH2C_AutoH2CPositive takes the h2c tunnel for a plain-http upstream
+// only when auto-h2c already holds a fresh positive verdict; with no verdict it
+// falls through to the h1 upgrade path.
+func TestWSTunnelH2C_AutoH2CPositive(t *testing.T) {
+	t.Run("fresh positive tunnels over h2c", func(t *testing.T) {
+		seen := make(chan podReq, 1)
+		podAddr := startWSH2CEchoPod(t, seen)
+
+		p := New()
+		p.EnableWSUpstreamH2C()
+		p.EnableAutoH2C(time.Minute)
+		p.autoH2C.store(podAddr, true) // verdict established by regular traffic
+
+		h := compress.Gzip().ServeHandler(wsH2CTunnelHandler(p, podAddr, "http"))
+		serverAddr := startH2CServer(t, h)
+
+		tr := h2cClient(t)
+		resp, err := tr.RoundTrip(extendedConnect(t, serverAddr, "/chat", strings.NewReader("")))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		got := <-seen
+		assert.Equal(t, http.MethodConnect, got.method, "pod hop was extended CONNECT")
+	})
+
+	t.Run("no verdict falls through to h1", func(t *testing.T) {
+		methodCh := make(chan string, 1)
+		upgradeCh := make(chan string, 1)
+		podAddr := startFakePodN(t, 1, func(conn net.Conn, req *http.Request, br *bufio.Reader) {
+			methodCh <- req.Method
+			upgradeCh <- req.Header.Get("Upgrade")
+			ws101(conn, req, br)
+		})
+
+		p := New()
+		p.EnableWSUpstreamH2C()
+		p.EnableAutoH2C(time.Minute) // enabled, but no verdict for podAddr
+
+		h := compress.Gzip().ServeHandler(wsH2CTunnelHandler(p, podAddr, "http"))
+		serverAddr := startH2CServer(t, h)
+
+		tr := h2cClient(t)
+		resp, err := tr.RoundTrip(extendedConnect(t, serverAddr, "/chat", strings.NewReader("")))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.MethodGet, <-methodCh, "pod saw the h1 upgrade")
+		assert.Equal(t, "websocket", <-upgradeCh)
+	})
+}
+
+// countingNotSupportedRT returns the extended-connect-not-supported error without
+// touching the request body (the real x/net client fails pre-flight), and counts
+// how many times it is asked to.
+type countingNotSupportedRT struct{ n int32 }
+
+func (s *countingNotSupportedRT) RoundTrip(*http.Request) (*http.Response, error) {
+	atomic.AddInt32(&s.n, 1)
+	return nil, errors.New("net/http: extended connect not supported by peer")
+}
+
+// TestWSTunnelH2C_NotSupportedFallsBack verifies a not-supported peer falls back to
+// the h1 path, caches the negative, and skips the attempt on the next request.
+func TestWSTunnelH2C_NotSupportedFallsBack(t *testing.T) {
+	methodCh := make(chan string, 2)
+	podAddr := startFakePodN(t, 2, func(conn net.Conn, req *http.Request, br *bufio.Reader) {
+		methodCh <- req.Method
+		ws101(conn, req, br)
+	})
+
+	p := New()
+	p.EnableWSUpstreamH2C()
+	stub := &countingNotSupportedRT{}
+	p.wsH2C = stub
+
+	serve := func() {
+		r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+		r.URL.Scheme = "h2c"
+		r.URL.Host = podAddr
+		r.Header.Set("Upgrade", "websocket")
+		r = r.WithContext(wsh2.MarkTunnel(r.Context(), io.NopCloser(strings.NewReader(""))))
+		w := httptest.NewRecorder()
+		p.ServeHTTP(w, r)
+		require.Equal(t, http.StatusOK, w.Code, "not-supported falls back to the h1 tunnel")
+	}
+
+	serve()
+	assert.True(t, p.wsH2CNegativeFresh(podAddr), "negative verdict cached")
+	assert.Equal(t, http.MethodGet, <-methodCh, "first request served over h1")
+
+	serve()
+	assert.Equal(t, http.MethodGet, <-methodCh, "second request served over h1")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&stub.n), "second request skips the h2c attempt")
+}
+
+// TestWSTunnelH2C_Refused relays a pod's non-2xx over h2c as a normal response.
+func TestWSTunnelH2C_Refused(t *testing.T) {
+	podAddr := startH2CServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-App", "v1")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("nope"))
+	}))
+
+	p := New()
+	p.EnableWSUpstreamH2C()
+	h := compress.Gzip().ServeHandler(wsH2CTunnelHandler(p, podAddr, "h2c"))
+	serverAddr := startH2CServer(t, h)
+
+	tr := h2cClient(t)
+	resp, err := tr.RoundTrip(extendedConnect(t, serverAddr, "/chat", strings.NewReader("")))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Equal(t, "v1", resp.Header.Get("X-App"), "app headers pass through")
+	assert.Empty(t, resp.Header.Get("Connection"), "hop headers stripped")
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "nope", string(body))
+}
+
+// TestWSTunnelH2C_DialErrorRetryable pins the h2c dial-error seam: a dead pod addr
+// panics with a retryable error, exactly like the h1 tunnel dial-error path.
+func TestWSTunnelH2C_DialErrorRetryable(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	ln.Close() // now refused
+
+	p := New()
+	p.EnableWSUpstreamH2C()
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r.URL.Scheme = "h2c"
+	r.URL.Host = addr
+	r.Header.Set("Upgrade", "websocket")
+	r = r.WithContext(wsh2.MarkTunnel(r.Context(), io.NopCloser(strings.NewReader(""))))
+	w := httptest.NewRecorder()
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		p.ServeHTTP(w, r)
+	}()
+
+	err, _ = recovered.(error)
+	require.Error(t, err, "dial error panics")
+	assert.True(t, IsRetryable(err), "h2c tunnel dial error is retryable")
+	assert.False(t, p.wsH2CNegativeFresh(addr), "a dial error is not a not-supported verdict")
+}

--- a/proxy/wstunnel.go
+++ b/proxy/wstunnel.go
@@ -1,0 +1,206 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/moonrhythm/parapet-ingress-controller/metric"
+	"github.com/moonrhythm/parapet-ingress-controller/wafclaim"
+	"github.com/moonrhythm/parapet-ingress-controller/wsh2"
+)
+
+// wsHandshakeTimeout bounds the TLS handshake, the upgrade-request write, and the
+// pod's response-header read, matching newHTTPTransport's ResponseHeaderTimeout.
+// Deadlines are cleared before splicing — a live WebSocket session is long-lived.
+const wsHandshakeTimeout = 3 * time.Minute
+
+// serveWSTunnel bridges a normalized extended-CONNECT WebSocket handshake to the
+// pod over the HTTP/1.1 upgrade it already speaks, then splices bytes both ways.
+// r.URL.Host is the resolved pod ip:port and r.URL.Scheme is http/https/h2c (set
+// by the route handler); stream is the parked client→server byte stream.
+func (p *Proxy) serveWSTunnel(w http.ResponseWriter, r *http.Request, stream io.ReadCloser) {
+	ctx := r.Context()
+	addr := r.URL.Host
+
+	conn, err := p.dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		// Dial error before the handshake: nothing was sent and the request body is
+		// http.NoBody, so this is retryable exactly like ReverseProxy.ErrorHandler's
+		// dial-error panic. The dialer already ran onError (bad-addr marking) and
+		// logged; retryMiddleware recovers this to retry / bad-gateway.
+		panic(err)
+	}
+	// Closure, not `defer conn.Close()`: conn is reassigned to the TLS wrapper
+	// below, and the close must tear down that final conn (with close-notify), not
+	// the captured raw TCP conn.
+	defer func() { conn.Close() }()
+
+	// https upstream: re-encrypt over TLS, HTTP/1.1 only (no h2 ALPN — this hop
+	// speaks the h1 WebSocket upgrade). Matches newHTTPTransport's TLS posture.
+	if r.URL.Scheme == "https" {
+		tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+		_ = conn.SetDeadline(time.Now().Add(wsHandshakeTimeout))
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			// The TCP connection was established, so the request may have reached the
+			// pod; do not retry. Nothing is written to the client yet.
+			slog.Warn("proxy: ws tunnel tls handshake failed", "addr", addr, "error", err)
+			http.Error(w, "Bad Gateway", http.StatusBadGateway)
+			metric.WSTunnel("upstream_error")
+			return
+		}
+		conn = tlsConn
+	}
+
+	key := wsh2.GenerateKey()
+	handshake := buildWSHandshake(r, key)
+
+	_ = conn.SetWriteDeadline(time.Now().Add(wsHandshakeTimeout))
+	if _, err := conn.Write(handshake); err != nil {
+		slog.Warn("proxy: ws tunnel write handshake failed", "addr", addr, "error", err)
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		metric.WSTunnel("upstream_error")
+		return
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(wsHandshakeTimeout))
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, r)
+	if err != nil {
+		// The request reached the pod; a failed/absent response must not be replayed.
+		slog.Warn("proxy: ws tunnel read response failed", "addr", addr, "error", err)
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		metric.WSTunnel("upstream_error")
+		return
+	}
+
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		// The pod refused the handshake (app auth / 404 / ...). Forward it as a
+		// normal response; the edge (or a direct h2 client) translates the non-200
+		// back into a non-101 for its own client.
+		copyHeader(w.Header(), resp.Header)
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+		resp.Body.Close()
+		metric.WSTunnel("refused")
+		return
+	}
+
+	if !wsh2.CheckAccept(resp.Header.Get("Sec-WebSocket-Accept"), key) {
+		slog.Warn("proxy: ws tunnel bad Sec-WebSocket-Accept", "addr", addr)
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		metric.WSTunnel("upstream_error")
+		return
+	}
+
+	// Accepted. Clear the handshake deadlines — the session is long-lived.
+	_ = conn.SetDeadline(time.Time{})
+
+	// Respond 200 on the h2 stream (the h2 side has no 101 / Sec-WebSocket-Accept):
+	// copy the negotiated subprotocol/extensions, dropping the pod-hop hop-by-hop
+	// headers and the accept proof, which is meaningless upstream of the h2 stream.
+	copyWSResponseHeader(w.Header(), resp.Header)
+	w.WriteHeader(http.StatusOK)
+
+	rc := http.NewResponseController(w)
+	flush := func() { _ = rc.Flush() }
+	flush() // commit the 200 before any frames
+
+	metric.WSTunnel("tunneled")
+	metric.WSTunnelActiveInc()
+	defer metric.WSTunnelActiveDec()
+
+	// Splice both directions. The pod→client side reads from br (not conn) so it
+	// drains any bytes the pod pipelined after the 101 that ReadResponse buffered.
+	// Closing an endpoint when one direction ends unblocks the other, so both
+	// copies return and the handler completes when the session ends.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = wsh2.Copy(conn, stream, nil)
+		conn.Close()
+	}()
+
+	_ = wsh2.Copy(w, br, flush)
+	stream.Close()
+	conn.Close()
+	<-done
+}
+
+// buildWSHandshake renders the HTTP/1.1 WebSocket upgrade request for the pod.
+// The request headers are already normalized (Connection: Upgrade, Upgrade:
+// websocket, Sec-WebSocket-Version/Protocol/Extensions); it stamps the generated
+// Sec-WebSocket-Key (the h2 side carried none) and drops the edge→core WAF claim,
+// which is never the pod's business.
+func buildWSHandshake(r *http.Request, key string) []byte {
+	r.Header.Del(wafclaim.Header)
+	r.Header.Set("Sec-WebSocket-Key", key)
+
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "GET %s HTTP/1.1\r\n", r.URL.RequestURI())
+	fmt.Fprintf(&b, "Host: %s\r\n", r.Host)
+	_ = r.Header.Write(&b)
+	b.WriteString("\r\n")
+	return b.Bytes()
+}
+
+// hopHeaders are the connection-scoped header fields httputil.ReverseProxy
+// strips when relaying a response — they describe this hop, not the payload,
+// and must never survive onto a different connection.
+var hopHeaders = []string{
+	"Connection",
+	"Proxy-Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te",
+	"Trailer",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+func isHopHeader(k string) bool {
+	ck := http.CanonicalHeaderKey(k)
+	for _, h := range hopHeaders {
+		if ck == h {
+			return true
+		}
+	}
+	return false
+}
+
+// copyHeader copies header values from src to dst, dropping hop-by-hop
+// headers. resp.Body is already transfer-decoded, so a copied
+// Transfer-Encoding would lie about the framing on the client connection
+// (Go's h1 server trusts a handler-set TE, corrupting the response); the rest
+// describe the now-closed pod hop, not the client's.
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		if isHopHeader(k) {
+			continue
+		}
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+// copyWSResponseHeader copies the pod's 101 response headers onto the h2 stream
+// response, minus the pod-hop hop-by-hop headers and the Sec-WebSocket-Accept
+// proof (meaningless on the h2 side; the edge synthesizes its own toward the
+// client).
+func copyWSResponseHeader(dst, src http.Header) {
+	for k, vv := range src {
+		if isHopHeader(k) || http.CanonicalHeaderKey(k) == "Sec-Websocket-Accept" {
+			continue
+		}
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}

--- a/proxy/wstunnel.go
+++ b/proxy/wstunnel.go
@@ -28,6 +28,18 @@ func (p *Proxy) serveWSTunnel(w http.ResponseWriter, r *http.Request, stream io.
 	ctx := r.Context()
 	addr := r.URL.Host
 
+	// Phase 3: when the pod speaks WS-over-h2c (explicit appProtocol: h2c, or a
+	// fresh auto-h2c positive verdict), tunnel stream-to-stream via extended CONNECT
+	// instead of dialing the h1 upgrade. A not-supported peer returns false, leaving
+	// the parked stream untouched so we fall through to the h1 path below.
+	if p.wsUpstreamH2C {
+		if key := upstreamKey(r); p.wsH2CEligible(r, key) {
+			if p.tryWSTunnelH2C(w, r, stream, key) {
+				return
+			}
+		}
+	}
+
 	conn, err := p.dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		// Dial error before the handshake: nothing was sent and the request body is

--- a/proxy/wstunnel_test.go
+++ b/proxy/wstunnel_test.go
@@ -1,0 +1,252 @@
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/moonrhythm/parapet/pkg/compress"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+
+	"github.com/moonrhythm/parapet-ingress-controller/wsh2"
+)
+
+// TestMain re-execs the test binary with GODEBUG=http2xconnect=1 when it's
+// missing, so the h2 server advertises SETTINGS_ENABLE_CONNECT_PROTOCOL (read in
+// package init). This keeps plain `go test ./...` green everywhere with no CI
+// changes: the child inherits the gate, runs the real tests, and its exit code
+// propagates.
+func TestMain(m *testing.M) {
+	const token = "http2xconnect=1"
+	if !strings.Contains(os.Getenv("GODEBUG"), token) {
+		godebug := token
+		if cur := os.Getenv("GODEBUG"); cur != "" {
+			godebug = cur + "," + token
+		}
+		cmd := exec.Command(os.Args[0], os.Args[1:]...)
+		cmd.Env = append(withoutGODEBUG(os.Environ()), "GODEBUG="+godebug)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			if ee, ok := err.(*exec.ExitError); ok {
+				os.Exit(ee.ExitCode())
+			}
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func withoutGODEBUG(env []string) []string {
+	out := env[:0:0]
+	for _, e := range env {
+		if strings.HasPrefix(e, "GODEBUG=") {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// wsTunnelHandler mimics the wsNormalize middleware + the route handler: it
+// normalizes an extended-CONNECT WebSocket handshake and points the proxy at the
+// fake pod, then proxies. It is wrapped in compress.Gzip below so the flush
+// through http.NewResponseController must traverse a parapet ResponseWriter
+// wrapper via Unwrap — the integration check that steady frames actually reach
+// the client.
+func wsTunnelHandler(t *testing.T, p *Proxy, podAddr string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if wsh2.IsExtendedConnect(r) && r.Header.Get(":protocol") == "websocket" {
+			r = wsh2.Normalize(r)
+		}
+		r.URL.Scheme = "http"
+		r.URL.Host = podAddr
+		p.ServeHTTP(w, r)
+	})
+}
+
+// startH2CServer serves handler as prior-knowledge h2c on a fresh listener and
+// returns its address. GODEBUG=http2xconnect=1 (set by TestMain) makes it
+// advertise extended CONNECT.
+func startH2CServer(t *testing.T, handler http.Handler) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	h2s := &http2.Server{}
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go h2s.ServeConn(c, &http2.ServeConnOpts{Handler: handler})
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// h2cClient returns an x/net http2.Transport that speaks prior-knowledge h2c.
+func h2cClient(t *testing.T) *http2.Transport {
+	tr := &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			return net.Dial(network, addr)
+		},
+	}
+	t.Cleanup(tr.CloseIdleConnections)
+	return tr
+}
+
+func extendedConnect(t *testing.T, serverAddr, path string, body io.Reader) *http.Request {
+	t.Helper()
+	r := &http.Request{
+		Method: http.MethodConnect,
+		URL:    &url.URL{Scheme: "http", Host: serverAddr, Path: path},
+		Host:   "example.com",
+		Header: http.Header{},
+		Body:   io.NopCloser(body),
+	}
+	r.Header[":protocol"] = []string{"websocket"}
+	r.Header.Set("Sec-WebSocket-Version", "13")
+	return r
+}
+
+// TestWSTunnelEndToEnd drives a real h2 extended CONNECT through the proxy tunnel
+// to a fake pod that speaks the h1 upgrade, and asserts bidirectional bytes flow.
+func TestWSTunnelEndToEnd(t *testing.T) {
+	keyCh := make(chan string, 1)
+	reqCh := make(chan *http.Request, 1)
+	podAddr := startFakePod(t, func(conn net.Conn, req *http.Request, br *bufio.Reader) {
+		reqCh <- req
+		key := req.Header.Get("Sec-WebSocket-Key")
+		keyCh <- key
+		fmt.Fprintf(conn, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\nSec-WebSocket-Protocol: chat\r\n\r\n", wsh2.AcceptKey(key))
+		// echo client frames back
+		_, _ = io.Copy(conn, br)
+	})
+
+	p := New()
+	h := compress.Gzip().ServeHandler(wsTunnelHandler(t, p, podAddr))
+	serverAddr := startH2CServer(t, h)
+
+	pr, pw := io.Pipe()
+	tr := h2cClient(t)
+	resp, err := tr.RoundTrip(extendedConnect(t, serverAddr, "/chat", pr))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "chat", resp.Header.Get("Sec-WebSocket-Protocol"))
+	assert.Empty(t, resp.Header.Get("Sec-WebSocket-Accept"), "accept proof stripped on the h2 side")
+
+	// the pod saw a valid h1 handshake
+	podReq := <-reqCh
+	assert.Equal(t, http.MethodGet, podReq.Method)
+	assert.Equal(t, "websocket", podReq.Header.Get("Upgrade"))
+	assert.NotEmpty(t, <-keyCh, "core generated a Sec-WebSocket-Key")
+
+	// client -> pod -> client round trip
+	_, err = pw.Write([]byte("ping"))
+	require.NoError(t, err)
+	got := make([]byte, 4)
+	_, err = io.ReadFull(resp.Body, got)
+	require.NoError(t, err)
+	assert.Equal(t, "ping", string(got))
+
+	pw.Close()
+}
+
+// TestWSTunnelRefused verifies a non-101 pod response is forwarded verbatim,
+// with its body intact and without the pod-hop's Connection/Transfer-Encoding
+// headers leaking through: resp.Body has already been transfer-decoded by the
+// time copyHeader runs, so a copied Transfer-Encoding would lie about the
+// framing, and Connection is hop-by-hop.
+func TestWSTunnelRefused(t *testing.T) {
+	podAddr := startFakePod(t, func(conn net.Conn, _ *http.Request, _ *bufio.Reader) {
+		fmt.Fprint(conn, "HTTP/1.1 403 Forbidden\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nnope\n\r\n0\r\n\r\n")
+	})
+
+	p := New()
+	h := compress.Gzip().ServeHandler(wsTunnelHandler(t, p, podAddr))
+	serverAddr := startH2CServer(t, h)
+
+	tr := h2cClient(t)
+	resp, err := tr.RoundTrip(extendedConnect(t, serverAddr, "/chat", strings.NewReader("")))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Transfer-Encoding"), "Transfer-Encoding must not leak to the client")
+	assert.Empty(t, resp.Header.Get("Connection"), "Connection must not leak to the client")
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "nope\n", string(body))
+}
+
+// TestServeWSTunnelDialErrorRetryable pins the dial-error seam: a tunnel dial
+// failure panics with a retryable error, which retryMiddleware recovers exactly
+// like today's ReverseProxy dial-error panic.
+func TestServeWSTunnelDialErrorRetryable(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	ln.Close() // now refused
+
+	p := New()
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r.URL.Scheme = "http"
+	r.URL.Host = addr
+	r.Header.Set("Upgrade", "websocket")
+	r = r.WithContext(wsh2.MarkTunnel(r.Context(), http.NoBody))
+	w := httptest.NewRecorder()
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		p.ServeHTTP(w, r)
+	}()
+
+	err, _ = recovered.(error)
+	require.Error(t, err, "dial error panics")
+	assert.True(t, IsRetryable(err), "tunnel dial error is retryable")
+}
+
+// startFakePod accepts one h1 WebSocket upgrade and hands the connection to fn.
+func startFakePod(t *testing.T, fn func(conn net.Conn, req *http.Request, br *bufio.Reader)) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+		br := bufio.NewReader(conn)
+		req, err := http.ReadRequest(br)
+		if err != nil {
+			return
+		}
+		_ = conn.SetReadDeadline(time.Time{})
+		fn(conn, req, br)
+	}()
+	return ln.Addr().String()
+}

--- a/wsh2/copy.go
+++ b/wsh2/copy.go
@@ -1,0 +1,49 @@
+package wsh2
+
+import (
+	"io"
+	"sync"
+)
+
+const bufferSize = 16 * 1024
+
+var bufferPool = sync.Pool{
+	New: func() any { b := make([]byte, bufferSize); return &b },
+}
+
+// Copy streams src to dst using a pooled buffer, calling flush (when non-nil)
+// after every write. The flush hook is what makes the pod→client direction of a
+// spliced tunnel usable: an h2 ResponseWriter buffers writes, so a WebSocket
+// frame must be flushed to reach the peer instead of waiting for more bytes. The
+// client→pod direction writes to a raw net.Conn and passes a nil flush.
+//
+// Copy returns nil on a clean EOF from src, or the first read/write error.
+// Callers close both endpoints when it returns so the opposite direction
+// unblocks.
+func Copy(dst io.Writer, src io.Reader, flush func()) error {
+	bp := bufferPool.Get().(*[]byte)
+	defer bufferPool.Put(bp)
+	buf := *bp
+
+	for {
+		nr, er := src.Read(buf)
+		if nr > 0 {
+			nw, ew := dst.Write(buf[:nr])
+			if flush != nil {
+				flush()
+			}
+			if ew != nil {
+				return ew
+			}
+			if nw < nr {
+				return io.ErrShortWrite
+			}
+		}
+		if er != nil {
+			if er == io.EOF {
+				return nil
+			}
+			return er
+		}
+	}
+}

--- a/wsh2/copy_test.go
+++ b/wsh2/copy_test.go
@@ -1,0 +1,42 @@
+package wsh2
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopy(t *testing.T) {
+	t.Parallel()
+
+	var dst bytes.Buffer
+	var flushes int
+	err := Copy(&dst, strings.NewReader("hello world"), func() { flushes++ })
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", dst.String())
+	assert.Positive(t, flushes, "flush called at least once")
+}
+
+func TestCopyNilFlush(t *testing.T) {
+	t.Parallel()
+
+	var dst bytes.Buffer
+	err := Copy(&dst, strings.NewReader("data"), nil)
+	require.NoError(t, err)
+	assert.Equal(t, "data", dst.String())
+}
+
+type errWriter struct{ err error }
+
+func (w errWriter) Write([]byte) (int, error) { return 0, w.err }
+
+func TestCopyWriteError(t *testing.T) {
+	t.Parallel()
+
+	want := assert.AnError
+	err := Copy(errWriter{err: want}, strings.NewReader("x"), nil)
+	assert.ErrorIs(t, err, want)
+}

--- a/wsh2/wsh2.go
+++ b/wsh2/wsh2.go
@@ -1,0 +1,117 @@
+// Package wsh2 bridges RFC 8441 extended-CONNECT WebSocket handshakes (the
+// HTTP/2 form) to the HTTP/1.1 upgrade the rest of the chain speaks. It is pure
+// (no k8s deps) so both the core proxy and the edge can import it.
+//
+// An h2 WebSocket handshake arrives as `:method: CONNECT` + `:protocol:
+// websocket` with the live client→server byte stream as the request body. The
+// core cannot inspect or splice that stream through the existing middleware
+// chain (body inspectors would block on / consume WebSocket frames), so
+// Normalize rewrites the request into the h1-upgrade shape and detaches the
+// stream into the request context — after which everything downstream is
+// oblivious to the difference from an h1 handshake.
+package wsh2
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/subtle"
+	"encoding/base64"
+	"io"
+	"net/http"
+)
+
+// wsGUID is the RFC 6455 §1.3 magic constant folded into the accept-key hash.
+const wsGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+// IsExtendedConnect reports whether r is an RFC 8441 extended CONNECT — the
+// HTTP/2 form of a WebSocket handshake. Go's h2 server surfaces the `:protocol`
+// pseudo-header in r.Header; an h1 client cannot produce it (colon-prefixed
+// field names are invalid HTTP/1.1 tokens and net/http rejects them), so this
+// match is inherently h2-only and not client-spoofable over h1.
+func IsExtendedConnect(r *http.Request) bool {
+	return r.Method == http.MethodConnect && r.Header.Get(":protocol") != ""
+}
+
+// Normalize rewrites an extended CONNECT WebSocket handshake in place into the
+// h1-upgrade shape the rest of the chain understands, parks the live
+// client→server stream in the request context (retrievable via TunnelStream),
+// and returns the request carrying that context. The caller must have confirmed
+// IsExtendedConnect and a `websocket` protocol.
+//
+// After Normalize the request is indistinguishable from an h1 WebSocket
+// handshake: request.method sees GET, and body inspectors (WAF InspectBody,
+// Coraza request body) see an empty body — exactly as they would for an h1
+// upgrade, whose body they also never read. Detaching the stream is mandatory:
+// left as r.Body it would be consumed by those inspectors, eating WebSocket
+// frames before the proxy could splice them.
+func Normalize(r *http.Request) *http.Request {
+	r.Method = http.MethodGet
+	r.Header.Set("Connection", "Upgrade")
+	r.Header.Set("Upgrade", "websocket")
+	r.Header.Del(":protocol")
+	// The spliced 200 response is byte-transparent; it must never be wrapped by
+	// the compress.Gzip/Zstd middlewares, so the handshake must not advertise a
+	// content coding.
+	r.Header.Del("Accept-Encoding")
+	// Go's h2 server keeps a client-sent content-length as a regular header on
+	// an extended CONNECT, but after the stream is detached below the handshake
+	// truthfully has no body. A surviving Content-Length (or Transfer-Encoding /
+	// Expect) would be written to the pod by the core's h1 handshake dial and
+	// desync the pod's parser — it would read WebSocket frames as body bytes.
+	r.Header.Del("Content-Length")
+	r.Header.Del("Transfer-Encoding")
+	r.Header.Del("Expect")
+
+	stream := r.Body
+	if stream == nil {
+		stream = http.NoBody
+	}
+	ctx := MarkTunnel(r.Context(), stream)
+	r.Body = http.NoBody
+	r.ContentLength = 0
+	return r.WithContext(ctx)
+}
+
+type tunnelCtxKey struct{}
+
+// MarkTunnel returns a child context carrying the parked client→server stream of
+// a normalized WebSocket handshake. The value is immutable and never cleared, so
+// it is safe to read from any goroutine that holds the context (unlike the
+// pooled per-request state map).
+func MarkTunnel(ctx context.Context, stream io.ReadCloser) context.Context {
+	return context.WithValue(ctx, tunnelCtxKey{}, stream)
+}
+
+// TunnelStream returns the parked stream set by MarkTunnel, if any.
+func TunnelStream(ctx context.Context) (io.ReadCloser, bool) {
+	s, ok := ctx.Value(tunnelCtxKey{}).(io.ReadCloser)
+	return s, ok
+}
+
+// GenerateKey returns a fresh base64-encoded 16-byte Sec-WebSocket-Key (RFC 6455
+// §4.1). The h2 handshake carries no key, so the core mints one for the h1
+// upgrade dial to the pod.
+func GenerateKey() string {
+	var b [16]byte
+	// crypto/rand.Read never returns an error on the platforms we target.
+	_, _ = rand.Read(b[:])
+	return base64.StdEncoding.EncodeToString(b[:])
+}
+
+// AcceptKey computes the RFC 6455 §4.2.2 Sec-WebSocket-Accept value for key:
+// base64(SHA1(key + wsGUID)).
+func AcceptKey(key string) string {
+	h := sha1.New()
+	io.WriteString(h, key)
+	io.WriteString(h, wsGUID)
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+// CheckAccept reports whether accept is the correct Sec-WebSocket-Accept for
+// key, in constant time. A mismatch means the peer did not complete the RFC 6455
+// handshake correctly.
+func CheckAccept(accept, key string) bool {
+	want := AcceptKey(key)
+	return subtle.ConstantTimeCompare([]byte(accept), []byte(want)) == 1
+}

--- a/wsh2/wsh2_test.go
+++ b/wsh2/wsh2_test.go
@@ -1,0 +1,122 @@
+package wsh2
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsExtendedConnect(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		method   string
+		protocol string
+		want     bool
+	}{
+		{"extended connect websocket", http.MethodConnect, "websocket", true},
+		{"extended connect other proto", http.MethodConnect, "foo", true},
+		{"plain connect", http.MethodConnect, "", false},
+		{"get with protocol", http.MethodGet, "websocket", false},
+		{"plain get", http.MethodGet, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(tc.method, "/", nil)
+			if tc.protocol != "" {
+				r.Header.Set(":protocol", tc.protocol)
+			}
+			assert.Equal(t, tc.want, IsExtendedConnect(r))
+		})
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	t.Parallel()
+
+	body := io.NopCloser(strings.NewReader("client-frames"))
+	r := httptest.NewRequest(http.MethodConnect, "/chat?room=1", body)
+	r.Header.Set(":protocol", "websocket")
+	r.Header.Set("Sec-WebSocket-Version", "13")
+	r.Header.Set("Sec-WebSocket-Protocol", "chat")
+	r.Header.Set("Accept-Encoding", "gzip")
+	r.Header.Set("Content-Length", "13")
+	r.Header.Set("Transfer-Encoding", "chunked")
+	r.Header.Set("Expect", "100-continue")
+	r.ContentLength = -1
+
+	out := Normalize(r)
+
+	assert.Equal(t, http.MethodGet, out.Method, "method rewritten to GET")
+	assert.Equal(t, "Upgrade", out.Header.Get("Connection"))
+	assert.Equal(t, "websocket", out.Header.Get("Upgrade"))
+	assert.Empty(t, out.Header.Get(":protocol"), ":protocol deleted")
+	assert.Empty(t, out.Header.Get("Accept-Encoding"), "Accept-Encoding deleted")
+	assert.Empty(t, out.Header.Get("Content-Length"), "Content-Length deleted")
+	assert.Empty(t, out.Header.Get("Transfer-Encoding"), "Transfer-Encoding deleted")
+	assert.Empty(t, out.Header.Get("Expect"), "Expect deleted")
+	assert.Equal(t, "13", out.Header.Get("Sec-WebSocket-Version"), "ws headers ride through")
+	assert.Equal(t, "chat", out.Header.Get("Sec-WebSocket-Protocol"))
+
+	// stream detached: body is empty, ContentLength 0.
+	assert.Equal(t, http.NoBody, out.Body)
+	assert.Zero(t, out.ContentLength)
+
+	// the original stream is parked in the context and readable.
+	stream, ok := TunnelStream(out.Context())
+	require.True(t, ok)
+	got, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	assert.Equal(t, "client-frames", string(got))
+}
+
+func TestNormalizeNilBody(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest(http.MethodConnect, "/", nil)
+	r.Body = nil
+	r.Header.Set(":protocol", "websocket")
+
+	out := Normalize(r)
+	stream, ok := TunnelStream(out.Context())
+	require.True(t, ok)
+	assert.Equal(t, http.NoBody, stream, "nil body parks as http.NoBody, never nil")
+}
+
+func TestTunnelStreamAbsent(t *testing.T) {
+	t.Parallel()
+
+	_, ok := TunnelStream(context.Background())
+	assert.False(t, ok)
+}
+
+// TestAcceptKeyVector pins the RFC 6455 §1.3 worked example.
+func TestAcceptKeyVector(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=", AcceptKey("dGhlIHNhbXBsZSBub25jZQ=="))
+}
+
+func TestGenerateKeyAndCheckAccept(t *testing.T) {
+	t.Parallel()
+
+	k1 := GenerateKey()
+	k2 := GenerateKey()
+	assert.NotEqual(t, k1, k2, "keys are random")
+
+	raw, err := base64.StdEncoding.DecodeString(k1)
+	require.NoError(t, err)
+	assert.Len(t, raw, 16, "16 random bytes per RFC 6455 §4.1")
+
+	assert.True(t, CheckAccept(AcceptKey(k1), k1))
+	assert.False(t, CheckAccept(AcceptKey(k1), k2), "accept for a different key is rejected")
+	assert.False(t, CheckAccept("", k1))
+}


### PR DESCRIPTION
## Why

Every WebSocket client costs one dedicated edge→core TCP connection, and one edge IP talking to one core VIP:443 exhausts the ephemeral source-port space around **28k–64k concurrent sockets** — long before FDs or memory matter. RFC 8441 (extended CONNECT) is the standard fix: each WebSocket rides a single h2 **stream**, so tens of thousands of sessions multiplex over a few TCP connections.

Design contract: **WEBSOCKET.md** (new). All three phases land here: core acceptance, edge tunnel (**default on**, `EDGE_UPSTREAM_WS_H2` opt-out), and core→pod extended CONNECT (**default on**, `UPSTREAM_WS_H2C` kill switch). With an h2c pod that opts in, the tunnel is stream-to-stream end-to-end: `client →(h1 WS)→ edge →(h2/h2c CONNECT)→ core →(h2c CONNECT)→ pod`.

## Core (phase 1) — accept extended CONNECT

- `wsh2/` (new, pure, edge-importable): extended-CONNECT ↔ h1-upgrade translation, stream detach via context, RFC 6455 key/accept synth+check, splice loop.
- `wsNormalize` middleware (first in the `m` chain) rewrites `CONNECT + :protocol: websocket` into the `GET + Upgrade` shape and **detaches the live stream** (`r.Body = http.NoBody`, stream parked in the context) — so WAF CEL rules, Coraza, rate limits, routing, logs, and body inspectors see exactly what an h1 WebSocket handshake looks like (WAF/Coraza body inspection does a blocking `r.Body` read; left attached it would eat frames). `:protocol ≠ websocket` → 501. Client-sent `Content-Length`/`Transfer-Encoding`/`Expect` are dropped (the detached handshake truthfully has no body — a surviving CL would desync the pod's parser).
- `proxy/wstunnel.go`: h2 streams have no `Hijacker`, so the proxy dials the pod itself (same dialer → bad-addr marking; dial errors panic into the existing `retryMiddleware`, safe because `NoBody` ⇒ retryable), performs the h1 upgrade (synthesizes `Sec-WebSocket-Key`, validates the pod's `Accept`), answers **200** on the stream and splices full-duplex. Pod refusals relay as normal responses with hop-by-hop/framing headers stripped.
- **Gating gotcha:** acceptance needs the real env var `GODEBUG=http2xconnect=1` — `//go:debug` does *not* work (both the h2 bundle and x/net read `os.Getenv` at init). Baked into the controller `Dockerfile`; `main.go` warns at startup when a pod-spec `GODEBUG` silently clobbers it.

## Edge (phase 2) — tunnel over the h2/h2c hop (default on, `EDGE_UPSTREAM_WS_H2` opt-out)

- Translates the client's h1 upgrade into extended CONNECT on **dedicated tunnel transports** — never the RPC transports (long-lived streams would pin their stream budget; the re-encrypt RPC transport can ALPN-negotiate h1, onto which a CONNECT would serialize as garbage). TLS mode is ALPN **h2-only**; plaintext is prior-knowledge h2c; both run PING keepalive (`ReadIdleTimeout` 30s) so a silently dead conn can't hold its sessions hostage.
- On the core's 200: hijacks the client conn, writes the synthesized 101 (`Sec-WebSocket-Accept` from the client's original key), splices. Non-200 relays as a plain h1 response.
- **Order-free rollout / why default-on is safe:** against a core that doesn't advertise the capability, the x/net client fails **pre-flight with zero wire cost** (blocks on first SETTINGS, writes nothing) → per-request fallback to the existing h1 upgrade path.

## Core→pod (phase 3) — WS-over-h2c to capable pods (default on, `UPSTREAM_WS_H2C` kill switch)

- `proxy/wsh2c.go`: a tunneled WebSocket to an h2c pod (explicit `appProtocol: h2c`, or a **fresh positive** auto-h2c verdict — WS requests still never establish or refresh that verdict) is attempted as extended CONNECT on a dedicated prior-knowledge h2c transport (shared dialer → bad-addr marking preserved).
- Not-supported pods fail pre-flight (parked stream untouched) → h1 upgrade fallback + per-Service negative cache (10m TTL, pruned on read; only negatives cached). Dial failures keep phase-1 retry semantics (error captured at the `DialTLSContext` seam, panic into `retryMiddleware`); post-dial failures 502 with no fallback (possible partial body consumption — a replay could duplicate frames).
- Expectation: almost no upstream advertises this by default (a Go pod needs its own `GODEBUG=http2xconnect=1`), so most Services cache the negative and ride h1 — the attempt is free-negative by design.

## Observability

- Core: `parapet_ws_tunnels{result}`, `parapet_ws_tunnel_active`, `parapet_ws_upstream_h2c{result}` (`not_supported` = pod fell back to h1).
- Edge: `parapet_edge_ws_upstream{protocol,result}` — a persistent `{http1,fallback}` rate is the "core lost its GODEBUG" alarm.
- SPEC.md (per-request order, env, metrics) and EDGE.md (upstream-protocol section) carry the contract rows.

## Tests

876 tests green across 28 packages (`-race` on `wsh2`/`proxy`/`edge`). Highlights:
- Full-loop integration: real h1 WS client → edge tunnel → in-process h2c core (normalize + tunnel) → fake pod echo — **hard-asserts the hop used `CONNECT + :protocol`** (can't pass via silent fallback), plus refused-path and generic-failure-fallback loops.
- Phase 3: pod-side extended CONNECT asserted (`CONNECT + :protocol`, no `Sec-WebSocket-Key`), auto-h2c-positive vs no-verdict routing, not-supported stub fallback with single-attempt negative-cache assertion, h2c refusal relay, h2c dial-error retryable panic.
- Server-side advertisement needs the GODEBUG at process init, so those test packages use a re-exec `TestMain` that appends `http2xconnect=1` — plain `go test ./...` stays green with no CI changes.
- Handshake-smuggling regressions: normalized requests shed `Content-Length`/`Transfer-Encoding`/`Expect`; refusal relays strip hop-by-hop/framing headers (chunked-refusal round-trips asserted on both hops).

## Notes for review

- The h1 WebSocket path is unchanged and remains the fallback everywhere; both new defaults are opt-out with per-request graceful degradation.
- Blast-radius trade: one edge→core conn now carries up to ~250 sessions; a conn reset kills them together (vs. port exhaustion killing *new* connections for everyone). PING keepalive bounds hostage time. `HTTP_SERVER_MAX_CONCURRENT_STREAMS` knob remains an open question in WEBSOCKET.md.