### PR TITLE
fix: reject zero-entry rule documents and multi-feature labels

### DIFF
--- a/controller_coraza.go
+++ b/controller_coraza.go
@@ -152,7 +152,22 @@ func (ctrl *Controller) reloadCorazaDebounced() {
 
 	ctrl.watchedCorazaConfigMaps.Range(func(_, value any) bool {
 		cm := value.(*v1.ConfigMap)
-		switch cm.Labels[corazaLabelKey] {
+		role := cm.Labels[corazaLabelKey]
+		// Refuse a ConfigMap labeled for more than one feature (one ConfigMap per
+		// feature, by policy): both reloaders would consume all its data values,
+		// and the lenient YAML parsers cross-parse the other feature's documents to
+		// zero entries — a multi-labeled ConfigMap would quietly feed each side an
+		// empty/garbage set. Gated on a recognized Coraza role because the fs
+		// backend ignores label selectors, so this store also holds other features'
+		// ConfigMaps there — those must fall through silently, not warn.
+		if role == roleGlobal || role == roleZone {
+			if other, ok := carriesOtherFeatureLabel(cm, corazaLabelKey); ok {
+				slog.Warn("coraza: ignoring configmap that also carries another feature label; use one configmap per feature",
+					"configmap", cm.Namespace+"/"+cm.Name, "other_label", other)
+				return true
+			}
+		}
+		switch role {
 		case roleGlobal:
 			// Global rules are platform-owned: only honored from the controller's
 			// own namespace so a tenant can't inject baseline rules.

--- a/controller_coraza_test.go
+++ b/controller_coraza_test.go
@@ -176,6 +176,21 @@ func TestReloadCoraza_ConcurrentReloadsRaceFree(t *testing.T) {
 	require.NotNil(t, ctrl.LookupCorazaZone("cust/gamma"))
 }
 
+func TestReloadCoraza_IgnoresMultiLabeledConfigMap(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newCorazaController()
+	cm := corazaCM("cust", "acme", roleZone, denyAttackURI)
+	// also labeled for the WAF: a ConfigMap must carry one feature label, else
+	// both reloaders consume its data and cross-parse to empty/garbage sets.
+	cm.Labels[wafLabelKey] = roleZone
+	ctrl.watchedCorazaConfigMaps.Store("cust/acme", cm)
+	ctrl.reloadCorazaDebounced()
+
+	assert.Nil(t, ctrl.LookupCorazaZone("cust/acme"),
+		"a multi-feature-labeled configmap is refused by the coraza reload")
+}
+
 func TestReloadCoraza_DisabledIsNoop(t *testing.T) {
 	t.Parallel()
 

--- a/controller_ratelimit.go
+++ b/controller_ratelimit.go
@@ -149,18 +149,18 @@ func (ctrl *Controller) reloadRateLimitDebounced() {
 	ctrl.watchedRLConfigMaps.Range(func(_, value any) bool {
 		cm := value.(*v1.ConfigMap)
 		role := cm.Labels[rateLimitLabelKey]
-		// Refuse a ConfigMap labeled for BOTH features (one ConfigMap per
+		// Refuse a ConfigMap labeled for more than one feature (one ConfigMap per
 		// feature, by policy): both reloaders would consume all its data values,
 		// and the lenient YAML parsers cross-parse the other feature's documents
-		// to zero entries silently — a both-labeled ConfigMap would quietly feed
-		// each side an empty/garbage set instead of erroring. Gated on a
-		// recognized ratelimit role because the fs backend ignores label
-		// selectors, so this store also holds WAF-only ConfigMaps there — those
-		// must fall through silently, not warn.
+		// to zero entries — a multi-labeled ConfigMap would quietly feed each side
+		// an empty/garbage set instead of erroring. Gated on a recognized ratelimit
+		// role because the fs backend ignores label selectors, so this store also
+		// holds other features' ConfigMaps there — those must fall through
+		// silently, not warn.
 		if role == roleGlobal || role == roleZone {
-			if _, alsoWAF := cm.Labels[wafLabelKey]; alsoWAF {
-				slog.Warn("ratelimit: ignoring configmap that also carries the waf label; use one configmap per feature",
-					"configmap", cm.Namespace+"/"+cm.Name)
+			if other, ok := carriesOtherFeatureLabel(cm, rateLimitLabelKey); ok {
+				slog.Warn("ratelimit: ignoring configmap that also carries another feature label; use one configmap per feature",
+					"configmap", cm.Namespace+"/"+cm.Name, "other_label", other)
 				return true
 			}
 		}

--- a/controller_transform.go
+++ b/controller_transform.go
@@ -158,15 +158,12 @@ func (ctrl *Controller) reloadTransformDebounced() {
 		// Refuse a ConfigMap labeled for more than one feature (one ConfigMap per
 		// feature, by deployer policy): every reloader consumes all data values, so
 		// a multi-labeled ConfigMap would feed each side the other's documents,
-		// which the lenient YAML parsers cross-parse to empty/garbage sets silently.
-		if _, ok := cm.Labels[wafLabelKey]; ok {
-			slog.Warn("transform: ignoring configmap that also carries the waf label; use one configmap per feature",
-				"configmap", cm.Namespace+"/"+cm.Name)
-			return true
-		}
-		if _, ok := cm.Labels[rateLimitLabelKey]; ok {
-			slog.Warn("transform: ignoring configmap that also carries the ratelimit label; use one configmap per feature",
-				"configmap", cm.Namespace+"/"+cm.Name)
+		// which the lenient YAML parsers cross-parse to empty/garbage sets. The
+		// role check above already gated on a recognized transform role (the fs
+		// backend rationale).
+		if other, ok := carriesOtherFeatureLabel(cm, transformLabelKey); ok {
+			slog.Warn("transform: ignoring configmap that also carries another feature label; use one configmap per feature",
+				"configmap", cm.Namespace+"/"+cm.Name, "other_label", other)
 			return true
 		}
 		if role == roleGlobal {

--- a/controller_waf.go
+++ b/controller_waf.go
@@ -191,7 +191,22 @@ func (ctrl *Controller) reloadWAFDebounced() {
 
 	ctrl.watchedConfigMaps.Range(func(_, value any) bool {
 		cm := value.(*v1.ConfigMap)
-		switch cm.Labels[wafLabelKey] {
+		role := cm.Labels[wafLabelKey]
+		// Refuse a ConfigMap labeled for more than one feature (one ConfigMap per
+		// feature, by policy): both reloaders would consume all its data values,
+		// and the lenient YAML parsers cross-parse the other feature's documents to
+		// zero entries — a multi-labeled ConfigMap would quietly feed each side an
+		// empty/garbage set. Gated on a recognized WAF role because the fs backend
+		// ignores label selectors, so this store also holds other features'
+		// ConfigMaps there — those must fall through silently, not warn.
+		if role == roleGlobal || role == roleZone {
+			if other, ok := carriesOtherFeatureLabel(cm, wafLabelKey); ok {
+				slog.Warn("waf: ignoring configmap that also carries another feature label; use one configmap per feature",
+					"configmap", cm.Namespace+"/"+cm.Name, "other_label", other)
+				return true
+			}
+		}
+		switch role {
 		case roleGlobal:
 			// Global rules are platform-owned: only honored from the controller's
 			// own namespace so a tenant can't inject baseline rules.

--- a/controller_waf_test.go
+++ b/controller_waf_test.go
@@ -424,6 +424,26 @@ rules:
 	}
 }
 
+func TestReloadWAF_IgnoresMultiLabeledConfigMap(t *testing.T) {
+	t.Parallel()
+
+	ctrl := newWAFController()
+	cm := wafCM("cust1", "acme", roleZone, `
+rules:
+  - id: r1
+    expression: "true"
+    action: log
+`)
+	// also labeled for the rate limiter: a ConfigMap must carry one feature label,
+	// else both reloaders consume its data and cross-parse to empty sets.
+	cm.Labels[rateLimitLabelKey] = roleZone
+	ctrl.watchedConfigMaps.Store("cust1/acme", cm)
+	ctrl.reloadWAFDebounced()
+
+	assert.Nil(t, ctrl.LookupZone("cust1/acme"),
+		"a multi-feature-labeled configmap is refused by the waf reload")
+}
+
 func TestReloadWAF_DisabledIsNoop(t *testing.T) {
 	t.Parallel()
 

--- a/edgecp/cachereload.go
+++ b/edgecp/cachereload.go
@@ -84,10 +84,10 @@ func (r *CacheReloader) drain(ctx context.Context, ch <-chan watch.Event) {
 
 // reload lists cache ConfigMaps across the watch namespace and rebuilds the
 // global set (podNamespace only) and the zone registry (any namespace). A
-// ConfigMap that also carries the WAF or rate-limit label is refused (one
-// ConfigMap per feature, mirroring the controller and the other reloaders: the
-// lenient YAML parsers would cross-parse the other feature's documents to zero
-// entries silently).
+// ConfigMap that also carries another feature's label is refused (one ConfigMap
+// per feature, mirroring the controller and the other reloaders: the lenient
+// YAML parsers would cross-parse the other feature's documents to zero entries
+// silently).
 func (r *CacheReloader) reload(ctx context.Context) error {
 	cms, err := k8s.GetConfigMaps(ctx, r.watchNamespace, CacheLabelKey)
 	if err != nil {
@@ -98,14 +98,9 @@ func (r *CacheReloader) reload(ctx context.Context) error {
 		cm := &cms[i]
 		role := cm.Labels[CacheLabelKey]
 		if role == wafRoleGlobal || role == wafRoleZone {
-			if _, alsoWAF := cm.Labels[WAFLabelKey]; alsoWAF {
-				slog.Warn("edgecp: ignoring configmap that carries both the cache and waf labels; use one configmap per feature",
-					"configmap", cm.Namespace+"/"+cm.Name)
-				continue
-			}
-			if _, alsoRL := cm.Labels[RateLimitLabelKey]; alsoRL {
-				slog.Warn("edgecp: ignoring configmap that carries both the cache and ratelimit labels; use one configmap per feature",
-					"configmap", cm.Namespace+"/"+cm.Name)
+			if other, ok := carriesOtherFeatureLabel(cm.Labels, CacheLabelKey); ok {
+				slog.Warn("edgecp: ignoring configmap that carries the cache label and another feature label; use one configmap per feature",
+					"configmap", cm.Namespace+"/"+cm.Name, "other_label", other)
 				continue
 			}
 		}

--- a/edgecp/corazareload.go
+++ b/edgecp/corazareload.go
@@ -81,7 +81,10 @@ func (r *CorazaReloader) drain(ctx context.Context, ch <-chan watch.Event) {
 }
 
 // reload lists Coraza ConfigMaps across the watch namespace and rebuilds the
-// global ruleset (podNamespace only) and the zone registry (any namespace).
+// global ruleset (podNamespace only) and the zone registry (any namespace). A
+// ConfigMap that also carries another feature's label is refused (one ConfigMap
+// per feature, mirroring the controller: the edge's lenient YAML parsers would
+// cross-parse the other feature's documents to zero entries silently).
 func (r *CorazaReloader) reload(ctx context.Context) error {
 	cms, err := k8s.GetConfigMaps(ctx, r.watchNamespace, CorazaLabelKey)
 	if err != nil {
@@ -90,6 +93,14 @@ func (r *CorazaReloader) reload(ctx context.Context) error {
 	projected := make([]wafConfigMap, 0, len(cms))
 	for i := range cms {
 		cm := &cms[i]
+		role := cm.Labels[CorazaLabelKey]
+		if role == corazaRoleGlobal || role == corazaRoleZone {
+			if other, ok := carriesOtherFeatureLabel(cm.Labels, CorazaLabelKey); ok {
+				slog.Warn("edgecp: ignoring configmap that carries the coraza label and another feature label; use one configmap per feature",
+					"configmap", cm.Namespace+"/"+cm.Name, "other_label", other)
+				continue
+			}
+		}
 		projected = append(projected, wafConfigMap{
 			namespace: cm.Namespace,
 			name:      cm.Name,

--- a/edgecp/featurelabel.go
+++ b/edgecp/featurelabel.go
@@ -1,0 +1,29 @@
+package edgecp
+
+// featureLabelKeys are the mutually-exclusive ConfigMap feature label keys the
+// control plane distributes. A single ConfigMap must carry at most one: every
+// reloader consumes ALL of a ConfigMap's data values, and the edge's lenient YAML
+// parsers cross-parse another feature's documents to zero entries — so a ConfigMap
+// labeled for two features would feed each edge store the other's data. Each
+// reloader refuses a ConfigMap carrying any of the OTHER keys (warn-and-skip).
+var featureLabelKeys = []string{
+	WAFLabelKey,
+	RateLimitLabelKey,
+	CorazaLabelKey,
+	CacheLabelKey,
+}
+
+// carriesOtherFeatureLabel reports whether labels carry a feature label other
+// than self (the caller's own feature key), returning the first such key. Callers
+// gate this on having recognized their own role first.
+func carriesOtherFeatureLabel(labels map[string]string, self string) (string, bool) {
+	for _, k := range featureLabelKeys {
+		if k == self {
+			continue
+		}
+		if _, ok := labels[k]; ok {
+			return k, true
+		}
+	}
+	return "", false
+}

--- a/edgecp/ratelimitreload.go
+++ b/edgecp/ratelimitreload.go
@@ -84,9 +84,9 @@ func (r *RateLimitReloader) drain(ctx context.Context, ch <-chan watch.Event) {
 
 // reload lists rate-limit ConfigMaps across the watch namespace and rebuilds
 // the global set (podNamespace only) and the zone registry (any namespace). A
-// ConfigMap that also carries the WAF label is refused (one ConfigMap per
-// feature, mirroring the controller: both reloaders would consume all its data
-// values and the lenient YAML parsers cross-parse the other feature's
+// ConfigMap that also carries another feature's label is refused (one ConfigMap
+// per feature, mirroring the controller: both reloaders would consume all its
+// data values and the lenient YAML parsers cross-parse the other feature's
 // documents to zero entries silently).
 func (r *RateLimitReloader) reload(ctx context.Context) error {
 	cms, err := k8s.GetConfigMaps(ctx, r.watchNamespace, RateLimitLabelKey)
@@ -98,9 +98,9 @@ func (r *RateLimitReloader) reload(ctx context.Context) error {
 		cm := &cms[i]
 		role := cm.Labels[RateLimitLabelKey]
 		if role == wafRoleGlobal || role == wafRoleZone {
-			if _, alsoWAF := cm.Labels[WAFLabelKey]; alsoWAF {
-				slog.Warn("edgecp: ignoring configmap that carries both the ratelimit and waf labels; use one configmap per feature",
-					"configmap", cm.Namespace+"/"+cm.Name)
+			if other, ok := carriesOtherFeatureLabel(cm.Labels, RateLimitLabelKey); ok {
+				slog.Warn("edgecp: ignoring configmap that carries the ratelimit label and another feature label; use one configmap per feature",
+					"configmap", cm.Namespace+"/"+cm.Name, "other_label", other)
 				continue
 			}
 		}

--- a/edgecp/wafreload.go
+++ b/edgecp/wafreload.go
@@ -84,7 +84,10 @@ func (r *WafReloader) drain(ctx context.Context, ch <-chan watch.Event) {
 }
 
 // reload lists WAF ConfigMaps across the watch namespace and rebuilds the global
-// ruleset (podNamespace only) and the zone registry (any namespace).
+// ruleset (podNamespace only) and the zone registry (any namespace). A ConfigMap
+// that also carries another feature's label is refused (one ConfigMap per
+// feature, mirroring the controller: the edge's lenient YAML parsers would
+// cross-parse the other feature's documents to zero entries silently).
 func (r *WafReloader) reload(ctx context.Context) error {
 	cms, err := k8s.GetConfigMaps(ctx, r.watchNamespace, WAFLabelKey)
 	if err != nil {
@@ -93,6 +96,14 @@ func (r *WafReloader) reload(ctx context.Context) error {
 	projected := make([]wafConfigMap, 0, len(cms))
 	for i := range cms {
 		cm := &cms[i]
+		role := cm.Labels[WAFLabelKey]
+		if role == wafRoleGlobal || role == wafRoleZone {
+			if other, ok := carriesOtherFeatureLabel(cm.Labels, WAFLabelKey); ok {
+				slog.Warn("edgecp: ignoring configmap that carries the waf label and another feature label; use one configmap per feature",
+					"configmap", cm.Namespace+"/"+cm.Name, "other_label", other)
+				continue
+			}
+		}
 		projected = append(projected, wafConfigMap{
 			namespace: cm.Namespace,
 			name:      cm.Name,

--- a/featurelabel.go
+++ b/featurelabel.go
@@ -1,0 +1,33 @@
+package controller
+
+import v1 "k8s.io/api/core/v1"
+
+// featureLabelKeys are the mutually-exclusive ConfigMap feature label keys. A
+// single ConfigMap must carry at most one of them: every feature reloader
+// consumes ALL of a ConfigMap's data values, and the lenient YAML parsers
+// cross-parse another feature's documents to zero entries — so a ConfigMap
+// labeled for two features would feed each side the other's data. Each reloader
+// refuses a ConfigMap carrying any of the OTHER keys (warn-and-skip).
+var featureLabelKeys = []string{
+	wafLabelKey,
+	rateLimitLabelKey,
+	corazaLabelKey,
+	transformLabelKey,
+}
+
+// carriesOtherFeatureLabel reports whether cm carries a feature label other than
+// self (the caller's own feature key), returning the first such key. Callers gate
+// this on having recognized their own role first, so the fs backend's
+// other-feature ConfigMaps (that store holds ConfigMaps the label selector didn't
+// filter) fall through silently rather than warn.
+func carriesOtherFeatureLabel(cm *v1.ConfigMap, self string) (string, bool) {
+	for _, k := range featureLabelKeys {
+		if k == self {
+			continue
+		}
+		if _, ok := cm.Labels[k]; ok {
+			return k, true
+		}
+	}
+	return "", false
+}

--- a/ratelimitrule/ratelimitrule.go
+++ b/ratelimitrule/ratelimitrule.go
@@ -114,6 +114,17 @@ func Parse(docs ...string) ([]Limit, error) {
 			errs = append(errs, fmt.Errorf("ratelimit: parse document: %w", err))
 			continue
 		}
+		// A non-whitespace document that unmarshals to zero limits is almost always
+		// a wrong root key (e.g. a WAF "rules:" doc that landed in a rate-limit
+		// ConfigMap): struct unmarshal silently drops unknown keys, so without this
+		// the caller would apply an empty set and advance its fingerprint, wiping
+		// the last-good limits. Treat it as a per-doc error so SetLimits keeps the
+		// previous set. The sanctioned way to clear is deleting the ConfigMap or
+		// emptying its data (a whitespace-only doc, skipped above).
+		if len(d.Limits) == 0 {
+			errs = append(errs, errors.New(`ratelimit: document has no limits (wrong root key? expected "limits:")`))
+			continue
+		}
 		out = append(out, d.Limits...)
 	}
 	return out, errors.Join(errs...)

--- a/ratelimitrule/ratelimitrule_test.go
+++ b/ratelimitrule/ratelimitrule_test.go
@@ -55,6 +55,31 @@ limits:
 		assert.Equal(t, "ok", limits[0].ID)
 	})
 
+	t.Run("wrong root key yields zero limits and errors", func(t *testing.T) {
+		// A WAF "rules:" document that landed in a rate-limit ConfigMap unmarshals
+		// to zero limits with no YAML error; without the zero-limits guard it would
+		// wipe the last-good set. It must error so SetLimits keeps the previous
+		// limits, and the good doc alongside it still parses (per-doc collection).
+		limits, err := ratelimitrule.Parse(
+			"rules:\n  - id: a\n    expression: \"true\"",
+			`
+limits:
+  - id: ok
+    rate: 1
+    window: 1s
+`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no limits")
+		require.Len(t, limits, 1)
+		assert.Equal(t, "ok", limits[0].ID)
+	})
+
+	t.Run("whitespace-only docs stay skipped (no error)", func(t *testing.T) {
+		limits, err := ratelimitrule.Parse("", "   \n\t")
+		require.NoError(t, err)
+		assert.Empty(t, limits)
+	})
+
 	t.Run("all fields map", func(t *testing.T) {
 		limits, err := ratelimitrule.Parse(`
 limits:

--- a/transformrule/transformrule.go
+++ b/transformrule/transformrule.go
@@ -197,6 +197,17 @@ func Parse(opts Options, docs ...string) (*Zone, error) {
 		if err := yaml.Unmarshal([]byte(doc), &d); err != nil {
 			return nil, fmt.Errorf("transform: parse document: %w", err)
 		}
+		// A non-whitespace document that unmarshals to zero transforms is almost
+		// always a wrong root key (e.g. a WAF "rules:" doc that landed in a
+		// transform ConfigMap): struct unmarshal silently drops unknown keys, so
+		// without this the caller would apply an empty (all-or-nothing) set and
+		// advance its fingerprint, wiping the last-good Zone. Reject it so the
+		// controller keeps the previous Zone. The sanctioned way to clear is
+		// deleting the ConfigMap or emptying its data (a whitespace-only doc,
+		// skipped above).
+		if len(d.Transforms) == 0 {
+			return nil, errors.New(`transform: document has no transforms (wrong root key? expected "transforms:")`)
+		}
 		rules = append(rules, d.Transforms...)
 	}
 
@@ -563,9 +574,10 @@ func (z *Zone) IDs() []string {
 	return out
 }
 
-// Empty reports whether the zone has no rules (a valid inert zone, e.g. from an
-// empty `transforms:` document). The plugin still mounts it as a cheap
-// pass-through.
+// Empty reports whether the zone has no rules (a valid inert zone, e.g. from a
+// ConfigMap whose data values are all whitespace — a non-whitespace document
+// that yields zero transforms is rejected by Parse). The plugin still mounts it
+// as a cheap pass-through.
 func (z *Zone) Empty() bool {
 	return len(z.reqRules) == 0 && len(z.respRules) == 0 && len(z.corsRules) == 0
 }

--- a/transformrule/transformrule_test.go
+++ b/transformrule/transformrule_test.go
@@ -309,10 +309,12 @@ transforms:
 	assert.Equal(t, "1", gotB, "other rules still apply")
 }
 
-func TestParse_EmptyDocIsInert(t *testing.T) {
+func TestParse_WhitespaceDocsAreInert(t *testing.T) {
 	t.Parallel()
 
-	z, err := transformrule.Parse(transformrule.Options{}, "transforms:\n")
+	// The sanctioned way to clear a zone is emptying the ConfigMap data (or
+	// deleting it): whitespace-only docs are skipped, yielding a valid empty Zone.
+	z, err := transformrule.Parse(transformrule.Options{}, "", "   \n\t")
 	require.NoError(t, err)
 	require.NotNil(t, z)
 	assert.True(t, z.Empty())
@@ -321,6 +323,19 @@ func TestParse_EmptyDocIsInert(t *testing.T) {
 	var proxied bool
 	serve(t, z, r, func(http.ResponseWriter, *http.Request) { proxied = true })
 	assert.True(t, proxied, "an empty zone is a pass-through")
+}
+
+func TestParse_WrongRootKeyErrors(t *testing.T) {
+	t.Parallel()
+
+	// A WAF "rules:" document that landed in a transform ConfigMap unmarshals to
+	// zero transforms with no YAML error; without the zero-transforms guard it
+	// would wipe the last-good Zone. It must error (all-or-nothing) so the
+	// controller keeps the previous Zone.
+	z, err := transformrule.Parse(transformrule.Options{}, "rules:\n  - id: a\n    expression: \"true\"")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no transforms")
+	assert.Nil(t, z)
 }
 
 func TestParse_CORSWildcardWithCredentialsRejected(t *testing.T) {

--- a/wafrule/wafrule.go
+++ b/wafrule/wafrule.go
@@ -66,6 +66,17 @@ func Parse(docs ...string) ([]waf.Rule, error) {
 			errs = append(errs, fmt.Errorf("waf: parse document: %w", err))
 			continue
 		}
+		// A non-whitespace document that unmarshals to zero rules is almost always
+		// a wrong root key (e.g. a rate-limit "limits:" doc that landed in a WAF
+		// ConfigMap): struct unmarshal silently drops unknown keys, so without this
+		// the caller would apply an empty ruleset and advance its fingerprint,
+		// wiping the last-good rules. Treat it as a per-doc error so SetRules keeps
+		// the previous ruleset. The sanctioned way to clear is deleting the
+		// ConfigMap or emptying its data (a whitespace-only doc, skipped above).
+		if len(d.Rules) == 0 {
+			errs = append(errs, errors.New(`waf: document has no rules (wrong root key? expected "rules:")`))
+			continue
+		}
 		for i, r := range d.Rules {
 			action, err := ParseAction(r.Action)
 			if err != nil {

--- a/wafrule/wafrule_test.go
+++ b/wafrule/wafrule_test.go
@@ -96,6 +96,27 @@ rules:
 		require.Error(t, err)
 	})
 
+	t.Run("wrong root key yields zero rules and errors", func(t *testing.T) {
+		// A rate-limit "limits:" document that landed in a WAF ConfigMap unmarshals
+		// to zero rules with no YAML error; without the zero-rules guard it would
+		// wipe the last-good ruleset. It must error so SetRules keeps the previous
+		// rules, and the good doc alongside it still parses (per-doc collection).
+		rules, err := wafrule.Parse(
+			"limits:\n  - id: a\n    rate: 1\n    window: 1s",
+			"rules:\n  - id: ok\n    expression: \"true\"",
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no rules")
+		require.Len(t, rules, 1)
+		assert.Equal(t, "ok", rules[0].ID)
+	})
+
+	t.Run("whitespace-only docs stay skipped (no error)", func(t *testing.T) {
+		rules, err := wafrule.Parse("", "   \n\t")
+		require.NoError(t, err)
+		assert.Empty(t, rules)
+	})
+
 	t.Run("rules feed waf.SetRules", func(t *testing.T) {
 		rules, err := wafrule.Parse(`
 rules:


### PR DESCRIPTION
## Findings 3 (high) + 10 (medium)

**Problem.** A non-whitespace YAML document with the wrong root key (e.g. a rate-limit `limits:` doc inside a WAF ConfigMap) unmarshals to zero entries with `err == nil`. The reloader then applies the empty set AND advances its fingerprint, silently replacing the last-good ruleset. Compounding it, `controller_waf.go` and `controller_coraza.go` did not refuse ConfigMaps carrying another feature's label, so dual-labeling a rate-limit doc with the WAF label wiped the WAF via this path.

## What changed and why

**(a) Zero-entry rule documents now error (all-or-nothing preserved).**
- `wafrule.Parse`, `ratelimitrule.Parse`: a non-whitespace doc that unmarshals to zero rules/limits is now a per-doc error (collected via `errors.Join`, exactly like their existing per-doc errors), with a message hinting a likely wrong root key. Whitespace-only docs stay skipped (the sanctioned clear = deleting the ConfigMap / emptying its data).
- `transformrule.Parse`: same contract, returned fail-fast as `nil, err` to match its existing all-or-nothing style.
- Any parse error keeps last-good and does NOT advance the fingerprint (existing reload logic already gates fingerprint advance on a clean parse). The edge inherits the fix through the same parsers; its apply loops already withhold etag/generation on failure — unchanged.
- Coraza is unaffected (bad SecLang already fails compile).
- `transformrule.Zone.Empty()` doc comment updated: an inert zone now comes only from all-whitespace docs, not an empty `transforms:` doc (which is now rejected).

**(b) Full multi-feature label matrix.** Each of the four controller reloaders (waf, ratelimit, coraza, transform) now refuses a ConfigMap carrying ANY of the other three feature label keys, using the same warn-and-skip pattern (and "gate on a recognized role" fs-backend rationale) `controller_ratelimit.go` already used. Extracted a shared `carriesOtherFeatureLabel` helper (`featurelabel.go`). Mirrored the same gap in the CP reloaders (`edgecp/wafreload.go`, `corazareload.go`, `ratelimitreload.go`, `cachereload.go`) via an `edgecp/featurelabel.go` helper covering waf/ratelimit/coraza/cache — waf/coraza refused none before, ratelimit/cache refused only a subset.

## Testing
- New parser tests per package: wrong-root non-empty doc errors (and the good doc alongside still parses), whitespace docs stay skipped, valid docs unchanged.
- New reloader dual-label refusal tests for waf and coraza, modeled on the existing ratelimit/transform tests.
- Updated `transformrule` inert test to feed whitespace (the empty-`transforms:` doc is now rejected).
- `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` (894 pass) and `go test -race` on all touched packages green.
