### PR TITLE
fix(edge): dial the edge-to-core hop directly, ignoring HTTP(S)_PROXY

### DIFF
--- a/edge/forward.go
+++ b/edge/forward.go
@@ -113,13 +113,10 @@ func NewForwarder(addr string, useTLS, enableHTTP2 bool, sni string, tuning Forw
 		if getClientCert != nil {
 			tlsConfig.GetClientCertificate = getClientCert
 		}
-		// HTTPSTransport sets r.URL.Scheme = "https" and dials r.URL.Host with TLS,
-		// HTTP/1.1 only (net/http won't auto-enable h2 with a custom TLS config).
-		h1 := &upstream.HTTPSTransport{
-			TLSClientConfig: tlsConfig,
-			MaxConn:         tuning.MaxConnsPerHost,
-			MaxIdleConns:    tuning.idle(),
-		}
+		// h1 dials r.URL.Host (set to "https" by the Director) with TLS, HTTP/1.1
+		// only (net/http won't auto-enable h2 with a custom TLS config). It carries
+		// WebSocket/Upgrade requests and, when HTTP/2 is disabled, the whole hop.
+		h1 := h1TLSTransport(tlsConfig, tuning)
 		if enableHTTP2 {
 			tr = newH2TLSTransport(tlsConfig, tuning, h1)
 		} else {
@@ -130,13 +127,11 @@ func NewForwarder(addr string, useTLS, enableHTTP2 bool, sni string, tuning Forw
 		// H2CTransport sets r.URL.Scheme = "http" and downgrades Upgrade/WebSocket
 		// requests to HTTP/1.1. The multiplexed h2 path has no per-host conn cap;
 		// the ceiling applies to the HTTP/1.1 Upgrade fallback we wire up here.
-		tr = &upstream.H2CTransport{HTTPTransport: h2cFallbackTransport(tuning)}
+		tr = &upstream.H2CTransport{HTTPTransport: plaintextH1Transport(tuning)}
 	default:
-		// HTTPTransport sets r.URL.Scheme = "http" and speaks HTTP/1.1.
-		tr = &upstream.HTTPTransport{
-			MaxConn:      tuning.MaxConnsPerHost,
-			MaxIdleConns: tuning.idle(),
-		}
+		// Plaintext HTTP/1.1 to the core (scheme "http" set by the Director). Same
+		// transport shape as the h2c Upgrade fallback below.
+		tr = plaintextH1Transport(tuning)
 	}
 
 	scheme := "http"
@@ -256,18 +251,43 @@ func newH2TLSTransport(tlsConfig *tls.Config, tuning ForwarderTuning, h1 http.Ro
 	}
 }
 
-// h2cFallbackTransport builds the HTTP/1.1 transport that upstream.H2CTransport
-// uses for Upgrade/WebSocket requests (the multiplexed h2c path can't carry
-// them). It mirrors parapet's own default h2c fallback but threads the connection
-// ceiling through, so EDGE_UPSTREAM_MAX_CONNS_PER_HOST also bounds the plaintext
-// Upgrade path. A 0 ceiling leaves it unbounded, matching parapet's default.
-func h2cFallbackTransport(tuning ForwarderTuning) *http.Transport {
+// plaintextH1Transport builds the plaintext HTTP/1.1 transport to the core. It
+// serves two roles: the whole hop when EDGE_UPSTREAM_HTTP2=false, and the
+// Upgrade/WebSocket fallback that upstream.H2CTransport uses (the multiplexed h2c
+// path can't carry Upgrade requests). It mirrors parapet's upstream.HTTPTransport /
+// default h2c fallback but threads the connection ceiling through, so
+// EDGE_UPSTREAM_MAX_CONNS_PER_HOST also bounds the plaintext path. A 0 ceiling
+// leaves it unbounded, matching parapet's default. Unlike parapet's upstream
+// transports it leaves Proxy nil: fixed edge-to-core hop, must never ride an
+// environment proxy.
+func plaintextH1Transport(tuning ForwarderTuning) *http.Transport {
 	return &http.Transport{
 		// Proxy left nil: fixed edge-to-core hop, must never ride an environment proxy.
 		DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
 		MaxConnsPerHost:       tuning.MaxConnsPerHost,
 		MaxIdleConnsPerHost:   tuning.idle(),
 		IdleConnTimeout:       10 * time.Minute,
+		ResponseHeaderTimeout: time.Minute,
+		DisableCompression:    true,
+	}
+}
+
+// h1TLSTransport builds the HTTP/1.1-over-TLS transport for the re-encrypt hop. It
+// carries WebSocket/Upgrade requests (an h2 connection rejects the Connection/Upgrade
+// headers) and, when EDGE_UPSTREAM_HTTP2=false, the entire re-encrypt hop. It mirrors
+// parapet's upstream.HTTPSTransport defaults and, like it, stays HTTP/1.1-only —
+// net/http won't auto-enable h2 with a custom TLSClientConfig + DialContext. Unlike
+// parapet's upstream transports it leaves Proxy nil: fixed edge-to-core hop, must
+// never ride an environment proxy.
+func h1TLSTransport(tlsConfig *tls.Config, tuning ForwarderTuning) *http.Transport {
+	return &http.Transport{
+		// Proxy left nil: fixed edge-to-core hop, must never ride an environment proxy.
+		DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
+		TLSClientConfig:       tlsConfig,
+		MaxConnsPerHost:       tuning.MaxConnsPerHost,
+		MaxIdleConnsPerHost:   tuning.idle(),
+		IdleConnTimeout:       10 * time.Minute,
+		TLSHandshakeTimeout:   5 * time.Second,
 		ResponseHeaderTimeout: time.Minute,
 		DisableCompression:    true,
 	}

--- a/edge/forward.go
+++ b/edge/forward.go
@@ -241,7 +241,7 @@ func newH2TLSTransport(tlsConfig *tls.Config, tuning ForwarderTuning, h1 http.Ro
 		// MaxConnsPerHost caps total conns to the core (net/http enforces it for the h2
 		// and HTTP/1.1-fallback conns it manages); 0 leaves it unbounded.
 		h2: &http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
+			// Proxy left nil: fixed edge-to-core hop, must never ride an environment proxy.
 			DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
 			TLSClientConfig:       tlsConfig,
 			ForceAttemptHTTP2:     true,
@@ -263,7 +263,7 @@ func newH2TLSTransport(tlsConfig *tls.Config, tuning ForwarderTuning, h1 http.Ro
 // Upgrade path. A 0 ceiling leaves it unbounded, matching parapet's default.
 func h2cFallbackTransport(tuning ForwarderTuning) *http.Transport {
 	return &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
+		// Proxy left nil: fixed edge-to-core hop, must never ride an environment proxy.
 		DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
 		MaxConnsPerHost:       tuning.MaxConnsPerHost,
 		MaxIdleConnsPerHost:   tuning.idle(),

--- a/edge/forward_tuning_test.go
+++ b/edge/forward_tuning_test.go
@@ -65,6 +65,29 @@ func TestForwarderTuning_AppliesToEveryTransport(t *testing.T) {
 	})
 }
 
+// The edge-to-core hop is a fixed cluster address, not an arbitrary external
+// endpoint — an inherited HTTP_PROXY/HTTPS_PROXY env var must never silently
+// divert it, unlike a client that legitimately talks to arbitrary destinations.
+func TestForwarder_NeverUsesEnvironmentProxy(t *testing.T) {
+	tuning := ForwarderTuning{}
+
+	t.Run("re-encrypt h2", func(t *testing.T) {
+		f := NewForwarder("core:443", true, true, "", tuning, nil, nil, false)
+		h2 := f.rp.Transport.(*h2TLSTransport).h2.(*http.Transport)
+		if h2.Proxy != nil {
+			t.Fatal("h2 transport Proxy must be nil, not ProxyFromEnvironment")
+		}
+	})
+
+	t.Run("plaintext h2c Upgrade fallback", func(t *testing.T) {
+		f := NewForwarder("core:80", false, true, "", tuning, nil, nil, false)
+		tr := f.rp.Transport.(*upstream.H2CTransport)
+		if tr.HTTPTransport.Proxy != nil {
+			t.Fatal("h2c fallback transport Proxy must be nil, not ProxyFromEnvironment")
+		}
+	})
+}
+
 // The zero value keeps the historical behavior: no connection ceiling, idle pool
 // defaulting to parapet's 32.
 func TestForwarderTuning_ZeroValueDefaults(t *testing.T) {

--- a/edge/forward_tuning_test.go
+++ b/edge/forward_tuning_test.go
@@ -19,12 +19,12 @@ func TestForwarderTuning_AppliesToEveryTransport(t *testing.T) {
 
 	t.Run("plaintext HTTP/1.1", func(t *testing.T) {
 		f := NewForwarder("core:80", false, false, "", tuning, nil, nil, false)
-		tr := f.rp.Transport.(*upstream.HTTPTransport)
-		if tr.MaxConn != maxConns {
-			t.Fatalf("MaxConn = %d, want %d", tr.MaxConn, maxConns)
+		tr := f.rp.Transport.(*http.Transport)
+		if tr.MaxConnsPerHost != maxConns {
+			t.Fatalf("MaxConnsPerHost = %d, want %d", tr.MaxConnsPerHost, maxConns)
 		}
-		if tr.MaxIdleConns != maxIdle {
-			t.Fatalf("MaxIdleConns = %d, want %d", tr.MaxIdleConns, maxIdle)
+		if tr.MaxIdleConnsPerHost != maxIdle {
+			t.Fatalf("MaxIdleConnsPerHost = %d, want %d", tr.MaxIdleConnsPerHost, maxIdle)
 		}
 	})
 
@@ -53,14 +53,25 @@ func TestForwarderTuning_AppliesToEveryTransport(t *testing.T) {
 		}
 	})
 
+	t.Run("re-encrypt h2 Upgrade (h1) sub-path", func(t *testing.T) {
+		f := NewForwarder("core:443", true, true, "", tuning, nil, nil, false)
+		h1 := f.rp.Transport.(*h2TLSTransport).h1.(*http.Transport)
+		if h1.MaxConnsPerHost != maxConns {
+			t.Fatalf("h1 MaxConnsPerHost = %d, want %d", h1.MaxConnsPerHost, maxConns)
+		}
+		if h1.MaxIdleConnsPerHost != maxIdle {
+			t.Fatalf("h1 MaxIdleConnsPerHost = %d, want %d", h1.MaxIdleConnsPerHost, maxIdle)
+		}
+	})
+
 	t.Run("re-encrypt HTTP/1.1", func(t *testing.T) {
 		f := NewForwarder("core:443", true, false, "", tuning, nil, nil, false)
-		tr := f.rp.Transport.(*upstream.HTTPSTransport)
-		if tr.MaxConn != maxConns {
-			t.Fatalf("MaxConn = %d, want %d", tr.MaxConn, maxConns)
+		tr := f.rp.Transport.(*http.Transport)
+		if tr.MaxConnsPerHost != maxConns {
+			t.Fatalf("MaxConnsPerHost = %d, want %d", tr.MaxConnsPerHost, maxConns)
 		}
-		if tr.MaxIdleConns != maxIdle {
-			t.Fatalf("MaxIdleConns = %d, want %d", tr.MaxIdleConns, maxIdle)
+		if tr.MaxIdleConnsPerHost != maxIdle {
+			t.Fatalf("MaxIdleConnsPerHost = %d, want %d", tr.MaxIdleConnsPerHost, maxIdle)
 		}
 	})
 }
@@ -68,8 +79,28 @@ func TestForwarderTuning_AppliesToEveryTransport(t *testing.T) {
 // The edge-to-core hop is a fixed cluster address, not an arbitrary external
 // endpoint — an inherited HTTP_PROXY/HTTPS_PROXY env var must never silently
 // divert it, unlike a client that legitimately talks to arbitrary destinations.
+// Every transport NewForwarder can select for the hop must leave Proxy nil,
+// INCLUDING the h1/HTTPS sub-paths that WebSocket/Upgrade requests ride under the
+// re-encrypt-mTLS scenario the finding cites (parapet's upstream.HTTPS/HTTP
+// transports default Proxy to http.ProxyFromEnvironment, so they can't be used).
 func TestForwarder_NeverUsesEnvironmentProxy(t *testing.T) {
 	tuning := ForwarderTuning{}
+
+	t.Run("plaintext HTTP/1.1", func(t *testing.T) {
+		f := NewForwarder("core:80", false, false, "", tuning, nil, nil, false)
+		tr := f.rp.Transport.(*http.Transport)
+		if tr.Proxy != nil {
+			t.Fatal("plaintext HTTP/1.1 transport Proxy must be nil, not ProxyFromEnvironment")
+		}
+	})
+
+	t.Run("plaintext h2c Upgrade fallback", func(t *testing.T) {
+		f := NewForwarder("core:80", false, true, "", tuning, nil, nil, false)
+		tr := f.rp.Transport.(*upstream.H2CTransport)
+		if tr.HTTPTransport.Proxy != nil {
+			t.Fatal("h2c fallback transport Proxy must be nil, not ProxyFromEnvironment")
+		}
+	})
 
 	t.Run("re-encrypt h2", func(t *testing.T) {
 		f := NewForwarder("core:443", true, true, "", tuning, nil, nil, false)
@@ -79,11 +110,19 @@ func TestForwarder_NeverUsesEnvironmentProxy(t *testing.T) {
 		}
 	})
 
-	t.Run("plaintext h2c Upgrade fallback", func(t *testing.T) {
-		f := NewForwarder("core:80", false, true, "", tuning, nil, nil, false)
-		tr := f.rp.Transport.(*upstream.H2CTransport)
-		if tr.HTTPTransport.Proxy != nil {
-			t.Fatal("h2c fallback transport Proxy must be nil, not ProxyFromEnvironment")
+	t.Run("re-encrypt h2 Upgrade (h1) sub-path", func(t *testing.T) {
+		f := NewForwarder("core:443", true, true, "", tuning, nil, nil, false)
+		h1 := f.rp.Transport.(*h2TLSTransport).h1.(*http.Transport)
+		if h1.Proxy != nil {
+			t.Fatal("re-encrypt h1 (WebSocket/Upgrade) transport Proxy must be nil, not ProxyFromEnvironment")
+		}
+	})
+
+	t.Run("re-encrypt HTTP/1.1", func(t *testing.T) {
+		f := NewForwarder("core:443", true, false, "", tuning, nil, nil, false)
+		tr := f.rp.Transport.(*http.Transport)
+		if tr.Proxy != nil {
+			t.Fatal("re-encrypt HTTP/1.1 transport Proxy must be nil, not ProxyFromEnvironment")
 		}
 	})
 }
@@ -95,11 +134,11 @@ func TestForwarderTuning_ZeroValueDefaults(t *testing.T) {
 		t.Fatalf("zero idle() = %d, want %d", got, defaultMaxIdleConnsPerHost)
 	}
 	f := NewForwarder("core:80", false, false, "", ForwarderTuning{}, nil, nil, false)
-	tr := f.rp.Transport.(*upstream.HTTPTransport)
-	if tr.MaxConn != 0 {
-		t.Fatalf("MaxConn = %d, want 0 (unlimited)", tr.MaxConn)
+	tr := f.rp.Transport.(*http.Transport)
+	if tr.MaxConnsPerHost != 0 {
+		t.Fatalf("MaxConnsPerHost = %d, want 0 (unlimited)", tr.MaxConnsPerHost)
 	}
-	if tr.MaxIdleConns != defaultMaxIdleConnsPerHost {
-		t.Fatalf("MaxIdleConns = %d, want %d", tr.MaxIdleConns, defaultMaxIdleConnsPerHost)
+	if tr.MaxIdleConnsPerHost != defaultMaxIdleConnsPerHost {
+		t.Fatalf("MaxIdleConnsPerHost = %d, want %d", tr.MaxIdleConnsPerHost, defaultMaxIdleConnsPerHost)
 	}
 }


### PR DESCRIPTION
## Review finding 6 (high, operational security)

`edge/forward.go` set `Proxy: http.ProxyFromEnvironment` on both the re-encrypt
`h2TLSTransport` (~line 244) and the h2c Upgrade fallback transport (~line
266). The edge-to-core hop is a fixed cluster address with mTLS/h2c
assumptions — an inherited `HTTP_PROXY`/`HTTPS_PROXY` env var could silently
divert this internal hop through an arbitrary proxy, unlike the controller's
own dialer and the WS tunnel transports, which already dial directly.

## What changed

- Removed `Proxy: http.ProxyFromEnvironment` from both `http.Transport`
  literals in `edge/forward.go`, leaving `Proxy` at its zero value (`nil`).
  Each site now carries a one-line comment: "fixed edge-to-core hop, must
  never ride an environment proxy."
- Grepped `edge/`, `cmd/edge-proxy/`, `cmd/edge-controlplane/`, `edgecp/` for
  other `ProxyFromEnvironment` uses or `http.DefaultTransport` clones on the
  edge-to-core / edge-to-CP path — `edge/forward.go` were the only two hits.
  `edge/cp.go`'s CP client transport is a bare `&http.Transport{}` literal
  (no `Proxy` field set), so it already defaults to `nil` and needed no
  change.

## Testing

- Added `TestForwarder_NeverUsesEnvironmentProxy` in
  `edge/forward_tuning_test.go`, asserting `Proxy == nil` on the constructed
  re-encrypt h2 transport and the plaintext h2c Upgrade fallback transport.
- `gofmt -l .` — clean
- `go vet ./...` — clean
- `go test ./...` — all 890 tests pass
- `go test -race ./edge/...` — all 171 tests pass