### PR TITLE
feat(edge): accept WebSocket-over-HTTP/2 from clients (RFC 8441)

### DIFF
--- a/Dockerfile.edge
+++ b/Dockerfile.edge
@@ -62,6 +62,12 @@ FROM gcr.io/distroless/static-debian12
 COPY --from=build /workspace/edge-proxy /usr/local/bin/edge-proxy
 COPY --from=geoip /geoip/ /geoip/
 
+# RFC 8441 extended CONNECT (WebSocket over HTTP/2) acceptance on the public :443
+# listener is gated by this real GODEBUG env var, read by the h2 server at startup.
+# A user-supplied GODEBUG in the pod spec REPLACES this value entirely — main.go
+# warns at startup when http2xconnect=1 is missing. See WEBSOCKET.md.
+ENV GODEBUG=http2xconnect=1
+
 # HTTPS (public TLS terminated here), plaintext HTTP, and the metrics endpoint.
 EXPOSE 443 80 9187
 

--- a/EDGE.md
+++ b/EDGE.md
@@ -988,7 +988,16 @@ into the controller Dockerfile) to advertise acceptance; against a core that
 doesn't, the attempt fails **pre-flight with zero wire cost** and the edge falls
 back to the HTTP/1.1 path per request — rollout is order-free. Fallbacks count in
 `parapet_edge_ws_upstream{protocol="http1",result="fallback"}` (a persistent
-non-zero rate is the "core lost its GODEBUG" alarm). Full design in
+non-zero rate is the "core lost its GODEBUG" alarm).
+
+The edge's **public `:443` also accepts WS-over-h2 from clients** (browsers):
+`Dockerfile.edge` bakes `GODEBUG=http2xconnect=1`, the shared normalize
+middleware rewrites the extended CONNECT into the h1-upgrade shape first in the
+chain (so edge WAF/rate-limit/cache treat h1 and h2 handshakes identically),
+and the Forwarder relays it stream-to-stream — h2 tunnel first, then an
+unconditional h1-upgrade bridge (`edge/wsbridge.go`), never ReverseProxy (an h2
+response stream has no `Hijacker`) — so h2-inbound WebSocket works even with
+the tunnel disabled or against an old core. Full design in
 [WEBSOCKET.md](WEBSOCKET.md).
 
 **Opt-out (`EDGE_UPSTREAM_HTTP2=false`)** forces HTTP/1.1 on both hops. Use it for

--- a/WEBSOCKET.md
+++ b/WEBSOCKET.md
@@ -2,8 +2,9 @@
 
 Status: **all three phases implemented** (core acceptance, edge tunnel —
 default on, `EDGE_UPSTREAM_WS_H2` opt-out — and core→pod extended CONNECT —
-default on, `UPSTREAM_WS_H2C` kill switch). SPEC.md / EDGE.md carry the
-contract rows.
+default on, `UPSTREAM_WS_H2C` kill switch), **plus edge public acceptance**:
+the edge's own `:443` listener accepts WS-over-h2 from clients (browsers) and
+relays it stream-to-stream. SPEC.md / EDGE.md carry the contract rows.
 
 ## Problem
 
@@ -29,9 +30,12 @@ on the **internal hops only** — client→edge and (by default) core→pod stay
 plain HTTP/1.1 WebSocket.
 
 ```
-client ──(h1 WS: GET + Upgrade)──▶ edge ──(h2/h2c extended CONNECT)──▶ core ──(h1 WS)──▶ pod
-                                                                        └─(phase 3, opt-in: h2c extended CONNECT when the pod advertises it)
+client ──(h1 WS, or h2 extended CONNECT)──▶ edge ──(h2/h2c extended CONNECT)──▶ core ──(h1 WS)──▶ pod
+                                                                                  └─(phase 3: h2c extended CONNECT when the pod advertises it)
 ```
+
+Every hop degrades to HTTP/1.1 independently, so any mix of old/new
+components keeps working.
 
 ## Protocol background (verified against Go 1.26.5 / x/net v0.56.0)
 
@@ -331,14 +335,40 @@ Following existing naming (`parapet_waf_matches`, `parapet_ratelimit_total`):
   normalization path, so this is a feature (direct clients gain WS-over-h2),
   not a hazard.
 
-## Scope and non-goals
+## Edge public acceptance: WS-over-h2 from clients
 
