### PR TITLE
fix(plugin): fail closed on malformed auth annotations

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -63,8 +63,8 @@ All keys are prefixed `parapet.moonrhythm.io/`. Applied per-Ingress.
 | `upstream-path` | path prefix | Prepend path (+ optional query) upstream |
 | `allow-remote` | comma-sep CIDRs | IP allowlist (403 otherwise; skips ACME) |
 | `strip-prefix` | path prefix | Strip prefix from request path |
-| `basic-auth` | `user:pass` | HTTP Basic Auth |
-| `forward-auth` | YAML (`url`, `authRequestHeaders`, `authResponseHeaders`) | Delegate auth to an external service |
+| `basic-auth` | `user:pass` | HTTP Basic Auth. A non-empty but malformed value (no colon, empty user, or empty pass) fails closed: all requests get 403, logged once at plugin time |
+| `forward-auth` | YAML (`url`, `authRequestHeaders`, `authResponseHeaders`) | Delegate auth to an external service. A non-empty but malformed value (bad YAML, missing/empty `url`, or unparsable `url`) fails closed: all requests get 403, logged once at plugin time |
 | `waf-zone` | zone id, or `ns/id` | Bind the Ingress to a WAF zone (see [WAF.md](WAF.md)) |
 | `coraza-zone` | zone id, or `ns/id` | Bind the Ingress to a Coraza (OWASP CRS / SecLang) zone (see [CORAZA.md](CORAZA.md)); inert when `CORAZA_ENABLED` is off. Cross-namespace refs allowed (the WAF model — rulesets are stateless) |
 | `ratelimit-zone` | zone id (same-namespace only) | Bind the Ingress to a rate-limit zone (see [RATELIMIT.md](RATELIMIT.md)); inert when `RATELIMIT_ENABLED` is off. Cross-namespace refs are NOT honored (zones carry shared counter state) |

--- a/plugin/auth.go
+++ b/plugin/auth.go
@@ -1,15 +1,30 @@
 package plugin
 
 import (
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
+	"github.com/moonrhythm/parapet"
 	"github.com/moonrhythm/parapet/pkg/authn"
 	"github.com/moonrhythm/parapet/pkg/headers"
 	"gopkg.in/yaml.v3"
 )
+
+// denyAll mounts a middleware that answers 403 Forbidden to every request,
+// without ever reaching the upstream. Used when an auth annotation is
+// present but malformed: failing open (mounting nothing) would let
+// unauthenticated traffic through an ingress that declares itself gated, so
+// a bad annotation must fail closed instead.
+func denyAll(ctx Context) {
+	ctx.Use(parapet.MiddlewareFunc(func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+		})
+	}))
+}
 
 var authHTTPClient = &http.Client{
 	Timeout: 10 * time.Second,
@@ -38,10 +53,16 @@ func BasicAuth(ctx Context) {
 
 	xs := strings.SplitN(ba, ":", 2)
 	if len(xs) != 2 {
+		slog.Error("plugin/BasicAuth: malformed basic-auth annotation, failing closed",
+			"ingress", ctx.ingressID())
+		denyAll(ctx)
 		return
 	}
 	user, pass := xs[0], xs[1]
 	if user == "" || pass == "" {
+		slog.Error("plugin/BasicAuth: malformed basic-auth annotation, failing closed",
+			"ingress", ctx.ingressID())
+		denyAll(ctx)
 		return
 	}
 
@@ -61,10 +82,22 @@ func ForwardAuth(ctx Context) {
 	}
 	err := yaml.Unmarshal([]byte(a), &obj)
 	if err != nil {
+		slog.Error("plugin/ForwardAuth: malformed forward-auth annotation, failing closed",
+			"ingress", ctx.ingressID(), "error", err)
+		denyAll(ctx)
+		return
+	}
+	if obj.URL == "" {
+		slog.Error("plugin/ForwardAuth: malformed forward-auth annotation, failing closed",
+			"ingress", ctx.ingressID(), "error", "missing url")
+		denyAll(ctx)
 		return
 	}
 	u, err := url.Parse(obj.URL)
 	if err != nil {
+		slog.Error("plugin/ForwardAuth: malformed forward-auth annotation, failing closed",
+			"ingress", ctx.ingressID(), "error", err)
+		denyAll(ctx)
 		return
 	}
 	// Make every response on a forward-auth-gated ingress non-cacheable at the

--- a/plugin/auth_test.go
+++ b/plugin/auth_test.go
@@ -62,6 +62,49 @@ func TestBasicAuth(t *testing.T) {
 	})
 }
 
