### PR TITLE
ci: disable setup-go remote cache on self-hosted runners

### DIFF
--- a/.github/workflows/edge-e2e.yaml
+++ b/.github/workflows/edge-e2e.yaml
@@ -30,6 +30,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.26.5'
+          # Self-hosted runner: local GOMODCACHE/GOCACHE beat the remote
+          # actions-cache restore (see go-test.yaml for the numbers).
+          cache: false
       - name: Install test deps (openssl, curl, python3, nc)
         run: |
           sudo apt-get update

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -24,6 +24,12 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
+        # Self-hosted runner: GOMODCACHE/GOCACHE persist on local disk between
+        # runs, so the default cache:true only re-downloads a multi-GB blob from
+        # GitHub's remote cache service every run (measured: ~7.5 min restore vs
+        # ~15 s of actual vet+test). The toolchain itself stays cached in the
+        # runner's tool cache regardless.
+        cache: false
     - run: go get -t -v ./...
     - run: go vet ./...
     - run: go test -race ./...


### PR DESCRIPTION
## Problem

`Go Test` and `edge-e2e` jobs spend ~95% of their wall clock inside `actions/setup-go@v5` (measured on run 29221904451):

| Step | Duration |
|---|---|
| setup-go | **7m 35s** |
| go get + vet + test -race | 16s |

The step log shows the toolchain itself is instant (`Found in cache @ /opt/hostedtoolcache/go/1.26.5/x64` in <1s). The time goes to the `cache: true` default: restoring a **2,311 MB** GOMODCACHE+GOCACHE blob from GitHub's remote cache service (~6.5 min download at ~6 MB/s + 68s untar) — every run.

## Why this is safe

Our runners are **persistent self-hosted machines**: `/root/go/pkg/mod` and `/root/.cache/go-build` survive between runs on local disk, which is strictly faster and fresher than any remote restore. The remote cache design exists for ephemeral GitHub-hosted runners; here it only overwrites warm local state with a stale 2.3 GB snapshot. Cache save on miss (multi-minute 2.3 GB upload) also disappears.

Expected result: setup-go drops from ~7.5 min to seconds; whole job from ~8 min to well under a minute. First run on a brand-new runner machine is the only case that pays a cold module download, once.

## Housekeeping note

With local caches doing the work, `/root/.cache/go-build` grows unbounded over months — an occasional `go clean -cache` (or a cron with `find -atime` pruning) on the runner boxes is worth having. Not part of this change.

## Testing

This PR's own CI runs exercise the changed workflows (both path-filter on their own files) — compare the setup-go step time on these checks against the table above.