### PR TITLE
docs(spec): annotation rate limits are per-pod best-effort and reset on reload

### DIFF
--- a/RATELIMIT.md
+++ b/RATELIMIT.md
@@ -26,6 +26,14 @@ This complements, not replaces, the existing limiters:
 | **Zone rate limits** | ConfigMap `…/ratelimit: zone` + `ratelimit-zone` annotation | request rate across a tenant's ingresses |
 | Annotation rate limits | `ratelimit-s/-m/-h` on one ingress | request rate per single ingress |
 
+The annotation limiters are **best-effort**: `plugin.RateLimit` builds a fresh
+strategy on every plugin run (every mux reload — any Ingress/Service/Secret
+change in the watch scope), so their counters silently reset on cluster churn,
+and they're per controller replica (no shared state). For durable,
+churn-resistant enforcement, use a rate-limit zone instead — `SetLimits`
+carries its `Limiter` (and therefore its counters) across reloads for
+unchanged limits.
+
 ## Limit schema (the contract)
 
 Each ConfigMap `data` value is one `limits:` document; multiple keys (and

--- a/SPEC.md
+++ b/SPEC.md
@@ -56,7 +56,7 @@ All keys are prefixed `parapet.moonrhythm.io/`. Applied per-Ingress.
 | `redirect-https` | `"true"` | 301 HTTP→HTTPS (skips `/.well-known/acme-challenge`) |
 | `hsts` | `"preload"` / any | Strict-Transport-Security header |
 | `redirect` | YAML map `host: url` (or `host: "code,url"`) | Host-level redirect rules |
-| `ratelimit-s` / `-m` / `-h` | integer | Fixed-window requests per second / minute / hour |
+| `ratelimit-s` / `-m` / `-h` | integer | Fixed-window requests per second / minute / hour — best-effort: per controller replica (no shared state), and counters reset on every route reload (any Ingress/Service/Secret change in the watch scope) since the strategy is rebuilt from scratch each time. For durable enforcement whose counters survive reloads, use `ratelimit-zone` (see [RATELIMIT.md](RATELIMIT.md)) instead |
 | `body-limitrequest` | bytes (int64) | Max request body size (413 above) |
 | `upstream-protocol` | `http` / `https` | Force upstream scheme |
 | `upstream-host` | hostname | Override `Host` sent upstream |


### PR DESCRIPTION
## Review finding 11 (medium; verdict: document, do not change code)

Problem: the `ratelimit-s`/`-m`/`-h` annotation limiters (`plugin.RateLimit`) construct fresh `FixedWindowPer*` strategies on every plugin run, i.e. on every mux reload (any Ingress/Service/Secret change in the watch scope), so their counters silently reset on cluster churn. They are also per controller replica (no shared state). This is accepted, existing behavior — the fix is to document it, not change it.

## What changed

- `SPEC.md`: the `ratelimit-s`/`-m`/`-h` annotation row now states these limiters are best-effort — per replica, reset on every route reload — and points to `ratelimit-zone` for durable enforcement whose counters survive reloads.
- `RATELIMIT.md`: added a short paragraph right after the "complements, not replaces" comparison table, contrasting the annotation limiters' reset-on-reload/per-replica behavior with the zone mechanism's counter-preserving `SetLimits`.

No Go code changed.

## Testing

- `gofmt -l .` — clean
- `go vet ./...` — clean
- `go test ./...` — 887 passed, 28 packages