+// TestBasicAuthMalformedFailsClosed guards against fail-open: a present but
+// malformed basic-auth annotation must deny every request with 403 rather
+// than silently mounting nothing (which would leave the ingress
+// unauthenticated).
+func TestBasicAuthMalformedFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		auth string
+	}{
+		{"NoColon", "nocolon"},
+		{"EmptyUser", ":onlypass"},
+		{"EmptyPass", "user:"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := Context{
+				Middlewares: &parapet.Middlewares{},
+				Ingress: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"parapet.moonrhythm.io/basic-auth": c.auth,
+						},
+					},
+				},
+			}
+			BasicAuth(ctx)
+
+			var called bool
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			w := httptest.NewRecorder()
+			ctx.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+			})).ServeHTTP(w, r)
+
+			assert.False(t, called)
+			assert.Equal(t, http.StatusForbidden, w.Code)
+		})
+	}
+}
+
 func TestForwardAuth(t *testing.T) {
 	t.Parallel()
 
@@ -124,6 +167,47 @@ authRequestHeaders:
 		})).ServeHTTP(w, r)
 		assert.False(t, called)
 	})
+}
+
+// TestForwardAuthMalformedFailsClosed guards against fail-open: a present
+// but malformed forward-auth annotation (bad YAML or a missing/empty url)
+// must deny every request with 403 rather than silently mounting nothing.
+func TestForwardAuthMalformedFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		config string
+	}{
+		{"BadYAML", "url: [unterminated"},
+		{"EmptyURL", "authRequestHeaders:\n- authorization\n"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := Context{
+				Middlewares: &parapet.Middlewares{},
+				Ingress: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"parapet.moonrhythm.io/forward-auth": c.config,
+						},
+					},
+				},
+			}
+			ForwardAuth(ctx)
+
+			var called bool
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			w := httptest.NewRecorder()
+			ctx.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+			})).ServeHTTP(w, r)
+
+			assert.False(t, called)
+			assert.Equal(t, http.StatusForbidden, w.Code)
+		})
+	}
 }
 
 // TestForwardAuthDoesNotFollowRedirect guards against a fail-open: an auth


### PR DESCRIPTION
## Summary

Review finding 2 (high, security): `plugin/auth.go` silently mounted nothing when a `basic-auth`/`forward-auth` annotation was present but malformed — `BasicAuth` on a bad colon split or empty user/pass, `ForwardAuth` on a YAML unmarshal error, a missing/empty `url`, or a `url.Parse` failure. Traffic flowed unauthenticated through an ingress whose annotation implied gating, with no log line to surface the problem.

## What changed

- Added a `denyAll(ctx)` helper (`plugin/auth.go`) that mounts a `parapet.MiddlewareFunc` answering `403 Forbidden` to every request.
- `BasicAuth`: on a non-empty but malformed value (no colon, empty user, or empty pass), logs `slog.Error` once at plugin time with `ctx.ingressID()` and calls `denyAll` instead of returning silently.
- `ForwardAuth`: on a non-empty but malformed value (YAML error, empty/missing `url`, or `url.Parse` error), same treatment — `slog.Error` + `denyAll`.
- The valid-annotation path (including the `Cache-Control: private` middleware and its ordering ahead of the authenticator) is unchanged.
- `SPEC.md`: noted under `basic-auth`/`forward-auth` that a malformed non-empty value fails closed (403 for all requests, logged once).

## Why this approach

Fail-closed matches the security intent of the annotation: a present auth annotation that fails to parse should never be equivalent to "no auth annotation." A single deny-all middleware, mounted once per Ingress reload (not per request), keeps the change minimal and consistent with how other plugins already log-and-degrade (e.g. `AllowRemote`'s empty-CIDR-list case).

## Testing

- `gofmt -l .` — clean
- `go vet ./...` — clean
- `go test ./...` — all pass (894 tests, 28 packages)
- `go test -race ./plugin/...` — all pass (75 tests)
- New table-driven tests in `plugin/auth_test.go`:
  - `TestBasicAuthMalformedFailsClosed`: `nocolon`, `:onlypass`, `user:` → 403
  - `TestForwardAuthMalformedFailsClosed`: malformed YAML, empty `url` → 403
  - Existing valid-path tests (`TestBasicAuth`, `TestForwardAuth`, `TestForwardAuthDoesNotFollowRedirect`) unchanged and still passing