### PR TITLE
fix(proxy): stop classifying bare deadline errors as retryable

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -39,13 +39,16 @@ used as-is). The referenced port must still be declared in the Service's
 forwarded by default). A pod-backed route always wins over an ExternalName one
 for the same Service host (only briefly possible across a type change).
 
-**Retry is connection-only**: a dial failure — or a
-connection broken before any response — is retried up to 5× with backoff,
-marking the pod bad and round-robining to another. An upstream that *responds* —
-**including with 502/503** — is **never** retried; its response passes through to
-the client unchanged. A responding upstream has already received and processed
-the request, so retrying could duplicate side effects and amplify load on a
-failing backend. Non-idempotent requests (body already read) are never retried.
+**Retry is dial-only**: only a dial failure — no connection established, so the
+request never left this process — is retried up to 5× with backoff, marking the
+pod bad and round-robining to another. Once a connection is established, any
+failure — including a connection broken before response headers, or a request
+deadline hit while waiting for a response — is **never** retried, same as an
+upstream that *responds* (**including with 502/503**): its response passes
+through to the client unchanged. A connected-but-failed or responding upstream
+may already have received and processed the request, so retrying could
+duplicate side effects and amplify load on a failing backend. Non-idempotent
+requests (body already read) are never retried.
 
 ## Annotations
 

--- a/proxy/dialer.go
+++ b/proxy/dialer.go
@@ -53,11 +53,13 @@ func isDialError(err error) bool {
 	if err == nil {
 		return false
 	}
-	// go1.19 i/o timeout error will now satisfy errors.Is(err, context.DeadlineExceeded)
-	if errors.Is(err, context.DeadlineExceeded) {
-		return true
-	}
-
+	// net.Dialer.DialContext always wraps its failures — including a ctx
+	// timeout mid-dial — in *net.OpError{Op: "dial"}, so that's the only
+	// signal that no connection was established and the request never left
+	// this process. A bare context.DeadlineExceeded (or any other error) can
+	// also surface after a successful connect (e.g. while awaiting response
+	// headers), and retrying that would replay a request the upstream may
+	// have already received.
 	var netOpError *net.OpError
 	return errors.As(err, &netOpError) && netOpError.Op == "dial"
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -88,13 +88,18 @@ func TestProxy(t *testing.T) {
 func TestIsRetryable(t *testing.T) {
 	t.Parallel()
 
-	// Only connection failures are retryable.
+	// Only a dial failure (no connection established, request never sent) is
+	// retryable — including one that timed out on the ctx deadline mid-dial.
 	assert.True(t, IsRetryable(&net.OpError{Op: "dial", Err: errors.New("connection refused")}))
-	assert.True(t, IsRetryable(context.DeadlineExceeded))
+	assert.True(t, IsRetryable(&net.OpError{Op: "dial", Err: context.DeadlineExceeded}))
 
-	// An upstream that responded (even 5xx) has processed the request — not a
-	// connection error, so not retryable. Neither is a mid-flight (non-dial)
-	// transport error or nil.
+	// Once a connection is established, any failure is never retried — even
+	// one that unwraps to context.DeadlineExceeded (e.g. hit while awaiting
+	// response headers) — because the upstream may already have received the
+	// request. Also not retryable: an upstream that responded (even 5xx), a
+	// non-dial (e.g. "read") transport error, and nil.
+	assert.False(t, IsRetryable(context.DeadlineExceeded))
+	assert.False(t, IsRetryable(&net.OpError{Op: "read", Err: context.DeadlineExceeded}))
 	assert.False(t, IsRetryable(errors.New("upstream returned 503")))
 	assert.False(t, IsRetryable(&net.OpError{Op: "read", Err: errors.New("connection reset")}))
 	assert.False(t, IsRetryable(nil))


### PR DESCRIPTION
## Summary

Review finding 4 (high, correctness) + finding 14 (SPEC alignment).

**Problem**: `proxy/dialer.go`'s `isDialError` returned `true` for any
`errors.Is(err, context.DeadlineExceeded)`, including a request deadline hit
*after* a successful connect (e.g. while awaiting response headers). This let
`retryMiddleware` replay a request the upstream had already received,
violating the documented dial-only retry contract.

**Fix**: deleted the bare `errors.Is(err, context.DeadlineExceeded)` branch
and kept only the `*net.OpError{Op:"dial"}` check. `net.Dialer.DialContext`
already wraps every dial-time failure — including a ctx timeout mid-dial — in
`*net.OpError{Op:"dial"}`, so the bare branch was redundant for real dial
timeouts and unsafe for post-connect ones. Also fixed the stale go1.19
comment and reworded `SPEC.md`'s retry section to say only a dial failure (no
connection established) is retried — once a connection is established, any
failure, including one broken before response headers, is never retried.

## Test plan

- [x] `proxy/proxy_test.go`'s `TestIsRetryable`: added a dial `*net.OpError`
  wrapping `context.DeadlineExceeded` (retryable) and asserted bare
  `context.DeadlineExceeded` and a non-dial (`Op:"read"`) `*net.OpError`
  wrapping `context.DeadlineExceeded` are NOT retryable.
- [x] `gofmt -l .` clean
- [x] `go vet ./...`
- [x] `go test ./...` (887 tests pass)
- [x] `go test -race ./proxy/... .` (150 tests pass)