### PR TITLE
fix(cert): normalize trailing-dot SNI in certificate lookup

### DIFF
--- a/cert/table.go
+++ b/cert/table.go
@@ -27,7 +27,10 @@ func (t *Table) Get(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) 
 	certs := t.nameToCertificate
 	t.mu.RUnlock()
 
-	name := strings.ToLower(clientHello.ServerName)
+	// RFC 6066 forbids a trailing dot in SNI, but some non-compliant clients
+	// send one anyway; trim it so "example.com." still matches the SAN
+	// "example.com".
+	name := strings.TrimSuffix(strings.ToLower(clientHello.ServerName), ".")
 
 	// exact name
 	if cert, ok := certs[name]; ok {

--- a/cert/table_test.go
+++ b/cert/table_test.go
@@ -56,6 +56,37 @@ func TestTable(t *testing.T) {
 		}
 	})
 
+	t.Run("ExactTrailingDot", func(t *testing.T) {
+		table := Table{}
+		certs := []*tls.Certificate{
+			{
+				Leaf: &x509.Certificate{
+					DNSNames: []string{
+						"example.com",
+					},
+				},
+			},
+			{
+				Leaf: &x509.Certificate{
+					DNSNames: []string{
+						"*.example.com",
+					},
+				},
+			},
+		}
+		table.Set(certs)
+		// RFC 6066 forbids a trailing dot, but non-compliant clients send one;
+		// it must still resolve the exact SAN.
+		cert, err := table.Get(&tls.ClientHelloInfo{
+			ServerName:        "example.com.",
+			SupportedVersions: []uint16{tls.VersionTLS13},
+		})
+		assert.NoError(t, err)
+		if assert.NotNil(t, cert) {
+			assert.Equal(t, certs[0], cert)
+		}
+	})
+
 	t.Run("Wildcard", func(t *testing.T) {
 		table := Table{}
 		certs := []*tls.Certificate{
@@ -77,6 +108,35 @@ func TestTable(t *testing.T) {
 		table.Set(certs)
 		cert, err := table.Get(&tls.ClientHelloInfo{
 			ServerName:        "www.example.com",
+			SupportedVersions: []uint16{tls.VersionTLS13},
+		})
+		assert.NoError(t, err)
+		if assert.NotNil(t, cert) {
+			assert.Equal(t, certs[1], cert)
+		}
+	})
+
+	t.Run("WildcardTrailingDot", func(t *testing.T) {
+		table := Table{}
+		certs := []*tls.Certificate{
+			{
+				Leaf: &x509.Certificate{
+					DNSNames: []string{
+						"example.com",
+					},
+				},
+			},
+			{
+				Leaf: &x509.Certificate{
+					DNSNames: []string{
+						"*.example.com",
+					},
+				},
+			},
+		}
+		table.Set(certs)
+		cert, err := table.Get(&tls.ClientHelloInfo{
+			ServerName:        "www.example.com.",
 			SupportedVersions: []uint16{tls.VersionTLS13},
 		})
 		assert.NoError(t, err)

--- a/edge/certstore.go
+++ b/edge/certstore.go
@@ -13,6 +13,7 @@ package edge
 
 import (
 	"crypto/tls"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -118,12 +119,26 @@ func (s *CertStore) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate
 		return c, nil
 	}
 	if s.onDemand != nil && hello.ServerName != "" {
-		s.fetchOnDemand(hello.ServerName)
-		if c, _ := s.table.Get(hello); c != nil {
-			return c, nil
+		// Normalize identically to cert.Table.Get and the control plane's authz/store
+		// (RFC 6066 forbids a trailing dot, but non-compliant clients send one) so the
+		// fetch key, negative cache, and CP authorization all agree on the same SNI —
+		// otherwise "example.com." and "example.com" fetch (and negative-cache) as two
+		// distinct domains, causing repeated on-demand churn.
+		sni := normalizeSNI(hello.ServerName)
+		if sni != "" {
+			s.fetchOnDemand(sni)
+			if c, _ := s.table.Get(hello); c != nil {
+				return c, nil
+			}
 		}
 	}
 	return nil, nil // -> self-signed fallback (client sees "unknown authority")
+}
+
+// normalizeSNI lowercases and trims a trailing dot, matching cert.Table.Get and
+// edgecp's CertStore.Get/Authz.Allowed so lookup, fetch key, and CP authz agree.
+func normalizeSNI(sni string) string {
+	return strings.ToLower(strings.TrimSuffix(sni, "."))
 }
 
 // fetchOnDemand resolves a missing SNI through the control plane under three guards:

--- a/edge/certstore_test.go
+++ b/edge/certstore_test.go
@@ -95,6 +95,30 @@ func TestCertStore_OnDemandFetchOnMiss(t *testing.T) {
 	assert.False(t, get(s, "denied.com"))
 }
 
+func TestCertStore_OnDemandFetchKeyNormalizesTrailingDotAndCase(t *testing.T) {
+	s := NewCertStore()
+	var got []string
+	s.SetOnDemand(func(sni string) {
+		got = append(got, sni)
+		if sni == "lazy.com" {
+			c, k := genCertPEM(t, "lazy.com")
+			s.Update(sni, c, k, "")
+		}
+	})
+	// RFC 6066 forbids a trailing dot, but non-compliant clients send one; the
+	// fetch key must match the lowercase, dot-trimmed form the control plane
+	// (and cert.Table.Get) normalize to, or every variant re-fetches/negative-
+	// caches as a distinct domain.
+	assert.True(t, get(s, "Lazy.Com."), "on-demand fetch normalizes SNI before fetching")
+	require.Len(t, got, 1)
+	assert.Equal(t, "lazy.com", got[0], "fetch key is lowercased and trailing-dot-trimmed")
+	// a subsequent lookup with a different case/dot variant is served from the
+	// already-populated store without another fetch.
+	assert.True(t, get(s, "lazy.com"))
+	assert.True(t, get(s, "LAZY.COM."))
+	assert.Len(t, got, 1)
+}
+
 func TestCertStore_OnDemandNegativeCacheSuppressesRepeat(t *testing.T) {
 	s := NewCertStore()
 	var calls int32


### PR DESCRIPTION
## Review finding

Finding 8 (medium): `cert/table.go`'s `Get` only lowercases the SNI, so a client sending a trailing-dot SNI ("example.com.") misses the SAN "example.com" and falls through to the self-signed fallback — and on the edge in serve-all mode, causes repeated on-demand fetch churn. `edgecp` already trims the dot (`edgecp/certstore.go`, `edgecp/authz.go`); the table and the edge fetch key must agree.

## What changed and why

- `cert/table.go`: `Get` now does `strings.TrimSuffix(name, ".")` after `strings.ToLower`, matching the normalization `edgecp.CertStore.Get` and `edgecp.Authz.Allowed` already apply.
- `edge/certstore.go`: the SNI-miss on-demand fetch path (`GetCertificate` → `fetchOnDemand`) now normalizes the SNI (lowercase + trim trailing dot) via a new `normalizeSNI` helper before using it as the fetch key, negative-cache key, and single-flight key — so the on-demand fetch, its negative cache, the cached-cert key, and the control plane's own normalization (which the CP already applies server-side) all agree on one canonical form instead of treating case/dot variants of the same host as distinct domains.

## Testing

- `cert/table_test.go`: added `ExactTrailingDot` and `WildcardTrailingDot` subtests confirming `"example.com."` resolves the exact SAN and `"www.example.com."` resolves the wildcard SAN.
- `edge/certstore_test.go`: added `TestCertStore_OnDemandFetchKeyNormalizesTrailingDotAndCase`, confirming a mixed-case, trailing-dot SNI ("Lazy.Com.") fetches under the normalized key "lazy.com", and that subsequent lookups with other case/dot variants of the same host are served from the store without a second fetch.
- `gofmt -l .` — clean
- `go vet ./...` — clean
- `go test ./...` — all packages pass
- `go test -race -v ./cert/... ./edge/...` — all pass