### PR TITLE
fix(edge): refuse startup on an unusable EDGE_CP_CA pin

### DIFF
--- a/cmd/edge-proxy/main.go
+++ b/cmd/edge-proxy/main.go
@@ -64,11 +64,15 @@ func main() {
 	}
 	var caPEM []byte
 	if p := os.Getenv("EDGE_CP_CA"); p != "" {
-		if b, err := os.ReadFile(p); err == nil {
-			caPEM = b
-		} else {
-			slog.Warn("edge: cannot read EDGE_CP_CA; using system roots", "path", p, "error", err)
+		// An explicit CA pin must never fail open to system roots: this channel
+		// carries the bearer token and TLS private keys, so an unreadable file is
+		// fatal rather than a silent fall-back.
+		b, err := os.ReadFile(p)
+		if err != nil {
+			slog.Error("edge: cannot read EDGE_CP_CA", "path", p, "error", err)
+			os.Exit(1)
 		}
+		caPEM = b
 	}
 	upstreamAddr := envOr("EDGE_UPSTREAM_ADDR", "parapet:80")
 	upstreamTLS := envOr("EDGE_UPSTREAM_TLS", "false") == "true"

--- a/edge/cp.go
+++ b/edge/cp.go
@@ -38,8 +38,10 @@ type CpClient struct {
 }
 
 // NewCpClient builds a client for base (e.g. https://controlplane:8443). caPEM,
-// when non-empty, is added as a trusted root (for a private CA); an unparseable
-// CA is ignored (system roots are used). A bad/empty base is reported.
+// when non-empty, is added as a trusted root (for a private CA) — an explicit
+// pin, so a caPEM that yields zero certs is an error rather than a silent
+// fall-back to system roots (this connection carries the bearer token and TLS
+// private keys; it must never fail open). A bad/empty base is also reported.
 func NewCpClient(base, token string, caPEM []byte) (*CpClient, error) {
 	if _, err := url.Parse(base); err != nil {
 		return nil, fmt.Errorf("edge: invalid control-plane endpoint %q: %w", base, err)
@@ -48,9 +50,10 @@ func NewCpClient(base, token string, caPEM []byte) (*CpClient, error) {
 	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 	if len(caPEM) > 0 {
 		pool := x509.NewCertPool()
-		if pool.AppendCertsFromPEM(caPEM) {
-			tlsConfig.RootCAs = pool
+		if !pool.AppendCertsFromPEM(caPEM) {
+			return nil, fmt.Errorf("edge: EDGE_CP_CA does not contain a valid PEM certificate")
 		}
+		tlsConfig.RootCAs = pool
 	}
 	transport := &http.Transport{
 		TLSClientConfig: tlsConfig,

--- a/edge/cp_test.go
+++ b/edge/cp_test.go
@@ -9,6 +9,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewCpClient_EmptyCAUsesSystemRoots(t *testing.T) {
+	cp, err := NewCpClient("https://controlplane:8443", "tok", nil)
+	require.NoError(t, err)
+	assert.NotNil(t, cp)
+}
+
+func TestNewCpClient_ValidCAPEMIsOK(t *testing.T) {
+	caPEM, _ := genCertPEM(t, "controlplane")
+	cp, err := NewCpClient("https://controlplane:8443", "tok", caPEM)
+	require.NoError(t, err)
+	assert.NotNil(t, cp)
+}
+
+func TestNewCpClient_GarbageCAPEMIsFatalError(t *testing.T) {
+	// An explicit EDGE_CP_CA pin must never silently fall back to system roots
+	// (this channel carries the bearer token and TLS private keys).
+	cp, err := NewCpClient("https://controlplane:8443", "tok", []byte("not a pem certificate"))
+	assert.Error(t, err)
+	assert.Nil(t, cp)
+}
+
 func TestCpClient_FetchCert200ParsesBodyAndEtagAndSendsBearer(t *testing.T) {
 	var gotAuth, gotPath, gotQuery string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Review finding 5 (high, security): `edge/cp.go`'s `NewCpClient` silently fell back to system roots when a non-empty `caPEM` failed to parse (`x509.AppendCertsFromPEM` returning false left `RootCAs` nil), and the doc comment explicitly said "an unparseable CA is ignored." `cmd/edge-proxy` compounded this by only warning when `EDGE_CP_CA` pointed at an unreadable file. This channel carries the edge bearer token and TLS private keys, so an explicit CA pin must fail closed, matching the posture `trust.NewClient` already has.

- `edge/cp.go`: `NewCpClient` now returns an error when `caPEM` is non-empty but `AppendCertsFromPEM` yields zero certs, instead of silently using system roots. Doc comment updated to describe the fail-closed behavior.
- `cmd/edge-proxy/main.go`: reading `EDGE_CP_CA` now exits fatally (`os.Exit(1)`) when the file is set but unreadable, instead of warning and falling back to system roots. The existing `NewCpClient` error path already exited fatally, so a rejected PEM is covered by that.

## Test plan
- Added `TestNewCpClient_EmptyCAUsesSystemRoots`, `TestNewCpClient_ValidCAPEMIsOK`, `TestNewCpClient_GarbageCAPEMIsFatalError` in `edge/cp_test.go`.
- `gofmt -l .` clean
- `go vet ./...` clean
- `go test ./...` — 890 passed, 28 packages
- `go test -race ./edge/... ./trust/...` — 197 passed, 2 packages (also exercises the real `edge.NewCpClient` + `trust.NewClient` combo in `trust/e2e_test.go`)