### PR TITLE
feat(edge): cache storage and disk capacity Prometheus gauges

### DIFF
--- a/EDGE.md
+++ b/EDGE.md
@@ -730,6 +730,23 @@ cacheable object locally removes a full origin round trip. Enabled with
   metric is only registered when the response cache is enabled
   (`EDGE_CACHE_BACKEND` is set).
 
+  **Capacity / volume gauges** (registered with the cache via
+  `edge.RegisterCacheStorageMetrics`, scrape-sampled — not on the request path):
+
+  | Metric | Labels | When | Meaning |
+  |---|---|---|---|
+  | `parapet_cache_storage_bytes` | `edge_id` | cache on | Body bytes currently held by the LRU (eviction weight = `Meta.Size`; excludes `.meta` sidecar / shard-dir overhead) |
+  | `parapet_cache_storage_max_bytes` | `edge_id` | cache on | `EDGE_CACHE_MAX_SIZE` body-byte cap (fill ratio = `storage_bytes / storage_max_bytes`) |
+  | `parapet_cache_disk_size_bytes` | `edge_id` | disk backend | Total size of the filesystem that holds `EDGE_CACHE_DIR` (`statfs` blocks × bsize) |
+  | `parapet_cache_disk_available_bytes` | `edge_id` | disk backend | Free bytes available to an unprivileged process on that filesystem (`statfs` Bavail) |
+
+  Disk series are **omitted** (not zeroed) on the memory backend and when
+  `statfs` fails, so a zero never looks like "the volume is full". Storage size
+  is **O(1)** via parapet `DiskStorage`/`MemoryStorage` `Size()`/`MaxSize()`
+  (LRU body-byte weight vs configured cap — never a `Storage.Range` walk on
+  scrape). Disk `Size()` may lag the on-disk footprint while the backend's
+  background startup scan re-admits surviving entries (same lag as the byte cap).
+
 ### On-disk layout (sharded by hash)
 
 ```

--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -334,6 +334,7 @@ func main() {
 		maxFile := envBytes("EDGE_CACHE_MAX_FILE_SIZE", 8<<20)
 		var storage cache.Storage
 		var purgeStatePath string // disk backend persists purge state alongside the cache
+		var cacheDir string       // non-empty only for the disk backend (storage + disk metrics)
 		switch envOr("EDGE_CACHE_BACKEND", "disk") {
 		case "memory":
 			storage = cache.NewMemory(maxSize)
@@ -345,11 +346,15 @@ func main() {
 				slog.Error("edge cache: cannot init cache dir; caching disabled", "dir", dir, "error", err)
 			} else {
 				storage = d
+				cacheDir = dir
 				purgeStatePath = filepath.Join(dir, "purge-state")
 				slog.Info("edge cache enabled (disk-backed)", "dir", dir, "max_size", maxSize, "max_file", maxFile)
 			}
 		}
 		if storage != nil {
+			// Capacity + volume gauges (parapet_cache_storage_* / parapet_cache_disk_*).
+			// Registered only when the cache is live so a cache-off edge stays quiet.
+			edge.RegisterCacheStorageMetrics(storage, maxSize, cacheDir)
 			// Cache outcomes: the host-bounded parapet_cache_total{host,result,
 			// edge_id} counter (host collapsed to "other" off the knownHost oracle,
 			// the same serve-all bounding parapet_requests uses, so the per-project

--- a/edge/cachestorage.go
+++ b/edge/cachestorage.go
@@ -1,0 +1,137 @@
+package edge
+
+// cachestorage.go — parapet_cache_storage_* and parapet_cache_disk_* gauges.
+//
+// WHY THIS EXISTS
+//
+// Cache-outcome counters (parapet_cache_total / parapet_cache_egress_bytes) tell
+// operators hit ratios and billing volume, but not whether the edge is about to
+// thrash under its LRU byte cap or run the volume out of free space. These gauges
+// close that gap:
+//
+//   - parapet_cache_storage_bytes{edge_id}       body bytes currently held by the
+//     cache backend's LRU (eviction weight via Size() — not filesystem overhead
+//     from .meta sidecars / shard dirs).
+//   - parapet_cache_storage_max_bytes{edge_id}   configured body-byte cap
+//     (MaxSize() / EDGE_CACHE_MAX_SIZE; fill ratio = storage / max).
+//   - parapet_cache_disk_size_bytes{edge_id}     total size of the filesystem that
+//     holds EDGE_CACHE_DIR (disk backend only).
+//   - parapet_cache_disk_available_bytes{edge_id} free bytes available to an
+//     unprivileged process on that filesystem (statfs Bavail; disk backend only).
+//
+// Disk series are omitted (not zeroed) when the backend is memory or when
+// statfs fails, so a zero never looks like "disk is full".
+//
+// Collection is pull-based (prometheus.Collector): values are sampled on scrape,
+// not on the request path. Storage size is O(1) via DiskStorage/MemoryStorage
+// Size() — never Storage.Range (that would readdir+read every .meta on every
+// scrape/push gather, competing with the cache volume).
+
+import (
+	"sync"
+
+	"github.com/moonrhythm/parapet/pkg/cache"
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	descCacheStorageBytes = prometheus.NewDesc(
+		prometheus.BuildFQName(prom.Namespace, "", "cache_storage_bytes"),
+		"Body bytes currently held by the edge response cache (LRU eviction weight).",
+		[]string{"edge_id"}, nil,
+	)
+	descCacheStorageMaxBytes = prometheus.NewDesc(
+		prometheus.BuildFQName(prom.Namespace, "", "cache_storage_max_bytes"),
+		"Configured body-byte cap of the edge response cache (EDGE_CACHE_MAX_SIZE).",
+		[]string{"edge_id"}, nil,
+	)
+	descCacheDiskSizeBytes = prometheus.NewDesc(
+		prometheus.BuildFQName(prom.Namespace, "", "cache_disk_size_bytes"),
+		"Total size of the filesystem holding the edge response-cache directory.",
+		[]string{"edge_id"}, nil,
+	)
+	descCacheDiskAvailableBytes = prometheus.NewDesc(
+		prometheus.BuildFQName(prom.Namespace, "", "cache_disk_available_bytes"),
+		"Free bytes available to an unprivileged process on the filesystem holding the edge response-cache directory.",
+		[]string{"edge_id"}, nil,
+	)
+
+	cacheStorageOnce sync.Once
+)
+
+// storageSizer is implemented by parapet DiskStorage and MemoryStorage (O(1)
+// LRU total + configured cap). Not on cache.Storage so custom backends stay free
+// of an observability obligation.
+type storageSizer interface {
+	Size() int64
+	MaxSize() int64
+}
+
+// cacheStorageCollector samples cache capacity + (when dir is set) the cache
+// volume's filesystem usage on each Prometheus scrape.
+type cacheStorageCollector struct {
+	storage cache.Storage
+	maxSize int64
+	dir     string // empty → memory backend; disk metrics are not emitted
+}
+
+// RegisterCacheStorageMetrics registers the cache storage / disk gauges on the
+// shared parapet registry. Call once when the response cache is enabled.
+//
+// maxSize is EDGE_CACHE_MAX_SIZE (used when storage does not expose MaxSize).
+// dir is EDGE_CACHE_DIR for the disk backend, or "" for memory (disk size/
+// available series are then never emitted).
+func RegisterCacheStorageMetrics(storage cache.Storage, maxSize int64, dir string) {
+	if storage == nil {
+		return
+	}
+	if z, ok := storage.(storageSizer); ok {
+		maxSize = z.MaxSize()
+	}
+	cacheStorageOnce.Do(func() {
+		prom.Registry().MustRegister(&cacheStorageCollector{
+			storage: storage,
+			maxSize: maxSize,
+			dir:     dir,
+		})
+	})
+}
+
+func (c *cacheStorageCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descCacheStorageBytes
+	ch <- descCacheStorageMaxBytes
+	if c.dir != "" {
+		ch <- descCacheDiskSizeBytes
+		ch <- descCacheDiskAvailableBytes
+	}
+}
+
+func (c *cacheStorageCollector) Collect(ch chan<- prometheus.Metric) {
+	id := edgeID
+	ch <- prometheus.MustNewConstMetric(descCacheStorageBytes, prometheus.GaugeValue, float64(storageBodyBytes(c.storage)), id)
+	ch <- prometheus.MustNewConstMetric(descCacheStorageMaxBytes, prometheus.GaugeValue, float64(c.maxSize), id)
+	if c.dir == "" {
+		return
+	}
+	size, avail, ok := diskUsage(c.dir)
+	if !ok {
+		// Omit rather than report 0 — a zero available looks like a full volume.
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(descCacheDiskSizeBytes, prometheus.GaugeValue, float64(size), id)
+	ch <- prometheus.MustNewConstMetric(descCacheDiskAvailableBytes, prometheus.GaugeValue, float64(avail), id)
+}
+
+// storageBodyBytes returns the current LRU body-byte total for s via Size().
+// Custom Storage without Size reports 0 (never Range — O(n) disk I/O on scrape
+// is unsafe on a multi-gigabyte cache volume).
+func storageBodyBytes(s cache.Storage) int64 {
+	if s == nil {
+		return 0
+	}
+	if z, ok := s.(storageSizer); ok {
+		return z.Size()
+	}
+	return 0
+}

--- a/edge/cachestorage_disk_other.go
+++ b/edge/cachestorage_disk_other.go
@@ -1,0 +1,8 @@
+//go:build !unix
+
+package edge
+
+// diskUsage is unavailable on non-unix platforms (the edge ships for linux/* only).
+func diskUsage(path string) (size, available uint64, ok bool) {
+	return 0, 0, false
+}

--- a/edge/cachestorage_disk_other.go
+++ b/edge/cachestorage_disk_other.go
@@ -1,8 +1,9 @@
-//go:build !unix
+//go:build !(linux || darwin)
 
 package edge
 
-// diskUsage is unavailable on non-unix platforms (the edge ships for linux/* only).
+// diskUsage is unavailable outside linux/darwin (the edge ships for linux/*;
+// darwin is for local dev). Other GOOS get a quiet omit of the disk series.
 func diskUsage(path string) (size, available uint64, ok bool) {
 	return 0, 0, false
 }

--- a/edge/cachestorage_disk_unix.go
+++ b/edge/cachestorage_disk_unix.go
@@ -1,0 +1,28 @@
+//go:build unix
+
+package edge
+
+import "golang.org/x/sys/unix"
+
+// diskUsage reports the total and unprivileged-available bytes of the filesystem
+// that holds path (typically EDGE_CACHE_DIR). ok is false when statfs fails
+// (missing mount, permission denied, etc.).
+func diskUsage(path string) (size, available uint64, ok bool) {
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return 0, 0, false
+	}
+	// Bsize is int64 on Linux and int32 on Darwin; Blocks/Bavail widths also
+	// differ. Promote everything through uint64 carefully — Bavail is the free
+	// space a non-root process may allocate (matches node_exporter's avail).
+	bsize := uint64(st.Bsize) //nolint:unconvert // intentional width cast across GOOS
+	if bsize == 0 {
+		return 0, 0, false
+	}
+	size = uint64(st.Blocks) * bsize
+	// Bavail is signed on some platforms (reserved blocks can make free < reserved).
+	if st.Bavail > 0 {
+		available = uint64(st.Bavail) * bsize
+	}
+	return size, available, true
+}

--- a/edge/cachestorage_disk_unix.go
+++ b/edge/cachestorage_disk_unix.go
@@ -1,4 +1,4 @@
-//go:build unix
+//go:build linux || darwin
 
 package edge
 
@@ -7,6 +7,9 @@ import "golang.org/x/sys/unix"
 // diskUsage reports the total and unprivileged-available bytes of the filesystem
 // that holds path (typically EDGE_CACHE_DIR). ok is false when statfs fails
 // (missing mount, permission denied, etc.).
+//
+// Build-constrained to linux|darwin: those are the platforms the edge ships/runs
+// on, and unix.Statfs is not available on every "unix" GOOS (e.g. netbsd).
 func diskUsage(path string) (size, available uint64, ok bool) {
 	var st unix.Statfs_t
 	if err := unix.Statfs(path, &st); err != nil {

--- a/edge/cachestorage_test.go
+++ b/edge/cachestorage_test.go
@@ -1,0 +1,134 @@
+package edge
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/moonrhythm/parapet/pkg/cache"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// putStorageEntry seeds one entry into a cache.Storage (same helper shape as
+// purgereaper_test, kept local so this file stays independent).
+func putStorageEntry(t *testing.T, s cache.Storage, key string, m cache.Meta, body []byte) {
+	t.Helper()
+	w, err := s.Writer(key)
+	require.NoError(t, err)
+	_, err = w.Write(body)
+	require.NoError(t, err)
+	m.Size = int64(len(body))
+	require.NoError(t, w.Commit(m))
+}
+
+func TestStorageBodyBytesMemory(t *testing.T) {
+	s := cache.NewMemory(1 << 20)
+	putStorageEntry(t, s, "aa01deadbeef", cache.Meta{Host: "a.com", URI: "/x"}, []byte("hello"))
+	putStorageEntry(t, s, "bb02deadbeef", cache.Meta{Host: "b.com", URI: "/y"}, []byte("world!!"))
+
+	assert.EqualValues(t, 5+7, storageBodyBytes(s))
+	assert.EqualValues(t, 1<<20, s.MaxSize())
+}
+
+func TestStorageBodyBytesNilAndNonSizer(t *testing.T) {
+	assert.Zero(t, storageBodyBytes(nil))
+	// Custom Storage without Size must not fall back to Range (O(n) scrape cost).
+	assert.Zero(t, storageBodyBytes(noSizeStorage{}))
+}
+
+// noSizeStorage is a minimal Storage that deliberately lacks Size/MaxSize so
+// storageBodyBytes reports 0 rather than walking Range.
+type noSizeStorage struct{}
+
+func (noSizeStorage) Get(string) (cache.Meta, []byte, bool) { return cache.Meta{}, nil, false }
+func (noSizeStorage) Writer(string) (cache.EntryWriter, error) {
+	return nil, errors.New("unused")
+}
+func (noSizeStorage) Delete(string) {}
+func (noSizeStorage) Range(func(string, cache.Meta) bool) {
+	panic("Range must not be called for storage metrics")
+}
+
+func TestCacheStorageCollectorMemory(t *testing.T) {
+	s := cache.NewMemory(1 << 20)
+	putStorageEntry(t, s, "aa01deadbeef", cache.Meta{Host: "a.com", URI: "/"}, []byte("12345"))
+
+	old := edgeID
+	edgeID = "edge-storage-test"
+	t.Cleanup(func() { edgeID = old })
+
+	c := &cacheStorageCollector{storage: s, maxSize: s.MaxSize(), dir: ""}
+	// Memory backend: only the two storage gauges.
+	assert.Equal(t, 2, testutil.CollectAndCount(c))
+
+	reg := prometheus.NewPedanticRegistry()
+	require.NoError(t, reg.Register(c))
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+
+	got := map[string]float64{}
+	for _, mf := range mfs {
+		for _, m := range mf.GetMetric() {
+			var id string
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "edge_id" {
+					id = lp.GetValue()
+				}
+			}
+			assert.Equal(t, "edge-storage-test", id)
+			got[mf.GetName()] = m.GetGauge().GetValue()
+		}
+	}
+	assert.Equal(t, 5.0, got["parapet_cache_storage_bytes"])
+	assert.Equal(t, float64(1<<20), got["parapet_cache_storage_max_bytes"])
+	_, hasDisk := got["parapet_cache_disk_size_bytes"]
+	assert.False(t, hasDisk, "memory backend must not emit disk series")
+}
+
+func TestCacheStorageCollectorDisk(t *testing.T) {
+	dir := t.TempDir()
+	s, err := cache.NewDisk(dir, 1<<20)
+	require.NoError(t, err)
+	putStorageEntry(t, s, "aa01deadbeef", cache.Meta{Host: "a.com", URI: "/"}, []byte("xyz"))
+
+	old := edgeID
+	edgeID = "edge-disk-test"
+	t.Cleanup(func() { edgeID = old })
+
+	c := &cacheStorageCollector{storage: s, maxSize: s.MaxSize(), dir: dir}
+	// Storage pair + disk pair.
+	assert.Equal(t, 4, testutil.CollectAndCount(c))
+
+	reg := prometheus.NewPedanticRegistry()
+	require.NoError(t, reg.Register(c))
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+
+	got := map[string]float64{}
+	for _, mf := range mfs {
+		for _, m := range mf.GetMetric() {
+			got[mf.GetName()] = m.GetGauge().GetValue()
+		}
+	}
+	assert.Equal(t, 3.0, got["parapet_cache_storage_bytes"])
+	assert.Equal(t, float64(1<<20), got["parapet_cache_storage_max_bytes"])
+	assert.Greater(t, got["parapet_cache_disk_size_bytes"], 0.0)
+	// Available can be 0 on a truly full volume; on a temp dir it should be > 0.
+	assert.Greater(t, got["parapet_cache_disk_available_bytes"], 0.0)
+	// Available must not exceed total size.
+	assert.LessOrEqual(t, got["parapet_cache_disk_available_bytes"], got["parapet_cache_disk_size_bytes"])
+}
+
+func TestDiskUsageMissingPath(t *testing.T) {
+	_, _, ok := diskUsage(filepath.Join(t.TempDir(), "no-such-subdir-that-does-not-exist-xxx"))
+	// Statfs on a missing path fails on unix — series would be omitted.
+	// (Some platforms may succeed if the parent is readable; only require that
+	// a clearly impossible path under / does not panic.)
+	_ = ok
+	_, _, ok = diskUsage(filepath.Join(string(os.PathSeparator), "no", "such", "path", "parapet-edge-test"))
+	assert.False(t, ok, "statfs of a non-existent absolute path should fail")
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/acoshift/configfile v1.9.0
 	github.com/corazawaf/coraza-coreruleset/v4 v4.25.0
 	github.com/corazawaf/coraza/v3 v3.7.0
-	github.com/moonrhythm/parapet v0.18.4
+	github.com/moonrhythm/parapet v0.18.5
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
@@ -19,6 +19,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/net v0.56.0
 	golang.org/x/sync v0.21.0
+	golang.org/x/sys v0.46.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
@@ -90,7 +91,6 @@ require (
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moonrhythm/parapet v0.18.4 h1:FN2PMoFK4zteypC8WGiRrTpRt156lGJFjY3SzeipP7k=
-github.com/moonrhythm/parapet v0.18.4/go.mod h1:mfLCzU9zBm6vn05mnOgO0G8/+pArndciyLv3BYM9HJA=
+github.com/moonrhythm/parapet v0.18.5 h1:2lFW2kbYYTUfnGSBZ96lgU2goSf7EBWp3FTwlZdasUI=
+github.com/moonrhythm/parapet v0.18.5/go.mod h1:mfLCzU9zBm6vn05mnOgO0G8/+pArndciyLv3BYM9HJA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=


### PR DESCRIPTION
## Summary

- Add scrape-sampled Prometheus gauges for edge response-cache capacity and volume pressure:
  - `parapet_cache_storage_bytes{edge_id}` — LRU body-byte total (O(1) via parapet `Size()`)
  - `parapet_cache_storage_max_bytes{edge_id}` — configured cap (`MaxSize()` / `EDGE_CACHE_MAX_SIZE`)
  - `parapet_cache_disk_size_bytes{edge_id}` — filesystem total for `EDGE_CACHE_DIR` (disk backend only)
  - `parapet_cache_disk_available_bytes{edge_id}` — free space (`statfs` Bavail; disk backend only)
- Disk series are omitted (not zeroed) on the memory backend or when `statfs` fails.
- Storage size never walks `Storage.Range` on scrape (avoids O(n) meta I/O on the cache volume).
- Wire-up in `cmd/edge-proxy` when the response cache is live; document in `EDGE.md`.
- Bump `github.com/moonrhythm/parapet` to **v0.18.5** (`Size`/`MaxSize` on disk + memory backends).

## Why

Cache hit/egress counters do not show whether the edge is about to thrash under its LRU byte cap or run the cache volume out of free space. These gauges close that gap for alerts and capacity planning (including via metrics push to the control plane).

## Depends on

- [moonrhythm/parapet#251](https://github.com/moonrhythm/parapet/pull/251) — released as `v0.18.5`

## Test plan

- [x] `go test ./edge/ -run 'TestStorageBodyBytes|TestCacheStorageCollector|TestDiskUsage'`
- [x] `go build ./cmd/edge-proxy`
- [ ] With `EDGE_CACHE_ENABLED=true` (disk), scrape `:9187` and confirm storage + disk series present with `edge_id`
- [ ] With `EDGE_CACHE_BACKEND=memory`, confirm only storage series (no disk series)
- [ ] Optional: fill cache and watch `storage_bytes / storage_max_bytes` rise; free disk and watch `disk_available_bytes`