-- **No WS-over-h2 on the edge's public listener.** The edge does not set the
-  `GODEBUG`; browsers keep opening h1 WebSocket connections to the edge. The
-  client→edge side has no tuple-exhaustion problem (many client IPs), and Go
-  offers no per-server opt-in — flipping it process-wide on the edge is all
-  risk, no need. Revisit if/when Go exposes structured opt-in
-  (`HTTP2Config` has no field for it as of Go 1.26).
+The edge's own `:443` (ALPN h2) accepts extended CONNECT from browsers
+(`Dockerfile.edge` bakes `GODEBUG=http2xconnect=1`; startup warning when a
+pod-spec `GODEBUG` clobbers it — h1 WebSocket is unaffected either way).
+There is no partial rollout inside one process: once the image ships, browsers
+WILL negotiate WS-over-h2, so the whole edge chain handles it unconditionally.
+
+- **Normalization is shared with the core** (`wsh2.NormalizeHandler`, mounted
+  first in the edge's `m` chain): the handshake is rewritten to the h1-upgrade
+  shape with the stream detached, so edge WAF/Coraza/rate limits/cache treat
+  h1 and h2 WebSocket handshakes identically, and client-supplied claim
+  headers still hit `StripWAFClaim` as usual.
+- **h2-inbound serving is tunnel-then-bridge, never ReverseProxy** (an h2
+  response stream has no `Hijacker`): the h2 tunnel relays stream-to-stream
+  (parked stream as the extended-CONNECT body, 200 answered on the client's
+  own stream); the **h1-upgrade bridge** (`edge/wsbridge.go`, the reverse of
+  the core's pod dial — generates the key, validates the core's accept, keeps
+  the WAF claim) is constructed unconditionally so h2-inbound WebSocket works
+  even with `EDGE_UPSTREAM_WS_H2` or `EDGE_UPSTREAM_HTTP2` off, or against a
+  core that doesn't advertise extended CONNECT.
+- **Fallback policy is strict**: only the provably pre-flight not-supported
+  error falls back from tunnel to bridge (no body goroutine ever started —
+  the parked stream is pristine). Any other tunnel failure may already have
+  streamed client frames as DATA frames, so it is a 502 — a bridge replay
+  would silently lose frames, and a stale x/net body reader could race the
+  bridge for later ones. (The h1-inbound path can fall back more broadly
+  because its request body is a pipe that holds nothing until the 101.)
+- Accounting stays one-event-per-request on `parapet_edge_ws_upstream`:
+  tunnel outcome `{h2,ok}`; not-supported→bridge `{http1,fallback}` (still
+  the "core lost its GODEBUG" alarm); bridge-direct `{http1,ok}`; terminal
+  failures `{…,error}`.
+
+## Scope and non-goals
 - **No QUIC / HTTP/3** — separate concern, separate document if ever.
 - **No WS frame inspection** — the tunnel is byte-transparent after the
   handshake, exactly like today's h1 splice.
@@ -349,13 +379,18 @@ Following existing naming (`parapet_waf_matches`, `parapet_ratelimit_total`):
 
 ```
 wsh2/                       # shared, pure, edge-importable (like corazawaf/):
-                            #   IsExtendedConnect/Normalize (+ stream detach via ctx),
-                            #   Sec-WebSocket-Key/Accept synth+check, splice loop
+                            #   IsExtendedConnect/Normalize/NormalizeHandler (+ stream
+                            #   detach via ctx), Sec-WebSocket-Key/Accept synth+check,
+                            #   splice loop
 proxy/wstunnel.go           # core: tunnel path for ctx-flagged requests (phase 1)
 cmd/parapet-ingress-controller/wsnormalize.go  # normalize middleware (mounted first in main.go's m chain)
 cmd/parapet-ingress-controller/main.go   # middleware mount + GODEBUG startup check
-Dockerfile                  # ENV GODEBUG=http2xconnect=1
+Dockerfile                  # ENV GODEBUG=http2xconnect=1 (controller)
+Dockerfile.edge             # ENV GODEBUG=http2xconnect=1 (edge public acceptance)
 edge/wstunnel.go            # edge: translate + dedicated tunnel transports (phase 2)
+                            #   + serveH2Inbound (h2-inbound stream-to-stream relay)
+edge/wsbridge.go            # edge: h1-upgrade bridge to the core (unconditional
+                            #   fallback for h2-inbound WebSocket)
 metric/ws.go                # core counters/gauge
 metric/observe/ws.go        # edge counter (leaf package — edge binaries stay off metric)
 proxy/wsh2c.go              # phase 3: pod-side extended CONNECT (dedicated h2c transport,

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/moonrhythm/parapet-ingress-controller/edge"
 	"github.com/moonrhythm/parapet-ingress-controller/geoip"
 	"github.com/moonrhythm/parapet-ingress-controller/trustcidr"
+	"github.com/moonrhythm/parapet-ingress-controller/wsh2"
 )
 
 var version = "HEAD"
@@ -87,6 +88,17 @@ func main() {
 	if upstreamWSH2 && !upstreamHTTP2 {
 		slog.Warn("EDGE_UPSTREAM_WS_H2 is ignored when EDGE_UPSTREAM_HTTP2=false; WebSocket rides HTTP/1.1")
 		upstreamWSH2 = false
+	}
+
+	// Accepting WS-over-HTTP/2 (RFC 8441 extended CONNECT) from clients on the
+	// public :443 listener is gated by the real GODEBUG env var, read by the h2
+	// server in package init(). A user-supplied GODEBUG in the pod spec REPLACES the
+	// Dockerfile's ENV entirely, silently disabling it — so verify at startup and
+	// warn (not fatal: h1 WebSocket is unaffected; clients just can't use WS-over-h2).
+	if !strings.Contains(os.Getenv("GODEBUG"), "http2xconnect=1") {
+		slog.Warn("WS-over-HTTP/2 acceptance DISABLED: GODEBUG does not contain http2xconnect=1 " +
+			"(a user-supplied GODEBUG replaces the image default); the edge will not accept " +
+			"WS-over-h2 from clients; h1 WebSocket unaffected")
 	}
 	// Per-host connection ceiling to the core (mirrors the controller's
 	// TR_MAX_CONNS_PER_HOST / TR_MAX_IDLE_CONNS_PER_HOST). MAX_CONNS_PER_HOST=0
@@ -453,6 +465,15 @@ func main() {
 	// before forwarding; the cache wraps the forwarder; X-Forwarded-Country/-ASN
 	// are set just before forwarding.
 	m := parapet.Middlewares{}
+	// First in the chain, unconditional: rewrite a client's RFC 8441 extended
+	// CONNECT WebSocket handshake into the h1-upgrade shape the rest of the chain
+	// (WAF/Coraza/rate limits/cache/forward) understands, so h1 and h2 WebSocket
+	// handshakes behave identically. A non-extended-CONNECT request pays only the
+	// two header checks. onBadProtocol is nil — a non-websocket :protocol is a
+	// malformed-client 501, not an edge metric.
+	m.Use(parapet.MiddlewareFunc(func(h http.Handler) http.Handler {
+		return wsh2.NormalizeHandler(h, nil)
+	}))
 	m.Use(health)
 	m.Use(host.StripPort())
 	m.Use(host.ToLower())

--- a/cmd/parapet-ingress-controller/wsnormalize.go
+++ b/cmd/parapet-ingress-controller/wsnormalize.go
@@ -19,18 +19,6 @@ import (
 // code that never fires.
 func wsNormalize() parapet.Middleware {
 	return parapet.MiddlewareFunc(func(h http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if !wsh2.IsExtendedConnect(r) {
-				h.ServeHTTP(w, r)
-				return
-			}
-			if r.Header.Get(":protocol") != "websocket" {
-				// We bridge WebSocket only.
-				metric.WSTunnel("bad_protocol")
-				http.Error(w, "Not Implemented", http.StatusNotImplemented)
-				return
-			}
-			h.ServeHTTP(w, wsh2.Normalize(r))
-		})
+		return wsh2.NormalizeHandler(h, func() { metric.WSTunnel("bad_protocol") })
 	})
 }

--- a/edge/forward.go
+++ b/edge/forward.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/moonrhythm/parapet"
 	"github.com/moonrhythm/parapet/pkg/upstream"
+
+	"github.com/moonrhythm/parapet-ingress-controller/wsh2"
 )
 
 // Forwarder is the terminal middleware that forwards a request to the in-cluster
@@ -31,8 +33,9 @@ import (
 // IP flows through. X-Forwarded-Country / X-Forwarded-ASN are set by
 // forwardGeoHeaders.
 type Forwarder struct {
-	rp *httputil.ReverseProxy
-	ws *wsTunnel // non-nil when EDGE_UPSTREAM_WS_H2 is on AND the upstream hop is h2
+	rp     *httputil.ReverseProxy
+	ws     *wsTunnel // non-nil when EDGE_UPSTREAM_WS_H2 is on AND the upstream hop is h2
+	bridge *wsBridge // always non-nil: the h1-upgrade fallback for h2-inbound WebSocket
 }
 
 // defaultMaxIdleConnsPerHost mirrors parapet's upstream.defaultMaxIdleConns (32):
@@ -166,7 +169,11 @@ func NewForwarder(addr string, useTLS, enableHTTP2 bool, sni string, tuning Forw
 		},
 	}
 
-	f := &Forwarder{rp: rp}
+	// The bridge is constructed unconditionally: an h2-inbound WebSocket (a client
+	// speaking WS-over-h2 to the edge's public listener) can never fall back to
+	// ReverseProxy, so it always needs the h1-upgrade path to the core — even when
+	// the h2 tunnel is off.
+	f := &Forwarder{rp: rp, bridge: newWSBridge(addr, useTLS, sni, getClientCert)}
 	if wsH2 && enableHTTP2 {
 		f.ws = newWSTunnel(addr, scheme, useTLS, sni, getClientCert)
 	}
@@ -279,10 +286,25 @@ func (t *h2TLSTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 // is ignored (the request is forwarded upstream).
 func (f *Forwarder) ServeHandler(_ http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if f.ws != nil && isWebSocketUpgrade(r) {
-			// serve returns false only before any byte reaches the client, so the
-			// fallback re-serves the original request on the h1 upgrade path.
-			if f.ws.serve(w, r) {
+		if isWebSocketUpgrade(r) {
+			if stream, ok := wsh2.TunnelStream(r.Context()); ok {
+				// h2-inbound WebSocket (client WS-over-h2, normalized): the response
+				// writer has no Hijacker, so ReverseProxy can't serve it. Try the h2
+				// tunnel first (if enabled), then the h1-upgrade bridge — never
+				// ReverseProxy. serveH2Inbound returns false ONLY on a not-supported
+				// core (provably pre-flight, parked stream pristine); any later
+				// tunnel failure it owns as a 502, so the bridge never replays a
+				// partially-consumed stream.
+				if f.ws != nil && f.ws.serveH2Inbound(w, r, stream) {
+					return
+				}
+				f.bridge.serve(w, r, stream, f.ws != nil)
+				return
+			}
+			// h1-inbound WebSocket: serve returns false only before any byte reaches
+			// the client, so the fallback re-serves the original request on the h1
+			// ReverseProxy upgrade path.
+			if f.ws != nil && f.ws.serve(w, r) {
 				return
 			}
 		}

--- a/edge/wsbridge.go
+++ b/edge/wsbridge.go
@@ -1,0 +1,172 @@
+package edge
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/moonrhythm/parapet-ingress-controller/metric/observe"
+	"github.com/moonrhythm/parapet-ingress-controller/wsh2"
+)
+
+// wsBridge serves an h2-inbound WebSocket (a normalized client extended CONNECT,
+// stream parked in the context) by dialing the core over the HTTP/1.1 upgrade it
+// always speaks — the reverse of the core's own pod dial (proxy.serveWSTunnel).
+// It is the unconditional fallback for h2-inbound WebSocket: it works even when
+// the h2 tunnel (wsTunnel) is disabled or the core doesn't advertise extended
+// CONNECT, since ReverseProxy cannot serve WebSocket on an h2 response stream.
+type wsBridge struct {
+	addr          string
+	useTLS        bool
+	sni           string
+	getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
+}
+
+func newWSBridge(addr string, useTLS bool, sni string, getClientCert func(*tls.CertificateRequestInfo) (*tls.Certificate, error)) *wsBridge {
+	return &wsBridge{addr: addr, useTLS: useTLS, sni: sni, getClientCert: getClientCert}
+}
+
+// serve dials the core, performs the h1 WebSocket upgrade, and — on 101 — answers
+// the client with a 200 on its h2 stream and splices both directions. fallback
+// selects the success accounting: true when a tunnel was attempted but the core
+// didn't advertise extended CONNECT (the {http1,fallback} "core lost its GODEBUG"
+// alarm), false when the tunnel is disabled ({http1,ok}). A dial or handshake
+// failure is a 502 with {http1,error} — nothing usable reached the client yet.
+func (b *wsBridge) serve(w http.ResponseWriter, r *http.Request, stream io.ReadCloser, fallback bool) {
+	ctx := r.Context()
+
+	conn, err := (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, "tcp", b.addr)
+	if err != nil {
+		slog.Warn("edge: ws bridge dial failed", "addr", b.addr, "error", err)
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		stream.Close()
+		observe.WSUpstream("http1", "error")
+		return
+	}
+	// Closure, not `defer conn.Close()`: conn is reassigned to the TLS wrapper
+	// below, and the close must tear down that final conn.
+	defer func() { conn.Close() }()
+
+	if b.useTLS {
+		// Re-encrypt with the same SNI / data-plane mTLS posture as the RPC transport
+		// but HTTP/1.1 ONLY (this hop speaks the h1 WebSocket upgrade, not h2).
+		cfg := &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: true, //nolint:gosec // cluster-internal hop, matches the RPC transport
+			NextProtos:         []string{"http/1.1"},
+		}
+		if b.sni != "" {
+			cfg.ServerName = b.sni
+		}
+		if b.getClientCert != nil {
+			cfg.GetClientCertificate = b.getClientCert
+		}
+		tlsConn := tls.Client(conn, cfg)
+		_ = conn.SetDeadline(time.Now().Add(wsHandshakeTimeout))
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			slog.Warn("edge: ws bridge tls handshake failed", "addr", b.addr, "error", err)
+			http.Error(w, "Bad Gateway", http.StatusBadGateway)
+			stream.Close()
+			observe.WSUpstream("http1", "error")
+			return
+		}
+		conn = tlsConn
+	}
+
+	key := wsh2.GenerateKey()
+	handshake := buildBridgeHandshake(r, key)
+
+	_ = conn.SetWriteDeadline(time.Now().Add(wsHandshakeTimeout))
+	if _, err := conn.Write(handshake); err != nil {
+		slog.Warn("edge: ws bridge write handshake failed", "addr", b.addr, "error", err)
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		stream.Close()
+		observe.WSUpstream("http1", "error")
+		return
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(wsHandshakeTimeout))
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, r)
+	if err != nil {
+		slog.Warn("edge: ws bridge read response failed", "addr", b.addr, "error", err)
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		stream.Close()
+		observe.WSUpstream("http1", "error")
+		return
+	}
+
+	result := "ok"
+	if fallback {
+		result = "fallback"
+	}
+
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		// The core refused the handshake (WAF / auth / app 4xx). Relay it as a normal
+		// response on the client's h2 stream; the h1 hop itself worked.
+		copyHeader(w.Header(), resp.Header)
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+		resp.Body.Close()
+		stream.Close()
+		observe.WSUpstream("http1", result)
+		return
+	}
+
+	if !wsh2.CheckAccept(resp.Header.Get("Sec-WebSocket-Accept"), key) {
+		slog.Warn("edge: ws bridge bad Sec-WebSocket-Accept", "addr", b.addr)
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		stream.Close()
+		observe.WSUpstream("http1", "error")
+		return
+	}
+
+	// Accepted. Clear the handshake deadlines — the session is long-lived.
+	_ = conn.SetDeadline(time.Time{})
+
+	copyWSResponseHeader(w.Header(), resp.Header)
+	w.WriteHeader(http.StatusOK)
+	rc := http.NewResponseController(w)
+	flush := func() { _ = rc.Flush() }
+	flush() // commit the 200 before any frames
+
+	observe.WSUpstream("http1", result)
+
+	// Splice both directions. The core→client side reads from br (not conn) so it
+	// drains any bytes the core pipelined after the 101 that ReadResponse buffered.
+	// Closing an endpoint when one direction ends unblocks the other.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = wsh2.Copy(conn, stream, nil)
+		conn.Close()
+	}()
+
+	_ = wsh2.Copy(w, br, flush)
+	stream.Close()
+	conn.Close()
+	<-done
+}
+
+// buildBridgeHandshake renders the HTTP/1.1 WebSocket upgrade request to the core.
+// r is already normalized (Connection: Upgrade, Upgrade: websocket,
+// Sec-WebSocket-Version/Protocol/Extensions, no Content-Length/Accept-Encoding);
+// it stamps the generated Sec-WebSocket-Key (the h2 side carried none). Unlike the
+// core's pod handshake it keeps any X-Parapet-Waf claim the edge stamped — the
+// core is the claim's audience, not the pod.
+func buildBridgeHandshake(r *http.Request, key string) []byte {
+	r.Header.Set("Sec-WebSocket-Key", key)
+
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "GET %s HTTP/1.1\r\n", r.URL.RequestURI())
+	fmt.Fprintf(&b, "Host: %s\r\n", r.Host)
+	_ = r.Header.Write(&b)
+	b.WriteString("\r\n")
+	return b.Bytes()
+}

--- a/edge/wstunnel.go
+++ b/edge/wstunnel.go
@@ -193,6 +193,80 @@ func (t *wsTunnel) serve(w http.ResponseWriter, r *http.Request) (handled bool) 
 	return true
 }
 
+// serveH2Inbound tunnels an h2-inbound WebSocket (a client's own RFC 8441
+// extended CONNECT, already normalized to GET+Upgrade with the live stream parked
+// in the context) to the core over extended CONNECT. Unlike serve there is no
+// client key, no 101, and no hijack: the parked stream is the request body
+// directly (x/net streams it as the client→core DATA frames) and the client is
+// answered with a 200 on its own h2 stream, which is natively full-duplex.
+//
+// It returns true when it owns the outcome (session spliced, refusal relayed) and
+// false ONLY before any byte reaches the client (not-supported / pre-commit
+// failure), so the caller falls back to the h1-upgrade bridge — never to
+// ReverseProxy, which cannot serve WebSocket on an h2 stream. On a false return it
+// counts nothing; the bridge records the terminal outcome (one event per request).
+func (t *wsTunnel) serveH2Inbound(w http.ResponseWriter, r *http.Request, stream io.ReadCloser) (handled bool) {
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	// The parked stream IS the request body — no pipe (x/net reads it directly).
+	creq := t.translate(ctx, r, stream)
+
+	timer := time.AfterFunc(wsHandshakeTimeout, cancel)
+	resp, err := t.tr.RoundTrip(creq)
+	timer.Stop()
+	if err != nil {
+		// ONLY the not-supported error may fall back to the bridge: it is provably
+		// pre-flight (x/net checks the peer's SETTINGS before writing anything, so no
+		// body goroutine ever started and the parked stream is pristine). Any other
+		// failure may have already streamed client frames from the parked stream as
+		// DATA frames — a bridge replay would lose them, and a stale x/net body
+		// reader could race the bridge for later frames — so it is a 502, never a
+		// fallback. (The h1-inbound serve can fall back more broadly because its
+		// request body is a pipe that holds nothing until the 101 commits.)
+		if strings.Contains(err.Error(), errExtendedConnectNotSupported) {
+			wsFallbackWarn.Do(func() {
+				slog.Warn("edge: core does not advertise WS-over-h2 (extended CONNECT); falling back to HTTP/1.1 — verify GODEBUG=http2xconnect=1 on the core", "error", err)
+			})
+			return false
+		}
+		slog.Warn("edge: ws h2-inbound tunnel handshake failed", "addr", t.addr, "error", err)
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		stream.Close()
+		observe.WSUpstream("h2", "error")
+		return true
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// The core refused the handshake (WAF block / auth / app 4xx). Relay it as a
+		// normal response on the client's h2 stream (works fine — no hijack needed).
+		copyHeader(w.Header(), resp.Header)
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+		resp.Body.Close()
+		stream.Close()
+		observe.WSUpstream("h2", "ok")
+		return true
+	}
+
+	// Accepted. Answer 200 on the client's h2 stream and splice.
+	copyWSResponseHeader(w.Header(), resp.Header)
+	w.WriteHeader(http.StatusOK)
+	rc := http.NewResponseController(w)
+	flush := func() { _ = rc.Flush() }
+	flush() // commit the 200 before any frames
+	observe.WSUpstream("h2", "ok")
+
+	// Splice core→client here; the client→core direction is x/net streaming the
+	// request body (the parked stream). Closing both endpoints on return unblocks
+	// that reader so the request completes when the session ends.
+	_ = wsh2.Copy(w, resp.Body, flush)
+	stream.Close()
+	resp.Body.Close()
+	cancel()
+	return true
+}
+
 // translate builds the extended-CONNECT clone of r on ctx, leaving r untouched so
 // the caller can still fall back with the original. body is the client→core pipe.
 // Per RFC 8441 the h2 handshake carries no Sec-WebSocket-Key/Accept, and
@@ -296,6 +370,21 @@ func isHopHeader(k string) bool {
 func copyHeader(dst, src http.Header) {
 	for k, vv := range src {
 		if isHopHeader(k) {
+			continue
+		}
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+// copyWSResponseHeader copies the accepted-handshake response headers onto the
+// client's h2 stream, minus the hop-by-hop headers and the Sec-WebSocket-Accept
+// proof (meaningless on the h2 side — the client's own extended CONNECT carried
+// no key, and the core/bridge's accept refers to a different hop).
+func copyWSResponseHeader(dst, src http.Header) {
+	for k, vv := range src {
+		if isHopHeader(k) || http.CanonicalHeaderKey(k) == "Sec-Websocket-Accept" {
 			continue
 		}
 		for _, v := range vv {

--- a/edge/wstunnel_h2inbound_test.go
+++ b/edge/wstunnel_h2inbound_test.go
@@ -1,0 +1,285 @@
+package edge
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+
+	"github.com/moonrhythm/parapet-ingress-controller/wsh2"
+)
+
+// edgeHandler wraps the Forwarder in the shared normalize middleware exactly as
+// cmd/edge-proxy mounts it, so an inbound extended CONNECT is normalized before it
+// reaches the Forwarder — the h2-inbound entry point under test.
+func edgeHandler(f *Forwarder) http.Handler {
+	return wsh2.NormalizeHandler(f.ServeHandler(nil), nil)
+}
+
+// h2cClient returns an x/net http2.Transport that speaks prior-knowledge h2c —
+// the stand-in for a browser talking WS-over-h2 to the edge's :443 listener.
+func h2cClient(t *testing.T) *http2.Transport {
+	tr := &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			return net.Dial(network, addr)
+		},
+	}
+	t.Cleanup(tr.CloseIdleConnections)
+	return tr
+}
+
+// extendedConnect builds a client RFC 8441 extended CONNECT WebSocket handshake.
+func extendedConnect(t *testing.T, serverAddr, path string, body io.Reader) *http.Request {
+	t.Helper()
+	r := &http.Request{
+		Method: http.MethodConnect,
+		URL:    &url.URL{Scheme: "http", Host: serverAddr, Path: path},
+		Host:   "example.com",
+		Header: http.Header{},
+		Body:   io.NopCloser(body),
+	}
+	r.Header[":protocol"] = []string{"websocket"}
+	r.Header.Set("Sec-WebSocket-Version", "13")
+	return r
+}
+
+// startFakeH1Core accepts one h1 WebSocket upgrade (the core's h1-upgrade hop the
+// edge bridge dials), asserts a Sec-WebSocket-Key is present, answers 101 with the
+// correct Accept, and echoes client frames. The observed key is sent on keyCh.
+func startFakeH1Core(t *testing.T, keyCh chan<- string) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		br := bufio.NewReader(conn)
+		req, err := http.ReadRequest(br)
+		if err != nil {
+			return
+		}
+		key := req.Header.Get("Sec-WebSocket-Key")
+		select {
+		case keyCh <- key:
+		default:
+		}
+		if key == "" {
+			fmt.Fprint(conn, "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n")
+			return
+		}
+		fmt.Fprintf(conn, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\n\r\n", wsh2.AcceptKey(key))
+		_, _ = io.Copy(conn, br) // echo
+	}()
+	return ln.Addr().String()
+}
+
+// TestWSH2Inbound_EndToEnd_Tunnel drives a client WS-over-h2 extended CONNECT into
+// the edge (normalize → Forwarder h2 tunnel) → an in-process h2c core (extended
+// CONNECT) → a fake pod echo. The client is answered 200 on its own h2 stream (no
+// 101/hijack), the echo flows both ways, and the edge→core hop used extended
+// CONNECT.
+func TestWSH2Inbound_EndToEnd_Tunnel(t *testing.T) {
+	podAddr := startFakePod(t)
+	saw := make(chan string, 1)
+	coreAddr := startH2CCore(t, coreWSHandler(t, podAddr, saw))
+
+	f := NewForwarder(coreAddr, false, true, "", ForwarderTuning{}, nil, nil, true)
+	require.NotNil(t, f.ws, "WS tunnel must be enabled")
+	edgeAddr := startH2CCore(t, edgeHandler(f))
+
+	pr, pw := io.Pipe()
+	tr := h2cClient(t)
+	resp, err := tr.RoundTrip(extendedConnect(t, edgeAddr, "/chat", pr))
+	require.NoError(t, err)
+	// Close the request body (pw) before resp.Body: the h2c client's
+	// resp.Body.Close blocks until the still-open request body finishes, so the
+	// deferred order (resp.Body first) would deadlock — a client half-close the
+	// production path never does (a real client resets the whole connection).
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode, "client answered 200 on its h2 stream")
+	assert.Empty(t, resp.Header.Get("Sec-WebSocket-Accept"), "no accept proof on the h2 side")
+
+	// the edge→core hop really used RFC 8441 extended CONNECT
+	assert.Equal(t, "CONNECT :protocol=websocket", <-saw)
+
+	// client -> edge -> core -> pod -> back
+	_, err = pw.Write([]byte("hello ws"))
+	require.NoError(t, err)
+	got := make([]byte, len("hello ws"))
+	_, err = io.ReadFull(resp.Body, got)
+	require.NoError(t, err)
+	assert.Equal(t, "hello ws", string(got))
+	pw.Close()
+}
+
+// TestWSH2Inbound_EndToEnd_Bridge drives a client WS-over-h2 into an edge whose h2
+// tunnel is DISABLED, so the h2-inbound request is served by the h1-upgrade bridge
+// to a fake h1 core. The bridge generates a Sec-WebSocket-Key, and the client is
+// answered 200 on its h2 stream with bidirectional echo.
+func TestWSH2Inbound_EndToEnd_Bridge(t *testing.T) {
+	keyCh := make(chan string, 1)
+	coreAddr := startFakeH1Core(t, keyCh)
+
+	f := NewForwarder(coreAddr, false, true, "", ForwarderTuning{}, nil, nil, false)
+	require.Nil(t, f.ws, "tunnel disabled — bridge is the only h2-inbound path")
+	require.NotNil(t, f.bridge)
+	edgeAddr := startH2CCore(t, edgeHandler(f))
+
+	pr, pw := io.Pipe()
+	tr := h2cClient(t)
+	resp, err := tr.RoundTrip(extendedConnect(t, edgeAddr, "/chat", pr))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotEmpty(t, <-keyCh, "bridge generated a Sec-WebSocket-Key for the h1 upgrade")
+
+	_, err = pw.Write([]byte("bridge"))
+	require.NoError(t, err)
+	got := make([]byte, len("bridge"))
+	_, err = io.ReadFull(resp.Body, got)
+	require.NoError(t, err)
+	assert.Equal(t, "bridge", string(got))
+	pw.Close()
+}
+
+// TestWSH2Inbound_NotSupported_BridgeFallback stubs the tunnel RoundTripper to
+// return the not-supported error (an old / GODEBUG-less core). The h2-inbound
+// request must fall back to the h1-upgrade bridge, which serves the session — the
+// {http1,fallback} accounting path.
+func TestWSH2Inbound_NotSupported_BridgeFallback(t *testing.T) {
+	keyCh := make(chan string, 1)
+	coreAddr := startFakeH1Core(t, keyCh)
+
+	f := NewForwarder(coreAddr, false, true, "", ForwarderTuning{}, nil, nil, true)
+	require.NotNil(t, f.ws)
+	// The real not-supported error is pre-flight and never reads the body, so the
+	// stub must not touch it either (the bridge reuses the same parked stream).
+	f.ws.tr = notSupportedRT{}
+	edgeAddr := startH2CCore(t, edgeHandler(f))
+
+	pr, pw := io.Pipe()
+	tr := h2cClient(t)
+	resp, err := tr.RoundTrip(extendedConnect(t, edgeAddr, "/chat", pr))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotEmpty(t, <-keyCh, "bridge fallback performed the h1 upgrade to the core")
+
+	_, err = pw.Write([]byte("fb"))
+	require.NoError(t, err)
+	got := make([]byte, len("fb"))
+	_, err = io.ReadFull(resp.Body, got)
+	require.NoError(t, err)
+	assert.Equal(t, "fb", string(got))
+	pw.Close()
+}
+
+// notSupportedRT mimics x/net's pre-flight not-supported failure: it returns the
+// error WITHOUT reading the request body (the parked client stream), so the
+// bridge fallback reuses that stream intact.
+type notSupportedRT struct{}
+
+func (notSupportedRT) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("net/http: extended connect not supported by peer")
+}
+
+// TestWSH2Inbound_GenericTunnelError_No502Bridge pins the fallback policy: any
+// tunnel failure OTHER than not-supported may have consumed client frames from
+// the parked stream (x/net streams the body as soon as headers are written), so
+// it must 502 — a bridge replay would silently lose those frames.
+func TestWSH2Inbound_GenericTunnelError_NoBridge(t *testing.T) {
+	keyCh := make(chan string, 1)
+	coreAddr := startFakeH1Core(t, keyCh)
+
+	f := NewForwarder(coreAddr, false, true, "", ForwarderTuning{}, nil, nil, true)
+	require.NotNil(t, f.ws)
+	f.ws.tr = genericErrRT{}
+	edgeAddr := startH2CCore(t, edgeHandler(f))
+
+	pr, pw := io.Pipe()
+	tr := h2cClient(t)
+	resp, err := tr.RoundTrip(extendedConnect(t, edgeAddr, "/chat", pr))
+	require.NoError(t, err)
+	// pw must close BEFORE resp.Body.Close(): the h2 client's Close blocks until
+	// the request body finishes (same teardown ordering as the tests above).
+	defer resp.Body.Close()
+	defer pw.Close()
+
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+	select {
+	case k := <-keyCh:
+		t.Fatalf("bridge must not run after a generic tunnel error (saw upgrade with key %q)", k)
+	default:
+	}
+}
+
+// genericErrRT mimics a mid-handshake tunnel failure (conn reset after headers
+// were written) — the class of error that may have partially consumed the body.
+type genericErrRT struct{}
+
+func (genericErrRT) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("http2: client connection lost")
+}
+
+// TestWSH2Inbound_BadProtocol_501 verifies a non-websocket :protocol on an
+// inbound extended CONNECT is refused with 501 by the normalize middleware.
+func TestWSH2Inbound_BadProtocol_501(t *testing.T) {
+	f := NewForwarder("127.0.0.1:1", false, true, "", ForwarderTuning{}, nil, nil, true)
+	edgeAddr := startH2CCore(t, edgeHandler(f))
+
+	tr := h2cClient(t)
+	r := extendedConnect(t, edgeAddr, "/chat", strings.NewReader(""))
+	r.Header[":protocol"] = []string{"bogus"}
+	resp, err := tr.RoundTrip(r)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+}
+
+// TestWSH2Inbound_Refused verifies a core refusal (403 on the extended-CONNECT
+// handshake) is relayed to the h2-inbound client as a 403 on its stream, with the
+// core-hop's Connection/Transfer-Encoding headers stripped.
+func TestWSH2Inbound_Refused(t *testing.T) {
+	coreAddr := startH2CCore(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Connection", "close")
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(http.StatusForbidden)
+		_ = http.NewResponseController(w).Flush()
+		_, _ = io.WriteString(w, "blocked")
+	}))
+
+	f := NewForwarder(coreAddr, false, true, "", ForwarderTuning{}, nil, nil, true)
+	edgeAddr := startH2CCore(t, edgeHandler(f))
+
+	tr := h2cClient(t)
+	resp, err := tr.RoundTrip(extendedConnect(t, edgeAddr, "/chat", strings.NewReader("")))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Transfer-Encoding"), "Transfer-Encoding must not leak to the client")
+	assert.Empty(t, resp.Header.Get("Connection"), "Connection must not leak to the client")
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "blocked", string(body))
+}

--- a/wsh2/wsh2.go
+++ b/wsh2/wsh2.go
@@ -73,6 +73,30 @@ func Normalize(r *http.Request) *http.Request {
 	return r.WithContext(ctx)
 }
 
+// NormalizeHandler wraps next with the extended-CONNECT normalization used by
+// both the core and the edge. A non-extended-CONNECT request passes through
+// paying only the two header checks in IsExtendedConnect; a `:protocol` other
+// than `websocket` is refused with 501 (we bridge WebSocket only), invoking
+// onBadProtocol first when non-nil (the core counts a metric there; the edge
+// passes nil). It is framework-neutral so each binary wraps it in its own
+// middleware type — keeping wsh2 free of a parapet import.
+func NormalizeHandler(next http.Handler, onBadProtocol func()) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !IsExtendedConnect(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if r.Header.Get(":protocol") != "websocket" {
+			if onBadProtocol != nil {
+				onBadProtocol()
+			}
+			http.Error(w, "Not Implemented", http.StatusNotImplemented)
+			return
+		}
+		next.ServeHTTP(w, Normalize(r))
+	})
+}
+
 type tunnelCtxKey struct{}
 
 // MarkTunnel returns a child context carrying the parked client→server stream of


### PR DESCRIPTION
## Why

Follow-up to #179 (merged): the edge→core and core→pod hops already multiplex WebSocket as RFC 8441 extended CONNECT streams, but browsers still opened one h1 connection per socket to the edge. This closes the last hop — the edge's public `:443` now accepts WS-over-h2 from clients, completing the picture:

```
client ──(h1 WS, or h2 extended CONNECT)──▶ edge ──(h2/h2c CONNECT)──▶ core ──(h1 WS / h2c CONNECT)──▶ pod
```

Every hop still degrades to HTTP/1.1 independently.

## What

- **`Dockerfile.edge`** bakes `GODEBUG=http2xconnect=1` (same mechanism/footgun as the controller image: a pod-spec `GODEBUG` replaces it silently — startup warning added; h1 WebSocket unaffected either way). Note there is no partial rollout inside one process: once the image ships, browsers negotiate WS-over-h2, so the whole chain handles it unconditionally.
- **Shared normalization**: the core's normalize middleware is promoted into `wsh2.NormalizeHandler` (core delegates to it, behavior identical) and mounted first in the edge chain — edge WAF/Coraza/rate limits/cache see the identical h1-upgrade shape for h1 and h2 handshakes, and client-supplied `X-Parapet-Waf` claims still hit `StripWAFClaim`.
- **h2-inbound serving is tunnel-then-bridge, never ReverseProxy** (an h2 response stream has no `Hijacker`):
  - `serveH2Inbound`: stream-to-stream relay over the existing extended-CONNECT tunnel — the parked client stream is the upstream request body (no pipe), the client is answered 200 on its own stream.
  - `edge/wsbridge.go` (new): an **unconditional** h1-upgrade bridge to the core — the reverse of the core's pod dial (generates `Sec-WebSocket-Key`, validates the core's `Accept`, keeps the WAF claim since the core is its audience). It serves h2-inbound WebSocket even with `EDGE_UPSTREAM_WS_H2` off, `EDGE_UPSTREAM_HTTP2=false`, or an old core.
- **Strict fallback policy** (the subtle correctness point): only the provably pre-flight *not-supported* error falls back from tunnel to bridge — x/net checks the peer's SETTINGS before writing anything, so no body goroutine ever started and the parked stream is pristine. Any other tunnel failure may already have streamed client frames as DATA frames; bridging there would replay the session minus consumed bytes (silent frame loss) and a stale x/net body reader could race the bridge for later frames — so it's an owned 502. The h1-inbound path keeps its broader fallback because its request body is a pipe holding nothing until the 101 commits. A test pins this policy.
- Accounting stays one event per request on `parapet_edge_ws_upstream`: tunnel `{h2,ok}`, not-supported→bridge `{http1,fallback}` (still the "core lost its GODEBUG" alarm), bridge-direct `{http1,ok}`, failures `{…,error}`.

## Tests

882 green across 28 packages, `-race` on `edge`/`wsh2`. New: h2-inbound tunnel end-to-end (asserts the edge→core hop used `CONNECT + :protocol`), h2-inbound bridge end-to-end against a raw h1 core (asserts key/accept round-trip), not-supported→bridge fallback (stub), generic-tunnel-error→502-never-bridge (pins the fallback policy), bad `:protocol`→501, refusal relay with hop headers stripped. Existing h1-inbound tests unchanged (no-regression contract).

WEBSOCKET.md's "no WS-over-h2 on the edge's public listener" non-goal is replaced by an "Edge public acceptance" section; EDGE.md updated.