### PR TITLE
fix(plugin): restrict redirect sources to hosts owned by the ingress

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -55,7 +55,7 @@ All keys are prefixed `parapet.moonrhythm.io/`. Applied per-Ingress.
 |---|---|---|
 | `redirect-https` | `"true"` | 301 HTTP→HTTPS (skips `/.well-known/acme-challenge`) |
 | `hsts` | `"preload"` / any | Strict-Transport-Security header |
-| `redirect` | YAML map `host: url` (or `host: "code,url"`) | Host-level redirect rules |
+| `redirect` | YAML map `host: url` (or `host: "code,url"`, `code` a 3xx) | Host-level redirect rules. The source host (the segment before the first `/`) must be a host the Ingress owns via `spec.rules[].host` or `spec.tls[].hosts` (exact, or an owned single-label `*.` wildcard); unowned sources are rejected so one tenant can't hijack another's host. A `code` outside 300–399 rejects the entry |
 | `ratelimit-s` / `-m` / `-h` | integer | Fixed-window requests per second / minute / hour |
 | `body-limitrequest` | bytes (int64) | Max request body size (413 above) |
 | `upstream-protocol` | `http` / `https` | Force upstream scheme |

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -102,10 +102,22 @@ func RedirectRules(ctx Context) {
 				"ingress", ctx.ingressID(), "error", err)
 			return
 		}
+		owned := ownedHosts(ctx.Ingress)
 		for srcHost, targetURL := range obj {
 			if srcHost == "" || targetURL == "" || strings.HasPrefix(srcHost, "/") {
 				continue
 			}
+
+			// The Routes map is shared across every ingress in the watch
+			// namespace(s) — last writer wins. Only let an ingress register a
+			// source host it actually owns via spec.rules / spec.tls, otherwise
+			// one tenant could hijack another tenant's host.
+			if h, _, _ := strings.Cut(srcHost, "/"); !hostOwned(owned, strings.ToLower(h)) {
+				slog.Error("plugin/RedirectRules: source host not owned by ingress, skipping",
+					"ingress", ctx.ingressID(), "src", srcHost)
+				continue
+			}
+
 			if !strings.HasSuffix(srcHost, "/") {
 				srcHost += "/"
 			}
@@ -114,10 +126,15 @@ func RedirectRules(ctx Context) {
 			status := http.StatusFound
 			if ts := strings.SplitN(targetURL, ",", 2); len(ts) == 2 {
 				st, _ := strconv.Atoi(ts[0])
-				if st > 0 {
-					status = st
-					target = ts[1]
+				// Only a 3xx status makes sense for a redirect; reject anything
+				// else outright rather than mistaking "<status>,<url>" for a URL.
+				if st < 300 || st > 399 {
+					slog.Error("plugin/RedirectRules: redirect status must be 3xx, skipping",
+						"ingress", ctx.ingressID(), "src", srcHost, "status", ts[0])
+					continue
 				}
+				status = st
+				target = ts[1]
 			}
 
 			ctx.Routes[srcHost] = ctx.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -126,6 +143,40 @@ func RedirectRules(ctx Context) {
 			slog.Debug("plugin/RedirectRules: registered", "src", srcHost, "target", target, "status", status)
 		}
 	}
+}
+
+// ownedHosts returns the lowercased set of hosts the ingress declares via
+// spec.rules[].host and spec.tls[].hosts.
+func ownedHosts(ing *networking.Ingress) map[string]struct{} {
+	owned := make(map[string]struct{})
+	for _, rule := range ing.Spec.Rules {
+		if rule.Host != "" {
+			owned[strings.ToLower(rule.Host)] = struct{}{}
+		}
+	}
+	for _, t := range ing.Spec.TLS {
+		for _, h := range t.Hosts {
+			if h != "" {
+				owned[strings.ToLower(h)] = struct{}{}
+			}
+		}
+	}
+	return owned
+}
+
+// hostOwned reports whether host is in the owned set, either by exact match or
+// by an owned single-label wildcard (owned "*.example.com" matches source
+// "foo.example.com") — the same one-label semantics as cert/table.go's climb.
+func hostOwned(owned map[string]struct{}, host string) bool {
+	if _, ok := owned[host]; ok {
+		return true
+	}
+	if i := strings.IndexByte(host, '.'); i >= 0 {
+		if _, ok := owned["*"+host[i:]]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // RateLimit injects rate limit middleware

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -158,6 +158,12 @@ api.example.com: 308,https://www.example.com/api`
 					"parapet.moonrhythm.io/redirect": config,
 				},
 			},
+			Spec: networking.IngressSpec{
+				Rules: []networking.IngressRule{
+					{Host: "example.com"},
+					{Host: "api.example.com"},
+				},
+			},
 		},
 		Routes: map[string]http.Handler{},
 	}
@@ -200,6 +206,15 @@ bad.example.com: ""`
 					"parapet.moonrhythm.io/redirect": config,
 				},
 			},
+			Spec: networking.IngressSpec{
+				Rules: []networking.IngressRule{
+					{Host: "a.example.com"},
+					{Host: "b.example.com"},
+					{Host: "c.example.com"},
+					{Host: "d.example.com"},
+					{Host: "bad.example.com"},
+				},
+			},
 		},
 		Routes: map[string]http.Handler{},
 	}
@@ -209,6 +224,89 @@ bad.example.com: ""`
 		assert.Contains(t, ctx.Routes, h, "valid rule must be registered even when another entry is invalid")
 	}
 	assert.NotContains(t, ctx.Routes, "bad.example.com/")
