### PR TITLE
fix(edgecp): re-check generation after subscribing to the trust-bundle notify channel

### DIFF
--- a/edgecp/issuance.go
+++ b/edgecp/issuance.go
@@ -160,15 +160,20 @@ func (s *Server) handleTrustBundle(w http.ResponseWriter, r *http.Request) {
 			}
 			s.genMu.Lock()
 			notify := s.genNotify
-			s.genMu.Unlock()
-			select {
-			case <-notify:
-			case <-time.After(watchTimeout):
-			case <-r.Context().Done():
-				return
-			}
-			// Re-load the snapshot: a SetSigner may have advanced it while we blocked.
+			// SetSigner stores signerState BEFORE it closes+replaces genNotify (both under
+			// genMu), so re-loading here observes any bump that raced our subscribe.
 			st = s.signerState.Load()
+			s.genMu.Unlock()
+			if st.gen <= since {
+				select {
+				case <-notify:
+				case <-time.After(watchTimeout):
+				case <-r.Context().Done():
+					return
+				}
+				// Re-load the snapshot: a SetSigner may have advanced it while we blocked.
+				st = s.signerState.Load()
+			}
 		}
 	}
 

--- a/edgecp/issuance_test.go
+++ b/edgecp/issuance_test.go
@@ -276,6 +276,49 @@ func TestTrustBundleWatchSlotReleaseReacquire(t *testing.T) {
 	waitSlots(0)
 }
 
+// A SetSigner that lands AFTER the watcher's initial stale-gen check but BEFORE it
+// captures the notify channel must not strand the watcher on the fresh (never-closed)
+// channel for watchTimeout: the handler re-loads signerState under genMu and returns the
+// already-available snapshot at once. We reproduce the window deterministically by holding
+// genMu so the watcher blocks at the capture, then applying SetSigner's store-then-swap
+// under the held lock before releasing.
+func TestTrustBundleWatchRechecksGenerationAfterSubscribe(t *testing.T) {
+	certPEM, keyPEM := testEdgeCA(t)
+	sg, _, _ := NewProvidedSigner(certPEM, keyPEM, time.Hour, time.Minute)
+	srv := NewServer(NewCertStore(), NewAuthz(nil)).WithSigner(sg, 1)
+	h := srv.Handler()
+
+	srv.genMu.Lock()
+
+	done := make(chan int, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest("GET", "/v1/trust-bundle?watch=1&since=1", nil))
+		done <- rec.Code
+	}()
+
+	// Let the watcher pass its initial (stale, gen=1) check and block on genMu.Lock while we
+	// still hold it — so its snapshot is the pre-advance one.
+	time.Sleep(20 * time.Millisecond)
+
+	// Advance the served generation exactly as SetSigner does — store the new snapshot BEFORE
+	// closing+replacing genNotify — under the lock we hold. The watcher then captures the fresh
+	// (still-open) channel; only the re-check saves it from blocking on it.
+	srv.signerState.Store(&signerGen{sg: sg, gen: 2})
+	close(srv.genNotify)
+	srv.genNotify = make(chan struct{})
+	srv.genMu.Unlock()
+
+	select {
+	case code := <-done:
+		if code != http.StatusOK {
+			t.Fatalf("watcher after subscribe-race: want 200, got %d", code)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher blocked on the fresh notify channel instead of returning the available snapshot")
+	}
+}
+
 func TestTrustBundleEndpoint(t *testing.T) {
 	certPEM, keyPEM := testEdgeCA(t)
 	sg, _, _ := NewProvidedSigner(certPEM, keyPEM, time.Hour, time.Minute)


### PR DESCRIPTION
## Review finding 15

**Problem:** In `edgecp/issuance.go` `handleTrustBundle`, between the initial `st.gen <= since` check and taking `notify := s.genNotify` under `genMu`, a concurrent `SetSigner` can advance the generation and close-and-replace `genNotify`. The watcher then blocks on the *new* channel for up to `watchTimeout` (~30s) even though fresh data is already available — not fail-open, just a delayed CA update.

## What changed and why

After capturing the notify channel under `genMu`, re-load `s.signerState` **in the same locked section** and only block when its `gen` is still `<= since`; otherwise fall through and respond with the fresh snapshot immediately.

This is sound because `SetSigner` (same file/lock) stores `signerState` *before* it closes+replaces `genNotify`, both under `genMu` — so any bump that raced the subscribe is already visible to the re-check. A one-line comment records that ordering fact. The deferred `watchGate` release still runs on the new fast-through path (no extra early `return`), so slot accounting is unchanged.

No SPEC/contract change: the served bundle is identical; only the rare up-to-30s stall is removed.

## Testing

- New `TestTrustBundleWatchRechecksGenerationAfterSubscribe` reproduces the window deterministically: it holds `genMu` so the watcher blocks at the capture after its initial stale check, applies `SetSigner`'s store-then-swap under the held lock, then releases — asserting the watcher returns 200 promptly (2s ceiling) rather than after `watchTimeout`. Verified the test **fails** (blocks ~30s) against unmodified code and **passes** with the fix.
- `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` (888 passed), `go test -race ./edgecp/` (138 passed).