### PR TITLE
fix: log non-retryable handler panics before answering 502

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
+	"runtime/debug"
 	"time"
 
 	"github.com/moonrhythm/parapet-ingress-controller/proxy"
@@ -35,6 +37,13 @@ func retryMiddleware(h http.Handler) http.Handler {
 					// retry
 					return
 				}
+				// Anything reaching here isn't an expected retryable dial
+				// failure, so it's likely a programming error (e.g. nil
+				// deref) somewhere in the middleware chain. Log it so it's
+				// distinguishable from an ordinary upstream failure — the
+				// 502 stays the response since re-panicking would reset the
+				// client connection and complicate the retry loop.
+				slog.Error("retry: recovered panic", "error", e, "stack", string(debug.Stack()))
 				http.Error(w, "Bad Gateway", http.StatusBadGateway)
 			}
 			ok = true

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,8 +1,10 @@
 package controller
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -78,4 +80,28 @@ func TestRetryMiddleware(t *testing.T) {
 		assert.Equal(t, int32(1), calls.Load(), "non-retryable error served once")
 		assert.Equal(t, http.StatusBadGateway, w.Code)
 	})
+}
+
+// A non-retryable panic is a programming error (e.g. nil deref) somewhere in
+// the middleware chain, indistinguishable from an upstream dial failure
+// unless it's logged. It must still answer 502 without retrying.
+func TestRetryMiddlewareLogsUnexpectedPanic(t *testing.T) {
+	// Not parallel: temporarily swaps the slog default to capture output. (Go runs
+	// non-parallel tests sequentially, so no concurrent slog user races the swap.)
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})))
+	defer slog.SetDefault(prev)
+
+	var calls atomic.Int32
+	r := httptest.NewRequest(http.MethodGet, "http://svc/", nil)
+	w := httptest.NewRecorder()
+	retryMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		calls.Add(1)
+		panic(errors.New("boom"))
+	})).ServeHTTP(w, r)
+
+	assert.Equal(t, int32(1), calls.Load(), "non-retryable error served once")
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.Contains(t, buf.String(), "boom", "the recovered panic must be logged")
 }


### PR DESCRIPTION
## Review finding 13
`retry.go`'s `tryServe` recovered ALL panics and answered 502 with no logging — a programming error (e.g. nil deref) anywhere in the middleware chain was indistinguishable from an upstream dial failure.

## What changed
On the recover path in `tryServe`, when the recovered value is neither `context.Canceled` nor a retryable dial panic (i.e. the path that already answers 502), `slog.Error` now logs the recovered value plus `runtime/debug.Stack()` before writing the response. The expected retryable-dial panics and the client-cancel path are left unlogged. The 502 response itself is unchanged (re-panicking was rejected per the triage — it would reset the client connection and complicate the retry loop).

## Testing
- Added `TestRetryMiddlewareLogsUnexpectedPanic` in `retry_test.go` (same slog-capture pattern used by `plugin/plugin_test.go`'s `TestAllowRemoteAllInvalidCIDRsLogsAndBlocks`): a handler panicking with a non-dial error is served once, answers 502, and the recovered value appears in the log output.
- `gofmt -l .` — clean
- `go vet ./...` — clean
- `go test ./...` — 888 passed
- `go test -race -run 'TestRetryMiddleware' .` — passed