+}
+
+func TestRedirectRulesHostOwnership(t *testing.T) {
+	t.Parallel()
+
+	config := `
+owned.example.com: https://target.example.com
+foo.wild.example.com: https://target-wild.example.com
+owned.example.com/old: https://target-path.example.com
+unowned.example.com: https://evil.example.com
+tls.example.com: https://target-tls.example.com`
+	ctx := Context{
+		Middlewares: &parapet.Middlewares{},
+		Ingress: &networking.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "ing",
+				Annotations: map[string]string{
+					"parapet.moonrhythm.io/redirect": config,
+				},
+			},
+			Spec: networking.IngressSpec{
+				Rules: []networking.IngressRule{
+					{Host: "owned.example.com"},
+					{Host: "*.wild.example.com"},
+				},
+				TLS: []networking.IngressTLS{
+					{Hosts: []string{"tls.example.com"}},
+				},
+			},
+		},
+		Routes: map[string]http.Handler{},
+	}
+	RedirectRules(ctx)
+
+	// exact-owned host (via spec.rules) registered
+	assert.Contains(t, ctx.Routes, "owned.example.com/")
+	// wildcard-owned source registered (owned "*.wild.example.com" matches "foo.wild.example.com")
+	assert.Contains(t, ctx.Routes, "foo.wild.example.com/")
+	// path-bearing source checked on its host part (trailing slash normalized)
+	assert.Contains(t, ctx.Routes, "owned.example.com/old/")
+	// host owned via spec.tls[].hosts registered
+	assert.Contains(t, ctx.Routes, "tls.example.com/")
+	// unowned host must be skipped — the hijack this fix prevents
+	assert.NotContains(t, ctx.Routes, "unowned.example.com/")
+}
+
+func TestRedirectRulesNon3xxStatusSkipped(t *testing.T) {
+	t.Parallel()
+
+	config := `
+owned.example.com: 200,https://target.example.com
+ok.example.com: 301,https://target-ok.example.com`
+	ctx := Context{
+		Middlewares: &parapet.Middlewares{},
+		Ingress: &networking.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"parapet.moonrhythm.io/redirect": config,
+				},
+			},
+			Spec: networking.IngressSpec{
+				Rules: []networking.IngressRule{
+					{Host: "owned.example.com"},
+					{Host: "ok.example.com"},
+				},
+			},
+		},
+		Routes: map[string]http.Handler{},
+	}
+	RedirectRules(ctx)
+
+	// a non-3xx status is rejected entirely (not treated as a URL)
+	assert.NotContains(t, ctx.Routes, "owned.example.com/")
+
+	// a valid "301,url" still works
+	if assert.Contains(t, ctx.Routes, "ok.example.com/") {
+		r := httptest.NewRequest(http.MethodGet, "http://ok.example.com/", nil)
+		w := httptest.NewRecorder()
+		ctx.Routes["ok.example.com/"].ServeHTTP(w, r)
+		assert.Equal(t, http.StatusMovedPermanently, w.Code)
+		assert.Equal(t, "https://target-ok.example.com", w.Header().Get("Location"))
+	}
 }
 
 func TestBodyLimit(t *testing.T) {


### PR DESCRIPTION
## Finding 1 (critical, multi-tenant security) + Finding 18 (nit)

`plugin.RedirectRules` wrote arbitrary host keys into the shared route map (`ctx.Routes[srcHost]`) with no check that the Ingress owns that host. Under a cluster-wide watch (`WATCH_NAMESPACE=""`) the controller merges every ingress's Routes into one map (last writer wins), so any tenant could register another tenant's host and steal its traffic. Finding 18: the `<status>,<url>` prefix accepted any `status > 0`, not just 3xx.

## What changed and why

- Build the set of hosts the Ingress owns from `spec.rules[].host` + `spec.tls[].hosts` (lowercased).
- For each redirect entry, take the host part of the source (segment before the first `/`) and register only if it matches an owned host: exact, or an owned single-label wildcard (`*.example.com` matches `foo.example.com`, the same one-label semantics as `cert/table.go`'s wildcard climb). Otherwise `slog.Error` naming the ingress + rejected source and skip.
- The `<status>,<url>` form now accepts only 300–399; anything else is logged and the entry skipped entirely (no URL fallback).
- SPEC.md redirect annotation row updated to document ownership + 3xx requirement.

## Testing

- New `TestRedirectRulesHostOwnership` (owned exact, wildcard-owned source, path-bearing source checked on host part, spec.tls-owned host, unowned host skipped) and `TestRedirectRulesNon3xxStatusSkipped` (non-3xx skipped, valid `301,url` still works).
- Existing redirect tests updated to declare owned hosts via spec.rules.
- `gofmt -l .` clean, `go vet ./...`, `go test ./...` (889 pass), `go test -race ./plugin/` pass.