### PR TITLE
fix(transform): validate header names at rule compile time

### DIFF
--- a/transformrule/transformrule.go
+++ b/transformrule/transformrule.go
@@ -36,6 +36,7 @@ import (
 	"github.com/moonrhythm/parapet/pkg/cors"
 	"github.com/moonrhythm/parapet/pkg/headers"
 	"github.com/moonrhythm/parapet/pkg/waf"
+	"golang.org/x/net/http/httpguts"
 	"gopkg.in/yaml.v3"
 )
 
@@ -285,12 +286,18 @@ func compileReqOps(ops []Op) ([]reqOp, error) {
 	for i, op := range ops {
 		switch op.Type {
 		case opSetHeader:
+			if err := validateHeaderNameValue(op.Name, op.Value); err != nil {
+				return nil, fmt.Errorf("set-header: %w", err)
+			}
 			name, value := op.Name, op.Value
 			out = append(out, func(_ http.ResponseWriter, r *http.Request, _ string) bool {
 				r.Header.Set(name, value)
 				return false
 			})
 		case opRemoveHeader:
+			if err := validateHeaderName(op.Name); err != nil {
+				return nil, fmt.Errorf("remove-header: %w", err)
+			}
 			name := op.Name
 			out = append(out, func(_ http.ResponseWriter, r *http.Request, _ string) bool {
 				r.Header.Del(name)
@@ -378,14 +385,42 @@ func compileRewriteQuery(op Op) (reqOp, error) {
 	}, nil
 }
 
+// validateHeaderName rejects a header-name op.Name that would misbehave at
+// emit time (net/http silently drops an invalid Set/Del token), so the
+// all-or-nothing compile catches a typo instead of shipping garbage.
+func validateHeaderName(name string) error {
+	if !httpguts.ValidHeaderFieldName(name) {
+		return fmt.Errorf("invalid header name %q", name)
+	}
+	return nil
+}
+
+// validateHeaderNameValue additionally rejects a header value carrying
+// disallowed bytes (e.g. a bare CR/LF), same rationale as validateHeaderName.
+func validateHeaderNameValue(name, value string) error {
+	if err := validateHeaderName(name); err != nil {
+		return err
+	}
+	if !httpguts.ValidHeaderFieldValue(value) {
+		return fmt.Errorf("invalid header value for %q", name)
+	}
+	return nil
+}
+
 func compileRespOps(ops []Op) ([]respOp, error) {
 	out := make([]respOp, 0, len(ops))
 	for i, op := range ops {
 		switch op.Type {
 		case opSetHeader:
+			if err := validateHeaderNameValue(op.Name, op.Value); err != nil {
+				return nil, fmt.Errorf("set-header: %w", err)
+			}
 			name, value := op.Name, op.Value
 			out = append(out, respOp{mutate: func(h http.Header) { h.Set(name, value) }})
 		case opRemoveHeader:
+			if err := validateHeaderName(op.Name); err != nil {
+				return nil, fmt.Errorf("remove-header: %w", err)
+			}
 			name := op.Name
 			out = append(out, respOp{mutate: func(h http.Header) { h.Del(name) }})
 		case opSetStatus:

--- a/transformrule/transformrule_test.go
+++ b/transformrule/transformrule_test.go
@@ -361,3 +361,87 @@ transforms:
 `)
 	require.Error(t, err, "redirect must be the only op in its rule")
 }
+
+func TestParse_InvalidHeaderNameRejectsWholeDocument(t *testing.T) {
+	t.Parallel()
+
+	// An invalid header-name token only misbehaved at emit time before this
+	// check; it must now reject the whole document all-or-nothing, alongside a
+	// rule that is otherwise fine.
+	z, err := transformrule.Parse(transformrule.Options{}, `
+transforms:
+- id: good
+  phase: response
+  ops:
+  - type: set-header
+    name: X-Good
+    value: "1"
+  priority: 0
+- id: bad-set-header
+  phase: request
+  ops:
+  - type: set-header
+    name: "Bad Header"
+    value: "1"
+  priority: 0
+`)
+	require.Error(t, err, "an invalid header name rejects the whole document")
+	assert.Nil(t, z)
+
+	z, err = transformrule.Parse(transformrule.Options{}, `
+transforms:
+- id: bad-remove-header
+  phase: response
+  ops:
+  - type: remove-header
+    name: "Bad Header"
+  priority: 0
+`)
+	require.Error(t, err, "an invalid header name rejects the whole document")
+	assert.Nil(t, z)
+}
+
+func TestParse_InvalidHeaderValueRejectsWholeDocument(t *testing.T) {
+	t.Parallel()
+
+	// A header value carrying a bare CR/LF is invalid and must reject the
+	// whole document, same as an invalid name.
+	z, err := transformrule.Parse(transformrule.Options{}, "transforms:\n"+
+		"- id: bad-value\n"+
+		"  phase: response\n"+
+		"  ops:\n"+
+		"  - type: set-header\n"+
+		"    name: X-Bad\n"+
+		"    value: \"line1\\rline2\"\n"+
+		"  priority: 0\n")
+	require.Error(t, err, "an invalid header value rejects the whole document")
+	assert.Nil(t, z)
+}
+
+func TestParse_ValidHeaderNameValueUnchanged(t *testing.T) {
+	t.Parallel()
+
+	// Valid header names/values (including hyphenated, mixed-case names and an
+	// ordinary value) still compile and apply exactly as before.
+	z, err := transformrule.Parse(transformrule.Options{}, `
+transforms:
+- id: ok
+  phase: response
+  ops:
+  - type: set-header
+    name: X-Custom-Header
+    value: "some value; with=punctuation"
+  - type: remove-header
+    name: Server
+  priority: 0
+`)
+	require.NoError(t, err)
+	require.NotNil(t, z)
+
+	w := serve(t, z, httptest.NewRequest(http.MethodGet, "/", nil), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Server", "origin/1.0")
+		w.WriteHeader(http.StatusOK)
+	})
+	assert.Equal(t, "some value; with=punctuation", w.Header().Get("X-Custom-Header"))
+	assert.Empty(t, w.Header().Get("Server"))
+}


### PR DESCRIPTION
## Summary

Review finding 19 (nit): `transformrule`'s `set-header`/`remove-header` ops accepted any `op.Name` string at compile time; an invalid header-name token (or, for `set-header`, an invalid value) only misbehaved when net/http silently dropped it at request/response emit time, instead of being caught by the package's all-or-nothing compile model.

## What changed and why

- `compileReqOps`/`compileRespOps` in `transformrule/transformrule.go` now validate the `set-header`/`remove-header` op's `Name` via `httpguts.ValidHeaderFieldName` (`golang.org/x/net/http/httpguts`, already a module dependency) and `set-header`'s `Value` via `httpguts.ValidHeaderFieldValue`, wrapped in the same `fmt.Errorf` style used by the other op validators in the file.
- A rejected op now bubbles up through `compileRule` → `Parse`'s existing all-or-nothing path, so a typo'd rule fails the whole document and the controller keeps the last-good zone live — matching the package doc comment's compile model.
- No `go.mod`/`go.sum` changes: `golang.org/x/net` is already a transitive dependency; only a new subpackage import.

## Test plan

- [x] `gofmt -l .` — clean
- [x] `go vet ./...`
- [x] `go test ./...` (890 tests) and `go test ./transformrule/... -race` — all pass
- [x] New tests in `transformrule/transformrule_test.go`:
  - `TestParse_InvalidHeaderNameRejectsWholeDocument` — bad `set-header`/`remove-header` name rejects the whole document
  - `TestParse_InvalidHeaderValueRejectsWholeDocument` — bad `set-header` value (bare CR) rejects the whole document
  - `TestParse_ValidHeaderNameValueUnchanged` — existing valid rules still compile and apply unchanged