### PR TITLE
fix(edge): strip Content-Length and Expect when translating WS upgrades to extended CONNECT

### DIFF
--- a/edge/wstunnel.go
+++ b/edge/wstunnel.go
@@ -282,6 +282,10 @@ func (t *wsTunnel) translate(ctx context.Context, r *http.Request, body io.ReadC
 	c.Header.Del("Upgrade")
 	c.Header.Del("Transfer-Encoding")
 	c.Header.Del("Sec-WebSocket-Key")
+	// A client-sent Content-Length/Expect describes the h1 upgrade GET, not the
+	// tunnel's live, lengthless stream (mirrors wsh2.Normalize's rationale).
+	c.Header.Del("Content-Length")
+	c.Header.Del("Expect")
 	c.Header.Set(":protocol", "websocket")
 	c.URL.Scheme = t.scheme
 	c.URL.Host = t.addr

--- a/edge/wstunnel_test.go
+++ b/edge/wstunnel_test.go
@@ -76,6 +76,23 @@ func TestWSTunnel_TranslateCloneShape(t *testing.T) {
 	assert.Empty(t, r.Header.Get(":protocol"))
 }
 
+// A client-supplied Content-Length/Expect on the upgrade GET describes that h1
+// request, not the tunnel's live, lengthless stream — carrying either onto the
+// extended CONNECT would desync the core's h2 request framing.
+func TestWSTunnel_TranslateStripsContentLengthAndExpect(t *testing.T) {
+	tun := &wsTunnel{scheme: "https", addr: "core:443"}
+	r := newWSHandshake("/chat")
+	r.Header.Set("Content-Length", "42")
+	r.Header.Set("Expect", "100-continue")
+
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	c := tun.translate(context.Background(), r, pr)
+
+	assert.Empty(t, c.Header.Get("Content-Length"), "Content-Length dropped (stream has no length)")
+	assert.Empty(t, c.Header.Get("Expect"), "Expect dropped (no body to negotiate)")
+}
+
 func TestWSTunnel_NotSupportedFallsBack(t *testing.T) {
 	rt := &stubRT{err: errors.New("net/http: extended connect not supported by peer")}
 	tun := &wsTunnel{tr: rt, scheme: "http", addr: "core:80"}


### PR DESCRIPTION
## Review finding 17

`edge/wstunnel.go`'s `translate` (~lines 276-289) deleted `Connection`/`Upgrade`/`Transfer-Encoding`/`Sec-WebSocket-Key` from the client's h1 upgrade GET when building the RFC 8441 extended-CONNECT clone, but left a client-supplied `Content-Length`/`Expect` intact. Only the h1-inbound `serve` path is exposed this way — h2-inbound requests already pass through `wsh2.Normalize`, which strips both headers. The tunnel body is a live, lengthless stream, so a surviving `Content-Length` on the extended CONNECT desyncs the core's h2 request framing.

## What changed

Added `c.Header.Del("Content-Length")` and `c.Header.Del("Expect")` to `translate`, with a one-line comment mirroring `wsh2.Normalize`'s existing rationale for the same strip.

## Testing

- Added `TestWSTunnel_TranslateStripsContentLengthAndExpect` in `edge/wstunnel_test.go`: builds a handshake request carrying `Content-Length` and `Expect`, calls `translate`, and asserts neither header survives on the CONNECT clone.
- `gofmt -l .` — clean
- `go vet ./...` — clean
- `go test ./...` — 888 passed
- `go test -race ./edge/...` — 169 passed