### PR TITLE
fix(plugin): allow-remote matches the trusted client IP, not the TCP peer

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -61,7 +61,7 @@ All keys are prefixed `parapet.moonrhythm.io/`. Applied per-Ingress.
 | `upstream-protocol` | `http` / `https` | Force upstream scheme |
 | `upstream-host` | hostname | Override `Host` sent upstream |
 | `upstream-path` | path prefix | Prepend path (+ optional query) upstream |
-| `allow-remote` | comma-sep CIDRs | IP allowlist (403 otherwise; skips ACME) |
+| `allow-remote` | comma-sep CIDRs | IP allowlist (403 otherwise; skips ACME); matches the parapet-resolved client IP (`X-Real-Ip`, trusted per `TRUST_PROXY`), not the TCP peer — same resolution as WAF/rate-limit/geo (`geoip.ClientIP`). Behind the edge or any trusted L7 hop this means an allowlist keyed on the *original client*, not the hop; configs that intentionally allowlisted a proxy/hop CIDR will need to allowlist the real client CIDR instead |
 | `strip-prefix` | path prefix | Strip prefix from request path |
 | `basic-auth` | `user:pass` | HTTP Basic Auth |
 | `forward-auth` | YAML (`url`, `authRequestHeaders`, `authResponseHeaders`) | Delegate auth to an external service |

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/yaml.v3"
 	networking "k8s.io/api/networking/v1"
 
+	"github.com/moonrhythm/parapet-ingress-controller/geoip"
 	"github.com/moonrhythm/parapet-ingress-controller/metric/observe"
 	"github.com/moonrhythm/parapet-ingress-controller/state"
 )
@@ -290,8 +291,12 @@ func AllowRemote(ctx Context) {
 			return false
 		}
 
-		remoteHost, _, _ := net.SplitHostPort(r.RemoteAddr)
-		remoteIP := net.ParseIP(remoteHost)
+		// Match the parapet-resolved client IP (X-Real-Ip, trusted per
+		// TRUST_PROXY), not the immediate TCP peer: behind the edge or any
+		// trusted L7 hop, r.RemoteAddr is the hop's IP, so an allowlist keyed
+		// on it would never match. geoip.ClientIP mirrors WAF/rate-limit/geo
+		// precedence and falls back to RemoteAddr when no header is set.
+		remoteIP := geoip.ClientIP(r)
 		for _, allow := range allowList {
 			if allow.Contains(remoteIP) {
 				return false

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -404,6 +404,36 @@ func TestAllowRemote(t *testing.T) {
 		assert.True(t, called)
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
+
+	// X-Real-Ip is the parapet-resolved client IP (set by the trust middleware;
+	// overwritten for untrusted peers, so it is safe to trust mid-chain). It must
+	// take precedence over RemoteAddr, which behind the edge/any trusted L7 hop is
+	// only the hop's IP.
+	t.Run("X-Real-Ip allow overrides denying RemoteAddr", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Set("X-Real-Ip", "192.168.0.32")
+		r.RemoteAddr = "10.0.0.1:1234" // hop IP, not in the allow-list
+		w := httptest.NewRecorder()
+		var called bool
+		ctx.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		})).ServeHTTP(w, r)
+		assert.True(t, called)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("X-Real-Ip deny overrides allowing RemoteAddr", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Set("X-Real-Ip", "192.168.1.32")
+		r.RemoteAddr = "127.0.0.1:1234" // hop IP, in the allow-list
+		w := httptest.NewRecorder()
+		var called bool
+		ctx.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		})).ServeHTTP(w, r)
+		assert.False(t, called)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
 }
 
 func TestAllowRemoteAllInvalidCIDRsLogsAndBlocks(t *testing.T) {


### PR DESCRIPTION
## Review finding
Finding 12 (medium): `plugin.AllowRemote` checked `r.RemoteAddr` — the immediate TCP peer. Parapet resolves the trusted client IP into `X-Real-Ip` (it never rewrites `RemoteAddr`), and WAF / rate limit / GeoIP all key on that header. Behind the edge or any trusted L7 hop, an `allow-remote` allowlist can never match (the predicate only ever sees the hop's IP), so the annotation silently blocks all traffic.

## What changed and why
- `plugin/plugin.go`: `AllowRemote`'s block predicate now resolves the client IP via `geoip.ClientIP` (trusted `X-Real-Ip` → first `X-Forwarded-For` → `RemoteAddr` fallback) instead of parsing `r.RemoteAddr` directly. This is the same precedence already used by the WAF/rate-limit/GeoIP resolvers, and is sound to trust mid-chain because parapet's `proxy` middleware (`github.com/moonrhythm/parapet@v0.18.5/proxy.go`, `distrust()`) unconditionally overwrites `X-Real-Ip`/`X-Forwarded-For` with the real peer IP for untrusted requests — an untrusted client can't spoof it.
- The acme-challenge exemption and the all-invalid-CIDR error log are unchanged.
- `SPEC.md`: documented that `allow-remote` matches the parapet-resolved client IP (`X-Real-Ip`, trusted per `TRUST_PROXY`), not the TCP peer, and called out the behavior change for configs that previously allowlisted hop/proxy CIDRs.

## Testing
- Added two subtests to `TestAllowRemote` in `plugin/plugin_test.go`: no-`X-Real-Ip` behavior (existing tests) is unchanged, and `X-Real-Ip` present now drives the allow/deny decision even when `RemoteAddr` would give the opposite answer.
- `gofmt -l .` — clean
- `go vet ./...` — clean
- `go test ./...` — all pass (889 tests, 28 packages)
- `go test -race ./plugin/... ./geoip/...` — all pass